### PR TITLE
feat(history): observe parity before shadow publication

### DIFF
--- a/docs/CANONICAL_HISTORY_PARITY_OBSERVER_V1.md
+++ b/docs/CANONICAL_HISTORY_PARITY_OBSERVER_V1.md
@@ -1,0 +1,146 @@
+# Canonical history parity observer v1
+
+## Status
+
+Implemented as a non-authoritative diagnostic boundary.
+
+The parity observer validates one canonical history read projection against the two current local authorities before that projection may advance the removable shadow store.
+
+It does not change what Metrora reports, display a new history surface, or make the shadow store a product dependency.
+
+## Invocation boundary
+
+The observer runs after the trusted reviewed-production scanner has:
+
+1. explicitly refreshed the canonical session cache;
+2. loaded a complete current-version session cache;
+3. received the endpoint identifier from the protected desktop runtime.
+
+The observer then loads the current daily cache. It runs only when that cache is both complete and backed by a trusted watermark.
+
+Renderer code cannot supply:
+
+- session or daily cache payloads;
+- source paths;
+- provider identities;
+- deduplication keys;
+- observations or activity groupings;
+- cost assignments;
+- shadow-store records.
+
+## Independent parity checks
+
+### Observation parity
+
+The observer independently walks the current session cache and derives one expected path-free observation payload for every endpoint-scoped source fingerprint.
+
+It compares those expected payloads with the projection by identity and canonical RFC 8785 content.
+
+The comparison covers:
+
+- collector and model identity;
+- timestamp;
+- token accounting;
+- immutable cost assignment and numeric cost state;
+- explicit unavailable cost;
+- estimation state;
+- speed.
+
+Exact duplicate source records are counted once. Reuse of one source identity with a conflicting payload fails closed.
+
+### Activity parity
+
+The observer independently reconstructs the activity partition as ordered sets of observation identities anchored to collector and turn timestamp.
+
+It requires:
+
+- every projected observation to belong to exactly one activity;
+- no activity to reference an absent observation;
+- no duplicate or conflicting activity payload;
+- the projected partition to equal the partition derived from the session cache.
+
+The observer does not expose private session identifiers.
+
+### Daily-history parity
+
+The observer independently removes project paths from the trusted daily cache and compares the complete canonical daily payload with the projection.
+
+This comparison includes:
+
+- headline totals;
+- token totals;
+- models and categories;
+- provider slices;
+- project statistics without paths;
+- carried-history markers;
+- the timezone used for day bucketing.
+
+The observation collection and daily snapshots remain separate authorities and are never added together.
+
+## Publication rule
+
+The order is strict:
+
+1. validate current cache versions and trust;
+2. build the read projection;
+3. prove observation, activity and daily parity;
+4. persist the projection through the canonical shadow store.
+
+A parity mismatch therefore cannot advance the shadow head.
+
+A successful result records only:
+
+- projection digest;
+- shadow publication outcome;
+- entity counts;
+- reconciliation counts;
+- the non-additive authority marker.
+
+## Failure behavior
+
+Parity is diagnostic, not a production gate.
+
+When the observer is invoked through reviewed production:
+
+- a mismatch or shadow-store integrity error leaves current analytics and reviewed production unchanged;
+- a generic sanitized warning is written to stderr;
+- the detailed exception is not copied into renderer, public event, report or telemetry output;
+- a diagnostic reporter failure is also prevented from becoming a production failure.
+
+An incomplete or untrusted daily cache does not mint a shadow snapshot. A later trusted refresh retries the observation through the same bounded path.
+
+## Privacy boundary
+
+The observer and shadow store do not persist:
+
+- prompts or responses;
+- source code or patches;
+- source or project paths;
+- private session identifiers;
+- private deduplication material;
+- commands, tool inputs or tool arguments;
+- secrets.
+
+Endpoint-scoped source fingerprints remain the public observation identity.
+
+## Authority boundary
+
+Current product authority remains unchanged:
+
+- session cache: source-present normalized call materialization;
+- trusted daily cache: durable daily totals and carried aggregate-only history;
+- canonical history shadow: removable diagnostic snapshots only;
+- CLI, desktop reports, Workspace, Android and APIs: no reads from the shadow store.
+
+Deleting the complete `history-shadow/v1` directory must leave current product behavior unchanged.
+
+## Deferred work
+
+This observer does not authorize:
+
+- consumer parity claims based on real-world observation duration;
+- CLI or desktop cutover;
+- replacement of session or daily caches;
+- migration or historical backfill;
+- database introduction;
+- remote sync, accounts, billing or managed infrastructure.

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,7 @@ This index separates user guidance, current product guarantees, public contracts
 - [Architecture](architecture.md) — current responsibility and authority map for the public codebase.
 - [Canonical history read projection v1](CANONICAL_HISTORY_READ_PROJECTION_V1.md) — shadow observation/activity identity and trusted daily-history boundary.
 - [Canonical history shadow store v1](CANONICAL_HISTORY_SHADOW_STORE_V1.md) — removable content-addressed persistence and cross-refresh reconciliation.
+- [Canonical history parity observer v1](CANONICAL_HISTORY_PARITY_OBSERVER_V1.md) — non-authoritative cache-to-shadow parity validation before snapshot publication.
 - [Pricing history](PRICING_HISTORY.md) — date-effective rates, settled assignments and historical-cost behavior.
 - [Collector inventory v1](COLLECTOR_INVENTORY_V1.md) — generated technical inventory of registered collectors and signed-measurement eligibility.
 - [Public contracts v1](PUBLIC_CONTRACTS_V1.md) — public schemas, signed-data behavior and compatibility commitments.

--- a/src/local-state/canonical-history-parity-observer.test.ts
+++ b/src/local-state/canonical-history-parity-observer.test.ts
@@ -1,0 +1,235 @@
+import { createHash } from 'node:crypto'
+import { describe, expect, it, vi } from 'vitest'
+
+import type { DailyCache, DailyEntry } from '../daily-cache.js'
+import type { CachedCall, CachedFile, SessionCache } from '../session-cache.js'
+import { projectCanonicalHistoryReadV1 } from './canonical-history-read-projection.js'
+import {
+  CanonicalHistoryParityMismatchError,
+  observeCanonicalHistoryParityV1,
+} from './canonical-history-parity-observer.js'
+
+const ENDPOINT_ID = 'ep_11111111-2222-4333-8444-555555555555'
+
+function sourceFingerprint(input: {
+  endpointId: string
+  provider: string
+  privateDeduplicationKey: string
+}): string {
+  return createHash('sha256')
+    .update('metrora-canonical-source-record-v1\0')
+    .update(input.endpointId)
+    .update('\0')
+    .update(input.provider)
+    .update('\0')
+    .update(input.privateDeduplicationKey)
+    .digest('hex')
+}
+
+function call(overrides: Partial<CachedCall> = {}): CachedCall {
+  return {
+    provider: 'zed',
+    model: 'gpt-5.6-luna',
+    modelProvider: 'zed.dev',
+    usage: {
+      inputTokens: 100,
+      outputTokens: 20,
+      cacheCreationInputTokens: 0,
+      cacheReadInputTokens: 25,
+      cachedInputTokens: 25,
+      reasoningTokens: 5,
+      webSearchRequests: 0,
+      cacheCreationOneHourTokens: 0,
+    },
+    costUSD: 0,
+    costAssignment: {
+      version: 1,
+      kind: 'explicit-zero',
+      amountMicrosUsd: 0,
+      reason: 'free-route',
+    },
+    speed: 'standard',
+    timestamp: '2026-08-01T21:00:00.000Z',
+    tools: [],
+    bashCommands: [],
+    skills: [],
+    subagentTypes: [],
+    deduplicationKey: 'zed:thread-1:request-1',
+    ...overrides,
+  }
+}
+
+function cachedFile(calls: CachedCall[], sessionId = 'session-1'): CachedFile {
+  return {
+    fingerprint: { dev: 1, ino: 2, mtimeMs: 3, sizeBytes: 4 },
+    mcpInventory: [],
+    turns: [{
+      timestamp: '2026-08-01T21:00:00.000Z',
+      sessionId,
+      userMessage: 'private prompt',
+      calls,
+    }],
+  }
+}
+
+function sessionCache(files: Record<string, CachedFile>): SessionCache {
+  return {
+    version: 8,
+    complete: true,
+    providers: {
+      zed: { envFingerprint: 'zed-test', files },
+    },
+  }
+}
+
+function day(): DailyEntry {
+  return {
+    date: '2026-08-01',
+    cost: 0,
+    savingsUSD: 0,
+    calls: 1,
+    sessions: 1,
+    inputTokens: 100,
+    outputTokens: 20,
+    cacheReadTokens: 25,
+    cacheWriteTokens: 0,
+    editTurns: 0,
+    oneShotTurns: 0,
+    models: {
+      'gpt-5.6-luna': {
+        calls: 1,
+        cost: 0,
+        savingsUSD: 0,
+        inputTokens: 100,
+        outputTokens: 20,
+        cacheReadTokens: 25,
+        cacheWriteTokens: 0,
+      },
+    },
+    categories: {
+      other: { turns: 1, cost: 0, savingsUSD: 0, editTurns: 0, oneShotTurns: 0 },
+    },
+    providers: {
+      zed: {
+        calls: 1,
+        cost: 0,
+        savingsUSD: 0,
+        sessions: 1,
+        inputTokens: 100,
+        outputTokens: 20,
+        cacheReadTokens: 25,
+        cacheWriteTokens: 0,
+        editTurns: 0,
+        oneShotTurns: 0,
+      },
+    },
+  }
+}
+
+function dailyCache(days: DailyEntry[] = [day()]): DailyCache {
+  return {
+    version: 17,
+    savingsConfigHash: 'test',
+    tzKey: 'UTC',
+    lastComputedDate: '2026-08-01',
+    days,
+    complete: true,
+    watermarkTrusted: true,
+  }
+}
+
+function persisted() {
+  return {
+    status: 'initialized' as const,
+    projectionSha256: 'a'.repeat(64),
+    reconciliation: {
+      observations: { added: 1, unchanged: 0, retainedOnly: 0 },
+      activities: { added: 1, unchanged: 0, retainedOnly: 0 },
+      dailySnapshots: { added: 1, unchanged: 0, retainedOnly: 0 },
+    },
+  }
+}
+
+describe('canonical history parity observer v1', () => {
+  it('persists only after source, activity and daily authority match', async () => {
+    const persist = vi.fn(async () => persisted())
+    const result = await observeCanonicalHistoryParityV1({
+      endpointId: ENDPOINT_ID,
+      sessionCache: sessionCache({ '/private/zed.sqlite': cachedFile([call()]) }),
+      dailyCache: dailyCache(),
+    }, { sourceFingerprint, persist })
+
+    expect(persist).toHaveBeenCalledTimes(1)
+    expect(result).toMatchObject({
+      outcome: 'matched',
+      shadowStatus: 'initialized',
+      counts: { observations: 1, activities: 1, dailySnapshots: 1 },
+      additiveAcrossAuthorities: false,
+    })
+  })
+
+  it('deduplicates one exact source observation without losing activity parity', async () => {
+    const duplicate = call()
+    const persist = vi.fn(async () => persisted())
+    const result = await observeCanonicalHistoryParityV1({
+      endpointId: ENDPOINT_ID,
+      sessionCache: sessionCache({
+        '/private/a.sqlite': cachedFile([call()]),
+        '/private/b.sqlite': cachedFile([duplicate]),
+      }),
+      dailyCache: dailyCache(),
+    }, { sourceFingerprint, persist })
+
+    expect(result.counts).toEqual({ observations: 1, activities: 1, dailySnapshots: 1 })
+  })
+
+  it('rejects a projection that drops a source observation before persistence', async () => {
+    const persist = vi.fn(async () => persisted())
+    await expect(observeCanonicalHistoryParityV1({
+      endpointId: ENDPOINT_ID,
+      sessionCache: sessionCache({ '/private/zed.sqlite': cachedFile([call()]) }),
+      dailyCache: dailyCache(),
+    }, {
+      sourceFingerprint,
+      persist,
+      project: input => {
+        const projection = structuredClone(projectCanonicalHistoryReadV1(input))
+        projection.observations = []
+        projection.activities = []
+        return projection
+      },
+    })).rejects.toBeInstanceOf(CanonicalHistoryParityMismatchError)
+    expect(persist).not.toHaveBeenCalled()
+  })
+
+  it('rejects a daily snapshot that differs from trusted daily-cache authority', async () => {
+    const persist = vi.fn(async () => persisted())
+    await expect(observeCanonicalHistoryParityV1({
+      endpointId: ENDPOINT_ID,
+      sessionCache: sessionCache({ '/private/zed.sqlite': cachedFile([call()]) }),
+      dailyCache: dailyCache(),
+    }, {
+      sourceFingerprint,
+      persist,
+      project: input => {
+        const projection = structuredClone(projectCanonicalHistoryReadV1(input))
+        projection.dailySnapshots[0]!.calls += 1
+        return projection
+      },
+    })).rejects.toThrow('daily snapshot projection does not match trusted daily-cache authority')
+    expect(persist).not.toHaveBeenCalled()
+  })
+
+  it('fails closed before projection when either canonical cache is untrusted', async () => {
+    const persist = vi.fn(async () => persisted())
+    const untrusted = dailyCache()
+    untrusted.watermarkTrusted = false
+
+    await expect(observeCanonicalHistoryParityV1({
+      endpointId: ENDPOINT_ID,
+      sessionCache: sessionCache({ '/private/zed.sqlite': cachedFile([call()]) }),
+      dailyCache: untrusted,
+    }, { sourceFingerprint, persist })).rejects.toBeInstanceOf(CanonicalHistoryParityMismatchError)
+    expect(persist).not.toHaveBeenCalled()
+  })
+})

--- a/src/local-state/canonical-history-parity-observer.ts
+++ b/src/local-state/canonical-history-parity-observer.ts
@@ -1,0 +1,426 @@
+import { TimestampSchema } from '../contracts/v1/common.js'
+import {
+  DAILY_CACHE_VERSION,
+  type DailyCache,
+  type DailyEntry,
+  type ProjectDayStats,
+  type ProviderDaySlice,
+} from '../daily-cache.js'
+import {
+  CostAssignmentV1Schema,
+  costAssignmentMatchesUsdV1,
+  type CostAssignmentV1,
+} from '../pricing/cost-assignment.js'
+import { CACHE_VERSION, type CachedCall, type SessionCache } from '../session-cache.js'
+import { canonicalizeRfc8785 } from '../vendor/rfc8785-canonicalize.js'
+import {
+  projectCanonicalHistoryReadV1,
+  type CanonicalActivityReadV1,
+  type CanonicalHistoryReadProjectionInputV1,
+  type CanonicalHistoryReadProjectionV1,
+  type CanonicalObservationReadV1,
+} from './canonical-history-read-projection.js'
+import {
+  persistCanonicalHistoryShadowV1,
+  type PersistCanonicalHistoryShadowResultV1,
+} from './canonical-history-shadow-store.js'
+
+export const CANONICAL_HISTORY_PARITY_OBSERVER_VERSION = 1 as const
+
+export type CanonicalHistoryParityCountsV1 = {
+  observations: number
+  activities: number
+  dailySnapshots: number
+}
+
+export type CanonicalHistoryParityObservationV1 = {
+  kind: 'metrora.canonical-history-parity-observation'
+  version: typeof CANONICAL_HISTORY_PARITY_OBSERVER_VERSION
+  outcome: 'matched'
+  projectionSha256: string
+  previousProjectionSha256?: string
+  shadowStatus: PersistCanonicalHistoryShadowResultV1['status']
+  counts: CanonicalHistoryParityCountsV1
+  reconciliation: PersistCanonicalHistoryShadowResultV1['reconciliation']
+  additiveAcrossAuthorities: false
+}
+
+export type CanonicalHistoryParityObserverDependenciesV1 = {
+  sourceFingerprint(input: {
+    endpointId: string
+    provider: string
+    privateDeduplicationKey: string
+  }): string
+  project?: (input: CanonicalHistoryReadProjectionInputV1) => CanonicalHistoryReadProjectionV1
+  persist?: (
+    projection: CanonicalHistoryReadProjectionV1,
+  ) => Promise<PersistCanonicalHistoryShadowResultV1>
+}
+
+export class CanonicalHistoryParityMismatchError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'CanonicalHistoryParityMismatchError'
+  }
+}
+
+type ObservationPayload = Omit<CanonicalObservationReadV1, 'observationId' | 'activityId'>
+type ActivityPayload = Omit<CanonicalActivityReadV1, 'activityId'>
+type PathFreeProjectDayStats = Omit<ProjectDayStats, 'path'>
+type PathFreeProviderDaySlice = Omit<ProviderDaySlice, 'projects'> & {
+  projects?: Record<string, PathFreeProjectDayStats>
+}
+type DailySnapshotPayload = Omit<
+  CanonicalHistoryReadProjectionV1['dailySnapshots'][number],
+  'snapshotId'
+>
+
+function canonical(value: unknown): string {
+  try {
+    return canonicalizeRfc8785(value)
+  } catch {
+    throw new CanonicalHistoryParityMismatchError('canonical history parity encountered non-canonical JSON')
+  }
+}
+
+function sameValue(left: unknown, right: unknown): boolean {
+  return canonical(left) === canonical(right)
+}
+
+function sortedRecord<T, R>(
+  input: Record<string, T> | undefined,
+  project: (value: T) => R,
+): Record<string, R> | undefined {
+  if (!input) return undefined
+  return Object.fromEntries(
+    Object.entries(input)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, value]) => [key, project(value)]),
+  )
+}
+
+function pathFreeProject(value: ProjectDayStats): PathFreeProjectDayStats {
+  return {
+    cost: value.cost,
+    calls: value.calls,
+    savingsUSD: value.savingsUSD,
+    sessions: value.sessions,
+  }
+}
+
+function pathFreeProvider(value: ProviderDaySlice): PathFreeProviderDaySlice {
+  return {
+    calls: value.calls,
+    cost: value.cost,
+    savingsUSD: value.savingsUSD,
+    ...(value.sessions !== undefined ? { sessions: value.sessions } : {}),
+    ...(value.inputTokens !== undefined ? { inputTokens: value.inputTokens } : {}),
+    ...(value.outputTokens !== undefined ? { outputTokens: value.outputTokens } : {}),
+    ...(value.cacheReadTokens !== undefined ? { cacheReadTokens: value.cacheReadTokens } : {}),
+    ...(value.cacheWriteTokens !== undefined ? { cacheWriteTokens: value.cacheWriteTokens } : {}),
+    ...(value.editTurns !== undefined ? { editTurns: value.editTurns } : {}),
+    ...(value.oneShotTurns !== undefined ? { oneShotTurns: value.oneShotTurns } : {}),
+    ...(value.models !== undefined ? { models: structuredClone(value.models) } : {}),
+    ...(value.categories !== undefined ? { categories: structuredClone(value.categories) } : {}),
+    ...(value.projects !== undefined ? { projects: sortedRecord(value.projects, pathFreeProject) } : {}),
+  }
+}
+
+function rawDailyPayload(day: DailyEntry, bucketTimeZone: string | null): DailySnapshotPayload {
+  return {
+    date: day.date,
+    cost: day.cost,
+    savingsUSD: day.savingsUSD,
+    calls: day.calls,
+    sessions: day.sessions,
+    inputTokens: day.inputTokens,
+    outputTokens: day.outputTokens,
+    cacheReadTokens: day.cacheReadTokens,
+    cacheWriteTokens: day.cacheWriteTokens,
+    editTurns: day.editTurns,
+    oneShotTurns: day.oneShotTurns,
+    models: Object.fromEntries(
+      Object.entries(day.models)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([key, value]) => [key, structuredClone(value)]),
+    ),
+    categories: Object.fromEntries(
+      Object.entries(day.categories)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([key, value]) => [key, structuredClone(value)]),
+    ),
+    providers: sortedRecord(day.providers, pathFreeProvider) ?? {},
+    ...(day.projects !== undefined ? { projects: sortedRecord(day.projects, pathFreeProject) } : {}),
+    ...(day.carried === true ? { carried: true as const } : {}),
+    bucketTimeZone,
+    authority: 'trusted-daily-cache',
+  }
+}
+
+function validatedCost(call: CachedCall): Pick<
+  ObservationPayload,
+  'costUSD' | 'costAssignment' | 'legacyCostUSD'
+> {
+  if (!call.costAssignment) {
+    throw new CanonicalHistoryParityMismatchError('canonical cached call has no immutable cost assignment')
+  }
+  const assignment = CostAssignmentV1Schema.parse(call.costAssignment) as CostAssignmentV1
+  if (assignment.kind === 'unavailable') {
+    if (call.costUSD !== undefined) {
+      throw new CanonicalHistoryParityMismatchError(
+        'unavailable cost assignment cannot carry a numeric canonical cost',
+      )
+    }
+    return {
+      costUSD: null,
+      costAssignment: structuredClone(assignment),
+      ...(call.legacyCostUSD !== undefined ? { legacyCostUSD: call.legacyCostUSD } : {}),
+    }
+  }
+  if (call.costUSD === undefined || !costAssignmentMatchesUsdV1(assignment, call.costUSD)) {
+    throw new CanonicalHistoryParityMismatchError(
+      'canonical cost assignment disagrees with cached cost',
+    )
+  }
+  return {
+    costUSD: call.costUSD,
+    costAssignment: structuredClone(assignment),
+    ...(call.legacyCostUSD !== undefined ? { legacyCostUSD: call.legacyCostUSD } : {}),
+  }
+}
+
+function rawObservationPayload(input: {
+  endpointId: string
+  collector: string
+  call: CachedCall
+  sourceFingerprint: CanonicalHistoryParityObserverDependenciesV1['sourceFingerprint']
+}): ObservationPayload {
+  const timestamp = TimestampSchema.safeParse(input.call.timestamp)
+  if (!timestamp.success) {
+    throw new CanonicalHistoryParityMismatchError('canonical cached call has an invalid timestamp')
+  }
+  if (input.call.provider !== input.collector) {
+    throw new CanonicalHistoryParityMismatchError(
+      'canonical cached call provider disagrees with its provider section',
+    )
+  }
+  if (!input.call.deduplicationKey) {
+    throw new CanonicalHistoryParityMismatchError(
+      'canonical cached call has an empty private deduplication key',
+    )
+  }
+  const sourceFingerprintSha256 = input.sourceFingerprint({
+    endpointId: input.endpointId,
+    provider: input.collector,
+    privateDeduplicationKey: input.call.deduplicationKey,
+  })
+  return {
+    sourceFingerprintSha256,
+    collector: input.collector,
+    timestamp: timestamp.data,
+    model: input.call.model,
+    ...(input.call.modelProvider !== undefined ? { modelProvider: input.call.modelProvider } : {}),
+    usage: structuredClone(input.call.usage),
+    ...validatedCost(input.call),
+    isEstimated: input.call.isEstimated === true,
+    speed: input.call.speed,
+  }
+}
+
+function addUniquePayload<T>(
+  target: Map<string, T>,
+  id: string,
+  payload: T,
+  label: string,
+): void {
+  const previous = target.get(id)
+  if (previous !== undefined && !sameValue(previous, payload)) {
+    throw new CanonicalHistoryParityMismatchError(`${label} identity resolved to conflicting payloads`)
+  }
+  target.set(id, previous ?? payload)
+}
+
+function expectedSessionAuthority(input: {
+  endpointId: string
+  sessionCache: SessionCache
+  sourceFingerprint: CanonicalHistoryParityObserverDependenciesV1['sourceFingerprint']
+}): { observations: Map<string, ObservationPayload>; activities: Set<string> } {
+  const observations = new Map<string, ObservationPayload>()
+  const activities = new Set<string>()
+  const observationActivity = new Map<string, string>()
+
+  for (const [collector, section] of Object.entries(input.sessionCache.providers)
+    .sort(([left], [right]) => left.localeCompare(right))) {
+    for (const [, file] of Object.entries(section.files)
+      .sort(([left], [right]) => left.localeCompare(right))) {
+      if (file.failed) continue
+      for (const turn of file.turns) {
+        if (turn.calls.length === 0) continue
+        const timestamp = TimestampSchema.safeParse(turn.timestamp)
+        if (!timestamp.success) {
+          throw new CanonicalHistoryParityMismatchError('canonical cached turn has an invalid timestamp')
+        }
+        const observationIds: string[] = []
+        for (const call of turn.calls) {
+          const payload = rawObservationPayload({
+            endpointId: input.endpointId,
+            collector,
+            call,
+            sourceFingerprint: input.sourceFingerprint,
+          })
+          const observationId = `observation-v1:${payload.sourceFingerprintSha256}`
+          addUniquePayload(observations, observationId, payload, 'observation')
+          if (!observationIds.includes(observationId)) observationIds.push(observationId)
+        }
+        const activity: ActivityPayload = {
+          collector,
+          timestamp: timestamp.data,
+          observationIds,
+        }
+        const activityKey = canonical(activity)
+        for (const observationId of observationIds) {
+          const previous = observationActivity.get(observationId)
+          if (previous !== undefined && previous !== activityKey) {
+            throw new CanonicalHistoryParityMismatchError(
+              'one canonical observation belongs to conflicting activities',
+            )
+          }
+          observationActivity.set(observationId, previous ?? activityKey)
+        }
+        activities.add(activityKey)
+      }
+    }
+  }
+
+  return { observations, activities }
+}
+
+function projectedSessionAuthority(
+  projection: CanonicalHistoryReadProjectionV1,
+): { observations: Map<string, ObservationPayload>; activities: Set<string> } {
+  const observations = new Map<string, ObservationPayload>()
+  for (const observation of projection.observations) {
+    const { observationId, activityId: _activityId, ...payload } = observation
+    addUniquePayload(observations, observationId, payload, 'projected observation')
+  }
+
+  const activities = new Set<string>()
+  const referenced = new Map<string, string>()
+  for (const activity of projection.activities) {
+    const { activityId: _activityId, ...payload } = activity
+    const key = canonical(payload)
+    if (activities.has(key)) {
+      throw new CanonicalHistoryParityMismatchError('projection contains duplicate activity payloads')
+    }
+    activities.add(key)
+    for (const observationId of activity.observationIds) {
+      if (!observations.has(observationId)) {
+        throw new CanonicalHistoryParityMismatchError(
+          'projection activity references a missing observation',
+        )
+      }
+      const previous = referenced.get(observationId)
+      if (previous !== undefined && previous !== key) {
+        throw new CanonicalHistoryParityMismatchError(
+          'projection observation is referenced by conflicting activities',
+        )
+      }
+      referenced.set(observationId, previous ?? key)
+    }
+  }
+  if (referenced.size !== observations.size) {
+    throw new CanonicalHistoryParityMismatchError(
+      'projection contains observations outside the activity partition',
+    )
+  }
+  return { observations, activities }
+}
+
+function assertMapParity<T>(
+  expected: Map<string, T>,
+  actual: Map<string, T>,
+  label: string,
+): void {
+  if (expected.size !== actual.size) {
+    throw new CanonicalHistoryParityMismatchError(`${label} count does not match source authority`)
+  }
+  for (const [id, payload] of expected) {
+    const projected = actual.get(id)
+    if (projected === undefined || !sameValue(payload, projected)) {
+      throw new CanonicalHistoryParityMismatchError(`${label} payload does not match source authority`)
+    }
+  }
+}
+
+function assertSetParity(expected: Set<string>, actual: Set<string>, label: string): void {
+  if (expected.size !== actual.size || [...expected].some(value => !actual.has(value))) {
+    throw new CanonicalHistoryParityMismatchError(`${label} partition does not match source authority`)
+  }
+}
+
+function assertDailyParity(dailyCache: DailyCache, projection: CanonicalHistoryReadProjectionV1): void {
+  const expected = dailyCache.days
+    .map(day => rawDailyPayload(day, dailyCache.tzKey ?? null))
+    .sort((left, right) => left.date.localeCompare(right.date) || canonical(left).localeCompare(canonical(right)))
+  const actual = projection.dailySnapshots
+    .map(({ snapshotId: _snapshotId, ...snapshot }) => snapshot)
+    .sort((left, right) => left.date.localeCompare(right.date) || canonical(left).localeCompare(canonical(right)))
+  if (!sameValue(expected, actual)) {
+    throw new CanonicalHistoryParityMismatchError(
+      'daily snapshot projection does not match trusted daily-cache authority',
+    )
+  }
+}
+
+export async function observeCanonicalHistoryParityV1(
+  input: CanonicalHistoryReadProjectionInputV1,
+  dependencies: CanonicalHistoryParityObserverDependenciesV1,
+): Promise<CanonicalHistoryParityObservationV1> {
+  if (input.sessionCache.version !== CACHE_VERSION || input.sessionCache.complete !== true) {
+    throw new CanonicalHistoryParityMismatchError(
+      'canonical history parity requires a complete current-version session cache',
+    )
+  }
+  if (
+    input.dailyCache.version !== DAILY_CACHE_VERSION
+    || input.dailyCache.complete !== true
+    || input.dailyCache.watermarkTrusted !== true
+  ) {
+    throw new CanonicalHistoryParityMismatchError(
+      'canonical history parity requires a trusted complete current-version daily cache',
+    )
+  }
+
+  const project = dependencies.project ?? projectCanonicalHistoryReadV1
+  const persist = dependencies.persist ?? (projection => persistCanonicalHistoryShadowV1(projection))
+  const projection = project(input)
+  const expected = expectedSessionAuthority({
+    endpointId: input.endpointId,
+    sessionCache: input.sessionCache,
+    sourceFingerprint: dependencies.sourceFingerprint,
+  })
+  const actual = projectedSessionAuthority(projection)
+
+  assertMapParity(expected.observations, actual.observations, 'observation')
+  assertSetParity(expected.activities, actual.activities, 'activity')
+  assertDailyParity(input.dailyCache, projection)
+
+  const persisted = await persist(projection)
+  return {
+    kind: 'metrora.canonical-history-parity-observation',
+    version: CANONICAL_HISTORY_PARITY_OBSERVER_VERSION,
+    outcome: 'matched',
+    projectionSha256: persisted.projectionSha256,
+    ...(persisted.previousProjectionSha256 !== undefined
+      ? { previousProjectionSha256: persisted.previousProjectionSha256 }
+      : {}),
+    shadowStatus: persisted.status,
+    counts: {
+      observations: projection.observations.length,
+      activities: projection.activities.length,
+      dailySnapshots: projection.dailySnapshots.length,
+    },
+    reconciliation: persisted.reconciliation,
+    additiveAcrossAuthorities: false,
+  }
+}

--- a/src/local-state/canonical-reviewed-production-scanner-parity.test.ts
+++ b/src/local-state/canonical-reviewed-production-scanner-parity.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import type { CachedCall, CachedFile, SessionCache } from '../session-cache.js'
+import {
+  scanCanonicalReviewedProductionCandidatesV1,
+  type CanonicalReviewedProductionScannerDependenciesV1,
+} from './canonical-reviewed-production-scanner.js'
+
+const ENDPOINT_ID = 'ep_11111111-2222-4333-8444-555555555555'
+const SOURCE_PATH = '/private/zed/db/threads.sqlite'
+
+function call(): CachedCall {
+  return {
+    provider: 'zed',
+    model: 'gpt-5.6-luna',
+    modelProvider: 'zed.dev',
+    usage: {
+      inputTokens: 100,
+      outputTokens: 20,
+      cacheCreationInputTokens: 0,
+      cacheReadInputTokens: 25,
+      cachedInputTokens: 25,
+      reasoningTokens: 5,
+      webSearchRequests: 0,
+      cacheCreationOneHourTokens: 0,
+    },
+    costUSD: 0,
+    costAssignment: {
+      version: 1,
+      kind: 'explicit-zero',
+      amountMicrosUsd: 0,
+      reason: 'free-route',
+    },
+    speed: 'standard',
+    timestamp: '2026-08-01T21:00:00.000Z',
+    tools: [],
+    bashCommands: [],
+    skills: [],
+    subagentTypes: [],
+    deduplicationKey: 'zed:thread-1:request-1',
+  }
+}
+
+function file(): CachedFile {
+  return {
+    fingerprint: { dev: 1, ino: 2, mtimeMs: 3, sizeBytes: 4 },
+    mcpInventory: [],
+    turns: [{
+      timestamp: '2026-08-01T21:00:00.000Z',
+      sessionId: 'private-session-id',
+      userMessage: 'private prompt',
+      calls: [call()],
+    }],
+  }
+}
+
+function cache(): SessionCache {
+  return {
+    version: 8,
+    complete: true,
+    providers: {
+      zed: { envFingerprint: 'zed-test', files: { [SOURCE_PATH]: file() } },
+    },
+  }
+}
+
+function dependencies(overrides: Partial<CanonicalReviewedProductionScannerDependenciesV1> = {}) {
+  const value = cache()
+  return {
+    refreshCanonicalCache: vi.fn(async () => undefined),
+    loadCanonicalCache: vi.fn(async () => value),
+    sourceExists: vi.fn(() => true),
+    providerDisplayName: vi.fn(async () => 'Zed'),
+    ...overrides,
+  } satisfies CanonicalReviewedProductionScannerDependenciesV1
+}
+
+function input() {
+  return {
+    endpointId: ENDPOINT_ID,
+    adapterVersion: '1.0.0-rc.7',
+    notBefore: '2026-08-01T20:00:00.000Z',
+  }
+}
+
+describe('canonical reviewed-production parity hook', () => {
+  it('observes the complete cache before returning reviewed candidates', async () => {
+    const observe = vi.fn(async () => undefined)
+    const deps = dependencies({ observeCanonicalHistoryParity: observe })
+
+    const result = await scanCanonicalReviewedProductionCandidatesV1(input(), deps)
+
+    expect(observe).toHaveBeenCalledTimes(1)
+    expect(observe).toHaveBeenCalledWith({ endpointId: ENDPOINT_ID, sessionCache: await deps.loadCanonicalCache() })
+    expect(result.candidates).toHaveLength(1)
+  })
+
+  it('reports a parity failure without changing reviewed-production output', async () => {
+    const failure = new Error('synthetic parity failure')
+    const report = vi.fn()
+    const deps = dependencies({
+      observeCanonicalHistoryParity: vi.fn(async () => { throw failure }),
+      reportCanonicalHistoryParityFailure: report,
+    })
+
+    const result = await scanCanonicalReviewedProductionCandidatesV1(input(), deps)
+
+    expect(report).toHaveBeenCalledWith(failure)
+    expect(result).toMatchObject({
+      withheldCount: 0,
+      failedCount: 0,
+    })
+    expect(result.candidates).toHaveLength(1)
+  })
+
+  it('does not let a diagnostic reporter become a production gate', async () => {
+    const deps = dependencies({
+      observeCanonicalHistoryParity: vi.fn(async () => { throw new Error('parity') }),
+      reportCanonicalHistoryParityFailure: vi.fn(() => { throw new Error('reporter') }),
+    })
+
+    await expect(scanCanonicalReviewedProductionCandidatesV1(input(), deps))
+      .resolves.toMatchObject({ withheldCount: 0, failedCount: 0 })
+  })
+})

--- a/src/local-state/canonical-reviewed-production-scanner.ts
+++ b/src/local-state/canonical-reviewed-production-scanner.ts
@@ -4,6 +4,7 @@ import * as z from 'zod/v4'
 
 import { collectorProvenanceProfileForCall } from '../contracts/v1/collector-provenance.js'
 import { OpaqueIdSchema, TimestampSchema } from '../contracts/v1/common.js'
+import { loadDailyCache } from '../daily-cache.js'
 import { normalizeExplicitModelProvider } from '../model-provider.js'
 import { cachedCallToApiCall, clearSessionCache, parseAllSessions } from '../parser.js'
 import { readCodexSessionModelProvider } from '../providers/codex-model-provider.js'
@@ -35,6 +36,11 @@ export type CanonicalReviewedProductionScannerDependenciesV1 = {
   sourceExists(path: string): boolean
   providerDisplayName(provider: string): Promise<string | undefined>
   codexModelProvider?(path: string): Promise<string | undefined>
+  observeCanonicalHistoryParity?(input: {
+    endpointId: string
+    sessionCache: SessionCache
+  }): Promise<void>
+  reportCanonicalHistoryParityFailure?(error: unknown): void
 }
 
 export class CanonicalReviewedProductionScannerIntegrityError extends Error {
@@ -99,6 +105,13 @@ function canonicalApiCall(cachedCall: CachedCall): ParsedApiCall {
   }
 }
 
+function reportParityFailure(error: unknown): void {
+  void error
+  process.stderr.write(
+    'metrora: canonical history parity observation failed; current analytics remain authoritative.\n',
+  )
+}
+
 function defaultDependencies(): CanonicalReviewedProductionScannerDependenciesV1 {
   return {
     refreshCanonicalCache: async () => {
@@ -112,6 +125,34 @@ function defaultDependencies(): CanonicalReviewedProductionScannerDependenciesV1
     sourceExists: existsSync,
     providerDisplayName: async provider => (await getProvider(provider))?.displayName,
     codexModelProvider: readCodexSessionModelProvider,
+    observeCanonicalHistoryParity: async ({ endpointId, sessionCache }) => {
+      const dailyCache = await loadDailyCache()
+      // The parity observer is diagnostic and must never mint authority from an
+      // incomplete or unstamped daily history. A later trusted refresh will run
+      // it automatically through this same path.
+      if (dailyCache.complete !== true || dailyCache.watermarkTrusted !== true) return
+      const { observeCanonicalHistoryParityV1 } = await import('./canonical-history-parity-observer.js')
+      await observeCanonicalHistoryParityV1({ endpointId, sessionCache, dailyCache }, {
+        sourceFingerprint: canonicalSourceRecordFingerprintSha256V1,
+      })
+    },
+    reportCanonicalHistoryParityFailure: reportParityFailure,
+  }
+}
+
+async function observeParityWithoutChangingProduction(
+  input: { endpointId: string; sessionCache: SessionCache },
+  dependencies: CanonicalReviewedProductionScannerDependenciesV1,
+): Promise<void> {
+  if (!dependencies.observeCanonicalHistoryParity) return
+  try {
+    await dependencies.observeCanonicalHistoryParity(input)
+  } catch (error) {
+    try {
+      dependencies.reportCanonicalHistoryParityFailure?.(error)
+    } catch {
+      // Diagnostics are not allowed to become a second production gate.
+    }
   }
 }
 
@@ -142,6 +183,8 @@ export async function scanCanonicalReviewedProductionCandidatesV1(
       'canonical session cache is incomplete after explicit refresh',
     )
   }
+
+  await observeParityWithoutChangingProduction({ endpointId, sessionCache: cache }, dependencies)
 
   const candidates: CanonicalReviewedProductionCandidateV1[] = []
   let withheldCount = 0


### PR DESCRIPTION
## Summary

Implement C3-P0.C as a non-authoritative parity observer that proves the canonical history projection matches current session and trusted daily-cache authorities before the removable shadow store advances.

- independently derive path-free source observations from the complete session cache;
- compare observation payloads and exact-duplicate handling against the projection;
- compare the activity partition without exposing private session identifiers;
- compare path-free daily payloads against the trusted complete daily cache;
- persist only after observation, activity and daily parity all succeed;
- return only digest, status, entity counts, reconciliation and the non-additive marker;
- attach the observer to the trusted reviewed-production refresh boundary;
- keep parity or diagnostic-reporter failures from changing reviewed-production output;
- emit only a generic local stderr warning on failure.

Implements the bounded observer in #130. It does not complete consumer parity, migration or C3 cutover.

## Authority boundary

- session cache remains source-present normalized materialization;
- trusted daily cache remains the durable totals authority;
- shadow snapshots remain removable diagnostics;
- CLI, desktop reports, Workspace, Android and APIs do not read the shadow store;
- no cache schema, displayed total, reviewed candidate, migration, server, sync, account or billing behavior changes.

## Scope

Exactly six files:

- `src/local-state/canonical-history-parity-observer.ts`
- `src/local-state/canonical-history-parity-observer.test.ts`
- `src/local-state/canonical-reviewed-production-scanner-parity.test.ts`
- `src/local-state/canonical-reviewed-production-scanner.ts`
- `docs/CANONICAL_HISTORY_PARITY_OBSERVER_V1.md`
- `docs/README.md`

## Validation before CI

- strict TypeScript check with repository-equivalent contracts: pass;
- isolated runtime characterization: pass;
- successful parity publication: pass;
- exact duplicate deduplication: pass;
- observation and daily mismatch reject before persistence: pass;
- untrusted cache rejects before projection: pass;
- parity failure leaves reviewed candidates unchanged: pass;
- diagnostic reporter failure cannot become a production gate: pass;
- observer module: 426 lines, below the 600-line architecture threshold;
- branch is one commit ahead of `d04bbc7adfa386c640c1068cca584579e38cad52` with no divergence.

Repository CI remains the integration authority.