### PR TITLE
ci: skip heavy validation for ordinary documentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,15 +18,65 @@ jobs:
     name: Version authority
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    outputs:
+      documentation_only: ${{ steps.surfaces.outputs.documentation_only }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
           node-version: '22.15.0'
       - name: Verify package and platform versions
         run: npm run version:check
+      - name: Test change-surface classifier
+        run: node --test scripts/draft-surface-classifier.node-test.mjs
+      - name: Classify changed surfaces conservatively
+        id: surfaces
+        shell: bash
+        env:
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PUSH_BASE_SHA: ${{ github.event.before }}
+        run: |
+          set -euo pipefail
+          base_sha="$PR_BASE_SHA"
+          if [ -z "$base_sha" ]; then
+            base_sha="$PUSH_BASE_SHA"
+          fi
+
+          if [ -z "$base_sha" ] || [[ "$base_sha" =~ ^0+$ ]]; then
+            echo 'No usable base commit is available; forcing full validation.'
+            {
+              echo 'parser=false'
+              echo 'providers=false'
+              echo 'local_state=false'
+              echo 'pricing=false'
+              echo 'desktop=false'
+              echo 'release=false'
+              echo 'powershell=false'
+              echo 'fallback_core=true'
+              echo 'documentation_only=false'
+              echo 'changed_count=unknown'
+            } >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          node scripts/draft-surface-classifier.mjs --base "$base_sha"
+      - name: Record documentation-only fast path
+        if: steps.surfaces.outputs.documentation_only == 'true'
+        shell: bash
+        run: |
+          {
+            echo '## Documentation-only validation'
+            echo
+            echo 'Heavy core, desktop and security jobs were skipped because every changed path is documentation-only.'
+            echo
+            echo 'Generated or release-sensitive documents remain classified under their owning validation surface.'
+          } >> "$GITHUB_STEP_SUMMARY"
 
   semgrep:
+    needs: version-authority
+    if: needs.version-authority.outputs.documentation_only != 'true'
     name: Security rules
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -48,8 +98,12 @@ jobs:
           fi
 
   targeted-draft:
+    needs: version-authority
     name: Targeted draft validation
-    if: github.event_name == 'pull_request' && github.event.pull_request.draft == true
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.draft == true &&
+      needs.version-authority.outputs.documentation_only != 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 35
     steps:
@@ -188,7 +242,10 @@ jobs:
         run: npm test -- --run --no-file-parallelism --exclude 'app/**'
 
   build:
-    if: github.event_name == 'push' || github.event.pull_request.draft == false
+    needs: version-authority
+    if: >-
+      needs.version-authority.outputs.documentation_only != 'true' &&
+      (github.event_name == 'push' || github.event.pull_request.draft == false)
     name: Core and desktop validation (${{ matrix.os }})
     strategy:
       fail-fast: false
@@ -276,7 +333,10 @@ jobs:
         run: npm --prefix app run build
 
   full-suite:
-    if: github.event_name == 'push' || github.event.pull_request.draft == false
+    needs: version-authority
+    if: >-
+      needs.version-authority.outputs.documentation_only != 'true' &&
+      (github.event_name == 'push' || github.event.pull_request.draft == false)
     name: Core test suite
     runs-on: ubuntu-latest
     timeout-minutes: 45

--- a/scripts/draft-surface-classifier.mjs
+++ b/scripts/draft-surface-classifier.mjs
@@ -49,6 +49,14 @@ const LOCAL_STATE_EXACT = new Set([
   'tests/cache-refresh-lock.test.ts',
 ])
 
+const GENERATED_PRICING_DOCUMENTS = new Set([
+  'docs/PRICING_HISTORY.md',
+])
+
+const GENERATED_PROVIDER_DOCUMENTS = new Set([
+  'docs/COLLECTOR_INVENTORY_V1.md',
+])
+
 function normalized(path) {
   return path.replaceAll('\\', '/')
 }
@@ -66,6 +74,14 @@ function emptyClassification() {
     documentation_only: true,
     fallback_paths: [],
   }
+}
+
+export function failClosedClassification(reason) {
+  const result = emptyClassification()
+  result.documentation_only = false
+  result.fallback_core = true
+  result.fallback_paths.push(reason)
+  return result
 }
 
 function isDocumentationPath(path) {
@@ -96,6 +112,18 @@ export function classifyDraftPaths(inputPaths) {
       path.startsWith('scripts/')
     ) {
       result.release = true
+      result.documentation_only = false
+      continue
+    }
+
+    if (GENERATED_PRICING_DOCUMENTS.has(path)) {
+      result.pricing = true
+      result.documentation_only = false
+      continue
+    }
+
+    if (GENERATED_PROVIDER_DOCUMENTS.has(path)) {
+      result.providers = true
       result.documentation_only = false
       continue
     }
@@ -256,9 +284,17 @@ function main() {
   }
 
   const base = process.argv[baseIndex + 1]
-  const changedPaths = changedPathsFrom(base)
-  const result = classifyDraftPaths(changedPaths)
-  applyPackageRisk(base, result, changedPaths)
+  let changedPaths = []
+  let result
+
+  try {
+    changedPaths = changedPathsFrom(base)
+    result = classifyDraftPaths(changedPaths)
+    applyPackageRisk(base, result, changedPaths)
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    result = failClosedClassification(`change classification failed: ${message}`)
+  }
 
   console.log(JSON.stringify({ changedPaths, ...result }, null, 2))
   writeGithubOutputs(result, changedPaths)

--- a/scripts/draft-surface-classifier.node-test.mjs
+++ b/scripts/draft-surface-classifier.node-test.mjs
@@ -4,6 +4,7 @@ import test from 'node:test'
 import {
   applyPackageChangeRisk,
   classifyDraftPaths,
+  failClosedClassification,
   isVersionOnlyPackageChange,
 } from './draft-surface-classifier.mjs'
 
@@ -56,6 +57,26 @@ test('allows ordinary documentation-only changes to remain cheap', () => {
   assert.equal(result.documentation_only, true)
   assert.equal(result.fallback_core, false)
   assert.equal(result.release, false)
+})
+
+test('keeps generated documentation on its owning validation surfaces', () => {
+  const result = classifyDraftPaths([
+    'docs/PRICING_HISTORY.md',
+    'docs/COLLECTOR_INVENTORY_V1.md',
+  ])
+
+  assert.equal(result.pricing, true)
+  assert.equal(result.providers, true)
+  assert.equal(result.documentation_only, false)
+  assert.equal(result.fallback_core, false)
+})
+
+test('forces complete validation when change classification cannot be trusted', () => {
+  const result = failClosedClassification('missing base commit')
+
+  assert.equal(result.documentation_only, false)
+  assert.equal(result.fallback_core, true)
+  assert.deepEqual(result.fallback_paths, ['missing base commit'])
 })
 
 test('treats release guidance, workflows and script helpers as release surfaces', () => {


### PR DESCRIPTION
## Summary

Reduce CI waste for ordinary documentation-only changes without weakening validation for executable, generated, release-sensitive or unknown surfaces.

- reuse the existing change-surface classifier as the single authority for both draft and ready-for-review pull requests;
- keep the lightweight version-authority job and classifier tests running on every change;
- skip Semgrep, the Ubuntu/Windows desktop matrix and the complete core suite only when every changed path is ordinary documentation;
- keep generated pricing and collector-inventory documents on their owning validation surfaces;
- fail closed to the complete core suite when the base commit or classification cannot be trusted;
- leave the Windows Candidate workflow unchanged.

## Scope

Exactly three files:

- `.github/workflows/ci.yml`
- `scripts/draft-surface-classifier.mjs`
- `scripts/draft-surface-classifier.node-test.mjs`

No runtime, parser, packaging, release artifact, product behavior or new CI gate is introduced.

## Validation

- classifier tests: 15/15 pass;
- ordinary documentation resolves to `documentation_only=true`;
- generated pricing/provider documents remain non-documentation-only;
- unknown paths and unusable base commits force `fallback_core=true`;
- branch is one commit ahead of `42c5f842eb8b2daa55def28be14c04849349c0a6` with no divergence.

This pull request intentionally runs the current full validation once because it changes the validation authority itself.