### PR TITLE
feat(history): persist canonical shadow snapshots

### DIFF
--- a/docs/CANONICAL_HISTORY_SHADOW_STORE_V1.md
+++ b/docs/CANONICAL_HISTORY_SHADOW_STORE_V1.md
@@ -1,0 +1,121 @@
+# Canonical history shadow store v1
+
+**Status:** C3-P0.B endpoint-local shadow persistence; no consumer authority.
+
+The shadow store persists successive outputs of the [canonical history read projection v1](CANONICAL_HISTORY_READ_PROJECTION_V1.md) so identity stability, retention and reconciliation can be tested across refreshes and source expiry.
+
+It does not replace the session cache, daily cache, reports, Workspace evidence or any user-visible read path.
+
+## Storage layout
+
+The store uses the canonical private Metrora data directory:
+
+```text
+history-shadow/
+└── v1/
+    ├── head.json
+    └── snapshots/
+        └── <projection-sha256>.json
+```
+
+Each snapshot is immutable and content-addressed by an RFC 8785 canonical digest of the complete projection.
+
+The head is a small atomic pointer to the latest accepted snapshot.
+
+## Publication order
+
+A distinct projection is published in this order:
+
+1. validate the projection version, authority boundary and privacy constraints;
+2. load and validate all retained snapshots;
+3. reject identity conflicts against retained history;
+4. write the immutable content-addressed snapshot atomically;
+5. advance the head atomically.
+
+If the process stops after step 4, the next identical call recognizes the existing snapshot and repairs the missing head.
+
+A head that points to a missing or invalid snapshot is an integrity failure. It is not treated as an empty store.
+
+## Idempotence and retention
+
+Writing the same projection again is a no-op:
+
+- no second snapshot is created;
+- the head timestamp is not rewritten;
+- observation, activity and daily-snapshot identities reconcile as unchanged.
+
+When a distinct projection becomes current:
+
+- the previous snapshot remains on disk;
+- the head advances to the new digest;
+- reconciliation reports identities that were added, unchanged or retained only in the previous head.
+
+Retained-only observations or activities are not silently copied into the new projection. Their earlier immutable snapshot remains available for later C3 reconciliation work.
+
+## Historical conflict detection
+
+Before accepting a new projection, the store scans all retained snapshots.
+
+One observation, activity or daily-snapshot identity may not resolve to different canonical payloads anywhere in retained shadow history.
+
+A conflicting reuse fails closed and does not advance the head.
+
+This rule still applies when the conflicting identity disappeared from the immediately previous head and reappears later.
+
+## Privacy boundary
+
+The store accepts only the content-minimal projection contract.
+
+It rejects persisted objects containing private source material such as:
+
+- source or project paths;
+- private session identifiers;
+- private deduplication keys;
+- prompts or responses;
+- commands or tool arguments.
+
+The shadow files contain hashed observation and activity identities, normalized accounting evidence and path-free trusted daily snapshots. They are local private state and are not export or synchronization contracts.
+
+## Current authority
+
+C3-P0.B is mechanically non-authoritative for product consumers:
+
+- session cache remains the source-present parse materialization;
+- trusted daily cache remains the historical totals authority;
+- CLI, desktop, Workspace and Android do not read the shadow store;
+- removing `history-shadow/v1` does not change existing product behavior.
+
+The store is evidence for future parity and migration decisions, not a migration itself.
+
+## Failure and recovery
+
+The store fails closed for:
+
+- unsupported projection or store versions;
+- invalid authority metadata;
+- malformed or duplicate identities;
+- invalid canonical JSON;
+- digest mismatch;
+- unexpected snapshot files;
+- corrupt head metadata;
+- missing head targets;
+- conflicts with any retained snapshot.
+
+Atomic temporary files use the existing local-state cleanup and Windows mutation retry behavior.
+
+No automatic deletion, compaction or destructive repair is performed in v1.
+
+## Non-goals
+
+This tranche does not provide:
+
+- a database or SQLite schema;
+- session-cache or daily-cache migration;
+- automatic backfill;
+- unioned canonical consumer reads;
+- CLI, desktop, Workspace or Android cutover;
+- server ingestion or synchronization;
+- account, billing or managed infrastructure;
+- a second parser, pricing or evidence engine.
+
+A later tranche must prove consumer parity, rollback and state-preserving migration before any current authority can change.

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,7 @@ This index separates user guidance, current product guarantees, public contracts
 - [Product lineage](PRODUCT_LINEAGE.md) — inherited foundations, material Metrora changes and compatibility identifiers.
 - [Architecture](architecture.md) — current responsibility and authority map for the public codebase.
 - [Canonical history read projection v1](CANONICAL_HISTORY_READ_PROJECTION_V1.md) — shadow observation/activity identity and trusted daily-history boundary.
+- [Canonical history shadow store v1](CANONICAL_HISTORY_SHADOW_STORE_V1.md) — removable content-addressed persistence and cross-refresh reconciliation.
 - [Pricing history](PRICING_HISTORY.md) — date-effective rates, settled assignments and historical-cost behavior.
 - [Collector inventory v1](COLLECTOR_INVENTORY_V1.md) — generated technical inventory of registered collectors and signed-measurement eligibility.
 - [Public contracts v1](PUBLIC_CONTRACTS_V1.md) — public schemas, signed-data behavior and compatibility commitments.

--- a/src/local-state/canonical-history-shadow-store.test.ts
+++ b/src/local-state/canonical-history-shadow-store.test.ts
@@ -1,0 +1,232 @@
+import { mkdtemp, mkdir, readFile, readdir, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import type { CanonicalHistoryReadProjectionV1 } from './canonical-history-read-projection.js'
+import {
+  CANONICAL_HISTORY_SHADOW_HEAD_KIND,
+  CANONICAL_HISTORY_SHADOW_SNAPSHOT_KIND,
+  CANONICAL_HISTORY_SHADOW_STORE_VERSION,
+  CanonicalHistoryShadowStoreIntegrityError,
+  canonicalHistoryShadowPathsV1,
+  canonicalHistoryShadowProjectionSha256V1,
+  persistCanonicalHistoryShadowV1,
+  readCanonicalHistoryShadowHeadV1,
+} from './canonical-history-shadow-store.js'
+
+const roots: string[] = []
+
+async function temporaryDataDir(): Promise<string> {
+  const path = await mkdtemp(join(tmpdir(), 'metrora-history-shadow-'))
+  roots.push(path)
+  return path
+}
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map(path => rm(path, { recursive: true, force: true })))
+})
+
+function hex(character: string): string {
+  return character.repeat(64)
+}
+
+function projection(character = 'a'): CanonicalHistoryReadProjectionV1 {
+  const observationId = `observation-v1:${hex(character)}`
+  const activityId = `activity-v1:${hex(character === 'f' ? 'e' : String.fromCharCode(character.charCodeAt(0) + 1))}`
+  const snapshotId = `history-day-v1:${hex(character === 'f' ? 'd' : String.fromCharCode(character.charCodeAt(0) + 2))}`
+  return {
+    version: 1,
+    authority: {
+      observations: 'shadow-session-cache',
+      activities: 'shadow-session-cache',
+      totals: 'trusted-daily-cache',
+      additiveAcrossAuthorities: false,
+    },
+    observations: [{
+      observationId,
+      activityId,
+      sourceFingerprintSha256: hex(character),
+      collector: 'zed',
+      timestamp: '2026-08-01T21:00:01.000Z',
+      model: `model-${character}`,
+      modelProvider: 'zed.dev',
+      usage: {
+        inputTokens: 100,
+        outputTokens: 20,
+        cacheCreationInputTokens: 0,
+        cacheReadInputTokens: 25,
+        cachedInputTokens: 25,
+        reasoningTokens: 5,
+        webSearchRequests: 0,
+        cacheCreationOneHourTokens: 0,
+      },
+      costUSD: 1.25,
+      costAssignment: {
+        version: 1,
+        kind: 'metered',
+        amountMicrosUsd: 1_250_000,
+        source: 'provider',
+      },
+      isEstimated: false,
+      speed: 'standard',
+    }],
+    activities: [{
+      activityId,
+      collector: 'zed',
+      timestamp: '2026-08-01T21:00:00.000Z',
+      observationIds: [observationId],
+    }],
+    dailySnapshots: [{
+      snapshotId,
+      date: '2026-08-01',
+      cost: 1.25,
+      savingsUSD: 0,
+      calls: 1,
+      sessions: 1,
+      inputTokens: 100,
+      outputTokens: 20,
+      cacheReadTokens: 25,
+      cacheWriteTokens: 0,
+      editTurns: 0,
+      oneShotTurns: 1,
+      models: {},
+      categories: {},
+      providers: {},
+      bucketTimeZone: 'Europe/Rome',
+      authority: 'trusted-daily-cache',
+    }],
+  }
+}
+
+describe('canonical history shadow store v1', () => {
+  it('publishes one immutable content-addressed snapshot and remains idempotent', async () => {
+    const dataDir = await temporaryDataDir()
+    const value = projection()
+    const first = await persistCanonicalHistoryShadowV1(value, {
+      dataDir,
+      now: () => new Date('2026-08-05T20:00:00.000Z'),
+    })
+    const paths = canonicalHistoryShadowPathsV1(dataDir)
+    const firstHead = await readFile(paths.head, 'utf-8')
+
+    expect(first.status).toBe('initialized')
+    expect(first.reconciliation.observations).toEqual({ added: 1, unchanged: 0, retainedOnly: 0 })
+    expect(await readdir(paths.snapshots)).toEqual([`${first.projectionSha256}.json`])
+
+    const second = await persistCanonicalHistoryShadowV1(value, {
+      dataDir,
+      now: () => new Date('2026-08-05T21:00:00.000Z'),
+    })
+
+    expect(second.status).toBe('unchanged')
+    expect(second.projectionSha256).toBe(first.projectionSha256)
+    expect(second.reconciliation.observations).toEqual({ added: 0, unchanged: 1, retainedOnly: 0 })
+    expect(await readFile(paths.head, 'utf-8')).toBe(firstHead)
+    expect(await readdir(paths.snapshots)).toEqual([`${first.projectionSha256}.json`])
+  })
+
+  it('advances the head without deleting earlier snapshots and reports retained-only identities', async () => {
+    const dataDir = await temporaryDataDir()
+    const first = await persistCanonicalHistoryShadowV1(projection('a'), { dataDir })
+    const second = await persistCanonicalHistoryShadowV1(projection('d'), { dataDir })
+    const paths = canonicalHistoryShadowPathsV1(dataDir)
+
+    expect(second.status).toBe('advanced')
+    expect(second.previousProjectionSha256).toBe(first.projectionSha256)
+    expect(second.reconciliation).toEqual({
+      observations: { added: 1, unchanged: 0, retainedOnly: 1 },
+      activities: { added: 1, unchanged: 0, retainedOnly: 1 },
+      dailySnapshots: { added: 1, unchanged: 0, retainedOnly: 1 },
+    })
+    expect((await readdir(paths.snapshots)).sort()).toEqual([
+      `${first.projectionSha256}.json`,
+      `${second.projectionSha256}.json`,
+    ].sort())
+    expect((await readCanonicalHistoryShadowHeadV1({ dataDir }))?.projectionSha256).toBe(second.projectionSha256)
+  })
+
+  it('rejects conflicting reuse of an observation identity and leaves the previous head unchanged', async () => {
+    const dataDir = await temporaryDataDir()
+    const firstProjection = projection()
+    const first = await persistCanonicalHistoryShadowV1(firstProjection, { dataDir })
+    const middle = await persistCanonicalHistoryShadowV1(projection('d'), { dataDir })
+    const conflicting = structuredClone(firstProjection)
+    conflicting.observations[0]!.model = 'conflicting-model'
+
+    await expect(persistCanonicalHistoryShadowV1(conflicting, { dataDir }))
+      .rejects.toThrow(CanonicalHistoryShadowStoreIntegrityError)
+
+    expect((await readCanonicalHistoryShadowHeadV1({ dataDir }))?.projectionSha256).toBe(middle.projectionSha256)
+    expect((await readdir(canonicalHistoryShadowPathsV1(dataDir).snapshots)).sort()).toEqual([
+      `${first.projectionSha256}.json`,
+      `${middle.projectionSha256}.json`,
+    ].sort())
+  })
+
+  it('repairs publication when the immutable snapshot exists but the head write was interrupted', async () => {
+    const dataDir = await temporaryDataDir()
+    const value = projection()
+    const digest = canonicalHistoryShadowProjectionSha256V1(value)
+    const paths = canonicalHistoryShadowPathsV1(dataDir)
+    await mkdir(paths.snapshots, { recursive: true })
+    await writeFile(join(paths.snapshots, `${digest}.json`), JSON.stringify({
+      kind: CANONICAL_HISTORY_SHADOW_SNAPSHOT_KIND,
+      version: CANONICAL_HISTORY_SHADOW_STORE_VERSION,
+      projectionSha256: digest,
+      createdAt: '2026-08-05T20:00:00.000Z',
+      projection: value,
+    }))
+
+    const result = await persistCanonicalHistoryShadowV1(value, {
+      dataDir,
+      now: () => new Date('2026-08-05T20:05:00.000Z'),
+    })
+
+    expect(result.status).toBe('recovered-head')
+    expect((await readCanonicalHistoryShadowHeadV1({ dataDir }))?.projectionSha256).toBe(digest)
+    expect(await readdir(paths.snapshots)).toEqual([`${digest}.json`])
+  })
+
+  it('fails closed for corrupt snapshots and missing head targets', async () => {
+    const dataDir = await temporaryDataDir()
+    const value = projection()
+    const stored = await persistCanonicalHistoryShadowV1(value, { dataDir })
+    const paths = canonicalHistoryShadowPathsV1(dataDir)
+    const snapshot = join(paths.snapshots, `${stored.projectionSha256}.json`)
+    const corrupted = JSON.parse(await readFile(snapshot, 'utf-8')) as Record<string, unknown>
+    const corruptedProjection = structuredClone(value)
+    corruptedProjection.observations[0]!.model = 'corrupted'
+    corrupted.projection = corruptedProjection
+    await writeFile(snapshot, JSON.stringify(corrupted))
+
+    await expect(readCanonicalHistoryShadowHeadV1({ dataDir }))
+      .rejects.toThrow(CanonicalHistoryShadowStoreIntegrityError)
+
+    const missingDataDir = await temporaryDataDir()
+    const missingPaths = canonicalHistoryShadowPathsV1(missingDataDir)
+    await mkdir(missingPaths.root, { recursive: true })
+    await writeFile(missingPaths.head, JSON.stringify({
+      kind: CANONICAL_HISTORY_SHADOW_HEAD_KIND,
+      version: CANONICAL_HISTORY_SHADOW_STORE_VERSION,
+      projectionSha256: hex('f'),
+      updatedAt: '2026-08-05T20:00:00.000Z',
+    }))
+
+    await expect(readCanonicalHistoryShadowHeadV1({ dataDir: missingDataDir }))
+      .rejects.toThrow(CanonicalHistoryShadowStoreIntegrityError)
+  })
+
+  it('refuses private source material before creating persistent shadow state', async () => {
+    const dataDir = await temporaryDataDir()
+    const unsafe = structuredClone(projection()) as CanonicalHistoryReadProjectionV1 & {
+      observations: Array<CanonicalHistoryReadProjectionV1['observations'][number] & { sessionId?: string }>
+    }
+    unsafe.observations[0]!.sessionId = 'private-session-id'
+
+    await expect(persistCanonicalHistoryShadowV1(unsafe, { dataDir }))
+      .rejects.toThrow(CanonicalHistoryShadowStoreIntegrityError)
+
+    await expect(readCanonicalHistoryShadowHeadV1({ dataDir })).resolves.toBeUndefined()
+  })
+})

--- a/src/local-state/canonical-history-shadow-store.ts
+++ b/src/local-state/canonical-history-shadow-store.ts
@@ -1,0 +1,419 @@
+import { createHash } from 'node:crypto'
+import { readdir } from 'node:fs/promises'
+import { join } from 'node:path'
+import * as z from 'zod/v4'
+
+import { Sha256DigestSchema, TimestampSchema } from '../contracts/v1/common.js'
+import {
+  atomicWritePrivateFile,
+  cleanupStaleAtomicTemps,
+  ensurePrivateDirectory,
+  readOptionalPrivateFile,
+} from './atomic-file.js'
+import {
+  CANONICAL_HISTORY_READ_PROJECTION_VERSION,
+  type CanonicalHistoryReadProjectionV1,
+} from './canonical-history-read-projection.js'
+import { defaultMetroraDataDir } from './endpoint-identity.js'
+import { withLocalStateLease } from './local-state-lease.js'
+import { canonicalizeRfc8785 } from '../vendor/rfc8785-canonicalize.js'
+
+export const CANONICAL_HISTORY_SHADOW_SNAPSHOT_KIND = 'metrora.canonical-history-shadow-snapshot' as const
+export const CANONICAL_HISTORY_SHADOW_HEAD_KIND = 'metrora.canonical-history-shadow-head' as const
+export const CANONICAL_HISTORY_SHADOW_STORE_VERSION = 1 as const
+
+const CanonicalHistoryShadowSnapshotV1Schema = z.strictObject({
+  kind: z.literal(CANONICAL_HISTORY_SHADOW_SNAPSHOT_KIND),
+  version: z.literal(CANONICAL_HISTORY_SHADOW_STORE_VERSION),
+  projectionSha256: Sha256DigestSchema,
+  createdAt: TimestampSchema,
+  projection: z.unknown(),
+})
+
+const CanonicalHistoryShadowHeadV1Schema = z.strictObject({
+  kind: z.literal(CANONICAL_HISTORY_SHADOW_HEAD_KIND),
+  version: z.literal(CANONICAL_HISTORY_SHADOW_STORE_VERSION),
+  projectionSha256: Sha256DigestSchema,
+  updatedAt: TimestampSchema,
+})
+
+export type CanonicalHistoryShadowSnapshotV1 = z.infer<typeof CanonicalHistoryShadowSnapshotV1Schema>
+export type CanonicalHistoryShadowHeadV1 = z.infer<typeof CanonicalHistoryShadowHeadV1Schema>
+
+export type CanonicalHistoryShadowStoreOptions = {
+  dataDir?: string
+  now?: () => Date
+}
+
+export type CanonicalHistoryShadowEntityReconciliationV1 = {
+  added: number
+  unchanged: number
+  retainedOnly: number
+}
+
+export type CanonicalHistoryShadowReconciliationV1 = {
+  observations: CanonicalHistoryShadowEntityReconciliationV1
+  activities: CanonicalHistoryShadowEntityReconciliationV1
+  dailySnapshots: CanonicalHistoryShadowEntityReconciliationV1
+}
+
+export type PersistCanonicalHistoryShadowResultV1 = {
+  status: 'initialized' | 'unchanged' | 'advanced' | 'recovered-head'
+  projectionSha256: string
+  previousProjectionSha256?: string
+  reconciliation: CanonicalHistoryShadowReconciliationV1
+}
+
+export class CanonicalHistoryShadowStoreIntegrityError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'CanonicalHistoryShadowStoreIntegrityError'
+  }
+}
+
+type EntityIndex = Map<string, string>
+
+type ProjectionIndex = {
+  observations: EntityIndex
+  activities: EntityIndex
+  dailySnapshots: EntityIndex
+}
+
+const FORBIDDEN_PERSISTED_KEYS = new Set([
+  'path',
+  'sourcePath',
+  'projectPath',
+  'sessionId',
+  'deduplicationKey',
+  'privateDeduplicationKey',
+  'userMessage',
+  'assistantMessage',
+  'prompt',
+  'response',
+  'command',
+  'commands',
+  'toolInput',
+  'toolArguments',
+])
+
+function canonicalProjectionJson(value: unknown): string {
+  try {
+    return canonicalizeRfc8785(value)
+  } catch {
+    throw new CanonicalHistoryShadowStoreIntegrityError('canonical history shadow projection is not valid canonical JSON')
+  }
+}
+
+export function canonicalHistoryShadowProjectionSha256V1(value: unknown): string {
+  return createHash('sha256')
+    .update('metrora-canonical-history-shadow-projection-v1')
+    .update('\0')
+    .update(canonicalProjectionJson(value))
+    .digest('hex')
+}
+
+function objectRecord(value: unknown, label: string): Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new CanonicalHistoryShadowStoreIntegrityError(`${label} must be an object`)
+  }
+  return value as Record<string, unknown>
+}
+
+function assertPrivacyBoundary(value: unknown, path = 'projection'): void {
+  if (Array.isArray(value)) {
+    value.forEach((child, index) => assertPrivacyBoundary(child, `${path}[${index}]`))
+    return
+  }
+  if (!value || typeof value !== 'object') return
+  for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
+    if (FORBIDDEN_PERSISTED_KEYS.has(key)) {
+      throw new CanonicalHistoryShadowStoreIntegrityError(`${path}.${key} is forbidden in shadow history`)
+    }
+    assertPrivacyBoundary(child, `${path}.${key}`)
+  }
+}
+
+function indexEntities(
+  input: unknown,
+  collection: string,
+  idField: string,
+): EntityIndex {
+  if (!Array.isArray(input)) {
+    throw new CanonicalHistoryShadowStoreIntegrityError(`${collection} must be an array`)
+  }
+  const index = new Map<string, string>()
+  for (const [position, value] of input.entries()) {
+    const record = objectRecord(value, `${collection}[${position}]`)
+    const id = record[idField]
+    if (typeof id !== 'string' || id.trim() === '') {
+      throw new CanonicalHistoryShadowStoreIntegrityError(`${collection}[${position}].${idField} must be a non-empty string`)
+    }
+    if (index.has(id)) {
+      throw new CanonicalHistoryShadowStoreIntegrityError(`${collection} contains duplicate identity ${id}`)
+    }
+    index.set(id, canonicalProjectionJson(record))
+  }
+  return index
+}
+
+function indexProjection(value: unknown): ProjectionIndex {
+  const projection = objectRecord(value, 'projection')
+  if (projection.version !== CANONICAL_HISTORY_READ_PROJECTION_VERSION) {
+    throw new CanonicalHistoryShadowStoreIntegrityError('shadow projection has an unsupported version')
+  }
+  const authority = objectRecord(projection.authority, 'projection.authority')
+  if (
+    authority.observations !== 'shadow-session-cache' ||
+    authority.activities !== 'shadow-session-cache' ||
+    authority.totals !== 'trusted-daily-cache' ||
+    authority.additiveAcrossAuthorities !== false
+  ) {
+    throw new CanonicalHistoryShadowStoreIntegrityError('shadow projection authority boundary is invalid')
+  }
+  assertPrivacyBoundary(projection)
+  return {
+    observations: indexEntities(projection.observations, 'projection.observations', 'observationId'),
+    activities: indexEntities(projection.activities, 'projection.activities', 'activityId'),
+    dailySnapshots: indexEntities(projection.dailySnapshots, 'projection.dailySnapshots', 'snapshotId'),
+  }
+}
+
+function mergeEntityIndex(target: EntityIndex, incoming: EntityIndex, label: string): void {
+  for (const [id, payload] of incoming) {
+    const prior = target.get(id)
+    if (prior !== undefined && prior !== payload) {
+      throw new CanonicalHistoryShadowStoreIntegrityError(
+        `${label} identity ${id} conflicts with retained shadow history`,
+      )
+    }
+    target.set(id, prior ?? payload)
+  }
+}
+
+async function readRetainedIndex(
+  paths: ReturnType<typeof canonicalHistoryShadowPathsV1>,
+): Promise<ProjectionIndex> {
+  const retained: ProjectionIndex = {
+    observations: new Map(),
+    activities: new Map(),
+    dailySnapshots: new Map(),
+  }
+  const entries = await readdir(paths.snapshots, { withFileTypes: true })
+  for (const entry of entries.sort((a, b) => a.name.localeCompare(b.name))) {
+    if (!entry.isFile() || entry.name.includes('.qovrion-tmp-')) continue
+    const match = /^([a-f0-9]{64})\.json$/u.exec(entry.name)
+    if (!match) {
+      throw new CanonicalHistoryShadowStoreIntegrityError(
+        `canonical history shadow contains unexpected snapshot file ${entry.name}`,
+      )
+    }
+    const digest = match[1]!
+    const bytes = await readOptionalPrivateFile(join(paths.snapshots, entry.name))
+    if (!bytes) {
+      throw new CanonicalHistoryShadowStoreIntegrityError(
+        `canonical history shadow snapshot ${entry.name} disappeared during reconciliation`,
+      )
+    }
+    const parsed = parseSnapshot(bytes, digest)
+    mergeEntityIndex(retained.observations, parsed.index.observations, 'observation')
+    mergeEntityIndex(retained.activities, parsed.index.activities, 'activity')
+    mergeEntityIndex(retained.dailySnapshots, parsed.index.dailySnapshots, 'daily snapshot')
+  }
+  return retained
+}
+
+function assertCompatibleWithRetainedHistory(
+  retained: ProjectionIndex,
+  current: ProjectionIndex,
+): void {
+  for (const [label, previous, next] of [
+    ['observation', retained.observations, current.observations],
+    ['activity', retained.activities, current.activities],
+    ['daily snapshot', retained.dailySnapshots, current.dailySnapshots],
+  ] as const) {
+    for (const [id, payload] of next) {
+      const prior = previous.get(id)
+      if (prior !== undefined && prior !== payload) {
+        throw new CanonicalHistoryShadowStoreIntegrityError(
+          `${label} identity ${id} conflicts with retained shadow history`,
+        )
+      }
+    }
+  }
+}
+
+function reconcileEntities(
+  previous: EntityIndex | undefined,
+  current: EntityIndex,
+  label: string,
+): CanonicalHistoryShadowEntityReconciliationV1 {
+  if (!previous) return { added: current.size, unchanged: 0, retainedOnly: 0 }
+  let added = 0
+  let unchanged = 0
+  for (const [id, payload] of current) {
+    const prior = previous.get(id)
+    if (prior === undefined) {
+      added++
+      continue
+    }
+    if (prior !== payload) {
+      throw new CanonicalHistoryShadowStoreIntegrityError(`${label} identity ${id} resolved to a conflicting payload`)
+    }
+    unchanged++
+  }
+  let retainedOnly = 0
+  for (const id of previous.keys()) {
+    if (!current.has(id)) retainedOnly++
+  }
+  return { added, unchanged, retainedOnly }
+}
+
+function reconcileProjection(
+  previous: ProjectionIndex | undefined,
+  current: ProjectionIndex,
+): CanonicalHistoryShadowReconciliationV1 {
+  return {
+    observations: reconcileEntities(previous?.observations, current.observations, 'observation'),
+    activities: reconcileEntities(previous?.activities, current.activities, 'activity'),
+    dailySnapshots: reconcileEntities(previous?.dailySnapshots, current.dailySnapshots, 'daily snapshot'),
+  }
+}
+
+export function canonicalHistoryShadowPathsV1(dataDir: string) {
+  const root = join(dataDir, 'history-shadow', 'v1')
+  return {
+    root,
+    snapshots: join(root, 'snapshots'),
+    head: join(root, 'head.json'),
+  }
+}
+
+function snapshotPath(paths: ReturnType<typeof canonicalHistoryShadowPathsV1>, digest: string): string {
+  return join(paths.snapshots, `${digest}.json`)
+}
+
+async function prepare(paths: ReturnType<typeof canonicalHistoryShadowPathsV1>): Promise<void> {
+  await ensurePrivateDirectory(paths.snapshots)
+  await cleanupStaleAtomicTemps(paths.snapshots)
+  await cleanupStaleAtomicTemps(paths.root)
+}
+
+function parseSnapshot(
+  bytes: Uint8Array,
+  expectedDigest: string,
+): { record: CanonicalHistoryShadowSnapshotV1; index: ProjectionIndex } {
+  let record: CanonicalHistoryShadowSnapshotV1
+  try {
+    record = CanonicalHistoryShadowSnapshotV1Schema.parse(JSON.parse(Buffer.from(bytes).toString('utf-8')))
+  } catch {
+    throw new CanonicalHistoryShadowStoreIntegrityError('canonical history shadow snapshot is invalid')
+  }
+  if (record.projectionSha256 !== expectedDigest) {
+    throw new CanonicalHistoryShadowStoreIntegrityError('canonical history shadow snapshot names a different digest')
+  }
+  const actualDigest = canonicalHistoryShadowProjectionSha256V1(record.projection)
+  if (actualDigest !== expectedDigest) {
+    throw new CanonicalHistoryShadowStoreIntegrityError('canonical history shadow snapshot digest does not match its projection')
+  }
+  return { record, index: indexProjection(record.projection) }
+}
+
+function parseHead(bytes: Uint8Array): CanonicalHistoryShadowHeadV1 {
+  try {
+    return CanonicalHistoryShadowHeadV1Schema.parse(JSON.parse(Buffer.from(bytes).toString('utf-8')))
+  } catch {
+    throw new CanonicalHistoryShadowStoreIntegrityError('canonical history shadow head is invalid')
+  }
+}
+
+async function readHeadSnapshot(
+  paths: ReturnType<typeof canonicalHistoryShadowPathsV1>,
+): Promise<{ head: CanonicalHistoryShadowHeadV1; snapshot: CanonicalHistoryShadowSnapshotV1; index: ProjectionIndex } | undefined> {
+  const headBytes = await readOptionalPrivateFile(paths.head)
+  if (!headBytes) return undefined
+  const head = parseHead(headBytes)
+  const snapshotBytes = await readOptionalPrivateFile(snapshotPath(paths, head.projectionSha256))
+  if (!snapshotBytes) {
+    throw new CanonicalHistoryShadowStoreIntegrityError('canonical history shadow head points to a missing snapshot')
+  }
+  const parsed = parseSnapshot(snapshotBytes, head.projectionSha256)
+  return { head, snapshot: parsed.record, index: parsed.index }
+}
+
+export async function persistCanonicalHistoryShadowV1(
+  projectionInput: CanonicalHistoryReadProjectionV1,
+  options: CanonicalHistoryShadowStoreOptions = {},
+): Promise<PersistCanonicalHistoryShadowResultV1> {
+  const dataDir = options.dataDir ?? defaultMetroraDataDir()
+  const now = options.now ?? (() => new Date())
+  const paths = canonicalHistoryShadowPathsV1(dataDir)
+  const projection = structuredClone(projectionInput)
+  const currentIndex = indexProjection(projection)
+  const projectionSha256 = canonicalHistoryShadowProjectionSha256V1(projection)
+  await prepare(paths)
+
+  return withLocalStateLease(paths.root, async () => {
+    const previous = await readHeadSnapshot(paths)
+    const retained = await readRetainedIndex(paths)
+    assertCompatibleWithRetainedHistory(retained, currentIndex)
+    const previousDigest = previous?.head.projectionSha256
+    const targetPath = snapshotPath(paths, projectionSha256)
+    const targetBytes = await readOptionalPrivateFile(targetPath)
+    const target = targetBytes ? parseSnapshot(targetBytes, projectionSha256) : undefined
+
+    if (
+      target &&
+      canonicalProjectionJson(target.record.projection) !== canonicalProjectionJson(projection)
+    ) {
+      throw new CanonicalHistoryShadowStoreIntegrityError('canonical history shadow digest collision')
+    }
+
+    const reconciliation = reconcileProjection(previous?.index, currentIndex)
+
+    if (previousDigest === projectionSha256) {
+      return {
+        status: 'unchanged' as const,
+        projectionSha256,
+        reconciliation,
+      }
+    }
+
+    if (!target) {
+      const record = CanonicalHistoryShadowSnapshotV1Schema.parse({
+        kind: CANONICAL_HISTORY_SHADOW_SNAPSHOT_KIND,
+        version: CANONICAL_HISTORY_SHADOW_STORE_VERSION,
+        projectionSha256,
+        createdAt: now().toISOString(),
+        projection,
+      })
+      await atomicWritePrivateFile(targetPath, JSON.stringify(record))
+    }
+
+    const head = CanonicalHistoryShadowHeadV1Schema.parse({
+      kind: CANONICAL_HISTORY_SHADOW_HEAD_KIND,
+      version: CANONICAL_HISTORY_SHADOW_STORE_VERSION,
+      projectionSha256,
+      updatedAt: now().toISOString(),
+    })
+    await atomicWritePrivateFile(paths.head, JSON.stringify(head))
+
+    return {
+      status: previous
+        ? 'advanced' as const
+        : target
+          ? 'recovered-head' as const
+          : 'initialized' as const,
+      projectionSha256,
+      ...(previousDigest ? { previousProjectionSha256: previousDigest } : {}),
+      reconciliation,
+    }
+  })
+}
+
+export async function readCanonicalHistoryShadowHeadV1(
+  options: Pick<CanonicalHistoryShadowStoreOptions, 'dataDir'> = {},
+): Promise<CanonicalHistoryShadowHeadV1 | undefined> {
+  const paths = canonicalHistoryShadowPathsV1(options.dataDir ?? defaultMetroraDataDir())
+  const loaded = await readHeadSnapshot(paths)
+  return loaded?.head
+}


### PR DESCRIPTION
## Summary

Implement C3-P0.B as removable endpoint-local shadow persistence for the canonical history read projection, without changing current cache or consumer authority.

- persist immutable RFC 8785 content-addressed projection snapshots;
- publish a snapshot before atomically advancing a small head pointer;
- keep identical writes idempotent without rewriting the head;
- repair an interrupted snapshot-before-head publication;
- retain every previous snapshot when a new projection becomes current;
- reconcile added, unchanged and retained-only observation, activity and daily-snapshot identities;
- reject conflicting identity reuse against every retained snapshot, not only the previous head;
- fail closed for malformed metadata, digest mismatch, unexpected files and missing head targets;
- reject private paths, session IDs, deduplication material, prompts, responses, commands and tool arguments before persistence.

This implements the bounded store from #128. It does not complete consumer parity, migration or C3 cutover.

## Authority boundary

- session cache remains the source-present parse materialization;
- trusted daily cache remains the product totals authority;
- CLI, desktop, Workspace, Android and APIs do not read this store;
- deleting `history-shadow/v1` leaves existing product behavior unchanged;
- no SQLite/database, cache-schema change, backfill, server, sync, account or billing behavior is introduced.

## Scope

Exactly four files:

- `src/local-state/canonical-history-shadow-store.ts`
- `src/local-state/canonical-history-shadow-store.test.ts`
- `docs/CANONICAL_HISTORY_SHADOW_STORE_V1.md`
- `docs/README.md`

## Validation before CI

- TypeScript syntax check: pass;
- isolated runtime characterization: pass;
- immutable/idempotent snapshot publication: pass;
- head advancement with retained historical snapshots: pass;
- historical conflict detection beyond the immediate head: pass;
- interrupted-publication head repair: pass;
- corrupt snapshot and missing-head-target rejection: pass;
- privacy-key rejection before persistent state: pass;
- production module: 419 lines, below the 600-line architecture threshold;
- branch is ahead-only from `e0d6357412c3f02590109c3b2537f0f0bed8133e`.

Repository CI remains the integration authority.