### PR TITLE
feat(history): add canonical read projection

### DIFF
--- a/docs/CANONICAL_HISTORY_READ_PROJECTION_V1.md
+++ b/docs/CANONICAL_HISTORY_READ_PROJECTION_V1.md
@@ -1,0 +1,118 @@
+# Canonical history read projection v1
+
+**Status:** C3-P0.A shadow read contract; implemented without consumer cutover.
+
+This contract makes source-observation and activity identity explicit while the existing trusted daily cache remains authoritative for user-visible historical totals.
+
+It is deliberately read-only. It does not create a database, migrate a cache, change reports or authorize synchronization.
+
+## Authorities
+
+The projection exposes three separate collections:
+
+1. **observations** — path-free identities and content-minimal accounting evidence derived from the complete current session cache;
+2. **activities** — deterministic groupings of source-observed calls derived from provider, private session identity, source timestamp and the first source-record fingerprint;
+3. **daily snapshots** — sanitized copies of the trusted complete daily cache, including carried history that can no longer be reconstructed from source files.
+
+Observation and activity collections are shadow authorities in v1. Daily snapshots remain the totals authority.
+
+These collections are **not additive**. A source-backed observation may also be represented inside a daily snapshot. Consumers must not sum observations and daily snapshots.
+
+## Observation identity
+
+The projection reuses `canonicalSourceRecordFingerprintSha256V1`, the same endpoint-scoped, path-free source-record identity already used by reviewed production.
+
+The fingerprint is derived from:
+
+- protected endpoint identity;
+- collector/provider section;
+- the collector's private deduplication key.
+
+The local source path and private deduplication key are not emitted. The endpoint scope prevents identical copied source records on different endpoints from becoming a public cross-device correlation handle.
+
+One fingerprint may resolve to only one observation representation. Conflicting reuse fails closed.
+
+## Activity identity
+
+An activity groups the ordered observations emitted by one cached turn.
+
+Its identity is derived from:
+
+- protected endpoint identity;
+- collector/provider section;
+- private session identity;
+- source-observed turn timestamp;
+- the first observation fingerprint.
+
+Private session identity is hashed and never emitted. Local day, timezone, cache version and file path are not activity-identity inputs.
+
+A timezone change may therefore move a daily snapshot boundary without changing observation or activity identity.
+
+## Accounting evidence
+
+Each observation preserves:
+
+- collector;
+- source timestamp;
+- model and explicit source-recorded model provider when available;
+- normalized token usage;
+- immutable cost assignment;
+- numeric canonical cost only when the assignment is settled;
+- legacy comparison cost when already retained by the session cache;
+- estimated-cost marker and speed class.
+
+`explicit-zero` remains numeric zero. `unavailable` remains `null` and is never converted into an intentional zero. Mismatched cost evidence fails closed.
+
+The projection does not reprice calls and does not introduce a second pricing engine.
+
+## Retained history
+
+Source files may expire while their history remains preserved in the daily cache. C3-P0.A keeps that history as a daily snapshot, including the `carried` marker.
+
+It does not invent source observations, activities, sessions or project assignments from aggregate-only history.
+
+Project paths are removed from snapshots. Existing local project keys and numeric rollups remain available for local reconciliation, while unavailable historical project detail stays unavailable.
+
+## Integrity requirements
+
+The projection requires:
+
+- the current session-cache version;
+- a complete session cache;
+- the current daily-cache version;
+- a complete daily cache;
+- a trusted daily watermark;
+- valid timestamps;
+- provider-section agreement;
+- non-empty private source and session identities;
+- internally consistent immutable cost assignments.
+
+Unknown, stale, incomplete or contradictory state fails closed.
+
+## Privacy boundary
+
+The projection omits:
+
+- source paths;
+- project paths;
+- private deduplication keys;
+- private session identifiers;
+- prompts and responses;
+- commands, tool inputs, source code and patches;
+- endpoint secrets and receipt material.
+
+It remains an endpoint-local internal projection. No export or remote transport is authorized by this contract.
+
+## Non-goals
+
+C3-P0.A does not provide:
+
+- persistent canonical-history storage;
+- cache-schema changes;
+- migration or backfill;
+- report, CLI, desktop, Workspace or Android cutover;
+- server ingestion or synchronization;
+- account, team, billing or managed infrastructure;
+- a second collector, parser, pricing or evidence implementation.
+
+A later shadow-persistence tranche must prove parity and rollback independently before any consumer can change authority.

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,7 @@ This index separates user guidance, current product guarantees, public contracts
 - [Product principles](PRODUCT_PRINCIPLES.md) — stable local-first, privacy, evidence and portability commitments.
 - [Product lineage](PRODUCT_LINEAGE.md) — inherited foundations, material Metrora changes and compatibility identifiers.
 - [Architecture](architecture.md) — current responsibility and authority map for the public codebase.
+- [Canonical history read projection v1](CANONICAL_HISTORY_READ_PROJECTION_V1.md) — shadow observation/activity identity and trusted daily-history boundary.
 - [Pricing history](PRICING_HISTORY.md) — date-effective rates, settled assignments and historical-cost behavior.
 - [Collector inventory v1](COLLECTOR_INVENTORY_V1.md) — generated technical inventory of registered collectors and signed-measurement eligibility.
 - [Public contracts v1](PUBLIC_CONTRACTS_V1.md) — public schemas, signed-data behavior and compatibility commitments.

--- a/src/local-state/canonical-history-read-projection.test.ts
+++ b/src/local-state/canonical-history-read-projection.test.ts
@@ -1,0 +1,264 @@
+import { describe, expect, it } from 'vitest'
+
+import { DAILY_CACHE_VERSION, type DailyCache, type DailyEntry } from '../daily-cache.js'
+import { CACHE_VERSION, type CachedCall, type CachedFile, type SessionCache } from '../session-cache.js'
+import {
+  CanonicalHistoryReadProjectionIntegrityError,
+  projectCanonicalHistoryReadV1,
+} from './canonical-history-read-projection.js'
+
+const ENDPOINT_ID = 'ep_11111111-2222-4333-8444-555555555555'
+
+function call(overrides: Partial<CachedCall> = {}): CachedCall {
+  return {
+    provider: 'zed',
+    model: 'gpt-5.6-luna',
+    modelProvider: 'zed.dev',
+    usage: {
+      inputTokens: 100,
+      outputTokens: 20,
+      cacheCreationInputTokens: 0,
+      cacheReadInputTokens: 25,
+      cachedInputTokens: 25,
+      reasoningTokens: 5,
+      webSearchRequests: 0,
+      cacheCreationOneHourTokens: 0,
+    },
+    costUSD: 1.25,
+    costAssignment: {
+      version: 1,
+      kind: 'metered',
+      amountMicrosUsd: 1_250_000,
+      source: 'provider',
+    },
+    speed: 'standard',
+    timestamp: '2026-08-01T21:00:01.000Z',
+    tools: [],
+    bashCommands: [],
+    skills: [],
+    subagentTypes: [],
+    deduplicationKey: 'zed:thread-1:request-1',
+    ...overrides,
+  }
+}
+
+function cachedFile(calls: CachedCall[], overrides: Partial<CachedFile> = {}): CachedFile {
+  return {
+    fingerprint: { dev: 1, ino: 2, mtimeMs: 3, sizeBytes: 4 },
+    mcpInventory: [],
+    turns: [{
+      timestamp: '2026-08-01T21:00:00.000Z',
+      sessionId: 'private-session-id',
+      userMessage: 'private prompt must not cross the projection',
+      calls,
+    }],
+    ...overrides,
+  }
+}
+
+function sessionCache(files: Record<string, CachedFile>, complete = true): SessionCache {
+  return {
+    version: CACHE_VERSION,
+    complete,
+    providers: {
+      zed: { envFingerprint: 'zed-test', files },
+    },
+  }
+}
+
+function day(overrides: Partial<DailyEntry> = {}): DailyEntry {
+  return {
+    date: '2026-08-01',
+    cost: 1.25,
+    savingsUSD: 0,
+    calls: 1,
+    sessions: 1,
+    inputTokens: 100,
+    outputTokens: 20,
+    cacheReadTokens: 25,
+    cacheWriteTokens: 0,
+    editTurns: 0,
+    oneShotTurns: 1,
+    models: {
+      'gpt-5.6-luna': {
+        calls: 1,
+        cost: 1.25,
+        savingsUSD: 0,
+        inputTokens: 100,
+        outputTokens: 20,
+        cacheReadTokens: 25,
+        cacheWriteTokens: 0,
+      },
+    },
+    categories: {
+      coding: { turns: 1, cost: 1.25, savingsUSD: 0, editTurns: 0, oneShotTurns: 1 },
+    },
+    providers: {
+      zed: {
+        calls: 1,
+        cost: 1.25,
+        savingsUSD: 0,
+        sessions: 1,
+        inputTokens: 100,
+        outputTokens: 20,
+        cacheReadTokens: 25,
+        cacheWriteTokens: 0,
+        projects: {
+          privateProject: { cost: 1.25, calls: 1, savingsUSD: 0, sessions: 1, path: '/private/project/path' },
+        },
+      },
+    },
+    projects: {
+      privateProject: { cost: 1.25, calls: 1, savingsUSD: 0, sessions: 1, path: '/private/project/path' },
+    },
+    ...overrides,
+  }
+}
+
+function dailyCache(days: DailyEntry[], options: { tzKey?: string; complete?: boolean; trusted?: boolean } = {}): DailyCache {
+  return {
+    version: DAILY_CACHE_VERSION,
+    savingsConfigHash: 'test',
+    tzKey: options.tzKey ?? 'Europe/Rome',
+    lastComputedDate: days.at(-1)?.date ?? null,
+    days,
+    complete: options.complete ?? true,
+    watermarkTrusted: options.trusted ?? true,
+  }
+}
+
+function project(input: { sessions?: SessionCache; days?: DailyCache } = {}) {
+  return projectCanonicalHistoryReadV1({
+    endpointId: ENDPOINT_ID,
+    sessionCache: input.sessions ?? sessionCache({ '/private/source-a': cachedFile([call()]) }),
+    dailyCache: input.days ?? dailyCache([day()]),
+  })
+}
+
+describe('canonical history read projection v1', () => {
+  it('keeps observation and activity identity independent from path, cache order, and timezone buckets', () => {
+    const first = project()
+    const moved = project({
+      sessions: sessionCache({ '/another/private/location': cachedFile([call()]) }),
+      days: dailyCache([day({ date: '2026-07-31' })], { tzKey: 'America/New_York' }),
+    })
+
+    expect(moved.observations.map(value => value.observationId)).toEqual(first.observations.map(value => value.observationId))
+    expect(moved.activities.map(value => value.activityId)).toEqual(first.activities.map(value => value.activityId))
+    expect(moved.dailySnapshots[0]!.date).not.toBe(first.dailySnapshots[0]!.date)
+    expect(moved.dailySnapshots[0]!.snapshotId).not.toBe(first.dailySnapshots[0]!.snapshotId)
+  })
+
+  it('is content-minimal and does not expose path, prompt, session id, or private deduplication material', () => {
+    const serialized = JSON.stringify(project())
+
+    expect(serialized).not.toContain('/private/source-a')
+    expect(serialized).not.toContain('/private/project/path')
+    expect(serialized).not.toContain('private prompt')
+    expect(serialized).not.toContain('private-session-id')
+    expect(serialized).not.toContain('zed:thread-1:request-1')
+    expect(serialized).toContain('privateProject')
+  })
+
+  it('deduplicates identical cache materializations and rejects conflicting reuse of one source identity', () => {
+    const duplicate = project({
+      sessions: sessionCache({
+        '/private/source-a': cachedFile([call()]),
+        '/private/source-b': cachedFile([call()]),
+      }),
+    })
+    expect(duplicate.observations).toHaveLength(1)
+    expect(duplicate.activities).toHaveLength(1)
+
+    expect(() => project({
+      sessions: sessionCache({
+        '/private/source-a': cachedFile([call()]),
+        '/private/source-b': cachedFile([call({ model: 'different-model' })]),
+      }),
+    })).toThrow(CanonicalHistoryReadProjectionIntegrityError)
+  })
+
+  it('preserves source-less carried history without inventing observations or activities', () => {
+    const projection = project({
+      sessions: {
+        version: CACHE_VERSION,
+        complete: true,
+        providers: {},
+      },
+      days: dailyCache([day({ carried: true })]),
+    })
+
+    expect(projection.observations).toEqual([])
+    expect(projection.activities).toEqual([])
+    expect(projection.dailySnapshots).toHaveLength(1)
+    expect(projection.dailySnapshots[0]).toMatchObject({
+      carried: true,
+      authority: 'trusted-daily-cache',
+    })
+    expect(projection.authority.additiveAcrossAuthorities).toBe(false)
+  })
+
+  it('keeps metered, explicit-zero, legacy-frozen, and unavailable cost evidence distinct', () => {
+    const projection = project({
+      sessions: sessionCache({
+        '/private/source-a': cachedFile([
+          call({ deduplicationKey: 'metered' }),
+          call({
+            deduplicationKey: 'zero',
+            costUSD: 0,
+            costAssignment: { version: 1, kind: 'explicit-zero', amountMicrosUsd: 0, reason: 'free-route' },
+          }),
+          call({
+            deduplicationKey: 'legacy',
+            costUSD: 1.5,
+            costAssignment: { version: 1, kind: 'legacy-frozen', amountMicrosUsd: 1_500_000, reason: 'unknown' },
+          }),
+          call({
+            deduplicationKey: 'unavailable',
+            costUSD: undefined,
+            costAssignment: { version: 1, kind: 'unavailable', reason: 'no-price-record' },
+          }),
+        ]),
+      }),
+    })
+
+    expect(projection.observations.map(value => value.costAssignment.kind).sort()).toEqual([
+      'explicit-zero',
+      'legacy-frozen',
+      'metered',
+      'unavailable',
+    ])
+    const unavailable = projection.observations.find(value => value.costAssignment.kind === 'unavailable')!
+    const explicitZero = projection.observations.find(value => value.costAssignment.kind === 'explicit-zero')!
+    expect(unavailable.costUSD).toBeNull()
+    expect(explicitZero.costUSD).toBe(0)
+  })
+
+  it('fails closed for incomplete, untrusted, stale-version, or contradictory cache authority', () => {
+    expect(() => project({ sessions: sessionCache({}, false) })).toThrow(CanonicalHistoryReadProjectionIntegrityError)
+    expect(() => project({ days: dailyCache([], { trusted: false }) })).toThrow(CanonicalHistoryReadProjectionIntegrityError)
+    expect(() => project({
+      sessions: sessionCache({ '/private/source-a': cachedFile([call({ provider: 'codex' })]) }),
+    })).toThrow(CanonicalHistoryReadProjectionIntegrityError)
+    expect(() => project({
+      sessions: { ...sessionCache({}), version: CACHE_VERSION - 1 },
+    })).toThrow(CanonicalHistoryReadProjectionIntegrityError)
+  })
+
+  it('returns deeply immutable, deterministically ordered output', () => {
+    const projection = project({
+      sessions: sessionCache({
+        '/z': cachedFile([call({ deduplicationKey: 'z' })]),
+        '/a': cachedFile([call({ deduplicationKey: 'a' })]),
+      }),
+    })
+
+    expect(projection.observations.map(value => value.observationId)).toEqual(
+      [...projection.observations.map(value => value.observationId)].sort(),
+    )
+    expect(Object.isFrozen(projection)).toBe(true)
+    expect(Object.isFrozen(projection.observations)).toBe(true)
+    expect(Object.isFrozen(projection.observations[0]!.usage)).toBe(true)
+    expect(Object.isFrozen(projection.dailySnapshots[0]!.providers)).toBe(true)
+  })
+})

--- a/src/local-state/canonical-history-read-projection.ts
+++ b/src/local-state/canonical-history-read-projection.ts
@@ -1,0 +1,332 @@
+import { createHash } from 'node:crypto'
+
+import { OpaqueIdSchema, TimestampSchema } from '../contracts/v1/common.js'
+import { DAILY_CACHE_VERSION, type DailyCache, type DailyEntry, type ProjectDayStats, type ProviderDaySlice } from '../daily-cache.js'
+import {
+  CostAssignmentV1Schema,
+  costAssignmentMatchesUsdV1,
+  type CostAssignmentV1,
+} from '../pricing/cost-assignment.js'
+import {
+  CACHE_VERSION,
+  type CachedCall,
+  type CachedUsage,
+  type SessionCache,
+} from '../session-cache.js'
+import { canonicalSourceRecordFingerprintSha256V1 } from './canonical-reviewed-production-scanner.js'
+
+export const CANONICAL_HISTORY_READ_PROJECTION_VERSION = 1 as const
+
+export type CanonicalObservationReadV1 = {
+  observationId: string
+  activityId: string
+  sourceFingerprintSha256: string
+  collector: string
+  timestamp: string
+  model: string
+  modelProvider?: string
+  usage: CachedUsage
+  costUSD: number | null
+  costAssignment: CostAssignmentV1
+  legacyCostUSD?: number
+  isEstimated: boolean
+  speed: 'standard' | 'fast'
+}
+
+export type CanonicalActivityReadV1 = {
+  activityId: string
+  collector: string
+  timestamp: string
+  observationIds: string[]
+}
+
+type PathFreeProjectDayStats = Omit<ProjectDayStats, 'path'>
+type PathFreeProviderDaySlice = Omit<ProviderDaySlice, 'projects'> & {
+  projects?: Record<string, PathFreeProjectDayStats>
+}
+
+export type CanonicalHistoryDaySnapshotV1 = Omit<DailyEntry, 'providers' | 'projects'> & {
+  snapshotId: string
+  bucketTimeZone: string | null
+  authority: 'trusted-daily-cache'
+  providers: Record<string, PathFreeProviderDaySlice>
+  projects?: Record<string, PathFreeProjectDayStats>
+}
+
+export type CanonicalHistoryReadProjectionV1 = {
+  version: typeof CANONICAL_HISTORY_READ_PROJECTION_VERSION
+  authority: {
+    observations: 'shadow-session-cache'
+    activities: 'shadow-session-cache'
+    totals: 'trusted-daily-cache'
+    additiveAcrossAuthorities: false
+  }
+  observations: CanonicalObservationReadV1[]
+  activities: CanonicalActivityReadV1[]
+  dailySnapshots: CanonicalHistoryDaySnapshotV1[]
+}
+
+export type CanonicalHistoryReadProjectionInputV1 = {
+  endpointId: string
+  sessionCache: SessionCache
+  dailyCache: DailyCache
+}
+
+export class CanonicalHistoryReadProjectionIntegrityError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'CanonicalHistoryReadProjectionIntegrityError'
+  }
+}
+
+function sha256Domain(domain: string, parts: readonly string[]): string {
+  const hash = createHash('sha256').update(domain).update('\0')
+  for (const part of parts) hash.update(part).update('\0')
+  return hash.digest('hex')
+}
+
+function stableJson(value: unknown): string {
+  if (value === null) return 'null'
+  if (typeof value === 'string' || typeof value === 'boolean') return JSON.stringify(value)
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) throw new CanonicalHistoryReadProjectionIntegrityError('canonical history accepts only finite numbers')
+    return JSON.stringify(value)
+  }
+  if (Array.isArray(value)) return `[${value.map(stableJson).join(',')}]`
+  if (value && typeof value === 'object') {
+    const record = value as Record<string, unknown>
+    return `{${Object.keys(record)
+      .filter(key => record[key] !== undefined)
+      .sort()
+      .map(key => `${JSON.stringify(key)}:${stableJson(record[key])}`)
+      .join(',')}}`
+  }
+  throw new CanonicalHistoryReadProjectionIntegrityError('canonical history cannot encode this value')
+}
+
+function deepFreeze<T>(value: T): T {
+  if (!value || typeof value !== 'object' || Object.isFrozen(value)) return value
+  Object.freeze(value)
+  for (const child of Object.values(value as Record<string, unknown>)) deepFreeze(child)
+  return value
+}
+
+function sortedRecord<T, R>(
+  input: Record<string, T> | undefined,
+  project: (value: T) => R,
+): Record<string, R> | undefined {
+  if (!input) return undefined
+  return Object.fromEntries(Object.entries(input).sort(([a], [b]) => a.localeCompare(b)).map(([key, value]) => [key, project(value)]))
+}
+
+function pathFreeProject(value: ProjectDayStats): PathFreeProjectDayStats {
+  return {
+    cost: value.cost,
+    calls: value.calls,
+    savingsUSD: value.savingsUSD,
+    sessions: value.sessions,
+  }
+}
+
+function pathFreeProvider(value: ProviderDaySlice): PathFreeProviderDaySlice {
+  return {
+    calls: value.calls,
+    cost: value.cost,
+    savingsUSD: value.savingsUSD,
+    ...(value.sessions !== undefined ? { sessions: value.sessions } : {}),
+    ...(value.inputTokens !== undefined ? { inputTokens: value.inputTokens } : {}),
+    ...(value.outputTokens !== undefined ? { outputTokens: value.outputTokens } : {}),
+    ...(value.cacheReadTokens !== undefined ? { cacheReadTokens: value.cacheReadTokens } : {}),
+    ...(value.cacheWriteTokens !== undefined ? { cacheWriteTokens: value.cacheWriteTokens } : {}),
+    ...(value.editTurns !== undefined ? { editTurns: value.editTurns } : {}),
+    ...(value.oneShotTurns !== undefined ? { oneShotTurns: value.oneShotTurns } : {}),
+    ...(value.models !== undefined ? { models: structuredClone(value.models) } : {}),
+    ...(value.categories !== undefined ? { categories: structuredClone(value.categories) } : {}),
+    ...(value.projects !== undefined ? { projects: sortedRecord(value.projects, pathFreeProject) } : {}),
+  }
+}
+
+function projectDailySnapshot(day: DailyEntry, bucketTimeZone: string | null): CanonicalHistoryDaySnapshotV1 {
+  const withoutId = {
+    date: day.date,
+    cost: day.cost,
+    savingsUSD: day.savingsUSD,
+    calls: day.calls,
+    sessions: day.sessions,
+    inputTokens: day.inputTokens,
+    outputTokens: day.outputTokens,
+    cacheReadTokens: day.cacheReadTokens,
+    cacheWriteTokens: day.cacheWriteTokens,
+    editTurns: day.editTurns,
+    oneShotTurns: day.oneShotTurns,
+    models: Object.fromEntries(Object.entries(day.models).sort(([a], [b]) => a.localeCompare(b)).map(([key, value]) => [key, structuredClone(value)])),
+    categories: Object.fromEntries(Object.entries(day.categories).sort(([a], [b]) => a.localeCompare(b)).map(([key, value]) => [key, structuredClone(value)])),
+    providers: sortedRecord(day.providers, pathFreeProvider) ?? {},
+    ...(day.projects !== undefined ? { projects: sortedRecord(day.projects, pathFreeProject) } : {}),
+    ...(day.carried === true ? { carried: true as const } : {}),
+    bucketTimeZone,
+    authority: 'trusted-daily-cache' as const,
+  }
+  return {
+    snapshotId: `history-day-v1:${sha256Domain('metrora-canonical-history-day-v1', [stableJson(withoutId)])}`,
+    ...withoutId,
+  }
+}
+
+function validatedCost(call: CachedCall): Pick<CanonicalObservationReadV1, 'costUSD' | 'costAssignment' | 'legacyCostUSD'> {
+  if (!call.costAssignment) {
+    throw new CanonicalHistoryReadProjectionIntegrityError('canonical cached call has no immutable cost assignment')
+  }
+  const assignment = CostAssignmentV1Schema.parse(call.costAssignment)
+  if (assignment.kind === 'unavailable') {
+    if (call.costUSD !== undefined) {
+      throw new CanonicalHistoryReadProjectionIntegrityError('unavailable cost assignment cannot carry a numeric canonical cost')
+    }
+    return {
+      costUSD: null,
+      costAssignment: structuredClone(assignment),
+      ...(call.legacyCostUSD !== undefined ? { legacyCostUSD: call.legacyCostUSD } : {}),
+    }
+  }
+  if (call.costUSD === undefined || !costAssignmentMatchesUsdV1(assignment, call.costUSD)) {
+    throw new CanonicalHistoryReadProjectionIntegrityError('canonical cost assignment disagrees with cached cost')
+  }
+  return {
+    costUSD: call.costUSD,
+    costAssignment: structuredClone(assignment),
+    ...(call.legacyCostUSD !== undefined ? { legacyCostUSD: call.legacyCostUSD } : {}),
+  }
+}
+
+function observationForCall(input: {
+  endpointId: string
+  collector: string
+  activityId: string
+  call: CachedCall
+}): CanonicalObservationReadV1 {
+  const timestamp = TimestampSchema.safeParse(input.call.timestamp)
+  if (!timestamp.success) throw new CanonicalHistoryReadProjectionIntegrityError('canonical cached call has an invalid timestamp')
+  if (input.call.provider !== input.collector) {
+    throw new CanonicalHistoryReadProjectionIntegrityError('canonical cached call provider disagrees with its provider section')
+  }
+  if (!input.call.deduplicationKey) {
+    throw new CanonicalHistoryReadProjectionIntegrityError('canonical cached call has an empty private deduplication key')
+  }
+  const sourceFingerprintSha256 = canonicalSourceRecordFingerprintSha256V1({
+    endpointId: input.endpointId,
+    provider: input.collector,
+    privateDeduplicationKey: input.call.deduplicationKey,
+  })
+  return {
+    observationId: `observation-v1:${sourceFingerprintSha256}`,
+    activityId: input.activityId,
+    sourceFingerprintSha256,
+    collector: input.collector,
+    timestamp: timestamp.data,
+    model: input.call.model,
+    ...(input.call.modelProvider !== undefined ? { modelProvider: input.call.modelProvider } : {}),
+    usage: structuredClone(input.call.usage),
+    ...validatedCost(input.call),
+    isEstimated: input.call.isEstimated === true,
+    speed: input.call.speed,
+  }
+}
+
+function sameValue(left: unknown, right: unknown): boolean {
+  return stableJson(left) === stableJson(right)
+}
+
+export function projectCanonicalHistoryReadV1(
+  inputValue: CanonicalHistoryReadProjectionInputV1,
+): CanonicalHistoryReadProjectionV1 {
+  const endpointId = OpaqueIdSchema.parse(inputValue.endpointId)
+  const { sessionCache, dailyCache } = inputValue
+
+  if (sessionCache.version !== CACHE_VERSION || sessionCache.complete !== true) {
+    throw new CanonicalHistoryReadProjectionIntegrityError('canonical history requires a complete current-version session cache')
+  }
+  if (
+    dailyCache.version !== DAILY_CACHE_VERSION ||
+    dailyCache.complete !== true ||
+    dailyCache.watermarkTrusted !== true
+  ) {
+    throw new CanonicalHistoryReadProjectionIntegrityError('canonical history requires a trusted complete current-version daily cache')
+  }
+
+  const observationsById = new Map<string, CanonicalObservationReadV1>()
+  const activitiesById = new Map<string, CanonicalActivityReadV1>()
+  const activityByObservation = new Map<string, string>()
+
+  for (const [collector, section] of Object.entries(sessionCache.providers).sort(([a], [b]) => a.localeCompare(b))) {
+    for (const [, file] of Object.entries(section.files).sort(([a], [b]) => a.localeCompare(b))) {
+      if (file.failed) continue
+      for (const turn of file.turns) {
+        if (!turn.sessionId) throw new CanonicalHistoryReadProjectionIntegrityError('canonical cached turn has an empty private session id')
+        const turnTimestamp = TimestampSchema.safeParse(turn.timestamp)
+        if (!turnTimestamp.success) throw new CanonicalHistoryReadProjectionIntegrityError('canonical cached turn has an invalid timestamp')
+        if (turn.calls.length === 0) continue
+
+        const firstCall = turn.calls[0]!
+        if (!firstCall.deduplicationKey) {
+          throw new CanonicalHistoryReadProjectionIntegrityError('canonical cached call has an empty private deduplication key')
+        }
+        const firstFingerprint = canonicalSourceRecordFingerprintSha256V1({
+          endpointId,
+          provider: collector,
+          privateDeduplicationKey: firstCall.deduplicationKey,
+        })
+        const activityId = `activity-v1:${sha256Domain('metrora-canonical-activity-v1', [
+          endpointId,
+          collector,
+          turn.sessionId,
+          turnTimestamp.data,
+          firstFingerprint,
+        ])}`
+
+        const observationIds: string[] = []
+        for (const call of turn.calls) {
+          const observation = observationForCall({ endpointId, collector, activityId, call })
+          const prior = observationsById.get(observation.observationId)
+          if (prior && !sameValue(prior, observation)) {
+            throw new CanonicalHistoryReadProjectionIntegrityError('one canonical source identity resolved to conflicting observations')
+          }
+          const priorActivity = activityByObservation.get(observation.observationId)
+          if (priorActivity && priorActivity !== activityId) {
+            throw new CanonicalHistoryReadProjectionIntegrityError('one canonical observation resolved to conflicting activities')
+          }
+          observationsById.set(observation.observationId, prior ?? observation)
+          activityByObservation.set(observation.observationId, activityId)
+          if (!observationIds.includes(observation.observationId)) observationIds.push(observation.observationId)
+        }
+
+        const activity: CanonicalActivityReadV1 = {
+          activityId,
+          collector,
+          timestamp: turnTimestamp.data,
+          observationIds,
+        }
+        const priorActivity = activitiesById.get(activityId)
+        if (priorActivity && !sameValue(priorActivity, activity)) {
+          throw new CanonicalHistoryReadProjectionIntegrityError('one canonical activity identity resolved to conflicting observations')
+        }
+        activitiesById.set(activityId, priorActivity ?? activity)
+      }
+    }
+  }
+
+  const projection: CanonicalHistoryReadProjectionV1 = {
+    version: CANONICAL_HISTORY_READ_PROJECTION_VERSION,
+    authority: {
+      observations: 'shadow-session-cache',
+      activities: 'shadow-session-cache',
+      totals: 'trusted-daily-cache',
+      additiveAcrossAuthorities: false,
+    },
+    observations: [...observationsById.values()].sort((a, b) => a.observationId.localeCompare(b.observationId)),
+    activities: [...activitiesById.values()].sort((a, b) => a.activityId.localeCompare(b.activityId)),
+    dailySnapshots: dailyCache.days
+      .map(day => projectDailySnapshot(day, dailyCache.tzKey ?? null))
+      .sort((a, b) => a.date.localeCompare(b.date) || a.snapshotId.localeCompare(b.snapshotId)),
+  }
+  return deepFreeze(projection)
+}


### PR DESCRIPTION
## Summary

Start C3-P0.A with a removable read-only projection that makes source-observation and activity identity explicit while leaving current reports and persistence authority unchanged.

- reuse the existing endpoint-scoped, path-free source-record fingerprint used by reviewed production;
- derive deterministic activity identities without using local day, timezone, cache version or file path;
- expose content-minimal observation accounting evidence with immutable cost assignments;
- preserve trusted daily-cache slices, including source-less carried history, as the separate totals authority;
- state mechanically that observation/activity and daily-snapshot collections are not additive;
- fail closed for stale, incomplete, untrusted or contradictory cache state;
- omit source paths, project paths, prompts, session IDs and private deduplication material.

Closes no consumer migration and does not complete C3-P0. Tracks the first tranche of #126.

## Authority boundary

- observations: shadow session-cache projection;
- activities: shadow session-cache projection;
- totals: current trusted daily cache;
- no database, writer, cache schema bump, migration, backfill or consumer cutover.

## Scope

Exactly four files:

- `src/local-state/canonical-history-read-projection.ts`
- `src/local-state/canonical-history-read-projection.test.ts`
- `docs/CANONICAL_HISTORY_READ_PROJECTION_V1.md`
- `docs/README.md`

No CLI, desktop, Android, Workspace, release packaging, server, account, sync or billing behavior is changed.

## Validation before CI

- strict isolated TypeScript check: pass;
- isolated runtime characterization: pass;
- path/timezone identity stability: pass;
- exact duplicate deduplication and conflicting identity rejection: pass;
- carried aggregate-only history preservation: pass;
- explicit-zero versus unavailable cost handling: pass;
- deep immutability and privacy omission checks: pass;
- source-size ratchet: 332 production lines, below the 600-line limit;
- branch is one commit ahead of `42c5f842eb8b2daa55def28be14c04849349c0a6` with no divergence.

Repository CI remains the integration authority.