### PR TITLE
docs: align public references with current product state

### DIFF
--- a/docs/CANONICAL_REVIEWED_PRODUCTION_SCANNER_V1.md
+++ b/docs/CANONICAL_REVIEWED_PRODUCTION_SCANNER_V1.md
@@ -1,91 +1,95 @@
 # Canonical reviewed-production scanner v1
 
-**Status:** W1.D.C.B.B.A scanner boundary. Secure desktop runtime/IPC/UI integration remains W1.D.C.B.B.B.
+**Status:** implemented and invoked by the protected desktop Workspace runtime after the explicit production action.
 
-This scanner is the trusted read-side counterpart to the reviewed-production orchestrator. It refreshes Metrora's existing canonical parser/cache path and derives eligible local Workspace production candidates from per-source cached calls.
+The scanner is the trusted read-side boundary that refreshes Metrora's existing parser/cache authority and derives eligible reviewed-production candidates from source-present cached calls.
 
-It does not create events, receipts, batches, exports, uploads, or analytics totals.
+It does not create events, receipts, batches, exports, uploads or analytics totals.
 
-## Authority
+## Reused authority
 
 The scanner reuses:
 
-- `clearSessionCache()` only to bypass the process-local Overview TTL;
-- `parseAllSessions()` as the canonical discovery, reconciliation, parse, settlement, and cache-publication path;
-- `loadCache()` and the current cache-completeness marker;
-- `cachedCallToApiCall()` for the exact normalized call and immutable cost assignment;
-- `collectorProvenanceProfileForCall()` for executable reviewed-path eligibility;
-- the provider registry for the local tool display name.
+- the canonical provider discovery and parsing path;
+- the existing session cache and completeness marker;
+- the normalized-call and immutable-cost projection;
+- the executable collector-provenance registry;
+- the provider registry for local tool display names.
 
-It does not create a second provider scan, parser, pricing calculation, cache, or call normalization path.
+It does not create a second provider scan, parser, pricing calculation, cache or normalization path.
 
-## Per-source rule
+## Source-present rule
 
-Candidates are derived only from current per-file cache entries whose source still exists locally.
+Candidates come only from current per-source cache entries whose underlying source still exists locally.
 
-A source-less durable or migrated cache entry may remain authoritative for historical analytics, but it cannot become newly produced evidence after the underlying source disappears. Its cached calls are counted as withheld and are not emitted as candidates.
+Source-less durable or migrated history may remain authoritative for ordinary historical analytics, but it cannot become newly produced signed evidence after the source disappears.
 
-A cache marked incomplete after the explicit canonical refresh is an integrity failure, not an empty successful scan.
+A cache marked incomplete after the explicit refresh is an integrity failure, not an empty successful scan.
+
+## Production scope
+
+Normal production is bounded from the protected local Workspace creation timestamp. Older history remains available to Overview analytics but is not silently backfilled or counted as failed evidence.
+
+The renderer cannot supply or alter the scope timestamp.
+
+See [Workspace production scope v1](WORKSPACE_PRODUCTION_SCOPE_V1.md).
 
 ## Eligibility
 
-A cached call becomes a candidate only when all of these are true:
+A cached call becomes a candidate only when:
 
-1. the source file is still present;
-2. the cached call provider matches its provider section;
-3. the private deduplication key is non-empty;
-4. the source supplied an explicit normalized model/API provider;
+1. its source still exists;
+2. its provider section and normalized provider agree;
+3. its private deduplication identity is valid;
+4. the source supplies an explicit model/API provider where required;
 5. the executable provenance registry resolves a reviewed profile;
-6. the provider registry can resolve the local tool display name.
+6. the provider registry resolves the local tool name.
 
-Missing explicit provider identity, unsupported collectors, estimated/unreviewed paths, unavailable provider modules, and source-less history are withheld rather than inferred.
+Missing provider identity, unsupported collectors, unreviewed paths, unavailable provider modules and source-less history are withheld rather than inferred.
 
-A provider-section mismatch, empty deduplication identity, incomplete cache, or malformed trusted state fails closed.
+Provider-section mismatch, empty private identity, incomplete cache or malformed trusted state fails closed.
 
 ## Context and privacy
 
-The scanner supplies only the context required by the existing reviewed producer:
+The scanner supplies only the context required by the reviewed producer:
 
-- session disclosure is `omit`;
-- no repository, project, account, prompt, response, code, patch, tool argument, local path, or private receipt is disclosed;
+- session disclosure remains omitted;
+- repository, project and account disclosure remain absent;
 - tool name comes from the provider registry;
-- adapter version is the current Metrora release supplied by the trusted main process;
-- GenAI operation is `other` when no stronger source-backed operation exists;
-- model/API provider comes only from the source-recorded normalized call.
+- adapter version comes from the trusted desktop runtime;
+- operation remains `other` when no stronger source-backed value exists;
+- model/API provider comes from normalized source evidence.
 
-The scanner does not select a public profile ID or source kind. The reviewed factory derives both from the executable registry.
+No prompt, response, code, patch, tool argument, unrestricted local path or private receipt crosses this boundary.
 
 ## Source-record fingerprint
 
-Each candidate receives a SHA-256 source-record fingerprint over a domain-separated composition of:
+Each candidate receives a SHA-256 fingerprint over a domain-separated composition of:
 
 - stable endpoint ID;
 - collector/provider section;
 - private per-call deduplication key.
 
-The local source path is used only for the source-presence check and is not an input to the public digest. The private deduplication key also never leaves the scanner; only the digest crosses into the reviewed event.
+The local source path is used only to confirm source presence and is not included in the public digest. The private key itself never leaves the scanner.
 
-Provider parsers already enforce the private deduplication identity globally within their provider, so adding a local path would not improve record identity. Excluding it also avoids creating a path-derived public correlation value. Including the endpoint ID prevents an identical local record on different endpoints from becoming a cross-device correlation handle. Endpoint-key rotation does not change the fingerprint.
+Including the endpoint ID prevents identical records on separate devices from becoming a cross-device correlation handle. Endpoint-key rotation does not change this fingerprint.
 
-## Counts
+## Counts and ordering
 
 The scanner returns:
 
-- `candidates`: eligible trusted calls and minimal contexts;
-- `withheldCount`: individual calls not eligible for production;
-- `failedCount`: source files already marked failed by the canonical parser/cache path.
+- eligible candidates;
+- a withheld-call count;
+- a failed-source count.
 
-A failed source file is counted once and contributes no invented calls.
+Provider sections and source paths are sorted, while canonical call order inside one source is preserved. The production orchestrator processes candidates sequentially so outbox order remains deterministic.
 
-## Ordering
+## Runtime boundary
 
-Provider sections and source paths are sorted. Within one source file, the scanner preserves canonical cached turn and call order. The production orchestrator then processes candidates sequentially, preserving deterministic outbox order.
+The scanner is packaged in a separate desktop bundle and loaded lazily only after the user requests reviewed production. The Electron renderer has no direct scanner API and cannot supply calls, providers, paths, costs or evidence claims.
+
+Opening Metrora or the Workspace view does not load this path or produce evidence.
 
 ## Non-goals
 
-- no renderer input;
-- no desktop runtime method, IPC channel, preload method, or button yet;
-- no inferred provider from collector or model label;
-- no automatic/background production;
-- no session, repository, project, or account disclosure;
-- no collector, parser, pricing, cache-schema, label, aggregation, batch, export, network, account, team, billing, mobile, or unrelated product redesign.
+The scanner does not provide automatic or background production, inferred providers, historical backfill, renderer-controlled scope, batch creation, export, network transport, account, team or billing behavior.

--- a/docs/CODEX_MODEL_PROVIDER_V1.md
+++ b/docs/CODEX_MODEL_PROVIDER_V1.md
@@ -1,80 +1,74 @@
 # Codex source-recorded model provider v1
 
-**Status:** bounded W1.D.C compatibility checkpoint.
+**Status:** implemented compatibility boundary for reviewed Codex measurements.
 
 Codex rollout files may include `session_meta.payload.model_provider`. Metrora preserves that source-recorded value so reviewed Workspace production can distinguish the AI/API provider from the Codex collector without inference.
 
 ## Source authority
 
-The only accepted source is:
+The accepted source is:
 
 ```text
 session_meta.payload.model_provider
 ```
 
-The value is normalized through the existing explicit-provider normalizer. Missing, malformed, path-like, or unsupported values remain unknown.
+The value passes through the existing explicit-provider normalizer. Missing, malformed, path-like or unsupported values remain unknown.
 
 Metrora does not infer the provider from:
 
 - collector name `codex`;
 - model label;
-- endpoint, account, or subscription;
-- pricing record;
-- historical assumptions about OpenAI products.
+- endpoint, account or subscription;
+- pricing records;
+- assumptions about a vendor or product.
 
 ## Fresh parser path
 
-The canonical provider registry decorates the existing Codex provider.
+The canonical provider registry decorates the existing Codex parser. Before a call enters the ordinary session cache, it:
 
-Before one parsed call enters the ordinary session cache, the decorator:
-
-1. reads a bounded prefix of the rollout until `session_meta`;
+1. reads a bounded rollout prefix until `session_meta`;
 2. extracts and normalizes `model_provider`;
-3. attaches it to every call from that source;
+3. attaches it to calls from that source;
 4. rejects a contradiction if the base parser already supplied a different explicit provider.
 
-The decorator does not change token parsing, cost settlement, deduplication, model labels, timestamps, tool attribution, or project/session grouping.
+This does not change tokens, settled cost, deduplication, model labels, timestamps, tools or project/session grouping.
 
-## Pre-upgrade cache compatibility
+## Existing-cache compatibility
 
-An existing complete session cache may contain Codex calls created before provider propagation.
+A complete cache created before provider propagation may contain Codex calls without the field.
 
-During explicit reviewed production only, the canonical scanner reads the same `session_meta.model_provider` for that source and reconciles it with the cached call:
+During explicit reviewed production, the scanner reads the same source metadata and reconciles it with the cached call:
 
-- missing cached provider + explicit source provider → use the source provider for the reviewed candidate;
-- matching providers → keep the cached provider;
-- contradictory providers → fail closed;
-- missing/invalid source provider → withhold the call.
+- missing cached provider plus explicit source provider — use the source value for the reviewed candidate;
+- matching providers — preserve the value;
+- contradictory providers — fail closed;
+- missing or invalid source provider — withhold the call.
 
-This compatibility path does not rewrite the cache, reprice usage, or create a second token parser. A later ordinary source reparse stores the provider through the decorated canonical provider.
+This compatibility path does not rewrite the cache, reprice usage or introduce a second token parser. A later ordinary reparse stores the provider through the canonical provider path.
 
 ## Privacy and bounds
 
 The metadata reader:
 
 - scans at most the first 256 lines;
-- extracts no prompt, response, code, patch, command, or tool content;
+- extracts no prompt, response, code, patch, command or tool content;
 - returns only a normalized provider identifier or unknown;
-- does not expose the rollout path or metadata to the renderer;
-- runs locally and requires no network or account service.
+- exposes no rollout path or source metadata to the renderer;
+- runs locally without an account or network service.
 
-## Reviewed production effect
+## Reviewed-production effect
 
-A Codex call becomes eligible only when all existing requirements also pass:
+A Codex call becomes eligible only when all ordinary requirements also pass:
 
-- source still exists;
-- canonical cache is complete;
+- the source still exists;
+- canonical cache state is complete;
 - private deduplication identity is valid;
-- Codex provenance profile is reviewed;
+- the concrete Codex provenance path is reviewed;
 - immutable cost evidence is valid or explicitly unavailable;
 - source-recorded provider is present and non-contradictory.
 
-This checkpoint does not broaden collector provenance or make every Codex record eligible automatically.
+This boundary does not make every Codex record eligible automatically.
 
 ## Non-goals
 
-- no provider inference;
-- no collector/parser rewrite;
-- no analytics-total or price change;
-- no cache-schema migration or destructive invalidation;
-- no renderer, IPC, network, account, billing, mobile, or unrelated product behavior.
+It adds no provider inference, collector rewrite, analytics or price change, destructive cache migration, renderer authority, network transport, account, billing or mobile behavior.

--- a/docs/DESKTOP_REVIEWED_PRODUCTION_V1.md
+++ b/docs/DESKTOP_REVIEWED_PRODUCTION_V1.md
@@ -1,118 +1,83 @@
 # Desktop reviewed production v1
 
-**Status:** W1.D.C.B.B.B desktop integration.
+**Status:** implemented in the secure desktop Workspace runtime and renderer.
 
-This checkpoint connects the canonical per-source reviewed-production scanner to the secure desktop Workspace runtime. It gives the user one explicit action to produce reviewed measurements without exposing canonical calls, source paths, provider claims, costs, fingerprints, receipts, or endpoint keys to the renderer.
+This component connects the canonical per-source reviewed-production scanner to the protected Workspace runtime. It gives the user one explicit production action without exposing canonical calls, source paths, provider claims, costs, fingerprints, receipts or endpoint keys to the renderer.
 
 ## Runtime split
 
-The desktop uses two staged main-process bundles:
+The desktop uses two main-process bundles:
 
-- `desktop-local-state.js` loads at Workspace runtime initialization and owns the OS-vault-backed endpoint identity, local Workspace state, lifecycle state, receipts, outbox, signed batches, and exports;
-- `desktop-reviewed-production.js` contains the canonical parser/cache scanner and is imported lazily only after the explicit production action.
+- `desktop-local-state.js` owns OS-vault-backed endpoint identity, local Workspace state, lifecycle, receipts, outbox, signed batches and exports;
+- `desktop-reviewed-production.js` owns the canonical parser/cache scanner and is imported lazily after the explicit production action.
 
-Opening Metrora or the Workspace screen does not load the parser bundle through this path and does not produce evidence.
+Opening Metrora or the Workspace view does not produce evidence.
 
-The existing Overview/CLI runtime remains the authority for ordinary analytics. The Workspace screen still projects its visible totals directly from the current Overview payload.
+Ordinary Overview and CLI analytics remain authoritative for user-facing totals. The Workspace view projects its scoped usage from the existing Overview payload rather than recalculating it.
 
 ## Explicit action
 
-The renderer exposes `produceWorkspaceMeasurements()` with no arguments.
+The renderer calls `produceWorkspaceMeasurements()` without measurement arguments.
 
-Electron main ignores any unexpected IPC arguments and calls the private runtime method with no renderer-owned data. The renderer cannot supply:
+Electron main ignores unexpected arguments and invokes the private runtime. The renderer cannot supply:
 
 - normalized calls;
-- collector or model-provider identity;
+- collector or AI-provider identity;
 - source paths or fingerprints;
 - historical cost assignments;
 - deduplication identities;
-- session, repository, project, or account claims;
-- receipt IDs, outbox records, keys, or evidence semantics.
+- session, repository, project or account claims;
+- receipts, outbox records or keys.
 
-The trusted scanner receives only the public endpoint ID and current Metrora adapter version from the private runtime.
+The trusted scanner receives only the public endpoint ID, current adapter version and protected production scope.
 
 ## Production flow
 
-When active:
+When production is active:
 
 1. the private production-control lease is acquired;
-2. the durable lifecycle state is checked;
-3. the lazy scanner bundle refreshes the existing canonical parser/cache path;
+2. lifecycle state is checked;
+3. the lazy scanner refreshes the canonical parser/cache path;
 4. eligible source-present reviewed candidates are derived;
-5. the existing one-call producer reuses the protected endpoint identity;
-6. private production receipts deduplicate or repair publication;
+5. the existing producer reuses the protected endpoint identity;
+6. private receipts deduplicate or repair publication;
 7. the public Workspace snapshot is refreshed;
 8. the renderer receives only bounded counts and public state.
 
-The bounded summary contains:
+The result reports paused or completed outcome, whether scanning occurred, and eligible, produced, existing, withheld and failed counts.
 
-- paused or completed outcome;
-- whether scanning occurred;
-- eligible count;
-- newly produced count;
-- already-existing count;
-- withheld count;
-- failed-source count.
+## Lifecycle and recovery
 
-It contains no calls, tokens, models, providers, paths, fingerprints, sessions, project references, receipts, keys, prompts, responses, code, patches, secrets, or tool arguments.
+Pause and resume are separate explicit zero-argument actions. Pause stops future production before scanning without changing ordinary analytics, historical pricing or existing evidence.
 
-## Pause and resume
+Recovery is also separate. It may reconcile known interrupted receipt publication and retry the same bounded production path, but it never deletes valid evidence, resets identity or bypasses blocked state.
 
-Pause and resume are explicit zero-argument actions.
+## User-visible sequence
 
-Pause applies before the canonical scan and affects only future reviewed Workspace production. It does not stop:
-
-- collectors or parser use for ordinary analytics;
-- Overview refreshes;
-- historical pricing or labels;
-- existing outbox records;
-- signed-batch creation;
-- evidence export.
-
-A pause requested while a production pass is already running waits for that atomic pass to finish. Later passes stop before scanning.
-
-## User sequence
-
-The Workspace view now presents four separate explicit steps:
+The Workspace view exposes separate actions to:
 
 1. create the local Workspace;
 2. produce reviewed measurements;
-3. create a signed batch;
-4. export independently verifiable evidence.
+3. pause or resume future production;
+4. inspect or explicitly recover local evidence state;
+5. create a signed batch;
+6. export independently verifiable evidence.
 
-None of these steps triggers another automatically.
-
-The view also shows pause/resume controls and the latest bounded production summary. Opening the screen performs only a public status read.
+No action silently triggers another.
 
 ## Failure boundary
 
-- canonical cache or provenance contradictions map to a bounded production-scan failure;
-- missing or unloadable lazy scanner runtime maps to production unavailable;
-- receipt collisions, outbox corruption, Workspace mismatch, quarantine, and other integrity failures remain fail-closed;
-- raw exception text, local paths, and private state do not cross IPC.
+- canonical cache or provenance contradictions become bounded production-scan failures;
+- missing or unloadable scanner code becomes production unavailable;
+- receipt collision, outbox corruption, Workspace mismatch and quarantine remain fail closed;
+- raw exception text, local paths and private state never cross IPC.
 
 Ordinary local analytics remain available when reviewed production is unavailable.
 
-## Packaging
+## Packaging and validation
 
-The root build emits `desktop-reviewed-production.js` as a separate entry. Desktop staging and portable packaging must include it together with `desktop-local-state.js`.
-
-Blocking validation covers:
-
-- scanner and orchestrator behavior;
-- protected identity reuse;
-- production, replay, pause, and refreshed evidence state;
-- lazy one-time module import;
-- zero-argument IPC and bounded failures;
-- renderer explicitness and pause semantics;
-- desktop typecheck/build;
-- staged runtime presence on Ubuntu and Windows.
+Desktop staging and Windows candidate packaging include both runtime bundles. Tests cover scanner/orchestrator behavior, protected identity reuse, production and replay, lifecycle enforcement, recovery, lazy loading, zero-argument IPC, bounded failures, renderer behavior, type checking and packaged bundle presence.
 
 ## Non-goals
 
-- no automatic or background production;
-- no automatic batch creation, export, upload, or publication;
-- no mandatory remote synchronization, account, team, entitlement, or billing dependency;
-- no alternate parser, cache, pricing, or analytics authority;
-- no recovery action that deletes or silently resets evidence;
-- no mobile or unrelated product behavior.
+This component does not add automatic background production, automatic batch creation or export, upload, hosted synchronization, account, team, entitlement, billing or a second parser, pricing or analytics authority.

--- a/docs/LOCAL_ENDPOINT_IDENTITY_AND_OUTBOX_V1.md
+++ b/docs/LOCAL_ENDPOINT_IDENTITY_AND_OUTBOX_V1.md
@@ -1,103 +1,71 @@
 # Metrora local endpoint identity, outbox and signed batches v1
 
-Status: **desktop vault, local Workspace identity, explicit reviewed production, outbox, signed-batch chain and independently verifiable export implemented; automatic collection and network sync remain disabled**.
+**Status:** implemented for the local personal Workspace. Automatic upload, hosted synchronization and server acknowledgement are not active.
 
-This layer gives one Metrora installation a durable cryptographic identity, a local personal workspace, a crash-recoverable queue for reviewed usage events and a locally verifiable signed-batch chain.
+This component gives one Metrora installation a durable cryptographic identity, a crash-recoverable reviewed-measurement outbox, an immutable signed-batch chain and independently verifiable local export.
 
-## Reused foundations
+## Cryptographic and storage foundations
 
-Metrora does not introduce custom cryptographic algorithms or a private JSON canonicalization standard.
+Metrora uses established platform and library primitives rather than custom cryptography:
 
-- Ed25519 signing, SHA-256, HMAC inputs, AES-256-GCM and secure random generation use Node.js Crypto.
-- Desktop secret wrapping uses Electron asynchronous `safeStorage` APIs.
-- RFC 8785 canonicalization adapts the Apache-2.0 `erdtman/canonicalize` implementation recorded in `THIRD_PARTY_NOTICES.md`.
-- Filesystem durability reuses the temp-file, file-fsync, rename and refresh-lease patterns already proven by the inherited cache.
-- No plaintext secret fallback is allowed.
+- Ed25519, SHA-256, HMAC, AES-256-GCM and secure randomness from Node.js Crypto;
+- Electron asynchronous `safeStorage` for desktop secret wrapping;
+- RFC 8785 canonicalization for interoperable signed-batch and export boundaries;
+- atomic private-file publication with fsync, rename and cross-process leases.
 
-Electron `safeStorage` remains a host concern rather than a dependency of the core. This keeps future CLI and server hosts free to use another mature credential backend without changing endpoint or batch formats.
+No plaintext fallback is allowed for endpoint signing or event-identity material.
 
-## Desktop OS vault
+## Desktop vault boundary
 
-The desktop bootstrap initializes local state after `app.whenReady()` and before the existing main module completes startup.
+The desktop host supports:
 
-Initially supported vault backends:
+- Windows DPAPI through Electron `safeStorage`;
+- macOS Keychain through Electron `safeStorage`.
 
-- Windows DPAPI through Electron asynchronous `safeStorage`;
-- macOS Keychain through Electron asynchronous `safeStorage`.
+Linux Workspace signing remains unavailable until an acceptable secure credential backend is implemented. Vault failure disables Workspace actions without blocking ordinary local analytics or creating replacement identity material.
 
-Linux is deliberately not enabled yet. Metrora does not accept Electron's weak `basic_text` fallback as protection for endpoint signing or HMAC material. A secure Linux Secret Service/keyring adapter can be added later behind the same core interface.
-
-The desktop stores only an OS-encrypted 32-byte master-key envelope under its `userData` directory. The master key protects the endpoint secret through AES-256-GCM and is never returned to the renderer or exposed over IPC. If Electron reports that ciphertext should be re-encrypted after OS key rotation, Metrora atomically rewraps it.
-
-Failure to access or decrypt the OS vault leaves Metrora in its existing local-only mode. It does not generate replacement identity material and does not fall back to plaintext.
+The desktop stores an operating-system-encrypted master-key envelope under its private local state. The master key protects the endpoint secret and never crosses into the renderer.
 
 ## Endpoint identity
 
-`loadOrCreateLocalEndpointIdentityV1()` creates:
+A local endpoint owns:
 
-- one stable opaque `endpointId`;
+- one stable opaque endpoint ID;
 - one Ed25519 signing key pair;
 - one 32-byte event-identity HMAC key;
-- generation and event-key version counters;
-- public SPKI key material and SHA-256 fingerprint;
-- creation, update and rotation timestamps.
+- identity-generation and event-key version counters;
+- public key material, fingerprint and lifecycle timestamps.
 
-The private PKCS#8 key and event HMAC key live only inside an authenticated AES-256-GCM envelope. The core never derives a weak key from usernames, hostnames or machine identifiers.
+Private keys remain inside an authenticated AES-256-GCM envelope. They are never derived from usernames, hostnames or machine identifiers.
 
-### Publication order and recovery
+Publication is ordered so interrupted creation or rotation can be repaired without silently replacing a known identity. Missing or contradictory secret state fails closed.
 
-The protected secret is written and fsynced before public metadata. Therefore:
+Rotation preserves the endpoint ID while changing signing and event-identity keys. Existing signed batches remain verifiable because each batch records the signer generation and public key that produced it.
 
-- secret present + metadata missing: metadata is reconstructed safely;
-- secret generation newer than public metadata: the interrupted publication is repaired;
-- metadata present + secret missing: recovery is required and Metrora fails closed;
-- wrong master key, same-generation mismatch or mismatched signing pair: recovery is required;
-- concurrent create, repair and rotation operations reuse the cross-process refresh lease.
+## Local personal Workspace
 
-Metrora never silently generates a replacement identity when evidence shows that an endpoint already existed.
+Workspace creation is explicit. Loading local state does not create a Workspace implicitly.
 
-### Rotation
+The local container binds:
 
-`rotateLocalEndpointIdentityV1()` preserves `endpointId` and creation time while incrementing:
+- one personal Workspace;
+- one active owner membership;
+- the existing protected endpoint identity;
+- versioned public Workspace, Membership and Endpoint records.
 
-- identity generation;
-- event-identity key version.
-
-It generates a new Ed25519 pair and a new HMAC key. Rotation intentionally breaks future public HMAC linkability. Signed batches embed the public key and generation that produced them, so batches from older generations remain independently verifiable.
-
-The local workspace reconciles the new public fingerprint without changing workspace, membership, subject or endpoint IDs. Private production receipts prevent old reviewed calls from being enqueued again under a new public event ID.
-
-## Local personal workspace
-
-`createLocalPersonalWorkspaceV1()` explicitly creates one local personal workspace with:
-
-- an active owner membership bound to a pseudonymous local subject;
-- active enrollment of the existing desktop endpoint identity;
-- exact public v1 Workspace, Membership and Endpoint records inside a Metrora-owned local container;
-- atomic, lease-protected and idempotent publication;
-- fail-closed corruption, cross-link, foreign-identity and stale-generation handling.
-
-Loading does not create a workspace implicitly. No server, account or network path is involved.
+Creation and reload are lease-protected, atomic and idempotent. No account, remote service or network operation is required.
 
 ## Reviewed measurement production
 
-`produceLocalReviewedMeasurementV1()` accepts one already-normalized call plus explicit source/tool/provider/session context. It:
+Reviewed production accepts only normalized calls admitted by the executable provenance registry. It preserves immutable historical cost assignments and publishes only validated, content-minimal measurement events.
 
-- loads the local workspace and enrolled endpoint;
-- invokes only the executable reviewed-provenance boundary;
-- uses immutable per-call cost assignments rather than mutable current pricing;
-- withholds unreviewed evidence or source-provider conflicts;
-- publishes only validated content-minimal `UsageMeasurementEventV1` records;
-- returns `enqueued` or `duplicate` through the local outbox;
-- performs no scan, automatic hook, upload or retry scheduling by itself.
+A registered collector is not automatically eligible for signed measurements. Unreviewed, contradictory or insufficient evidence is withheld rather than converted into an optimistic claim.
 
-A supported collector is not automatically eligible. Only an exact reviewed evidence path can produce an event.
+Production is an explicit Workspace action. Opening Metrora or the Workspace view does not scan sources or create events.
 
-The accepted desktop Workspace uses the separate canonical scanner and orchestrator to invoke this producer explicitly from complete source-present state. Opening the app or Workspace screen does not produce events.
+## Local outbox
 
-## Local measurement outbox
-
-The outbox accepts only validated `UsageMeasurementEventV1` objects. It does not call parsers or transmit data.
+The outbox stores immutable measurement events and separate side records:
 
 ```text
 <METRORA_DATA_DIR>/outbox/v1/
@@ -108,157 +76,69 @@ The outbox accepts only validated `UsageMeasurementEventV1` objects. It does not
   quarantine/<sha256(event-id)>.json
 ```
 
-Event identifiers are hashed for filenames so CloudEvents IDs never become filesystem paths and remain portable on Windows.
+Core rules:
 
-### Append-only semantics
+- event files and production receipts are immutable;
+- acknowledgements and quarantine decisions never rewrite events;
+- retrying the same identity and payload is idempotent;
+- conflicting reuse of an event or production identity fails closed;
+- sequence numbers are reserved before publication and never reused;
+- filenames contain hashes rather than raw event identifiers or local paths.
 
-- event files are immutable;
-- production receipts are immutable private recovery/index records;
-- acknowledgements are separate immutable marker files;
-- quarantine decisions are separate immutable marker files;
-- acknowledgement never deletes or rewrites an event;
-- retrying the same event ID and payload returns the existing sequence;
-- reusing one event ID for another payload is rejected;
-- reusing one private production identity for another semantic event is rejected.
+## Rotation-safe production receipts
 
-### Rotation-safe production receipts
+Public event IDs intentionally change when the event-identity key rotates. A separate private production receipt preserves repeated-scan idempotency across rotation.
 
-The event ID is HMAC-derived and intentionally changes after event-key rotation. To preserve repeated-scan idempotency, the reviewed producer also derives a private SHA-256 production key from:
+The receipt binds the Workspace, stable endpoint, reviewed profile, source fingerprint and private normalized-call identity. Only a digest is stored; raw private deduplication material is never written into public events, batches or exports.
 
-- workspace ID;
-- stable endpoint ID;
-- reviewed profile ID;
-- source fingerprint;
-- private normalized-call deduplication key.
-
-The raw private deduplication key is never stored. The production receipt contains the digest, the semantic event digest excluding the rotating public event ID, and the original immutable outbox record.
-
-The semantic comparison also excludes the Metrora adapter release version. A normal application upgrade is not a new measurement. Evidence profile, source identity, scope, disclosure, provider/model facts, token facts and cost remain bound.
-
-The receipt is published before the public event file. Therefore:
-
-- an interruption between receipt and event publication can be repaired;
-- reprojection after HMAC-key rotation returns the original event record;
-- changed public semantics under the same private production identity fail closed;
-- the private production digest is never copied into a public event or signed batch.
-
-### Sequence allocation
-
-The counter is atomically advanced before an event is published. A crash may leave a sequence gap, but a reserved sequence is never reused. The maximum safe-integer value is reserved as an exhaustion sentinel and is rejected before event publication.
-
-### Event digest
-
-The outbox uses the narrow Metrora local v1 canonicalization contract for event idempotency. It is not advertised as RFC 8785. Interoperable RFC 8785 canonicalization begins at the signed-batch boundary.
-
-The frozen v1 identifier retains its historical value. Changing an already-issued identifier requires a future contract version rather than an in-place rename.
+Publishing the receipt before the public event permits deterministic repair after interruption without creating a second semantic measurement.
 
 ## Signed measurement batches
 
-`createNextSignedMeasurementBatchV1()` selects pending immutable events in sequence order and creates a bounded `MeasurementBatchV1`.
-
-```text
-<METRORA_DATA_DIR>/batches/v1/
-  signed/<first>-<last>-<batch-sha256>.json
-  acks/<sha256(batch-id)>.json
-```
-
-Each signed record binds:
+Pending events are selected in sequence order and bound into immutable signed batches. Each signed record includes:
 
 - first and last outbox sequence;
 - event count;
-- RFC 8785 SHA-256 digest of the public batch;
-- previous batch digest;
-- producer endpoint and Metrora/adapter versions;
-- the full public measurement batch;
-- signer generation, SPKI public key and fingerprint;
-- Ed25519 signature over the RFC 8785 canonical range + digest + batch payload.
+- RFC 8785 payload digest;
+- previous-batch digest;
+- producing endpoint and adapter versions;
+- signer generation, public key and fingerprint;
+- Ed25519 signature.
 
-The current chain is reconstructed from verified immutable files. There is no mutable head pointer that can advance without publishing a batch. Sequence ranges must not overlap and every batch after the first must bind the exact previous digest.
+The chain is reconstructed from verified immutable files rather than a mutable head pointer. Sequence ranges cannot overlap, and every later batch must bind the exact preceding digest.
 
-A signed batch can remain verifiable after endpoint key rotation because it carries its signer public key and fingerprint. The stable endpoint ID still defines chain ownership.
-
-### Batch acknowledgement
-
-Batch acknowledgements are immutable side records. Acknowledging one batch:
-
-- binds the receipt to the batch ID, digest and last accepted sequence;
-- idempotently acknowledges each member event with a batch-derived receipt;
-- rejects a conflicting receipt;
-- never deletes the signed batch or source events.
-
-No server currently issues these receipts. The API is a local contract for a separately authorized future synchronization protocol.
+Batch acknowledgements are immutable side records. No server currently issues them.
 
 ## User-owned evidence export
 
-The accepted Workspace runtime can export a bounded signed package containing the public Workspace, endpoint and complete included signed-batch chain.
+The local Workspace can export a bounded JSON package containing the public Workspace, enrolled endpoint and complete included signed-batch chain.
 
-The verifier checks:
+Independent verification checks schemas, digests, sequence ranges, chain links, embedded public keys, signatures and Workspace/endpoint binding.
 
-- public contract validity;
-- batch payload digests;
-- sequence ranges and previous-digest links;
-- embedded signer fingerprints and public keys;
-- Ed25519 signatures;
-- Workspace and endpoint binding;
-- export-level integrity.
+The export excludes:
 
-The export excludes private production receipts, acknowledgement receipt IDs, endpoint private keys, local paths, prompts, responses, source code, patches, secrets and raw tool arguments.
+- private keys and event-identity keys;
+- private production receipts and acknowledgement receipt IDs;
+- prompts, responses, source code, patches and secrets;
+- raw tool arguments and unrestricted local paths.
 
-The package is user-owned. Creating it does not authorize upload, retention, indexing or remote processing.
+Creating an export does not authorize upload, indexing, retention or remote processing.
 
-## Durability and concurrency
+## Recovery and durability
 
-- private directories use restrictive creation modes;
-- temp files are created exclusively;
-- file contents are fsynced before rename;
-- parent-directory fsync is attempted where supported;
-- transactions reuse the cross-platform refresh lease with heartbeat and stale-owner takeover;
-- stale temp files are cleaned without touching canonical records;
-- Windows CI runs identity, workspace, reviewed production, outbox and signed-batch tests plus a real Electron DPAPI probe.
+Private writes use restrictive directories, exclusive temporary files, fsync where supported, atomic rename and cross-process leases. Known interrupted publication can be reconciled without deleting valid evidence or generating a replacement identity.
 
-## Deployment-neutral future boundary
+Malformed, foreign, conflicting, quarantined or cryptographically inconsistent state remains blocked for explicit review.
 
-Any future managed or customer-operated Workspace mode may validate public contracts, endpoint and batch signatures, sequence ranges, digest chains and duplicate delivery.
+## Current limits
 
-It must not:
+This component does not provide:
 
-- receive private production identities or endpoint key material;
-- reparse source data;
-- reconstruct canonical calls from a remote copy;
-- infer missing providers or labels;
-- recalculate tokens or settled historical prices;
-- silently repair rejected evidence;
-- override local recovery, quarantine or lifecycle state;
-- become required for local analytics or export.
+- automatic background production;
+- network transport or hosted synchronization;
+- a retry scheduler or server acknowledgement issuer;
+- account, team, tenant, entitlement or billing behavior;
+- remote recovery or lifecycle control;
+- destructive compaction or retention deletion.
 
-Network outage or service failure must leave endpoint collection and local history usable. Repeated delivery must be idempotent before synchronization can be considered trustworthy.
-
-## Explicit non-goals
-
-This layer does not add:
-
-- automatic event creation during every scan;
-- CLI keyring setup;
-- network transport or hosted sync;
-- a retry scheduler;
-- a server acknowledgement implementation;
-- account or tenant provisioning;
-- team enrollment or hosted Workspace authentication;
-- enterprise private deployment;
-- DSSE/Sigstore packaging;
-- compaction or retention deletion;
-- repository-path derivation;
-- new collector provenance profiles;
-- billing, entitlement, SSO/SCIM, Kubernetes or remote lifecycle control.
-
-## Current boundary and sequence
-
-The local identity, reviewed production, outbox, signed-batch chain and independently verifiable export are implemented and accepted as part of Workspace v1.
-
-The active product milestone is MTR-R1.C trustworthy Windows distribution. It does not authorize a network uploader or server.
-
-C3-P0 — Canonical Observation, Activity and History Authority is ratified as the next public core authority milestone after Windows distribution and before physical Android validation.
-
-This document does not define or anticipate C3 storage, SQLite use, schemas, observation/activity/history identity, cache/live reconciliation, timezone behavior or migration mechanics.
-
-Managed synchronization, accounts, billing, private deployment and remote management remain separate future decisions and are not authorized by this documentation alignment.
+Ordinary local collection, analytics and export remain usable without a Workspace or remote service.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,38 +1,47 @@
 # Metrora documentation
 
-This index separates user guidance, product guarantees, public contracts and contributor-facing technical references.
+This index separates user guidance, current product guarantees, public contracts and contributor-facing technical references.
 
 ## Use Metrora
 
-- [Getting started](GETTING_STARTED.md) — build from source, run the first reports and understand the current release boundary.
+- [Getting started](GETTING_STARTED.md) — build from source, run the first reports and understand the current distribution boundary.
 - [CLI reference](CLI_REFERENCE.md) — public commands grouped by task.
 - [Supported tools](SUPPORTED_TOOLS.md) — local collector coverage and evidence boundaries.
-- [Provider documentation](providers/) — source locations, formats, known limitations and parser notes for individual integrations.
+- [Provider documentation](providers/) — source locations, formats, limitations and parser notes for individual integrations.
 
 ## Understand the product
 
 - [Product principles](PRODUCT_PRINCIPLES.md) — stable local-first, privacy, evidence and portability commitments.
-- [Product lineage](PRODUCT_LINEAGE.md) — what came from the CodeBurn baseline and what Metrora changed or added.
+- [Product lineage](PRODUCT_LINEAGE.md) — inherited foundations, material Metrora changes and compatibility identifiers.
+- [Architecture](architecture.md) — current responsibility and authority map for the public codebase.
 - [Pricing history](PRICING_HISTORY.md) — date-effective rates, settled assignments and historical-cost behavior.
-- [Collector inventory v1](COLLECTOR_INVENTORY_V1.md) — generated technical inventory of registered collectors and signed-sharing eligibility.
-- [Public contracts v1](PUBLIC_CONTRACTS_V1.md) — public schemas, canonical signed-data behavior and compatibility commitments.
-- [Technical identity compatibility](TECHNICAL_IDENTITY_COMPATIBILITY.md) — legacy identifiers retained to protect local state and integrations.
+- [Collector inventory v1](COLLECTOR_INVENTORY_V1.md) — generated technical inventory of registered collectors and signed-measurement eligibility.
+- [Public contracts v1](PUBLIC_CONTRACTS_V1.md) — public schemas, signed-data behavior and compatibility commitments.
+- [Technical identity compatibility](TECHNICAL_IDENTITY_COMPATIBILITY.md) — identifiers retained to protect local state and integrations.
 
 ## Local Workspace and evidence
 
-- [Workspace v1](WORKSPACE_V1.md) — local personal Workspace boundary and lifecycle.
-- [Local endpoint identity and outbox v1](LOCAL_ENDPOINT_IDENTITY_AND_OUTBOX_V1.md) — protected endpoint identity and durable local delivery state.
-- [Workspace evidence export v1](WORKSPACE_EVIDENCE_EXPORT_V1.md) — independently verifiable evidence export.
-- [Workspace recovery v1](WORKSPACE_RECOVERY_V1.md) — deterministic non-destructive recovery behavior.
-- [Reviewed event factory v1](REVIEWED_EVENT_FACTORY_V1.md) — reviewed production boundary for measurement events.
+- [Workspace v1](WORKSPACE_V1.md) — canonical current description of the local personal Workspace and its user-visible lifecycle.
+- [Local endpoint identity and outbox v1](LOCAL_ENDPOINT_IDENTITY_AND_OUTBOX_V1.md) — protected identity, immutable local evidence records and signed batches.
+- [Workspace production scope v1](WORKSPACE_PRODUCTION_SCOPE_V1.md) — trusted production window and historical-scope boundary.
+- [Workspace evidence export v1](WORKSPACE_EVIDENCE_EXPORT_V1.md) — independently verifiable user-owned export.
+- [Workspace recovery v1](WORKSPACE_RECOVERY_V1.md) — read-only inspection and explicit non-destructive recovery.
+- [Reviewed event factory v1](REVIEWED_EVENT_FACTORY_V1.md) — provenance-gated projection of normalized calls into public measurement events.
+
+Component references in this section explain bounded implementation responsibilities. They do not define product sequencing or a private roadmap; [Workspace v1](WORKSPACE_V1.md) is the current status authority.
 
 ## Distribution and releases
 
-- [Windows distribution](WINDOWS_DISTRIBUTION.md) — official Windows package and identity boundary.
-- [Windows release candidate v1](WINDOWS_RELEASE_CANDIDATE_V1.md) — candidate manifest and verification contract.
+- [Windows distribution](WINDOWS_DISTRIBUTION.md) — canonical current Windows package, identity and publication boundary.
+- [Windows release candidate v1](WINDOWS_RELEASE_CANDIDATE_V1.md) — unsigned candidate manifest and independent verification contract.
+- [Windows format derivation v1](WINDOWS_FORMAT_DERIVATION_V1.md) — one-payload portable and installer derivation.
+- [Windows clean install v1](WINDOWS_CLEAN_INSTALL_V1.md) — isolated NSIS installation and state-preservation contract.
+- [Windows interrupted upgrade recovery v1](WINDOWS_INTERRUPTED_UPGRADE_RECOVERY_V1.md) — deterministic interruption fixture and recovery contract.
 - [Versioning](VERSIONING.md) — release-candidate and platform build-version authority.
 - [Releasing Metrora](../RELEASING.md) — public release responsibilities and prohibitions.
 - [Changelog](../CHANGELOG.md) — Metrora-originated public changes.
+
+Historical and guided acceptance documents preserve reproducible public evidence for the source and artifact they name. They do not override the current release status in [Windows distribution](WINDOWS_DISTRIBUTION.md), [Versioning](VERSIONING.md) or the root [README](../README.md).
 
 ## Contribute safely
 
@@ -44,4 +53,4 @@ This index separates user guidance, product guarantees, public contracts and con
 
 ## Documentation rule
 
-Public documentation should explain current behavior, stable guarantees, known limitations and reproducible contribution requirements. Internal staffing, budgets, private infrastructure, unpublished commercial plans and speculative implementation sequences do not belong in this repository.
+Public documentation explains current behavior, stable guarantees, known limitations, reproducible contracts and contribution requirements. Internal staffing, budgets, private infrastructure, unpublished commercial plans, milestone codes and product sequencing do not belong in this repository.

--- a/docs/REVIEWED_EVENT_FACTORY_V1.md
+++ b/docs/REVIEWED_EVENT_FACTORY_V1.md
@@ -1,148 +1,105 @@
 # Metrora reviewed event factory v1
 
-Status: **implemented and connected to an explicit local Workspace producer; automatic collection and network transport remain disabled**.
+**Status:** implemented and used by explicit local Workspace production.
 
-`createReviewedUsageMeasurementEventV1()` is the single first-party composition boundary between:
+`createReviewedUsageMeasurementEventV1()` is the first-party projection boundary between a normalized local call, the executable collector-provenance registry, immutable cost evidence and the public measurement contract.
 
-- an existing normalized `ParsedApiCall`;
-- the reviewed collector provenance registry;
-- fail-closed quality and cost-evidence resolution;
-- the public CloudEvents measurement adapter.
-
-`produceLocalReviewedMeasurementV1()` is the first Workspace v1 production boundary above it. The producer loads the local workspace, reuses the protected endpoint event-identity key, invokes the reviewed factory in immutable-assignment mode, and writes only created events to the durable local outbox.
-
-Neither function scans providers or uploads data automatically.
+`produceLocalReviewedMeasurementV1()` loads the active local Workspace and protected endpoint identity, invokes that factory and writes only accepted events into the durable outbox. Neither function scans providers or transmits data.
 
 ## Explicit context
 
-The factory and producer do not discover or infer the following facts:
+The factory does not infer:
 
-- repository, project, account, or session disclosure;
-- tool name and version;
+- repository, project, account or session disclosure;
+- tool name or version;
 - Metrora adapter version;
 - source fingerprint;
-- actual AI/API provider;
-- GenAI operation;
+- AI/API provider;
+- operation name;
 - requested model.
 
-The caller must supply them. In particular, collector `codex` never implies AI provider `openai`: the actual provider remains an explicit field. A source-recorded `modelProvider`, when present, must agree with the declared provider or the event is withheld.
+The trusted caller supplies those facts. A collector name never implies the AI provider, and a source-recorded provider must agree with the declared provider or the event is withheld.
 
-The local producer does not accept caller-selected workspace, endpoint, or event-key values. It loads the existing local personal workspace, uses its enrolled endpoint, and uses the already-protected endpoint identity material.
+Workspace and endpoint identities are loaded from protected local state rather than accepted from renderer input.
 
-## Profile-owned fields
+## Profile-owned evidence
 
-The caller cannot choose the public collector profile identity or source kind. When evidence is approved, the factory derives:
+The executable provenance registry owns the reviewed profile and source kind. It resolves token, model, session, reasoning and cost quality per concrete source path.
 
-- `collector.adapterId` from the reviewed profile ID;
-- `collector.sourceKind` from the reviewed profile source kind;
-- token/model/session quality from `resolveMeasurementEvidenceV1()`;
-- cost evidence from the immutable per-call assignment in Workspace production.
+This prevents estimated content-length fallback from being labelled as measured and prevents a mutable current-price catalog from reinterpreting settled history.
 
-This prevents a content-length fallback from being labelled as a measured token-count path and prevents a mutable current-price feed from reinterpreting settled history.
+## Immutable cost authority
 
-`collector.adapterVersion` remains explicit because it identifies the Metrora implementation release, while the provenance profile separately pins the inherited parser fingerprint.
+Workspace production requires the immutable per-call cost assignment.
 
-## Cost authority
+- compatible provider- or client-metered evidence remains metered;
+- compatible token pricing remains an explicit estimated valuation;
+- numeric zero remains different from unavailable cost;
+- bounded legacy values retain their documented quality;
+- missing, malformed or contradictory assignments become unavailable rather than being repriced from the current catalog.
 
-The factory supports two bounded cost-evidence modes:
-
-- `current-compatible` preserves the earlier isolated-factory behavior for callers that have not crossed the runtime settlement boundary;
-- `immutable-assignment` is mandatory for Workspace production.
-
-In immutable-assignment mode:
-
-- a matching `metered` assignment is accepted only when the reviewed profile declares the same provider/client/billing-export source;
-- a matching `token-price` assignment becomes token-pricing cost only for a profile reviewed as local token pricing;
-- an explicit numeric zero remains different from unavailable cost;
-- a matching legacy-frozen value remains an estimated `other` value;
-- an unavailable assignment produces unavailable cost;
-- a missing, malformed, contradictory, or profile-incompatible assignment produces unavailable cost rather than current-price fallback.
-
-Reviewed usage is not discarded merely because cost is unavailable. Measurement v1 does not yet expose the full local `priceRecordId`, zero reason, or rate-band detail; those remain authoritative in the endpoint's immutable local assignment and can be carried by a later evidence/export contract without changing the event amount.
+A call can still produce a useful reviewed measurement when cost is unavailable.
 
 ## Session disclosure
 
-Session sharing is a discriminated decision:
+Session sharing is explicit:
 
-- `{ mode: "omit" }` produces no session ID and forces session quality to `unknown`;
-- `{ mode: "include", sessionId }` requires a concrete non-empty ID.
+- `omit` publishes no session identifier and keeps session quality unknown;
+- `include` requires one concrete non-empty session identifier.
 
-There is no boolean or implicit default that can accidentally claim session identity.
+There is no implicit default that can accidentally claim session identity.
 
-## Created, duplicate, and withheld
+## Enqueued, duplicate and withheld
 
-A reviewed call with unavailable pricing still creates a useful measurement event whose cost is `unavailable`.
-
-A call is withheld when its collector path or reasoning attribution is not reviewed, or when a source-recorded model provider conflicts with the declared provider. Withheld calls do not touch the outbox.
-
-A produced event is written through the existing append-only outbox:
+Accepted events pass through the append-only outbox:
 
 - `enqueued` means the immutable record was published for the first time;
-- `duplicate` means the same private production identity was already published;
-- reusing one production identity for a different semantic measurement fails closed;
-- the same public event ID with different bytes remains a collision.
+- `duplicate` means the same private production identity already exists with identical semantics;
+- conflicting reuse of one event or production identity fails closed.
 
-Malformed normalized facts, invalid context, foreign workspace identity, corrupted state, or invalid outbox state throw rather than being silently repaired.
+Calls are withheld when the concrete source path is not reviewed, reasoning attribution is unsupported or source-provider evidence conflicts. Withheld calls do not touch the outbox.
 
 ## Rotation-safe idempotency
 
-The public event ID is intentionally HMAC-derived from the endpoint event-identity key. Rotating that key breaks future linkability as designed, so the same source call would otherwise receive a different public ID after rotation.
+Public event IDs are HMAC-derived and intentionally change after event-key rotation. A private production receipt binds the stable Workspace, endpoint, reviewed profile, source fingerprint and normalized-call identity.
 
-Workspace production therefore creates a separate private receipt key from:
+Only the receipt digest is stored. Publishing it before the public event permits deterministic repair after interruption and returns the original event after key rotation instead of creating a duplicate.
 
-- workspace ID;
-- stable endpoint ID;
-- reviewed provenance profile ID;
-- source fingerprint;
-- the private normalized-call deduplication key.
-
-Only the SHA-256 digest of that composition is stored. The raw deduplication key never enters the receipt, event, or batch.
-
-The receipt stores the original immutable outbox record and its semantic digest. It is published before the public event file. Therefore:
-
-- an interruption between receipt and event publication is repairable on the next identical production;
-- endpoint HMAC-key rotation returns the original event record instead of producing a duplicate;
-- changed tokens, cost, scope, provider, disclosure, or other public semantics under the same production identity are rejected;
-- the private production digest is not exported or signed into a public batch.
+Changed tokens, cost, scope, provider or disclosure under the same production identity are rejected.
 
 ## Privacy boundary
 
-The factory ultimately calls the existing allowlist adapter. The event, outbox record, and private production receipt never serialize:
+The event, outbox record and private receipt never serialize:
 
-- private deduplication keys;
-- prompts or responses;
-- source code or patches;
-- tool sequences, MCP names, skills, or subagents;
-- shell commands, filenames, or local paths;
-- endpoint HMAC/event-identity keys;
-- endpoint private signing keys.
+- raw private deduplication keys;
+- prompts, responses, source code or patches;
+- tool sequences, commands, filenames or unrestricted local paths;
+- endpoint event-identity or signing keys.
 
-The public event contains only the structured measurement fields allowed by the v1 contract.
+Only allowlisted structured measurement fields enter the public contract.
 
 ## Current reviewed paths
 
-Workspace production remains limited to the paths admitted by the executable provenance registry:
+The executable registry currently admits six concrete paths across four collectors:
 
 - Claude JSONL usage;
 - Codex measured token-count records;
 - Codex content-length fallback with estimated quality;
 - Gemini message usage;
-- Zed request token usage with explicit source-recorded model provider;
-- Zed cumulative-remainder usage with explicit source-recorded model provider.
+- Zed request token usage with explicit source-recorded provider;
+- Zed cumulative-remainder usage with explicit source-recorded provider.
 
-A collector being locally supported does not make it eligible for Workspace production.
+Local collector support does not imply signed-measurement eligibility.
 
-## Non-goals
+## Responsibility boundary
 
-- no automatic scan/parser/cache hook;
-- no source-fingerprint or provider inference;
-- no repository-ID derivation from local paths;
-- no automatic session disclosure;
-- no signed workspace batch creation in this tranche;
-- no retry scheduler, synchronization, account, hosted service, or network transport;
-- no additional collector profiles;
-- no change to collectors, token accounting, historical pricing, observed labels, or analytics totals.
+The factory and one-call producer do not:
 
-## Next safe step
+- scan provider stores;
+- create signed batches or exports;
+- schedule retries;
+- upload data;
+- create accounts or hosted services;
+- change collector parsing, token accounting, historical pricing or analytics totals.
 
-W1.C can bind pending workspace-authorized outbox records into the existing immutable signed-batch chain and add a verifiable local export. It must preserve outbox sequence order, signer generation, previous-digest chaining, acknowledgements, quarantine state, private receipt recovery, and the same content-minimal boundary without activating an uploader.
+Canonical scanning, lifecycle control, batch creation, recovery and export remain separate explicit Workspace responsibilities.

--- a/docs/WINDOWS_CLEAN_INSTALL_V1.md
+++ b/docs/WINDOWS_CLEAN_INSTALL_V1.md
@@ -1,125 +1,97 @@
 # Windows clean install and uninstall v1
 
-**Status:** public R1.B.B contract for unsigned NSIS validation
+**Status:** implemented CI contract for unsigned NSIS installation validation.
 
-## Purpose
+This contract proves that the NSIS candidate can be installed, launched and removed in a disposable Windows environment without changing canonical product bytes or deleting user-owned local state.
 
-R1.B.B proves that the unsigned NSIS candidate produced by R1.B.A can be installed and removed in a disposable Windows environment without changing Metrora product bytes or deleting user-owned local state.
-
-This is release engineering validation. It is not code signing, publication, updater activation or a claim that the installer is trusted by Windows.
+It is release-engineering validation. It is not code signing, publication, updater activation or a claim that Windows trusts the installer publisher.
 
 ## Installer policy
 
-The current Windows installer is:
+The current installer is:
 
 - NSIS x64;
-- per-user (`perMachine: false`);
-- assisted (`oneClick: false`);
+- per-user;
+- assisted rather than one-click;
 - unsigned;
-- configured explicitly with `deleteAppDataOnUninstall: false`.
+- configured with application-data deletion disabled.
 
-Silent test execution uses the NSIS `/S` option. The disposable installation directory is supplied as the final `/D=<path>` argument.
-
-## Disposable boundary
-
-The CI test uses a unique directory below the Windows runner temporary root for:
-
-- installed application files;
-- temporary roaming application data;
-- temporary local application data;
-- a user-owned local-state sentinel.
-
-The installation directory contains no spaces so the NSIS `/D` argument can remain final and unquoted.
-
-The test restores the original environment and removes its temporary files after verification. It does not inspect or export user content.
+CI uses a disposable installation directory and isolated roaming/local application-data roots.
 
 ## Installed layout
 
-Every canonical product file from `win-unpacked` must exist in the installed application directory with the same path, size and SHA-256.
+Every canonical product file from the unpacked payload must exist in the installed directory with the same path, size and SHA-256.
 
 The only accepted installed-format additions are:
 
 - `Uninstall Metrora.exe`;
 - `resources/elevate.exe`.
 
-A changed canonical file, missing canonical file, empty format-specific file or any undeclared extra file fails the gate.
+Changed, missing, empty or undeclared files fail validation.
 
 ## Identity checks
 
 The installed candidate must expose:
 
-- executable `ProductName` equal to `Metrora`;
-- executable file description containing `Metrora`;
-- one logical per-user Windows uninstall registration in HKCU, even when the same key is visible through both registry views;
-- uninstall `DisplayName` beginning with `Metrora` and including the packaged version;
-- publisher `Vensent`;
-- an uninstall command targeting `Uninstall Metrora.exe` in the disposable installation directory;
-- at least one Start Menu shortcut named `Metrora.lnk` targeting the installed `Metrora.exe`.
+- product name `Metrora`;
+- file description containing `Metrora`;
+- one logical per-user uninstall registration under HKCU;
+- versioned Metrora display name;
+- publisher display `Vensent`;
+- an uninstall command targeting the local uninstaller;
+- a canonical Start Menu shortcut targeting `Metrora.exe`.
 
-The public `appId` remains `eu.metrora.desktop` and is already bound by the R1.A/R1.B.A source and manifest checks.
+The application ID remains `eu.metrora.desktop`.
 
-The accepted R1.B physical result predates this publisher-policy update and therefore remains historical evidence for the then-current development identity. A future release candidate must pass this contract again with Vensent before it can become an official Metrora distribution.
+Historical acceptance reports remain bound to the identity present in their original source and artifact. A later official candidate must pass the current identity contract again.
 
 ## Runtime smoke checks
 
-The installed candidate must pass both:
+The installed candidate must pass:
 
-1. installed compatibility CLI `--version` execution;
-2. installed Electron application launch, remaining alive for a bounded smoke window before controlled termination.
+1. bundled compatibility CLI version execution;
+2. bounded Electron launch without early failure.
 
-The launch test does not perform Workspace production, evidence export or network publication.
+The smoke test does not produce Workspace evidence, export data or publish over a network.
 
 ## User-owned state preservation
 
-Before installation, CI creates a sentinel inside the disposable equivalent of:
+Before installation, CI creates a sentinel in the disposable equivalent of the Metrora local-state directory.
 
-```text
-%APPDATA%\metrora-desktop\metrora-local-state
-```
+Installation, first launch and uninstall must preserve it byte-for-byte.
 
-The sentinel digest is recorded locally for the duration of the test.
-
-The following operations must preserve the sentinel byte-for-byte:
-
-- silent installation;
-- first application launch;
-- silent uninstall.
-
-Uninstall must remove the application executable, uninstall registry entry and Metrora Start Menu shortcut while leaving the user-owned state sentinel unchanged.
+Successful uninstall removes application files, registration and shortcuts while leaving user-owned local state intact.
 
 ## Failure model
 
-The gate fails on:
+Validation fails on:
 
-- installer non-zero exit;
+- installer or uninstaller failure;
 - missing executable or uninstaller;
 - installed payload drift;
-- incorrect product identity;
-- missing, duplicated or inconsistent uninstall metadata;
-- per-user installation registered outside HKCU;
-- missing canonical shortcut;
-- CLI failure;
-- early Electron exit;
-- uninstall non-zero exit;
-- residual installed executable, registry entry or shortcut;
-- deletion or mutation of user-owned local state.
+- incorrect product or publisher identity;
+- missing, duplicated or inconsistent registration;
+- registration outside the per-user boundary;
+- missing or incorrect shortcut;
+- CLI or bounded launch failure;
+- residual application authority after uninstall;
+- deletion or mutation of user-owned state.
 
-No failure path is allowed to reset or delete real user state.
+No failure path is allowed to reset real user data.
 
-## What R1.B.B does not prove
+## Scope
 
-R1.B.B does not yet prove:
+This isolated contract proves clean installation, first launch and removal for the candidate under test.
 
-- upgrade from an earlier candidate;
-- interrupted upgrade recovery;
-- repair/reinstall behavior;
-- rollback compatibility;
-- physical-machine SmartScreen behavior;
-- publisher authenticity;
-- update-channel authenticity.
+The Windows candidate workflow separately validates:
 
-Those remain R1.B.C, R1.B.D and later signing work.
+- same-version reinstall and repair;
+- historical upgrade, rollback and re-upgrade;
+- controlled interruption and deterministic recovery;
+- independent candidate verification.
+
+Physical-machine UX, Store identity, publisher authenticity and official publication remain separate acceptance boundaries.
 
 ## Evolution
 
-Any change to accepted installed extras, uninstall data policy, identity rules or smoke behavior requires an explicit contract update. The test must not silently broaden its allowlist to make a new installer pass.
+Any change to installed extras, uninstall data policy, identity rules or smoke behavior requires an explicit contract update. Tests must not silently broaden their allowlists to make a new installer pass.

--- a/docs/WINDOWS_FORMAT_DERIVATION_V1.md
+++ b/docs/WINDOWS_FORMAT_DERIVATION_V1.md
@@ -1,18 +1,12 @@
 # Windows format derivation v1
 
-**Status:** public R1.B.A contract for unsigned installer and portable candidates
+**Status:** implemented contract for unsigned portable and NSIS candidate derivation.
 
-## Purpose
+Metrora builds one canonical unpacked Windows application payload. The portable directory and NSIS installer are derived from isolated copies of that same payload rather than separate product builds.
 
-Metrora must not build the portable application and NSIS installer as two independent product payloads.
-
-The Windows candidate workflow builds one canonical unpacked application directory, records its complete inventory, copies it into the portable format and creates an isolated installer-source copy for electron-builder `--prepackaged` NSIS creation.
-
-This contract proves the relationship between those formats without claiming that NSIS bytes are reproducible or that an unsigned installer is an official release.
+This proves the relationship between formats without claiming reproducible NSIS bytes or official publisher authenticity.
 
 ## Candidate layout
-
-The downloaded candidate contains:
 
 ```text
 Metrora-Windows-Candidate/
@@ -29,136 +23,96 @@ Metrora-Windows-Candidate/
     └── Metrora-Setup-<version>.exe
 ```
 
-An optional installer blockmap may appear beside the setup executable when the packaging tool produces one.
+An optional blockmap may appear beside the setup executable when produced by the packaging tool.
 
 ## Canonical payload
 
-The canonical product payload is the one `win-unpacked` directory produced after:
+The canonical payload is the single `win-unpacked` directory produced after installing pinned dependencies, staging the bundled CLI, generating brand assets, building Electron main and renderer code and running the packaging hook.
 
-1. installing pinned root and desktop dependencies;
-2. staging the compatibility CLI;
-3. generating canonical Signal Grid assets;
-4. building Electron main and renderer code;
-5. running electron-builder once with the unpacked-directory target;
-6. completing the existing `afterPack` staging hook.
+`CANONICAL_PRODUCT_PAYLOAD.jsonl` records every file by canonical path, size and SHA-256.
 
-`CANONICAL_PRODUCT_PAYLOAD.jsonl` records every file in that directory by canonical path, size and SHA-256.
-
-The canonical directory is not passed to NSIS. It remains unchanged and is re-inventoried after installer creation. Any mutation causes the workflow to fail.
+The canonical directory is never passed directly to NSIS. It remains unchanged and is re-inventoried after installer creation.
 
 ## Portable derivation
 
-The portable directory begins as a recursive copy of the canonical payload.
+The portable directory starts as a recursive copy of the canonical payload. Canonical application files must remain byte-identical.
 
-Canonical application files must remain byte-identical. The only permitted portable-only files are:
+Permitted portable-only additions are limited to:
 
 - `README.txt`;
 - `Run-Metrora-Baseline.cmd`;
 - `Run-Metrora-Baseline.ps1`;
-- R1.A release manifest, schema, inventory, attestation and metadata checksum files.
+- release manifest, schema, inventory, attestation and metadata checksums.
 
-Missing canonical files, changed canonical files or any undeclared extra file fail verification.
-
-The R1.A verifier remains authoritative for the portable release manifest and source binding.
+Missing, changed or undeclared files fail verification.
 
 ## Installer derivation
 
-The workflow creates a separate recursive copy of the canonical unpacked payload and passes only that copy to electron-builder through `--prepackaged`.
+The workflow creates a separate copy of the canonical payload and passes it to electron-builder through `--prepackaged`. It does not run a second application build for the installer.
 
-The workflow does not run a second application build for the installer. Every canonical product file in the installer-source copy must remain byte-identical.
+Electron-builder may add the documented non-empty elevation helper under `resources/elevate.exe`. Any other product-payload drift fails the installer-source check.
 
-Electron-builder NSIS may add exactly one packaging helper:
-
-- `resources/elevate.exe`.
-
-The helper must be non-empty. A missing helper, changed canonical file, removed canonical file or any other addition fails the dedicated installer-source gate. The canonical `win-unpacked` directory remains untouched.
-
-Accepted installer outputs are:
-
-- exactly one `Metrora-Setup-<version>.exe`;
-- an optional `.blockmap` produced by the same packaging step.
-
-Other files are not included in the candidate's installer directory.
-
-R1.B.A records installer bytes and the derivation method. It does not yet prove the files installed by NSIS match the canonical payload; unattended install and post-install comparison belong to R1.B.B.
+Accepted installer output is one versioned setup executable plus an optional blockmap.
 
 ## Format derivation manifest
 
 `FORMAT_DERIVATION.json` records:
 
-- manifest schema and SHA-256;
+- schema identity and digest;
 - public source commit;
-- canonical Metrora product identity and version;
-- Signal Grid v1 identity;
+- product and version identity;
+- Signal Grid identity;
 - canonical payload inventory summary;
 - portable release-manifest digest;
 - exact portable-only file set;
 - installer derivation method;
-- every installer output path, size and SHA-256;
+- installer output paths, sizes and digests;
 - explicit reproducibility limits.
 
-`FORMAT_SHA256SUMS.txt` covers:
-
-- canonical product payload inventory;
-- format derivation manifest;
-- format derivation schema.
-
-The public source commit remains authoritative. The format manifest is evidence of derivation, not a second packaging configuration.
+The format manifest is derivation evidence, not a second packaging configuration.
 
 ## Verification
 
 The Windows workflow:
 
-1. runs native manifest, derivation and installer-source tests;
+1. tests the manifest and derivation libraries;
 2. builds the canonical unpacked payload once;
-3. prepares the portable copy and canonical inventory;
-4. adds only documented portable helpers;
-5. generates and verifies the R1.A portable manifest;
-6. copies the canonical payload into an isolated NSIS source directory;
-7. builds NSIS from that copy with `--prepackaged`;
-8. proves every canonical file in the NSIS copy remains byte-identical and only the documented elevation helper was added;
-9. proves the original canonical directory did not change;
-10. proves the portable copy still contains identical canonical files;
-11. inventories installer outputs;
-12. writes and verifies the derivation manifest;
-13. smoke-tests the portable CLI;
-14. uploads the complete combined candidate.
+3. inventories it;
+4. derives the portable copy and adds only allowed helpers;
+5. creates and verifies the portable release manifest;
+6. derives the NSIS source from an isolated canonical copy;
+7. verifies that canonical files remain identical;
+8. verifies that the original canonical directory did not change;
+9. inventories installer outputs;
+10. writes and verifies format metadata;
+11. smoke-tests the portable CLI;
+12. uploads the combined candidate.
 
-A separate Ubuntu job downloads the candidate and repeats:
+A separate Ubuntu job downloads the candidate and repeats canonical inventory, portable comparison, source binding, installer-digest and format-metadata verification.
 
-- canonical inventory validation;
-- portable/canonical comparison;
-- R1.A portable verification against canonical Git blobs;
-- installer digest verification;
-- format metadata verification.
+## Allowed claims and limits
 
-Cross-platform verification proves content and derivation metadata. It does not run the Windows installer.
-
-## Reproducibility language
-
-Allowed R1.B.A claim:
+Allowed:
 
 > Portable and NSIS candidates derive from one verified canonical unpacked product payload.
 
-Not yet allowed:
+This contract alone does not establish:
 
-- installed NSIS files verified against the canonical payload;
 - byte-for-byte reproducible NSIS output;
 - official publisher authenticity;
 - trusted update-channel authenticity;
-- supported upgrade or rollback guarantees.
+- platform acceptance or publication.
 
-The manifest records `installerByteReproducibilityProven: false`.
+Installed-layout, migration and interruption behavior are validated by separate Windows contracts and workflow steps.
 
 ## Security and privacy boundary
 
-- all artifacts remain unsigned;
+- candidates remain unsigned unless a later protected channel explicitly states otherwise;
 - public CI receives no signing authority;
 - candidate metadata contains no endpoint, Workspace or user data;
-- the installer cannot replace product bytes without changing the recorded format derivation;
 - user-owned local state is not part of either product payload;
-- clean install, uninstall, upgrade and rollback remain separate R1.B acceptance work.
+- deployment tooling may not alter product semantics after the canonical build.
 
 ## Evolution
 
-A format-derivation contract change requires a new explicit version. R1.B.B may add installation evidence that references this v1 manifest; it must not silently reinterpret the canonical payload or permitted portable extras.
+A format-contract change requires an explicit version. Later installation evidence may reference this manifest but must not reinterpret the canonical payload or silently broaden permitted additions.

--- a/docs/WINDOWS_INTERRUPTED_UPGRADE_RECOVERY_V1.md
+++ b/docs/WINDOWS_INTERRUPTED_UPGRADE_RECOVERY_V1.md
@@ -1,138 +1,113 @@
 # Windows interrupted upgrade recovery v1
 
-**Status:** R1.B.C.B implementation contract
+**Status:** implemented CI contract for controlled installer interruption and deterministic recovery.
 
-## Purpose
+This contract proves that an interrupted Windows installer run cannot silently leave Metrora with ambiguous application authority or damaged user-owned local state.
 
-Prove that an interrupted Windows installer run cannot silently leave Metrora with ambiguous application authority or damaged user-owned local state.
-
-This contract covers an unsigned, disposable CI fixture. It does not enable an automatic updater, remote recovery service, signing authority, public release or support backdoor.
+It uses an unsigned disposable test fixture. It does not add updater logic, network recovery, signing authority, public release behavior or a support backdoor.
 
 ## Controlled interruption
 
-The interruption test must not depend on arbitrary sleep timing or random deletion of application files.
+The test does not depend on arbitrary sleep timing or random file deletion.
 
-A dedicated test-only NSIS include inserts a runtime checkpoint into an installer derived from the same current canonical payload used by the ordinary candidate.
-
-The checkpoint:
+A test-only NSIS include inserts a runtime checkpoint into an installer derived from the same canonical current payload as the ordinary candidate. The checkpoint:
 
 - exists only in the interruption fixture;
-- writes one unique marker below the disposable runner temporary directory;
-- waits inside the installer until released or terminated;
-- runs only during installation;
+- writes one unique marker below the disposable runner directory;
+- waits until released or terminated;
 - contains no product, Workspace or user-state logic;
-- is never copied into the ordinary candidate output;
+- is never copied into ordinary candidate output;
 - is never uploaded or published.
 
-CI terminates the fixture only after observing the expected marker.
+CI terminates the fixture only after observing the checkpoint marker.
 
-## Current candidate authority
+## Candidate authority
 
-The ordinary current candidate remains built once by the existing Windows candidate job.
+The ordinary current candidate remains the recovery authority.
 
-The interruption fixture may repackage an isolated copy of the same canonical current payload with the test-only NSIS include. It is not a second product build and cannot replace the ordinary candidate manifest or installer.
+The interruption fixture repackages an isolated copy of the canonical payload with the test-only include. It is not a second product build and cannot replace the ordinary manifest or installer.
 
-After interruption, recovery must use the ordinary current installer, not the fixture.
+Recovery always uses the ordinary current installer.
 
-## State classification
+## Interrupted-state classification
 
-The interrupted installation directory is classified independently from installer process exit or registry assumptions.
+The installation is classified independently from process exit and registry assumptions:
 
-Allowed classifications are:
-
-- `baseline-complete` — every historical baseline product file matches and the current payload does not;
-- `candidate-complete` — every current product file matches and the baseline payload does not;
-- `absent` — no product payload or Windows application authority remains;
+- `baseline-complete` — historical baseline files are complete and current files are not;
+- `candidate-complete` — current files are complete and baseline files are not;
+- `absent` — no application payload or Windows authority remains;
 - `mixed` — files or authorities do not form one accepted complete state.
 
-The classifier compares canonical file paths, sizes and SHA-256 digests. Windows registration and shortcut authority are checked separately by the lifecycle harness.
+Classification compares canonical paths, sizes and SHA-256 digests. Registration and shortcut authority are inventoried separately.
 
-A mixed state is never treated as a valid installed application.
+A mixed state is never treated as healthy.
 
 ## Recovery policy
 
-Recovery is local to the disposable test installation.
+Recovery is confined to the disposable test installation:
 
-- `candidate-complete`: validate the current installation and normalize any missing Windows authority through the ordinary current installer if needed;
-- `baseline-complete`: retry the ordinary current upgrade;
-- `absent`: install the ordinary current candidate;
-- `mixed`: remove disposable application authority only, verify its absence, then install the ordinary current candidate.
+- `candidate-complete` — validate current installation and normalize missing Windows authority if needed;
+- `baseline-complete` — retry the ordinary current upgrade;
+- `absent` — install the ordinary current candidate;
+- `mixed` — remove disposable application authority only, verify absence and install the ordinary current candidate.
 
 Recovery must converge to:
 
-- the exact current canonical payload;
-- the expected current executable and CLI version;
-- one logical HKCU uninstall registration;
+- the exact canonical current payload;
+- the expected executable and CLI version;
+- one logical per-user uninstall registration;
 - one canonical Start Menu shortcut;
 - successful bounded Electron launch;
-- no competing baseline or mixed application authority.
+- no competing baseline or mixed authority.
 
 ## User-owned local state
 
-Before baseline installation, CI creates a sentinel in the disposable equivalent of:
+Before baseline installation, CI creates a sentinel in the disposable Metrora local-state directory.
 
-```text
-%APPDATA%\metrora-desktop\metrora-local-state
-```
+Its digest is checked after baseline launch, interruption, termination, classification, any bounded cleanup, recovery launch and final application removal.
 
-The sentinel digest is verified:
+The fixture, classifier and recovery harness may not reset, rewrite, inspect, export or upload Workspace evidence.
 
-- after baseline installation and launch;
-- after the interruption checkpoint is reached;
-- immediately after installer termination;
-- after interrupted-state classification;
-- after cleanup where required;
-- after current-candidate recovery and launch;
-- after final application removal.
+## Windows authority checks
 
-The interruption fixture, classifier and recovery harness may not reset, rewrite, inspect, export or upload Workspace evidence.
-
-## Windows authority classification
-
-File classification alone is not enough.
-
-The harness also inventories:
+File classification alone is insufficient. The harness also inventories:
 
 - logical HKCU uninstall registrations;
 - registrations outside HKCU;
-- canonical Start Menu shortcuts;
-- shortcut targets;
+- canonical Start Menu shortcuts and targets;
 - installed executable version where available.
 
-Before recovery, incomplete or conflicting Windows authority is reported as part of the bounded interruption result. It must not be accepted as healthy.
-
-After recovery, exactly one canonical current authority is required.
+Incomplete or conflicting authority is reported and cannot pass as healthy. After recovery, exactly one canonical current authority is required.
 
 ## Failure model
 
-The gate fails when:
+Validation fails when:
 
-- the test-only installer cannot prove that the checkpoint was reached;
-- the fixture appears in ordinary candidate output;
-- the installer cannot be terminated deterministically;
-- state classification is impossible or contradictory;
-- a mixed state is accepted without cleanup;
-- cleanup targets anything outside the disposable installation;
-- recovery does not converge to the canonical current payload;
+- the checkpoint cannot be proven;
+- the fixture enters ordinary candidate output;
+- termination is not deterministic;
+- state classification is contradictory;
+- a mixed state is accepted without bounded cleanup;
+- cleanup targets anything outside the disposable application authority;
+- recovery does not converge to the canonical candidate;
 - registration, shortcut, executable or CLI authority remains ambiguous;
 - the application cannot launch after recovery;
-- user-owned local state changes;
-- the ordinary candidate no longer passes independent verification.
+- user-owned state changes;
+- independent candidate verification fails.
 
 ## Explicit prohibitions
 
-R1.B.C.B must not introduce:
+The interruption contract must not introduce:
 
-- updater logic in the product runtime;
+- runtime updater or background installer monitoring;
 - network access or remote repair;
-- background installer monitoring in Metrora;
 - hidden support commands;
 - deletion of real user data;
 - publication of the interruption fixture;
-- a second current payload build;
-- relaxed payload, registry or shortcut allowlists;
+- a second current product build;
+- relaxed payload, registration or shortcut allowlists;
 - changes to Workspace, parser, pricing, provider or evidence semantics.
 
 ## Completion criteria
 
-R1.B.C.B completes only when the controlled interruption is observed on Windows, the resulting state is classified, recovery converges to the ordinary current candidate, local state remains byte-identical and every existing release/architecture/brand gate remains green.
+The contract passes only when the controlled interruption is observed on Windows, the resulting state is classified, recovery converges to the ordinary candidate, local state remains byte-identical and the candidate still passes independent verification.

--- a/docs/WINDOWS_RELEASE_CANDIDATE_V1.md
+++ b/docs/WINDOWS_RELEASE_CANDIDATE_V1.md
@@ -1,160 +1,120 @@
 # Windows release candidate manifest v1
 
-**Status:** public R1.A contract for unsigned Windows candidates
+**Status:** implemented public contract for unsigned Windows engineering candidates.
 
-## Purpose
+Metrora Windows candidates must be traceable to one reviewed public source commit and independently verifiable after download.
 
-Metrora Windows candidates must be traceable to one reviewed public source and independently verifiable after download.
+This contract separates:
 
-This contract separates three different claims:
+1. **Payload integrity** — every candidate payload file is inventoried by path, size and SHA-256.
+2. **Source and input binding** — the manifest records the source commit, tree, timestamp and release-critical Git blobs.
+3. **Build-run attestation** — variable CI execution metadata is bound to the deterministic manifest without becoming part of it.
 
-1. **Payload integrity** — every file in the candidate directory is inventoried by path, size and SHA-256.
-2. **Source/input binding** — the manifest records the public source commit, tree, source timestamp and hashes of release-critical Git blobs.
-3. **Build-run attestation** — variable CI metadata is bound to the deterministic manifest without becoming part of it.
-
-R1.A does not claim byte-for-byte reproduction of Electron output, NSIS output or the GitHub artifact ZIP. That claim requires separate evidence and remains future work.
+It does not claim byte-for-byte reproduction of Electron, NSIS or archive output.
 
 ## Candidate files
 
-A candidate directory contains:
+The portable candidate contains:
 
 - `RELEASE_MANIFEST.json` — deterministic product, source, build-input and payload summary;
-- `RELEASE_MANIFEST.schema.json` — the exact public v1 schema copied from the declared Git commit;
-- `PAYLOAD_MANIFEST.jsonl` — one canonically sorted JSON record per payload file;
-- `BUILD_ATTESTATION.json` — variable CI run metadata bound to the manifest digest;
-- `SHA256SUMS.txt` — checksums for the four metadata files above;
+- `RELEASE_MANIFEST.schema.json` — the public schema copied from the declared commit;
+- `PAYLOAD_MANIFEST.jsonl` — one sorted record per payload file;
+- `BUILD_ATTESTATION.json` — build execution metadata bound to the manifest digest;
+- `SHA256SUMS.txt` — checksums for the metadata files;
 - the Metrora application payload.
 
-Release metadata files are excluded from the payload inventory to avoid circular hashing. They are verified through the manifest/attestation/checksum chain.
+Release metadata is excluded from the payload inventory to avoid circular hashing and is verified through its own checksum chain.
 
 ## Deterministic manifest
 
 `RELEASE_MANIFEST.json` records:
 
-- canonical Metrora product name, package name, application ID, version and homepage;
-- Signal Grid identity name and version;
-- public repository, source commit, Git tree and commit timestamp;
+- product name, package name, application ID, version and homepage;
+- Signal Grid identity;
+- source repository, commit, tree and timestamp;
 - Windows target and candidate classification;
 - exact Node, Electron and electron-builder versions;
-- hashes of the exact Git blobs for root/app lockfiles, package definitions, workflow and brand identity source;
-- manifest-schema hash;
-- payload inventory hash, file count and total bytes;
-- an explicit reproducibility statement.
+- hashes of release-critical package, lockfile, workflow and brand-source blobs;
+- schema hash;
+- payload inventory digest, file count and byte count;
+- explicit reproducibility limits.
 
-The manifest does not include workflow run IDs, mutable timestamps, runner image labels or branch names.
-
-Two builds with identical source, declared tool versions, build-input blobs and payload bytes produce the same release manifest and payload inventory even when CI run metadata differs.
+Mutable workflow-run identifiers, branch labels and build timestamps stay in the separate attestation.
 
 ## Canonical source authority
 
-Release-critical source files are read as bytes directly from the declared Git commit, not from the operating system's materialized working tree.
+Release-critical inputs are read as bytes from the declared Git commit rather than the materialized checkout. This prevents line-ending conversion from changing input hashes across operating systems.
 
-This prevents platform checkout behavior such as CRLF/LF conversion from changing source-input hashes between Windows and Linux.
-
-The verifier also proves that:
-
-- the declared tree belongs to the declared commit;
-- the declared source timestamp is the commit timestamp;
-- the input set is complete and cannot be shortened;
-- product version, package name, application ID, homepage and Signal Grid metadata agree with the source package;
-- Electron and electron-builder versions agree with the source lockfile;
-- the bundled manifest schema is byte-identical to the schema blob in the source commit.
-
-A working-tree mode exists only for isolated unit fixtures. Production creation and verification use Git-blob authority.
+Verification also proves that declared tree and timestamp belong to the commit, required inputs are complete, package identity agrees with source metadata, tool versions agree with lockfiles and the bundled schema matches the source blob.
 
 ## Build attestation
 
-`BUILD_ATTESTATION.json` records the individual build execution:
+`BUILD_ATTESTATION.json` records the individual execution, including manifest digest, automation provider, workflow, run and attempt, source ref, build time and runner identity.
 
-- manifest SHA-256;
-- automation provider and workflow;
-- run ID and attempt;
-- source ref;
-- build time;
-- runner OS and image label.
+The attestation is expected to vary between runs. It does not change the deterministic payload or source manifest.
 
-The attestation is expected to vary between runs. It does not change the deterministic manifest or payload inventory.
-
-A future signing tranche may bind additional protected signing evidence to the accepted unsigned manifest. Public CI does not sign or hold signing authority.
+Public pull-request CI does not hold signing authority.
 
 ## Payload inventory
 
-Each non-empty line in `PAYLOAD_MANIFEST.jsonl` is a strict JSON object:
+Each non-empty `PAYLOAD_MANIFEST.jsonl` line is a strict object:
 
 ```json
 {"path":"resources/app.asar","size":123456,"sha256":"..."}
 ```
 
-Rules:
-
-- paths use `/` separators;
-- paths are relative and traversal-free;
-- entries are sorted by deterministic code-point order;
-- paths are unique;
-- sizes are non-negative safe integers;
-- SHA-256 digests use lowercase hexadecimal;
-- every payload file is listed;
-- no unlisted payload file is permitted.
-
-Filesystem links or other unsupported entry types fail candidate creation rather than being interpreted differently across operating systems.
+Paths are relative, traversal-free, unique, `/`-separated and deterministically sorted. Sizes are non-negative safe integers and digests are lowercase SHA-256. Missing, additional or unsupported filesystem entries fail verification.
 
 ## Independent verification
 
-The canonical verifier:
+The verifier:
 
-1. validates the manifest identity and supported version;
+1. validates manifest identity and schema;
 2. checks the expected source commit when supplied;
-3. verifies commit tree and timestamp;
-4. re-hashes the fixed release-input set from canonical Git blobs;
-5. verifies product and toolchain metadata against the same commit;
-6. verifies the source schema matches the bundled schema;
-7. validates metadata checksums;
-8. verifies the attestation binds the manifest;
-9. re-inventories every downloaded payload file;
-10. rejects missing, extra, resized or modified files.
+3. verifies source tree and timestamp;
+4. re-hashes the fixed input set from Git blobs;
+5. verifies package and toolchain metadata;
+6. verifies the bundled schema;
+7. validates metadata checksums and attestation binding;
+8. re-inventories every downloaded payload file;
+9. rejects missing, additional, resized or modified files.
 
-The Windows workflow verifies before upload. A separate Ubuntu job downloads the uploaded artifact and repeats verification against the same source commit.
+The Windows workflow verifies before upload. A separate Ubuntu job downloads the uploaded candidate and repeats content and source-binding verification.
 
-Verification on another operating system proves content and source binding, not Windows executable behavior or signature validity.
+Cross-platform verification proves bytes and provenance, not Windows runtime behavior or signature validity.
 
 ## Candidate classifications
 
 ### `unsigned-development-artifact`
 
-Used for pull requests, ordinary main-branch validation and controlled engineering tests. It is not an official release.
+Used for ordinary validation and controlled engineering tests. It is not an official release.
 
 ### `unsigned-release-candidate`
 
-Used only through an explicit workflow dispatch when the source is intended for a later protected signing/acceptance step. It is still not an official release and must remain clearly separated from signed downloads.
+Used through explicit workflow dispatch when source is being evaluated for a later protected distribution step. It remains unsigned and must not be presented as an official channel package.
 
-An official signed release requires R1.B–R1.E acceptance and protected signing evidence.
+## Allowed claims
 
-## Reproducibility language
+Allowed:
 
-Allowed R1.A claim:
+> Payload contents and declared build inputs are deterministic and independently verifiable.
 
-> Payload contents and build inputs are deterministic and independently verifiable.
+Not established by this contract:
 
-Not yet allowed:
-
-- byte-for-byte reproducible Electron directory;
-- byte-for-byte reproducible NSIS installer;
-- byte-for-byte reproducible GitHub artifact ZIP;
+- byte-for-byte reproducible Electron, NSIS or archive output;
 - official publisher authenticity;
-- trusted update-channel authenticity.
-
-The manifest records `byteForByteArchiveProven: false` and verification rejects a contrary claim under v1.
+- trusted update-channel authenticity;
+- acceptance by a distribution platform.
 
 ## Security and privacy boundary
 
 - public workflows receive no signing keys or protected release credentials;
-- manifest and attestation contain no endpoint identity, Workspace data, local paths, prompts, responses, code or user content;
-- candidate metadata exposes only public source/build information;
-- private signing may not alter product semantics after public acceptance;
+- candidate metadata contains no endpoint, Workspace or user data;
+- private signing or channel packaging may not alter already reviewed product semantics;
 - development candidates remain visibly distinct from official releases.
+
+An official distribution requires exact platform-issued product identity, platform-specific acceptance and an explicit publication decision. See [Windows distribution](WINDOWS_DISTRIBUTION.md).
 
 ## Compatibility and evolution
 
-Manifest v1 is append-resistant through strict verification and an explicit schema. A future version uses a new `kind`/version contract or a documented compatible extension; it must not silently reinterpret v1 fields.
-
-The public source commit remains the final authority for code and contract meaning. The manifest is an evidence index, not a second release database.
+Manifest v1 is strict. A future contract uses a new version or documented compatible extension rather than silently reinterpreting existing fields. The declared public source commit remains authoritative for code and contract meaning.

--- a/docs/WORKSPACE_PRODUCTION_LIFECYCLE_V1.md
+++ b/docs/WORKSPACE_PRODUCTION_LIFECYCLE_V1.md
@@ -1,23 +1,23 @@
 # Workspace production lifecycle v1
 
-**Status:** W1.D.C.A durable local lifecycle contract.
+**Status:** implemented, persisted and enforced by the local Workspace runtime.
 
-This contract controls only whether future reviewed Workspace measurements may be produced. It does not control Metrora collectors, parser execution, canonical analytics, historical pricing, existing outbox events, signed batches, or evidence exports.
+This contract controls only whether future explicit reviewed-measurement production may run. It does not control ordinary collectors, parsing, analytics, historical pricing, existing outbox events, signed batches or exports.
 
 ## Default behavior
 
-A local personal Workspace with no lifecycle file is treated as:
+A local personal Workspace without a lifecycle file is treated as:
 
 - production mode `active`;
 - revision `0`;
 - not yet persisted;
 - no lifecycle update timestamp.
 
-Reading this default never creates a file. Existing Workspace installations therefore remain compatible without migration or silent state mutation.
+Reading that default does not create a file, so existing Workspace state remains compatible without silent mutation.
 
 ## Durable state
 
-The private endpoint stores one strict versioned record under the existing Workspace local-state directory:
+The private endpoint stores one strict versioned record containing:
 
 - stable Workspace ID;
 - stable endpoint ID;
@@ -25,86 +25,66 @@ The private endpoint stores one strict versioned record under the existing Works
 - positive monotonic revision;
 - creation and latest-update timestamps.
 
-The record contains no signing key, event-identity key, production receipt, deduplication key, source path, prompt, response, source code, patch, secret, tool argument, normalized call, token count, cost, model label, or provider claim.
+The record contains no keys, receipts, source paths, prompts, responses, code, tool arguments, normalized calls, token counts, costs or provider claims.
 
-Writes reuse Metrora's existing cross-process Workspace lease and atomic private-file publication. Concurrent identical requests produce one transition; later requests are idempotent.
+Writes reuse the Workspace cross-process lease and atomic private-file publication. Concurrent identical requests converge on one transition; repeated requests are idempotent.
 
 ## Pause semantics
 
-Pause means only:
+Pause means:
 
-> A future explicit Workspace reviewed-production action must perform no production while this mode is `paused`.
+> A future explicit reviewed-production action must stop before the canonical source scan.
 
 Pause does not:
 
-- stop local tool discovery or parsing;
-- change the Overview payload;
-- alter calls, sessions, tokens, costs, pricing coverage, models, providers, projects, or labels;
-- delete, quarantine, acknowledge, sign, export, or upload existing evidence;
+- stop local discovery, parsing or Overview refreshes;
+- change calls, sessions, tokens, costs, models, providers, projects or labels;
+- delete, quarantine, acknowledge, sign or export existing evidence;
 - reset receipts or the append-only outbox;
-- disable local analytics for users who do not use Workspace.
+- disable ordinary analytics.
 
-W1.D.C.A persists and exposes this policy but does not yet implement the reviewed-production orchestrator. Enforcement at the production entry point belongs to W1.D.C.B.
+A pause requested while one atomic production pass is active waits for that pass to finish. Later passes stop before scanning.
 
 ## Resume semantics
 
-Resume changes only the durable mode back to `active` and increments the revision. It never deletes the lifecycle file or rewrites earlier evidence.
+Resume changes only the durable mode to `active` and advances the revision. It never deletes lifecycle history or rewrites earlier evidence.
 
-An already-active absent state is a no-op and remains unpersisted. An already-active or already-paused persisted state is also a no-op and preserves its revision and timestamp.
+Requesting the already-active or already-paused state is a no-op that preserves revision and timestamp.
 
 ## Identity and recovery
 
-The record is bound to the Workspace and stable enrolled endpoint, not to a particular endpoint-key generation. Normal forward key rotation therefore preserves the production mode.
+Lifecycle state binds the stable Workspace and endpoint, not one key generation. Normal endpoint-key rotation therefore preserves the production mode.
 
-Metrora fails closed and requires recovery when:
-
-- the JSON or schema is invalid;
-- timestamps or revision are contradictory;
-- the record refers to a different Workspace;
-- the record refers to a different endpoint;
-- the private state cannot be read safely.
-
-Recovery does not mean deletion or reset. W1.D.C.C will expose only deterministic, non-destructive recovery actions for known states.
+Malformed, cross-bound or contradictory lifecycle state fails closed. Recovery is explicit and non-destructive; it does not mean deleting the record or resetting identity.
 
 ## Desktop boundary
 
-The secure main-process Workspace runtime adds the lifecycle summary to its strict public snapshot:
+The secure main-process runtime exposes a bounded public lifecycle summary:
 
 - mode;
 - revision;
 - whether a durable record exists;
 - latest update timestamp, or `null` for the implicit default.
 
+The desktop UI provides explicit pause and resume controls. IPC actions take no renderer-supplied mode or measurement data; the main process selects the exact private transition.
+
 Before Workspace creation the lifecycle summary is `null`.
 
-IPC exposes two fixed no-argument actions:
+## Validation boundary
 
-- pause Workspace production;
-- resume Workspace production.
-
-The handlers choose the exact private mode. Renderer input cannot supply a mode, call, provider, provenance profile, source fingerprint, cost assignment, path, receipt, or evidence claim.
-
-No W1.D.C.A user-interface control is enabled yet. The bridge exists so the later focused lifecycle UI can remain a narrow client of the main-process authority.
-
-## Validation
-
-Blocking tests cover:
+Tests cover:
 
 - Workspace-required behavior;
-- non-creating active default;
+- the non-creating active default;
 - atomic pause publication;
 - concurrent idempotency;
-- monotonic resume without deletion;
+- monotonic resume;
 - endpoint-key rotation;
 - malformed and cross-bound fail-closed state;
 - public snapshot privacy;
-- fixed pause/resume IPC mapping and sanitized errors;
-- unchanged evidence state across lifecycle transitions;
-- Ubuntu full-suite and Windows secure desktop-runtime execution.
+- fixed pause/resume IPC mapping;
+- unchanged evidence state across lifecycle transitions.
 
 ## Non-goals
 
-- no reviewed-measurement scan or production;
-- no automatic/background action;
-- no batch, export, upload, synchronization, account, team, billing, mobile, or unrelated product behavior;
-- no new collector, parser, pricing, cache, aggregation, or analytics authority.
+This lifecycle does not add automatic production, background work, upload, synchronization, account, team, billing, mobile or alternate analytics behavior.

--- a/docs/WORKSPACE_RECOVERY_V1.md
+++ b/docs/WORKSPACE_RECOVERY_V1.md
@@ -1,138 +1,79 @@
 # Workspace recovery v1
 
-**Status:** W1.D.C.D local recovery checkpoint, amended by physical Windows acceptance and the read-only bootstrap inspection remediation.
+**Status:** implemented as read-only inspection plus a separate explicit non-destructive recovery action.
 
-Workspace recovery validates protected local state, reconciles already-authorized private production receipts, and may retry one bounded canonical production path. It is not a reset, cleanup command, historical backfill, quarantine bypass, or evidence editor.
+Workspace recovery validates protected local state, reconciles already-authorized private production receipts and may retry the normal bounded production path. It is not a reset, cleanup command, historical backfill, quarantine bypass or evidence editor.
 
 ## Bootstrap inspection versus recovery
 
-Opening Metrora or the Workspace screen performs two distinct read paths:
+Opening Metrora or the Workspace view uses two read paths:
 
-1. a fast bootstrap reads only protected Workspace identity and production lifecycle so the screen can open without enumerating evidence directories;
-2. an automatic read-only inspection then loads the complete public evidence summary in the background.
+1. a fast bootstrap reads protected Workspace identity and lifecycle state;
+2. an automatic read-only inspection loads the complete public evidence summary.
 
-While the read-only inspection is pending, the desktop shows an indeterminate verification state and does not present zero counts as if no evidence existed. Production, signing, export, and recovery remain disabled until that first inspection settles. The inspection never scans canonical usage, repairs receipts, produces events, creates batches, exports, uploads, deletes, resets, or changes lifecycle state.
+While inspection is pending, the desktop shows an indeterminate verification state rather than false zero counts. Inspection never scans canonical usage, repairs receipts, produces events, creates batches, exports, uploads or changes lifecycle state.
 
-A completed read-only inspection survives at the product level because every new desktop session repeats the same non-mutating inspection and presents the persisted evidence counts again. It does not persist a shortcut or trust a previous in-memory result.
-
-Recovery remains a separate explicit zero-argument action:
-
-```text
-Check & recover local state
-```
-
-The renderer cannot request deletion, reset, source selection, receipt selection, provider changes, lifecycle changes, time boundaries, historical backfill, or evidence replacement. Unexpected IPC arguments are ignored.
+Recovery remains a separate explicit action. The renderer cannot request deletion, reset, source selection, provider changes, time boundaries, historical backfill or evidence replacement.
 
 ## Safe recovery path
 
-When the Workspace exists, production is active, and current evidence is not blocked, quarantined, or invalid, recovery performs two bounded operations:
+When a Workspace exists, production is active and current evidence is not blocked or quarantined, recovery performs two bounded operations:
 
-1. reconcile the private production-receipt index with the append-only outbox;
-2. run the normal reviewed-production retry scoped from the protected Workspace `createdAt` timestamp.
+1. reconcile private production receipts with the append-only outbox;
+2. retry normal reviewed production from the protected Workspace creation timestamp.
 
-Receipt reconciliation is independent of the scanner scope. This matters when an older or interrupted production pass wrote a valid private receipt before its corresponding public event file and then stopped. Recovery can republish only that original immutable event without restarting historical production.
+Receipt reconciliation is independent of scanner scope. If an interrupted pass committed a valid private receipt before publishing its public event, recovery can restore that exact event without restarting historical production.
 
-The normal retry may safely:
-
-- refresh canonical local source/cache state;
-- inspect only source-present calls at or after Workspace creation;
-- deduplicate already published in-scope calls;
-- return a refreshed public Workspace snapshot.
-
-The receipt is authoritative for interrupted publication. Recovery never generates a competing identity or a second semantic event for the same production key.
+The retry may refresh current source/cache state, inspect only source-present in-scope calls and deduplicate already published measurements.
 
 ## Outcomes
 
-The public summary reports one outcome:
+The public summary reports one bounded outcome:
 
-- `workspace-required` — no local Workspace exists; no state is created;
-- `paused` — production is paused; no receipt repair, scan, or mutation occurs;
-- `blocked` — evidence is invalid, quarantined, or otherwise blocked; no repair or retry occurs;
-- `healthy` — neither receipt publication nor in-scope production required reconciliation;
-- `reconciled` — one or more private receipts were republished or already-known in-scope production was preserved without duplication.
+- `workspace-required` — no local Workspace exists;
+- `paused` — production is paused, so no repair or scan occurs;
+- `blocked` — invalid, quarantined or inconsistent evidence prevents mutation;
+- `healthy` — no reconciliation was needed;
+- `reconciled` — one or more receipts or already-known measurements were preserved without duplication.
 
-The summary also states:
-
-- whether the bounded retry was attempted;
-- a bounded blocker category;
-- `receiptRepairCount`, an integer count only;
-- the ordinary bounded production summary when a retry occurred.
-
-It contains no calls, token values, model/provider details, paths, fingerprints, deduplication identities, receipt IDs, keys, prompts, responses, code, patches, secrets, or tool arguments.
+The summary exposes only whether retry occurred, a bounded blocker category, receipt-repair count and the ordinary production summary when applicable.
 
 ## Fail-closed states
 
-The automatic read-only inspection reports failure without mutation when evidence cannot be parsed or verified. It never falls back to zero counts and never starts recovery automatically.
+Read-only inspection reports failure without mutation. It never falls back to zero counts and never starts recovery automatically.
 
-Recovery stops before receipt reconciliation and scanning when:
+Recovery stops before repair and scanning when:
 
 - the Workspace does not exist;
 - production is paused;
-- public evidence is blocked;
-- any invalid event is present;
-- any quarantined evidence is present.
+- evidence is blocked;
+- invalid or quarantined evidence is present.
 
-Receipt reconciliation fails closed when:
+Receipt reconciliation fails closed when filenames, schemas, private production identities, immutable event bytes or semantic digests conflict.
 
-- a receipt filename is malformed or disagrees with its private production key;
-- a receipt cannot be parsed through the strict schema;
-- its immutable event or semantic digest conflicts with canonical evidence;
-- reconciliation produces contradictory event counts.
+Recovery never:
 
-Recovery does not:
-
-- delete invalid or quarantined records;
-- clear blockers;
-- reset endpoint identity or keys;
-- reset lifecycle revision or pause state;
-- rewrite signed batches or acknowledgements;
-- remove valid receipts or outbox events;
-- bypass source/provider/provenance validation;
-- reprice historical usage;
-- convert pre-Workspace analytics history into evidence;
-- create a batch, export, upload, or publish automatically.
-
-A scanner, receipt, outbox, Workspace, lifecycle, or evidence integrity error remains a bounded failure requiring explicit review. It is not downgraded to success.
+- deletes invalid, quarantined or valid records;
+- clears blockers;
+- resets endpoint identity or lifecycle;
+- rewrites signed batches or acknowledgements;
+- bypasses provenance validation;
+- reprices historical usage;
+- converts pre-Workspace history into evidence;
+- creates a batch, export or upload automatically.
 
 ## Desktop boundary
 
-The protected main-process runtime owns both paths. Electron exposes:
+The protected main process owns bootstrap, complete inspection and recovery. The renderer receives public snapshots and bounded summaries only. Raw exceptions, private paths, calls, receipt identities and keys remain private.
 
-- a fast bootstrap status read;
-- a separate complete read-only inspection;
-- the explicit zero-argument recovery action.
+Older staged runtimes without the recovery capability return an explicit unavailable result rather than pretending recovery succeeded.
 
-The renderer receives only public snapshots and bounded summaries. Older staged runtimes without the recovery capability return `workspace-recovery-unavailable`. Raw exceptions and local paths never cross IPC.
+## Persistence and scope
 
-## Complete local flow
+Every desktop session repeats read-only inspection against persisted local state. Normal production and recovery remain scoped from Workspace creation; pre-Workspace history stays available to ordinary Overview analytics.
 
-Blocking tests validate the persisted local sequence:
-
-1. create Workspace;
-2. produce one reviewed event at or after Workspace creation;
-3. pause production;
-4. verify recovery stops before receipt repair or scanning;
-5. resume production;
-6. reproduce idempotently through the existing receipt;
-7. create one signed batch;
-8. export one independently verifiable package;
-9. dispose and zero private identity buffers;
-10. reopen the same endpoint and Workspace;
-11. run the automatic read-only inspection and expose the same persisted evidence counts;
-12. recover/deduplicate without a second event or batch;
-13. export the same one-event chain again.
-
-A separate interruption test removes only the public event file after its private receipt commits, then makes the bounded source retry return no candidate. Recovery still restores the original event and sequence directly from the receipt. A second recovery performs zero repairs.
-
-## Historical scope
-
-Normal Produce and Recovery do not backfill pre-Workspace history. That history remains available to canonical Overview analytics. Historical evidence import is outside this recovery contract.
+Tests cover creation, production, pause/resume, receipt reconciliation, batching, export, disposal, reopen, repeated inspection and idempotent recovery.
 
 ## Non-goals
 
-- no destructive repair or reset;
-- no automatic recovery or production at startup;
-- no normal-action historical backfill;
-- no remote recovery authority or support backdoor;
-- no account, team, entitlement, billing, mobile, or unrelated product behavior;
-- no collector, pricing, label, or aggregation redesign.
+Recovery provides no destructive reset, startup mutation, historical backfill, remote support authority, account, team, billing, mobile or alternate collector/pricing behavior.


### PR DESCRIPTION
## Summary

Align public documentation with the behavior currently implemented at `62d8e452511b54c235c37a3746324b49fbafa762`, after verifying code, desktop wiring, Android source, Windows packaging, collector inventory, open release work and the existing private product/operations sources of truth.

- clarify which documents own current product and release status;
- keep Workspace component references, but remove stale implementation checkpoints and already-completed “next steps”;
- document the implemented create/produce/pause/recover/batch/export desktop path accurately;
- preserve technical Windows manifest, derivation, install and interruption contracts while removing internal program sequencing;
- distinguish historical acceptance evidence from current release authority;
- remove public roadmap and milestone details already maintained in the private commercial and infrastructure repositories.

## Verified current state

- local Workspace creation, reviewed production, lifecycle controls, recovery, signed batches and evidence export are wired from the protected runtime through Electron IPC to the renderer;
- Windows currently derives verified portable and unsigned NSIS candidates from one canonical payload, with install, migration, interruption and recovery validation;
- no AppX/Store package or official stable Windows release exists yet;
- Android companion pairing, encrypted snapshot, refresh and revocation exist in source and automated tests, while physical acceptance remains outstanding;
- the canonical future-history authority is not implemented;
- the executable collector inventory registers 38 collectors and six approved signed-measurement paths.

## Scope

Documentation only: 12 Markdown files.

No code, schema, workflow, issue, release artifact or private repository is modified. No new CI gate or workflow is added.

## Validation

- compared the branch against the exact public base commit;
- confirmed the branch is ahead only and modifies Markdown files only;
- checked every new relative link against existing repository paths;
- reviewed the resulting index and component boundaries for current-state authority, privacy and release-status consistency.
