### PR TITLE
docs(providers): complete collector guide coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The current version identifies public source under development. It is not a clai
 ### Product identity and public documentation
 
 - Canonicalized CLI help, usage examples, diagnostics and default export names around the `metrora` command while preserving versioned compatibility schemas and markers.
+- Completed public provider-guide coverage for all 38 registered local collectors and corrected stale inventory metadata without changing evidence approval.
 - Established Metrora™ as the product identity, Signal Grid™ as the canonical visual identity and Vensent™ as the publisher identity.
 - Established the independent `1.0.0-rc.N` candidate line while preserving `0.9.19` as an immutable historical source and migration baseline.
 - Separated the Metrora MIT licence from the preserved CodeBurn upstream notice.

--- a/docs/COLLECTOR_INVENTORY_V1.md
+++ b/docs/COLLECTOR_INVENTORY_V1.md
@@ -17,7 +17,7 @@ These labels describe current evidence boundaries. They are not a public impleme
 | antigravity | lazy | protobuf-rpc-cache-and-statusline | docs/providers/antigravity.md | available | source-documented | withheld |
 | claude | core | jsonl-and-desktop-session-files | docs/providers/claude.md | available | signed-approved | approved |
 | cline | core | unassessed | docs/providers/cline.md | available | local-only | withheld |
-| codebuff | core | unassessed | missing | available | local-only | withheld |
+| codebuff | core | unassessed | docs/providers/codebuff.md | available | local-only | withheld |
 | codewhale | core | unassessed | docs/providers/codewhale.md | available | local-only | withheld |
 | codex | core | rollout-jsonl | docs/providers/codex.md | available | signed-approved | approved |
 | copilot | core | otel-sqlite-and-legacy-multi-store | docs/providers/copilot.md | available | source-documented | withheld |
@@ -34,17 +34,17 @@ These labels describe current evidence boundaries. They are not a public impleme
 | ibm-bob | core | unassessed | docs/providers/ibm-bob.md | available | local-only | withheld |
 | kilo-code | core | unassessed | docs/providers/kilo-code.md | available | local-only | withheld |
 | kimi | core | unassessed | docs/providers/kimi.md | available | local-only | withheld |
-| kimicode | core | unassessed | missing | available | local-only | withheld |
+| kimicode | core | unassessed | docs/providers/kimicode.md | available | local-only | withheld |
 | kiro | core | chat-json-estimated | docs/providers/kiro.md | available | source-documented | withheld |
 | lingtai-tui | core | unassessed | docs/providers/lingtai-tui.md | available | local-only | withheld |
 | mistral-vibe | core | session-meta-and-jsonl | docs/providers/mistral-vibe.md | available | source-documented | withheld |
 | mux | core | unassessed | docs/providers/mux.md | available | local-only | withheld |
 | omp | core | unassessed | docs/providers/omp.md | available | local-only | withheld |
-| open-design | core | unassessed | missing | available | local-only | withheld |
+| open-design | core | unassessed | docs/providers/open-design.md | available | local-only | withheld |
 | openclaw | core | agent-jsonl | docs/providers/openclaw.md | available | source-documented | withheld |
 | opencode | lazy | sqlite-or-file-storage | docs/providers/opencode.md | available | source-documented | withheld |
 | pi | core | unassessed | docs/providers/pi.md | available | local-only | withheld |
-| quickdesk | core | unassessed | missing | available | local-only | withheld |
+| quickdesk | core | unassessed | docs/providers/quickdesk.md | available | local-only | withheld |
 | qwen | core | unassessed | docs/providers/qwen.md | available | local-only | withheld |
 | roo-code | core | unassessed | docs/providers/roo-code.md | available | local-only | withheld |
 | vercel-gateway | lazy | unassessed | docs/providers/vercel-gateway.md | available | local-only | withheld |
@@ -58,8 +58,8 @@ These labels describe current evidence boundaries. They are not a public impleme
 - Registered local collectors: **38**.
 - Approved for signed Workspace measurements: **4 collectors / 6 path-specific profiles**.
 - Local collectors with signed sharing withheld: **34**.
-- Provider documentation present: **34**.
-- Documentation gaps: **codebuff, kimicode, open-design, quickdesk**.
+- Provider documentation present: **38**.
+- Documentation gaps: **none**.
 
 ## Approval gate
 

--- a/docs/SUPPORTED_TOOLS.md
+++ b/docs/SUPPORTED_TOOLS.md
@@ -18,7 +18,7 @@ This is an evidence boundary, not a product-priority ranking.
 | `antigravity` | Available | Protobuf/RPC cache and status-line sources documented; path-specific signed review incomplete | Withheld |
 | `claude` | Available | JSONL and desktop session evidence reviewed | Approved |
 | `cline` | Available | Local collector registered; signed-evidence audit incomplete | Withheld |
-| `codebuff` | Available | Local collector registered; public provider guide pending | Withheld |
+| `codebuff` | Available | Chat JSON, token fields, credit fallback and tool normalization documented; signed-evidence audit incomplete | Withheld |
 | `codewhale` | Available | Local collector registered; signed-evidence audit incomplete | Withheld |
 | `codex` | Available | Rollout JSONL measured and fallback evidence reviewed | Approved |
 | `copilot` | Available | OTEL, SQLite and legacy multi-store sources documented; path-specific signed review incomplete | Withheld |
@@ -35,17 +35,17 @@ This is an evidence boundary, not a product-priority ranking.
 | `ibm-bob` | Available | Local collector registered; signed-evidence audit incomplete | Withheld |
 | `kilo-code` | Available | Local collector registered; signed-evidence audit incomplete | Withheld |
 | `kimi` | Available | Local collector registered; signed-evidence audit incomplete | Withheld |
-| `kimicode` | Available | Local collector registered; public provider guide pending | Withheld |
+| `kimicode` | Available | Agent-wire token, cache and tool evidence documented; signed-evidence audit incomplete | Withheld |
 | `kiro` | Available | Legacy chat JSON with estimated fields documented | Withheld |
 | `lingtai-tui` | Available | Local collector registered; signed-evidence audit incomplete | Withheld |
 | `mistral-vibe` | Available | Session metadata and JSONL evidence documented | Withheld |
 | `mux` | Available | Local collector registered; signed-evidence audit incomplete | Withheld |
 | `omp` | Available | Local collector registered; signed-evidence audit incomplete | Withheld |
-| `open-design` | Available | Local collector registered; public provider guide pending | Withheld |
+| `open-design` | Available | Per-run JSONL token, cache and reasoning evidence documented; signed-evidence audit incomplete | Withheld |
 | `openclaw` | Available | Agent JSONL evidence documented | Withheld |
 | `opencode` | Available | SQLite and file-storage evidence documented | Withheld |
 | `pi` | Available | Local collector registered; signed-evidence audit incomplete | Withheld |
-| `quickdesk` | Available | Local collector registered; public provider guide pending | Withheld |
+| `quickdesk` | Available | Metrics JSONL, SQLite enrichment and fallback estimation documented; signed-evidence audit incomplete | Withheld |
 | `qwen` | Available | Local collector registered; signed-evidence audit incomplete | Withheld |
 | `roo-code` | Available | Local collector registered; signed-evidence audit incomplete | Withheld |
 | `vercel-gateway` | Available | Local collector registered; signed-evidence audit incomplete | Withheld |
@@ -69,19 +69,10 @@ Metrora must preserve those differences in downstream reporting. A source that e
 
 ## Provider documentation
 
-Detailed source paths, formats, caches, deduplication behavior and known limitations live under [`docs/providers`](providers/).
+Every registered collector now has a public provider guide under [`docs/providers`](providers/). Each guide records the current source location, storage format, caching, deduplication behavior and known limitations supported by the implementation and tests.
 
-Current public provider guides are missing for:
-
-- `codebuff`;
-- `kimicode`;
-- `open-design`;
-- `quickdesk`.
-
-Those gaps are documentation gaps, not a claim that the registered local collectors are disabled.
+Complete guide coverage does **not** promote a collector to signed Workspace approval. Signed approval remains limited to concrete source paths with fixture parity, field-level provenance, pricing reconciliation, privacy review and required manual validation.
 
 ## Technical inventory
 
-[`COLLECTOR_INVENTORY_V1.md`](COLLECTOR_INVENTORY_V1.md) is generated from the executable collector inventory and is checked against the provider registry in tests.
-
-Signed Workspace approval requires concrete fixture parity, field-level provenance, pricing reconciliation, privacy review and manual validation when the source depends on a live IDE, RPC process or mutable database.
+[`COLLECTOR_INVENTORY_V1.md`](COLLECTOR_INVENTORY_V1.md) is generated from the executable collector inventory and is checked against the provider registry and provider-guide files in tests.

--- a/docs/providers/README.md
+++ b/docs/providers/README.md
@@ -12,6 +12,7 @@ For the architectural picture, see `../architecture.md`.
 |---|---|---|---|
 | [Claude](claude.md) | JSONL (no parser) | `src/providers/claude.ts` | none (covered indirectly) |
 | [Cline](cline.md) | JSON | `src/providers/cline.ts` | `tests/providers/cline.test.ts` |
+| [Codebuff](codebuff.md) | JSON | `src/providers/codebuff.ts` | `tests/providers/codebuff.test.ts` |
 | [CodeWhale](codewhale.md) | JSON | `src/providers/codewhale.ts` | `tests/providers/codewhale.test.ts` |
 | [Codex](codex.md) | JSONL | `src/providers/codex.ts` | `tests/providers/codex.test.ts` |
 | [Copilot](copilot.md) | JSONL + SQLite (OTel) + Nitrite .db (JetBrains) | `src/providers/copilot.ts` | `tests/providers/copilot.test.ts` |
@@ -26,6 +27,7 @@ For the architectural picture, see `../architecture.md`.
 | [Kimi Code](kimicode.md) | JSONL | `src/providers/kimicode.ts` | `tests/providers/kimicode.test.ts` |
 | [LingTai TUI](lingtai-tui.md) | JSONL | `src/providers/lingtai-tui.ts` | `tests/providers/lingtai-tui.test.ts` |
 | [Mistral Vibe](mistral-vibe.md) | JSON / JSONL | `src/providers/mistral-vibe.ts` | `tests/providers/mistral-vibe.test.ts` |
+| [Open Design](open-design.md) | JSONL | `src/providers/open-design.ts` | `tests/providers/open-design.test.ts` |
 | [OpenClaw](openclaw.md) | JSONL | `src/providers/openclaw.ts` | `tests/providers/openclaw.test.ts` |
 | [Pi](pi.md) | JSONL | `src/providers/pi.ts` | `tests/providers/pi.test.ts` |
 | [OMP](omp.md) | JSONL | `src/providers/pi.ts` | `tests/providers/omp.test.ts` |

--- a/docs/providers/codebuff.md
+++ b/docs/providers/codebuff.md
@@ -1,0 +1,89 @@
+# Codebuff
+
+Codebuff local chat usage, credit cost and tool activity.
+
+- **Source:** `src/providers/codebuff.ts`
+- **Loading:** eager
+- **Test:** `tests/providers/codebuff.test.ts`
+
+## Where it reads from
+
+Codebuff retains the former Manicode directory name on disk. By default Metrora scans every installed channel:
+
+```text
+~/.config/manicode
+~/.config/manicode-dev
+~/.config/manicode-staging
+```
+
+Set `CODEBUFF_DATA_DIR` to scan one explicit root instead. Passing a provider override has the same single-root behavior.
+
+Each channel uses:
+
+```text
+<channel>/projects/<project>/chats/<chat-id>/
+├── chat-messages.json
+└── run-state.json                 optional
+```
+
+A chat is discovered only when `chat-messages.json` exists. When available, `run-state.json` supplies the original working directory so the session is grouped under the real project basename rather than a sanitized storage folder.
+
+## Storage format
+
+`chat-messages.json` is a JSON array. The parser emits one call for each `ai`, `agent` or `assistant` message that contains either token usage or a non-zero Codebuff credit value.
+
+Token usage is read in this order:
+
+1. direct message metadata (`metadata.usage` or `metadata.codebuff.usage`);
+2. the newest assistant usage entry in the stashed RunState message history;
+3. no tokens, with cost derived from credits when credits are available.
+
+The parser accepts common camelCase and snake_case token names for input, output, cache read and cache creation. When token counts identify a priceable model, Metrora calculates cost from those tokens. Otherwise credits are converted using the conservative public pay-as-you-go rate of **$0.01 per credit**.
+
+Model attribution prefers direct metadata, then the stashed provider model, then the observed Codebuff agent type, and finally the generic `codebuff` identifier.
+
+Tool blocks are normalized into Metrora's canonical Read, Grep, Glob, Edit, Write, Bash, Agent, TodoWrite, WebFetch and WebSearch categories where a known mapping exists. Terminal command blocks also populate the bash-command breakdown. Framing tools such as `suggest_followups` and `end_turn` are ignored for task classification.
+
+Messages with neither tokens nor credits are skipped. A missing or malformed chat file produces no calls rather than failing the provider scan.
+
+## Caching
+
+Codebuff is an eager provider using the shared session cache. Each chat directory is represented by its `chat-messages.json` source. `CODEBUFF_DATA_DIR` and the provider parser version participate in the configuration fingerprint used by the cache layer.
+
+The provider reads only local Codebuff files. It does not call a Codebuff billing API to reconcile credits, subscriptions or invoices.
+
+## Deduplication
+
+Each call uses:
+
+```text
+codebuff:<absolute-chat-directory>:<message-id-or-array-index>
+```
+
+The absolute chat directory keeps identical message IDs from separate chats distinct.
+
+Session IDs include the channel and chat ID when the path follows the normal store layout:
+
+```text
+<channel>/<chat-id>
+```
+
+This prevents the same timestamp-named chat under stable, development and staging channels from collapsing into one session.
+
+## Quirks
+
+- Codebuff was formerly named Manicode, so the default storage directories intentionally retain `manicode`.
+- Credit-derived cost is a conservative estimate. Subscription users may pay less than the displayed pay-as-you-go equivalent.
+- Token-priced cost takes precedence over credit conversion when usable token counts and model pricing exist.
+- User messages are attached to the next accounted assistant message and cleared after that call.
+- A chat ID is commonly an ISO-like timestamp; it supplies a fallback timestamp when message metadata does not.
+- Tool and agent blocks may be nested. The parser walks nested agent blocks recursively.
+
+## When fixing a bug here
+
+1. Test stable, development and staging roots when changing discovery.
+2. Preserve the single-root behavior of `CODEBUFF_DATA_DIR` and explicit overrides.
+3. Keep token-based pricing ahead of credit conversion.
+4. Test direct usage, stashed RunState usage and credit-only messages separately.
+5. Preserve channel-scoped session IDs and absolute-path message deduplication.
+6. Use sanitized fixtures; chat messages and working directories can contain private information.

--- a/docs/providers/open-design.md
+++ b/docs/providers/open-design.md
@@ -1,0 +1,88 @@
+# Open Design
+
+Open Design per-run model usage from local event logs.
+
+- **Source:** `src/providers/open-design.ts`
+- **Loading:** eager
+- **Test:** `tests/providers/open-design.test.ts`
+
+## Where it reads from
+
+The default application-data root is platform-specific:
+
+```text
+macOS   ~/Library/Application Support/Open Design
+Windows %APPDATA%/Open Design
+Linux   ~/.config/Open Design
+```
+
+Set `CODEBURN_OPEN_DESIGN_DIR` to use an explicit root. The override may point to an application root, a namespace `data` directory, or a `runs` directory.
+
+The provider recognizes these layouts:
+
+```text
+<root>/data/runs/<run-id>/events.jsonl
+<root>/runs/<run-id>/events.jsonl
+<root>/namespaces/<namespace>/data/runs/<run-id>/events.jsonl
+```
+
+Each `events.jsonl` file is one session source. The namespace or enclosing data root becomes the project label. Duplicate paths discovered through overlapping layouts are removed.
+
+## Storage format
+
+`events.jsonl` contains one JSON object per line. Malformed lines are skipped independently.
+
+The parser follows three event forms:
+
+- `start` events can establish the initial model for a run;
+- `agent` events with `data.type = status` can change the active model;
+- `agent` events with `data.type = usage` provide token counts.
+
+Usage fields map as follows:
+
+| Open Design | Metrora |
+| --- | --- |
+| `input_tokens` | total input before cache separation |
+| `cached_read_tokens` | cache read and cached input |
+| `output_tokens` | output |
+| `thought_tokens` | reasoning |
+
+Because cached input is included in the reported input total, Metrora subtracts `cached_read_tokens` from `input_tokens` before recording uncached input. Pricing uses uncached input, cache read, ordinary output and reasoning output through the shared pricing authority.
+
+A usage event is emitted only after a model has been observed from `start` or a status transition. Runs without usage events contribute no calls. Open Design does not expose tool activity or a user-message field through this parser.
+
+Timestamps can be ISO strings or numeric millisecond epochs. Invalid or absent timestamps remain empty and may be excluded by date-scoped aggregation.
+
+## Caching
+
+Open Design is an eager provider using the shared session cache. Every run's `events.jsonl` is fingerprinted as an independent source. The override directory and provider parser version participate in the provider configuration fingerprint.
+
+The files are read locally; no Open Design account or network API is required.
+
+## Deduplication
+
+Each usage call uses:
+
+```text
+open-design:<run-id>:<event-id>
+```
+
+When an event has no usable ID, the parser assigns a stable per-file fallback counter for that parse. A shared deduplication set prevents the same usage event from being counted twice across repeated scans.
+
+## Quirks
+
+- A run can switch models. Each usage event is attributed to the most recently observed model.
+- A `start` event can seed the model before any later status event.
+- Cache-read tokens are included in Open Design's input total and must be separated before pricing.
+- Reasoning tokens are priced with output tokens while remaining separately reported.
+- The environment variable retains the historical `CODEBURN_` prefix for compatibility; it is not the product name.
+- Known model display aliases are presentation-only. Raw model identifiers remain the accounting authority.
+
+## When fixing a bug here
+
+1. Test both start-seeded and status-transition model attribution.
+2. Preserve cache-read subtraction from total input.
+3. Cover ISO and numeric timestamps in date-scoped aggregation.
+4. Keep malformed JSONL lines isolated from later valid events.
+5. Test duplicate event IDs with a shared deduplication set.
+6. Do not infer tools, prompts or costs beyond the fields present in the event log.

--- a/src/providers/collector-inventory.test.ts
+++ b/src/providers/collector-inventory.test.ts
@@ -18,23 +18,22 @@ describe('CollectorInventoryV1', () => {
     expect(new Set(inventoried).size).toBe(38)
   })
 
-  it('points every collector at a real provider module and every claimed document at a real file', () => {
+  it('points every collector at a real provider module and provider guide', () => {
     for (const entry of CollectorInventoryV1.entries) {
       expect(existsSync(join(process.cwd(), entry.modulePath)), entry.provider).toBe(true)
-      if (entry.documentationPath) {
-        expect(existsSync(join(process.cwd(), entry.documentationPath)), entry.provider).toBe(true)
-      }
+      expect(entry.documentationPath, entry.provider).not.toBeNull()
+      expect(existsSync(join(process.cwd(), entry.documentationPath!)), entry.provider).toBe(true)
     }
   })
 
-  it('tracks the current documentation gaps explicitly', () => {
+  it('tracks complete provider documentation coverage separately from evidence approval', () => {
     expect(collectorInventorySummaryV1()).toEqual({
       total: 38,
       approved: 4,
       priority: 8,
       pending: 26,
-      documented: 34,
-      documentationGaps: ['codebuff', 'kimicode', 'open-design', 'quickdesk'],
+      documented: 38,
+      documentationGaps: [],
     })
   })
 

--- a/src/providers/collector-inventory.ts
+++ b/src/providers/collector-inventory.ts
@@ -130,7 +130,7 @@ const entries = [
   priority('warp', 'src/providers/warp.ts', 'docs/providers/warp.md', 'lazy', 'sqlite-weighted-estimation', 2),
 
   pending('cline', 'src/providers/cline.ts', 'docs/providers/cline.md', 'core'),
-  pending('codebuff', 'src/providers/codebuff.ts', null, 'core'),
+  pending('codebuff', 'src/providers/codebuff.ts', 'docs/providers/codebuff.md', 'core'),
   pending('codewhale', 'src/providers/codewhale.ts', 'docs/providers/codewhale.md', 'core'),
   pending('crush', 'src/providers/crush.ts', 'docs/providers/crush.md', 'lazy'),
   pending('cursor-agent', 'src/providers/cursor-agent.ts', 'docs/providers/cursor-agent.md', 'lazy'),
@@ -143,13 +143,13 @@ const entries = [
   pending('ibm-bob', 'src/providers/ibm-bob.ts', 'docs/providers/ibm-bob.md', 'core'),
   pending('kilo-code', 'src/providers/kilo-code.ts', 'docs/providers/kilo-code.md', 'core'),
   pending('kimi', 'src/providers/kimi.ts', 'docs/providers/kimi.md', 'core'),
-  pending('kimicode', 'src/providers/kimicode.ts', null, 'core'),
+  pending('kimicode', 'src/providers/kimicode.ts', 'docs/providers/kimicode.md', 'core'),
   pending('lingtai-tui', 'src/providers/lingtai-tui.ts', 'docs/providers/lingtai-tui.md', 'core'),
   pending('mux', 'src/providers/mux.ts', 'docs/providers/mux.md', 'core'),
   pending('omp', 'src/providers/pi.ts', 'docs/providers/omp.md', 'core'),
-  pending('open-design', 'src/providers/open-design.ts', null, 'core'),
+  pending('open-design', 'src/providers/open-design.ts', 'docs/providers/open-design.md', 'core'),
   pending('pi', 'src/providers/pi.ts', 'docs/providers/pi.md', 'core'),
-  pending('quickdesk', 'src/providers/quickdesk.ts', null, 'core'),
+  pending('quickdesk', 'src/providers/quickdesk.ts', 'docs/providers/quickdesk.md', 'core'),
   pending('qwen', 'src/providers/qwen.ts', 'docs/providers/qwen.md', 'core'),
   pending('roo-code', 'src/providers/roo-code.ts', 'docs/providers/roo-code.md', 'core'),
   pending('vercel-gateway', 'src/providers/vercel-gateway.ts', 'docs/providers/vercel-gateway.md', 'lazy'),
@@ -221,6 +221,9 @@ export function renderCollectorInventoryMarkdownV1(): string {
     lines.push(`| ${item.provider} | ${item.loading} | ${item.sourceFamily} | ${item.documentationPath ?? 'missing'} | available | ${publicEvidenceStatus(item)} | ${item.shareEligibility} |`)
   }
   const summary = collectorInventorySummaryV1()
+  const documentationGaps = summary.documentationGaps.length > 0
+    ? summary.documentationGaps.join(', ')
+    : 'none'
   lines.push(
     '',
     '## Current totals',
@@ -229,7 +232,7 @@ export function renderCollectorInventoryMarkdownV1(): string {
     `- Approved for signed Workspace measurements: **${summary.approved} collectors / ${reviewedProvenanceProfileIdsV1().length} path-specific profiles**.`,
     `- Local collectors with signed sharing withheld: **${summary.total - summary.approved}**.`,
     `- Provider documentation present: **${summary.documented}**.`,
-    `- Documentation gaps: **${summary.documentationGaps.join(', ')}**.`,
+    `- Documentation gaps: **${documentationGaps}**.`,
     '',
     '## Approval gate',
     '',


### PR DESCRIPTION
## Summary

Complete public provider-guide coverage for all 38 registered local collectors without changing parser behavior or signed Workspace approval.

- add implementation-grounded guides for Codebuff and Open Design;
- register the existing Kimi Code and Quick Desktop guides that stale inventory metadata still marked as missing;
- update the provider index and supported-tools matrix;
- require every registered collector to point to a real guide;
- regenerate the collector inventory with 38/38 documentation coverage and zero documentation gaps.

## Public boundary

Documentation completeness remains separate from evidence approval. Codebuff, Kimi Code, Open Design and Quick Desktop remain local-only for signed Workspace purposes; no collector is promoted by this change.

## Validation

The checked-in inventory must match the executable renderer byte-for-byte. Provider modules, provider guides, registry coverage and signed-provenance restrictions remain covered by the collector inventory tests. No screenshots, roadmap or internal priority sequence is added.