### PR TITLE
fix(antigravity): install hook through canonical Metrora CLI

### DIFF
--- a/docs/providers/antigravity.md
+++ b/docs/providers/antigravity.md
@@ -1,6 +1,6 @@
 # Antigravity
 
-Google Antigravity (CLI and IDE). CodeBurn discovers session files on disk and queries the local language-server RPC endpoint to parse them.
+Google Antigravity (CLI and IDE). Metrora discovers session files on disk and queries the local language-server RPC endpoint to parse them.
 
 - **Source:** `src/providers/antigravity.ts`
 - **Loading:** lazy via `src/providers/index.ts`. Lazy because the protobuf dependency is heavy.
@@ -8,7 +8,7 @@ Google Antigravity (CLI and IDE). CodeBurn discovers session files on disk and q
 
 ## Where it reads from
 
-CodeBurn discovers Antigravity sessions from local directories on disk, then queries the live language-server process (if running) to fetch detailed trajectory generator metadata:
+Metrora discovers Antigravity sessions from local directories on disk, then queries the live language-server process (if running) to fetch detailed trajectory generator metadata:
 
 1. **Session Discovery:** It scans the following folders for `.pb` or `.db` files:
    - **Antigravity CLI:** `%USERPROFILE%\.gemini\antigravity-cli\conversations` (and `implicit`)
@@ -21,18 +21,30 @@ Antigravity exposes slightly different process flags across platforms:
 POSIX builds have used `--https_server_port` and `--csrf_token`; Windows
 builds can expose `--extension_server_port` and
 `--extension_server_csrf_token`. Both space-separated and `--flag=value`
-forms are supported. The parser identifies the target app type using the `--app-data-dir` flag (e.g., `antigravity`, `antigravity-cli`, or `antigravity-ide`).
+forms are supported. The parser identifies the target app type using the `--app-data-dir` flag (for example, `antigravity`, `antigravity-cli`, or `antigravity-ide`).
 
-For Antigravity CLI (`agy`), CodeBurn can also install an opt-in status line
-hook with `codeburn antigravity-hook install`. The hook records the CLI's
-sanitized `context_window.current_usage` payload while `agy` is still alive,
-without prompts or local working-directory paths. It also attempts a best-effort
-RPC snapshot for full response metadata. The installed command points at a
-persistent `codeburn` binary from PATH rather than a local build artifact, and
-running `codeburn antigravity-hook install` again repairs older CodeBurn-owned
-statusLine commands that used stale absolute paths. Remove it with `codeburn
-antigravity-hook uninstall`; if `--force` replaced an existing statusLine
-command, uninstall restores that previous command.
+For Antigravity CLI (`agy`), Metrora can install an opt-in status line hook:
+
+```bash
+metrora antigravity-hook install
+```
+
+The hook records the CLI's sanitized `context_window.current_usage` payload
+while `agy` is still alive, without prompts or local working-directory paths.
+It also attempts a best-effort RPC snapshot for full response metadata.
+
+The installed command resolves a persistent `metrora` executable from `PATH`.
+The historical `codeburn` alias remains an accepted fallback for compatible
+existing installations, and running the install command again repairs an older
+Metrora-owned hook that points at a stale alias or build path. Remove the hook
+with:
+
+```bash
+metrora antigravity-hook uninstall
+```
+
+If `--force` replaced an existing custom status line, uninstall restores that
+previous command.
 
 ## Storage format
 
@@ -40,7 +52,7 @@ Protobuf. Cascade and response objects map to `ParsedProviderCall` directly.
 
 ## Caching
 
-Custom file cache at `$CODEBURN_CACHE_DIR/antigravity-results.json` (defaults to `~/.cache/codeburn/`). The cache is also used as the data source when the RPC endpoint is unavailable, not just as an optimization. Bumping the cache version forces a recompute.
+Custom file cache at `$CODEBURN_CACHE_DIR/antigravity-results.json` (defaults to `~/.cache/codeburn/`). These retained names are compatibility identifiers. The cache is also used as the data source when the RPC endpoint is unavailable, not just as an optimization. Bumping the cache version forces a recompute.
 
 ## Deduplication
 

--- a/src/antigravity-statusline.ts
+++ b/src/antigravity-statusline.ts
@@ -8,12 +8,15 @@ import {
   snapshotAntigravityStatusLinePayload,
 } from './providers/antigravity.js'
 import {
-  buildPersistentCodeburnLookupPath,
-  resolvePersistentCodeburnPathFromPath,
+  buildPersistentMetroraLookupPath,
+  resolvePersistentMetroraPathFromPath,
 } from './persistent-codeburn.js'
 
-export { buildPersistentCodeburnLookupPath as buildAntigravityHookLookupPath } from './persistent-codeburn.js'
-export { resolvePersistentCodeburnPathFromPath } from './persistent-codeburn.js'
+export { buildPersistentMetroraLookupPath as buildAntigravityHookLookupPath } from './persistent-codeburn.js'
+export {
+  resolvePersistentCodeburnPathFromPath,
+  resolvePersistentMetroraPathFromPath,
+} from './persistent-codeburn.js'
 
 type Settings = Record<string, unknown> & {
   statusLine?: {
@@ -26,13 +29,13 @@ type Settings = Record<string, unknown> & {
 type StatusLineSettings = NonNullable<Settings['statusLine']>
 
 const PERSISTENT_CLI_REQUIRED_MESSAGE =
-  'The Antigravity hook needs a persistent codeburn command. Install CodeBurn globally first: npm install -g codeburn'
+  'The Antigravity hook needs a persistent metrora command. Install Metrora so metrora is available on PATH. Existing codeburn installs remain supported.'
 
 function isObject(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value)
 }
 
-function isCodeBurnHook(command: unknown): boolean {
+function isMetroraHook(command: unknown): boolean {
   return typeof command === 'string' && /(?:^|\s)agy-statusline-hook$/.test(command.trim())
 }
 
@@ -42,11 +45,11 @@ function shellQuote(value: string): string {
 }
 
 async function hookCommand(): Promise<string> {
-  const codeburnPath = await resolvePersistentCodeburnPathFromPath(
-    buildPersistentCodeburnLookupPath(),
+  const metroraPath = await resolvePersistentMetroraPathFromPath(
+    buildPersistentMetroraLookupPath(),
     PERSISTENT_CLI_REQUIRED_MESSAGE,
   )
-  return `${shellQuote(codeburnPath)} agy-statusline-hook`
+  return `${shellQuote(metroraPath)} agy-statusline-hook`
 }
 
 function settingsPath(): string {
@@ -121,17 +124,17 @@ async function clearPreviousStatusLine(): Promise<void> {
 export async function installAntigravityStatusLineHook(force = false): Promise<'installed' | 'already-installed'> {
   const settings = await readSettings()
   const existing = settings.statusLine
-  if (existing && !isCodeBurnHook(existing.command) && !force) {
+  if (existing && !isMetroraHook(existing.command) && !force) {
     throw new Error(
       'Antigravity CLI already has a custom statusLine command. Re-run with --force to replace it.'
     )
   }
 
   const command = await hookCommand()
-  if (isCodeBurnHook(existing?.command) && existing?.command === command && existing.type === 'command' && existing.padding === 0) {
+  if (isMetroraHook(existing?.command) && existing?.command === command && existing.type === 'command' && existing.padding === 0) {
     return 'already-installed'
   }
-  if (existing && !isCodeBurnHook(existing.command)) await savePreviousStatusLine(existing)
+  if (existing && !isMetroraHook(existing.command)) await savePreviousStatusLine(existing)
 
   settings.statusLine = {
     type: 'command',
@@ -144,7 +147,7 @@ export async function installAntigravityStatusLineHook(force = false): Promise<'
 
 export async function uninstallAntigravityStatusLineHook(): Promise<'removed' | 'restored' | 'not-installed'> {
   const settings = await readSettings()
-  if (!isCodeBurnHook(settings.statusLine?.command)) return 'not-installed'
+  if (!isMetroraHook(settings.statusLine?.command)) return 'not-installed'
 
   const previous = await readPreviousStatusLine()
   if (previous) settings.statusLine = previous

--- a/src/persistent-codeburn.ts
+++ b/src/persistent-codeburn.ts
@@ -5,6 +5,9 @@ import { delimiter, join } from 'path'
 export const PERSISTENT_CLI_REQUIRED_MESSAGE =
   'CodeBurn needs a persistent codeburn command. Install CodeBurn globally first: npm install -g codeburn'
 
+export const PERSISTENT_METRORA_CLI_REQUIRED_MESSAGE =
+  'Metrora needs a persistent metrora command. Install Metrora so metrora is available on PATH. The legacy codeburn alias is accepted for compatibility.'
+
 const DEFAULT_CLI_LOOKUP_PATHS = process.platform === 'win32'
   ? []
   : ['/opt/homebrew/bin', '/usr/local/bin', '/usr/bin', '/bin']
@@ -17,13 +20,25 @@ export function buildPersistentCodeburnLookupPath(existingPath = process.env.PAT
   return parts.join(delimiter)
 }
 
+export function buildPersistentMetroraLookupPath(existingPath = process.env.PATH ?? ''): string {
+  return buildPersistentCodeburnLookupPath(existingPath)
+}
+
 export function isTransientNpxPath(path: string): boolean {
   return path.includes('/_npx/') || path.includes('/.npm/_npx/') || path.includes('\\_npx\\')
 }
 
+function commandExecutableNames(command: string): string[] {
+  if (process.platform !== 'win32') return [command]
+  return [`${command}.cmd`, `${command}.exe`, `${command}.bat`, command]
+}
+
 function codeburnExecutableNames(): string[] {
-  if (process.platform !== 'win32') return ['codeburn']
-  return ['codeburn.cmd', 'codeburn.exe', 'codeburn.bat', 'codeburn']
+  return commandExecutableNames('codeburn')
+}
+
+function metroraExecutableNames(): string[] {
+  return commandExecutableNames('metrora')
 }
 
 async function executableExists(path: string): Promise<boolean> {
@@ -35,13 +50,14 @@ async function executableExists(path: string): Promise<boolean> {
   }
 }
 
-export async function resolvePersistentCodeburnPathFromPath(
+async function resolvePersistentExecutableFromPath(
   lookupPath: string,
-  message: string = PERSISTENT_CLI_REQUIRED_MESSAGE,
-): Promise<string> {
+  executableNames: readonly string[],
+): Promise<string | undefined> {
+  const directories = lookupPath.split(delimiter).filter(Boolean)
   const seen = new Set<string>()
-  for (const dir of lookupPath.split(delimiter).filter(Boolean)) {
-    for (const executable of codeburnExecutableNames()) {
+  for (const executable of executableNames) {
+    for (const dir of directories) {
       const candidate = join(dir, executable)
       if (seen.has(candidate)) continue
       seen.add(candidate)
@@ -49,7 +65,25 @@ export async function resolvePersistentCodeburnPathFromPath(
       if (await executableExists(candidate)) return candidate
     }
   }
+  return undefined
+}
+
+export async function resolvePersistentCodeburnPathFromPath(
+  lookupPath: string,
+  message: string = PERSISTENT_CLI_REQUIRED_MESSAGE,
+): Promise<string> {
+  const persistentPath = await resolvePersistentExecutableFromPath(lookupPath, codeburnExecutableNames())
+  if (persistentPath) return persistentPath
   throw new Error(message)
+}
+
+export async function resolvePersistentMetroraPathFromPath(
+  lookupPath: string,
+  message: string = PERSISTENT_METRORA_CLI_REQUIRED_MESSAGE,
+): Promise<string> {
+  const canonicalPath = await resolvePersistentExecutableFromPath(lookupPath, metroraExecutableNames())
+  if (canonicalPath) return canonicalPath
+  return resolvePersistentCodeburnPathFromPath(lookupPath, message)
 }
 
 export function resolvePersistentCodeburnPathFromWhichOutput(

--- a/src/persistent-codeburn.ts
+++ b/src/persistent-codeburn.ts
@@ -56,8 +56,8 @@ async function resolvePersistentExecutableFromPath(
 ): Promise<string | undefined> {
   const directories = lookupPath.split(delimiter).filter(Boolean)
   const seen = new Set<string>()
-  for (const executable of executableNames) {
-    for (const dir of directories) {
+  for (const dir of directories) {
+    for (const executable of executableNames) {
       const candidate = join(dir, executable)
       if (seen.has(candidate)) continue
       seen.add(candidate)

--- a/tests/antigravity-statusline.test.ts
+++ b/tests/antigravity-statusline.test.ts
@@ -100,6 +100,23 @@ describe('Antigravity CLI statusLine hook installer', () => {
     })
   })
 
+  it('preserves PATH order between canonical metrora executables', async () => {
+    await withTempSettings(async ({ dir }) => {
+      const firstBin = join(dir, 'first-bin')
+      const secondBin = join(dir, 'second-bin')
+      const firstMetrora = join(firstBin, executableName('metrora'))
+      const secondMetrora = join(secondBin, executableName('metrora'))
+      await mkdir(firstBin, { recursive: true })
+      await mkdir(secondBin, { recursive: true })
+      await writeExecutable(firstMetrora)
+      await writeExecutable(secondMetrora)
+
+      const resolved = await resolvePersistentMetroraPathFromPath([firstBin, secondBin].join(delimiter))
+
+      expect(resolved).toBe(firstMetrora)
+    })
+  })
+
   it('falls back to a persistent codeburn alias when metrora is unavailable', async () => {
     await withTempSettings(async ({ dir }) => {
       const legacyBin = join(dir, 'legacy-only')

--- a/tests/antigravity-statusline.test.ts
+++ b/tests/antigravity-statusline.test.ts
@@ -1,4 +1,4 @@
-import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from 'fs/promises'
+import { chmod, mkdir, mkdtemp, readFile, rm, unlink, writeFile } from 'fs/promises'
 import { tmpdir } from 'os'
 import { delimiter, join } from 'path'
 import { describe, expect, it } from 'vitest'
@@ -7,25 +7,54 @@ import {
   buildAntigravityHookLookupPath,
   installAntigravityStatusLineHook,
   resolvePersistentCodeburnPathFromPath,
+  resolvePersistentMetroraPathFromPath,
   uninstallAntigravityStatusLineHook,
 } from '../src/antigravity-statusline.js'
 
+type TempHookFixture = {
+  dir: string
+  settingsPath: string
+  binDir: string
+  metroraPath: string
+  codeburnPath: string
+}
+
+function executableName(command: string): string {
+  return process.platform === 'win32' ? `${command}.cmd` : command
+}
+
+async function writeExecutable(path: string): Promise<void> {
+  await writeFile(path, process.platform === 'win32' ? '@echo off\r\n' : '#!/bin/sh\n')
+  await chmod(path, 0o755)
+}
+
 describe('Antigravity CLI statusLine hook installer', () => {
-  async function withTempSettings(run: (dir: string, settingsPath: string) => Promise<void>) {
-    const dir = await mkdtemp(join(tmpdir(), 'codeburn-agy-hook-'))
+  async function withTempSettings(run: (fixture: TempHookFixture) => Promise<void>) {
+    const dir = await mkdtemp(join(tmpdir(), 'metrora-agy-hook-'))
     const settingsPath = join(dir, 'settings.json')
     const binDir = join(dir, 'bin')
-    const codeburnPath = join(binDir, process.platform === 'win32' ? 'codeburn.cmd' : 'codeburn')
+    const metroraPath = join(binDir, executableName('metrora'))
+    const codeburnPath = join(binDir, executableName('codeburn'))
     await mkdir(binDir, { recursive: true })
-    await writeFile(codeburnPath, process.platform === 'win32' ? '@echo off\r\n' : '#!/bin/sh\n')
-    await chmod(codeburnPath, 0o755)
+    await writeExecutable(metroraPath)
+    await writeExecutable(codeburnPath)
+
+    const previousSettingsPath = process.env['CODEBURN_ANTIGRAVITY_SETTINGS_PATH']
+    const previousCacheDir = process.env['CODEBURN_CACHE_DIR']
+    const previousPath = process.env.PATH
     process.env['CODEBURN_ANTIGRAVITY_SETTINGS_PATH'] = settingsPath
     process.env['CODEBURN_CACHE_DIR'] = join(dir, 'cache')
     process.env.PATH = binDir
 
     try {
-      await run(dir, settingsPath)
+      await run({ dir, settingsPath, binDir, metroraPath, codeburnPath })
     } finally {
+      if (previousSettingsPath === undefined) delete process.env['CODEBURN_ANTIGRAVITY_SETTINGS_PATH']
+      else process.env['CODEBURN_ANTIGRAVITY_SETTINGS_PATH'] = previousSettingsPath
+      if (previousCacheDir === undefined) delete process.env['CODEBURN_CACHE_DIR']
+      else process.env['CODEBURN_CACHE_DIR'] = previousCacheDir
+      if (previousPath === undefined) delete process.env.PATH
+      else process.env.PATH = previousPath
       await rm(dir, { recursive: true, force: true })
     }
   }
@@ -37,27 +66,64 @@ describe('Antigravity CLI statusLine hook installer', () => {
     if (process.platform !== 'win32') expect(lookupPath.split(delimiter)).toContain('/opt/homebrew/bin')
   })
 
-  it('skips transient npx codeburn shims when resolving the hook command', async () => {
-    await withTempSettings(async (dir) => {
+  it('skips transient npx metrora shims when resolving the canonical hook command', async () => {
+    await withTempSettings(async ({ dir }) => {
       const npxBin = join(dir, '.npm', '_npx', 'abcd', 'node_modules', '.bin')
       const persistentBin = join(dir, 'persistent-bin')
-      const npxCodeburn = join(npxBin, process.platform === 'win32' ? 'codeburn.cmd' : 'codeburn')
-      const persistentCodeburn = join(persistentBin, process.platform === 'win32' ? 'codeburn.cmd' : 'codeburn')
+      const npxMetrora = join(npxBin, executableName('metrora'))
+      const persistentMetrora = join(persistentBin, executableName('metrora'))
       await mkdir(npxBin, { recursive: true })
       await mkdir(persistentBin, { recursive: true })
-      await writeFile(npxCodeburn, process.platform === 'win32' ? '@echo off\r\n' : '#!/bin/sh\n')
-      await writeFile(persistentCodeburn, process.platform === 'win32' ? '@echo off\r\n' : '#!/bin/sh\n')
-      await chmod(npxCodeburn, 0o755)
-      await chmod(persistentCodeburn, 0o755)
+      await writeExecutable(npxMetrora)
+      await writeExecutable(persistentMetrora)
 
-      const resolved = await resolvePersistentCodeburnPathFromPath([npxBin, persistentBin].join(delimiter))
+      const resolved = await resolvePersistentMetroraPathFromPath([npxBin, persistentBin].join(delimiter))
 
-      expect(resolved).toBe(persistentCodeburn)
+      expect(resolved).toBe(persistentMetrora)
+    })
+  })
+
+  it('prefers metrora globally even when a codeburn alias appears earlier on PATH', async () => {
+    await withTempSettings(async ({ dir }) => {
+      const legacyBin = join(dir, 'legacy-bin')
+      const canonicalBin = join(dir, 'canonical-bin')
+      const legacyCodeburn = join(legacyBin, executableName('codeburn'))
+      const canonicalMetrora = join(canonicalBin, executableName('metrora'))
+      await mkdir(legacyBin, { recursive: true })
+      await mkdir(canonicalBin, { recursive: true })
+      await writeExecutable(legacyCodeburn)
+      await writeExecutable(canonicalMetrora)
+
+      const resolved = await resolvePersistentMetroraPathFromPath([legacyBin, canonicalBin].join(delimiter))
+
+      expect(resolved).toBe(canonicalMetrora)
+    })
+  })
+
+  it('falls back to a persistent codeburn alias when metrora is unavailable', async () => {
+    await withTempSettings(async ({ dir }) => {
+      const legacyBin = join(dir, 'legacy-only')
+      const legacyCodeburn = join(legacyBin, executableName('codeburn'))
+      await mkdir(legacyBin, { recursive: true })
+      await writeExecutable(legacyCodeburn)
+
+      expect(await resolvePersistentMetroraPathFromPath(legacyBin)).toBe(legacyCodeburn)
+      expect(await resolvePersistentCodeburnPathFromPath(legacyBin)).toBe(legacyCodeburn)
+    })
+  })
+
+  it('reports the canonical command when neither persistent executable exists', async () => {
+    await withTempSettings(async ({ dir }) => {
+      const emptyBin = join(dir, 'empty-bin')
+      await mkdir(emptyBin, { recursive: true })
+
+      await expect(resolvePersistentMetroraPathFromPath(emptyBin))
+        .rejects.toThrow(/persistent metrora command/)
     })
   })
 
   it('backs up and restores an existing custom statusLine when forced', async () => {
-    await withTempSettings(async (dir, settingsPath) => {
+    await withTempSettings(async ({ dir, settingsPath }) => {
       const customStatusLine = {
         type: 'command',
         command: 'custom-statusline',
@@ -82,8 +148,8 @@ describe('Antigravity CLI statusLine hook installer', () => {
     })
   })
 
-  it('installs CodeBurn statusLine when no statusLine exists', async () => {
-    await withTempSettings(async (_dir, settingsPath) => {
+  it('installs the canonical metrora statusLine when no statusLine exists', async () => {
+    await withTempSettings(async ({ settingsPath, metroraPath, codeburnPath }) => {
       expect(await installAntigravityStatusLineHook(false)).toBe('installed')
       expect(await installAntigravityStatusLineHook(false)).toBe('already-installed')
 
@@ -92,14 +158,15 @@ describe('Antigravity CLI statusLine hook installer', () => {
         type: 'command',
         padding: 0,
       })
+      expect(settings.statusLine.command).toContain(metroraPath)
+      expect(settings.statusLine.command).not.toContain(codeburnPath)
       expect(settings.statusLine.command).toContain('agy-statusline-hook')
-      expect(settings.statusLine.command).toContain(join(_dir, 'bin'))
       expect(settings.statusLine.command).not.toContain('dist/cli.js')
     })
   })
 
-  it('repairs an existing stale CodeBurn statusLine command without force', async () => {
-    await withTempSettings(async (dir, settingsPath) => {
+  it('repairs an existing stale legacy statusLine command without force', async () => {
+    await withTempSettings(async ({ settingsPath, metroraPath }) => {
       await writeFile(settingsPath, JSON.stringify({
         statusLine: {
           type: 'command',
@@ -111,14 +178,14 @@ describe('Antigravity CLI statusLine hook installer', () => {
       expect(await installAntigravityStatusLineHook(false)).toBe('installed')
 
       const settings = JSON.parse(await readFile(settingsPath, 'utf-8'))
-      expect(settings.statusLine.command).toContain(join(dir, 'bin'))
+      expect(settings.statusLine.command).toContain(metroraPath)
       expect(settings.statusLine.command).toContain('agy-statusline-hook')
       expect(settings.statusLine.command).not.toContain('codeburn-agy-statusline/dist/cli.js')
     })
   })
 
-  it('treats a custom statusLine that only mentions the hook token as custom, not CodeBurn-owned', async () => {
-    await withTempSettings(async (_dir, settingsPath) => {
+  it('treats a custom statusLine that only mentions the hook token as custom, not Metrora-owned', async () => {
+    await withTempSettings(async ({ settingsPath }) => {
       const custom = 'mybar --note "runs agy-statusline-hook nightly"'
       await writeFile(settingsPath, JSON.stringify({
         statusLine: { type: 'command', command: custom, padding: 0 },
@@ -131,12 +198,13 @@ describe('Antigravity CLI statusLine hook installer', () => {
     })
   })
 
-  it('removes CodeBurn statusLine when there is no previous hook backup', async () => {
-    await withTempSettings(async (_dir, settingsPath) => {
+  it('removes a legacy codeburn statusLine when there is no previous hook backup', async () => {
+    await withTempSettings(async ({ settingsPath, metroraPath, codeburnPath }) => {
+      await unlink(metroraPath)
       await writeFile(settingsPath, JSON.stringify({
         statusLine: {
           type: 'command',
-          command: 'codeburn agy-statusline-hook',
+          command: `${codeburnPath} agy-statusline-hook`,
           padding: 0,
         },
       }))


### PR DESCRIPTION
## Summary

Fix the Antigravity status-line installer so a normal Metrora installation can install a Metrora feature without requiring the legacy `codeburn` executable name.

- add a canonical persistent-CLI resolver that prefers `metrora` across the complete lookup PATH;
- preserve normal PATH order between multiple `metrora` executables;
- continue rejecting transient npm/npx shims;
- fall back to the persistent `codeburn` alias for compatibility;
- repair old hook commands toward the canonical executable without `--force`;
- preserve legacy uninstall/restore behavior;
- update the provider guide to use canonical `metrora antigravity-hook` commands;
- leave retained `CODEBURN_*` cache/state names and the legacy menubar resolver unchanged.

Closes #133.

The separately tracked language-server late-start/restart defect remains in #132 and is not mixed into this PR.

## Scope

Exactly four files:

- `src/persistent-codeburn.ts`
- `src/antigravity-statusline.ts`
- `tests/antigravity-statusline.test.ts`
- `docs/providers/antigravity.md`

No provider parsing, RPC, token, cost, deduplication, cache schema, package alias or persisted-state migration changes.

## Validation before CI

- strict TypeScript validation of the changed source modules: pass;
- runtime characterization of canonical preference, legacy fallback, install, repair and uninstall: pass;
- exact branch comparison: ahead-only from `c3fea73170afec55d2fccfd17e7d526d1ff3c5b7`, zero divergence;
- public diff: four authorized files only.

Repository CI is the integration authority. Merge remains Founder-authorized.