### PR TITLE
release(windows): prepare 1.0.0-rc.7 GitHub preview

### DIFF
--- a/.github/workflows/windows-physical-acceptance.yml
+++ b/.github/workflows/windows-physical-acceptance.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - '.github/workflows/windows-physical-acceptance.yml'
       - 'AVVIA-TEST-FISICO-METRORA.cmd'
+      - 'docs/WINDOWS_GITHUB_PRE_RELEASE_ACCEPTANCE_V1.md'
       - 'docs/WINDOWS_PHYSICAL_ACCEPTANCE_R1BD.md'
       - 'docs/WINDOWS_PHYSICAL_ACCEPTANCE_GUIDED.md'
       - 'scripts/*Physical-Acceptance*.ps1'
@@ -20,6 +21,7 @@ on:
     paths:
       - '.github/workflows/windows-physical-acceptance.yml'
       - 'AVVIA-TEST-FISICO-METRORA.cmd'
+      - 'docs/WINDOWS_GITHUB_PRE_RELEASE_ACCEPTANCE_V1.md'
       - 'docs/WINDOWS_PHYSICAL_ACCEPTANCE_R1BD.md'
       - 'docs/WINDOWS_PHYSICAL_ACCEPTANCE_GUIDED.md'
       - 'scripts/*Physical-Acceptance*.ps1'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,8 @@ The current version identifies public source under development. It is not a clai
 - Derived portable and installer formats from one canonical application payload.
 - Validated clean installation, removal, upgrade, repair, controlled rollback, interruption recovery and user-owned state preservation.
 - Completed bounded physical Windows keyboard, scaling, theme, reduced-motion and Narrator acceptance for the unsigned engineering candidate.
+- Added physical-acceptance report v2 with an explicit migration baseline and candidate-derived transitions while preserving historical report v1 verification.
+- Added a public unsigned GitHub pre-release acceptance contract and version-scoped `1.0.0-rc.7` preparation record.
 
 ## 0.9.19 — Metrora public source baseline
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -58,6 +58,25 @@ npm --prefix app run build
 
 Platform workflows add their own manifest, payload, installation, update, rollback and state-preservation checks.
 
+## GitHub Windows pre-release
+
+An unsigned Windows GitHub pre-release is a technical-evaluation channel. It is separate from Microsoft Store signing and certification.
+
+The final candidate must come from an explicit `Metrora Windows Candidate` workflow dispatch on one exact reviewed `main` commit with classification `unsigned-release-candidate`. A pull-request merge ref, ordinary development artifact or local rebuild is not publication authority.
+
+Before a GitHub pre-release may be published:
+
+1. all applicable repository and Windows workflow jobs pass for the exact commit;
+2. the complete downloaded candidate verifies against its source and format manifests;
+3. the guided two-profile physical acceptance produces a valid version 2 PASS report;
+4. release assets are derived from that accepted candidate without rebuilding or patching product bytes;
+5. final checksums, manifests, release notes, known limitations and rollback wording are reviewed;
+6. publication receives an explicit stop/go.
+
+The public acceptance contract is [`docs/WINDOWS_GITHUB_PRE_RELEASE_ACCEPTANCE_V1.md`](docs/WINDOWS_GITHUB_PRE_RELEASE_ACCEPTANCE_V1.md). The version-scoped preparation record is [`release/1.0.0-rc.7/GITHUB_PRE_RELEASE.md`](release/1.0.0-rc.7/GITHUB_PRE_RELEASE.md).
+
+A GitHub pre-release must state that portable and installer assets are unsigned, may trigger SmartScreen, require manual updates and are not Microsoft Store certified. It must not be presented as the stable release merely because GitHub labels it as a release object.
+
 ## Versioning and notes
 
 Metrora uses semantic versioning. The first independent candidate line is `1.0.0-rc.N`; the first official stable release is `1.0.0`. A release change updates every version-bearing package and generated metadata deliberately. See [`docs/VERSIONING.md`](docs/VERSIONING.md).

--- a/docs/README.md
+++ b/docs/README.md
@@ -40,6 +40,9 @@ Component references in this section explain bounded implementation responsibili
 - [Windows format derivation v1](WINDOWS_FORMAT_DERIVATION_V1.md) — one-payload portable and installer derivation.
 - [Windows clean install v1](WINDOWS_CLEAN_INSTALL_V1.md) — isolated NSIS installation and state-preservation contract.
 - [Windows interrupted upgrade recovery v1](WINDOWS_INTERRUPTED_UPGRADE_RECOVERY_V1.md) — deterministic interruption fixture and recovery contract.
+- [Windows GitHub pre-release acceptance v1](WINDOWS_GITHUB_PRE_RELEASE_ACCEPTANCE_V1.md) — current unsigned technical-preview source, candidate, physical and publication gates.
+- [Windows physical acceptance guided path](WINDOWS_PHYSICAL_ACCEPTANCE_GUIDED.md) — two-profile guided execution for the current candidate.
+- [Windows physical acceptance R1.B.D](WINDOWS_PHYSICAL_ACCEPTANCE_R1BD.md) — historical `0.9.19` acceptance contract and evidence boundary.
 - [Versioning](VERSIONING.md) — release-candidate and platform build-version authority.
 - [Releasing Metrora](../RELEASING.md) — public release responsibilities and prohibitions.
 - [Changelog](../CHANGELOG.md) — Metrora-originated public changes.

--- a/docs/WINDOWS_DISTRIBUTION.md
+++ b/docs/WINDOWS_DISTRIBUTION.md
@@ -33,7 +33,9 @@ An official Windows package must:
 
 Portable and installer candidates may be published only as clearly labelled technical artifacts with their exact signature status, checksums and source binding.
 
-They must not be described as an official signed distribution or as equivalent to a channel-certified package.
+An unsigned GitHub pre-release follows the separate source, candidate, physical and publication gates in [Windows GitHub pre-release acceptance v1](WINDOWS_GITHUB_PRE_RELEASE_ACCEPTANCE_V1.md).
+
+Technical artifacts must not be described as an official signed distribution or as equivalent to a channel-certified package.
 
 ## Acceptance gates
 

--- a/docs/WINDOWS_GITHUB_PRE_RELEASE_ACCEPTANCE_V1.md
+++ b/docs/WINDOWS_GITHUB_PRE_RELEASE_ACCEPTANCE_V1.md
@@ -35,7 +35,7 @@ The candidate authority is:
 
 A pull-request merge ref, locally rebuilt candidate, manually reconstructed directory or artifact from another commit is not release authority.
 
-The product version and desktop build version come from the repository version authority. They may not be patched after the product build.
+The public product version and Windows file version come from the repository version authority. They may not be patched after the product build.
 
 ## Automated gates
 
@@ -60,8 +60,8 @@ Current candidates use `metrora.windows-physical-acceptance-report` version 2.
 
 Version 2 records both:
 
-- the exact candidate source commit and product version;
-- the exact historical migration baseline commit and product version.
+- the exact candidate source commit, public product version and Windows file version;
+- the exact historical migration baseline commit, public product version and Windows file version.
 
 The current migration baseline is the accepted Metrora `0.9.19` Windows source at commit:
 
@@ -69,15 +69,17 @@ The current migration baseline is the accepted Metrora `0.9.19` Windows source a
 80c3a5a1a116a0bc2fd5352b9fee2afc58207f15
 ```
 
-Migration transitions are derived from the declared baseline and candidate versions. For `1.0.0-rc.7`, a PASS requires:
+The active candidate has public product version `1.0.0-rc.7` and Windows file version `1.0.0.7`. Migration lifecycle labels use the installed Windows file versions because that is the executable identity verified by the installer harness.
+
+A PASS therefore requires:
 
 ```text
 installed-0.9.19
-upgraded-1.0.0-rc.7
-reinstalled-1.0.0-rc.7
+upgraded-1.0.0.7
+reinstalled-1.0.0.7
 uninstalled-for-rollback
 rolled-back-0.9.19
-re-upgraded-1.0.0-rc.7
+re-upgraded-1.0.0.7
 uninstalled
 ```
 
@@ -109,7 +111,7 @@ After physical PASS, release assets must be derived only from the accepted downl
 Published assets must remain traceable to:
 
 - source commit;
-- product version;
+- public product version and Windows file version;
 - workflow run and attempt;
 - release manifest digest;
 - format manifest digest;

--- a/docs/WINDOWS_GITHUB_PRE_RELEASE_ACCEPTANCE_V1.md
+++ b/docs/WINDOWS_GITHUB_PRE_RELEASE_ACCEPTANCE_V1.md
@@ -1,0 +1,140 @@
+# Windows GitHub pre-release acceptance v1
+
+## Status
+
+Active acceptance contract for the first unsigned Metrora Windows GitHub pre-release.
+
+No candidate is accepted or published merely because this contract exists. The final candidate must be built from an exact reviewed `main` commit, pass automated and physical acceptance, and receive an explicit publication decision.
+
+This contract does not govern Microsoft Store packaging, signing or certification.
+
+## Channel boundary
+
+The GitHub channel is intended for technical evaluators who deliberately choose an unsigned Windows candidate.
+
+It may provide:
+
+- a verified portable ZIP;
+- an explicitly unsigned NSIS installer;
+- SHA-256 checksums;
+- release, payload and format manifests;
+- a sanitized physical-acceptance report;
+- release notes and known limitations.
+
+It must not be described as a stable release, a signed package, a Microsoft-certified package or an automatic update channel.
+
+## Source and build authority
+
+The candidate authority is:
+
+1. one reviewed public `main` commit;
+2. one explicit `Metrora Windows Candidate` workflow dispatch for that commit with classification `unsigned-release-candidate`;
+3. the complete downloaded workflow artifact ZIP;
+4. the manifests, inventories and checksums contained in that artifact;
+5. independent post-download verification from the same workflow run.
+
+A pull-request merge ref, locally rebuilt candidate, manually reconstructed directory or artifact from another commit is not release authority.
+
+The product version and desktop build version come from the repository version authority. They may not be patched after the product build.
+
+## Automated gates
+
+Before physical acceptance begins, the exact candidate commit must pass the applicable repository checks, including:
+
+- version authority;
+- core and desktop tests;
+- architecture and security boundaries;
+- public identity checks;
+- Windows payload build and format derivation;
+- clean install and removal;
+- migration, reinstall, rollback and re-upgrade;
+- controlled interruption and recovery;
+- independent verification of the downloaded candidate;
+- physical-acceptance report and PowerShell runtime guards.
+
+A skipped required job, stale run, failed job or candidate from another commit is a stop condition.
+
+## Physical acceptance report v2
+
+Current candidates use `metrora.windows-physical-acceptance-report` version 2.
+
+Version 2 records both:
+
+- the exact candidate source commit and product version;
+- the exact historical migration baseline commit and product version.
+
+The current migration baseline is the accepted Metrora `0.9.19` Windows source at commit:
+
+```text
+80c3a5a1a116a0bc2fd5352b9fee2afc58207f15
+```
+
+Migration transitions are derived from the declared baseline and candidate versions. For `1.0.0-rc.7`, a PASS requires:
+
+```text
+installed-0.9.19
+upgraded-1.0.0-rc.7
+reinstalled-1.0.0-rc.7
+uninstalled-for-rollback
+rolled-back-0.9.19
+re-upgraded-1.0.0-rc.7
+uninstalled
+```
+
+Historical report version 1 remains valid for the bounded `0.9.18` to `0.9.19` acceptance it originally described. Version 2 does not reinterpret or overwrite that evidence.
+
+## Physical execution
+
+Use a clean checkout at the exact candidate commit and the intact downloaded candidate ZIP.
+
+The guided entry point is:
+
+```text
+AVVIA-TEST-FISICO-METRORA.cmd
+```
+
+The procedure keeps the established two-profile safety split:
+
+1. the existing primary Windows profile performs portable preservation and reopen checks only;
+2. a separate local Windows user performs clean install, uninstall, migration, rollback and re-upgrade tests.
+
+The final report must verify against the exact candidate commit and must not contain usernames, local paths, prompts, responses, Workspace identifiers, keys, receipts or evidence contents.
+
+A FAIL remains evidence. Do not delete user-owned state, alter the report or rebuild the candidate to manufacture a PASS.
+
+## Release-asset boundary
+
+After physical PASS, release assets must be derived only from the accepted downloaded candidate. Product binaries must not be rebuilt or modified.
+
+Published assets must remain traceable to:
+
+- source commit;
+- product version;
+- workflow run and attempt;
+- release manifest digest;
+- format manifest digest;
+- physical-acceptance report digest;
+- final release-asset SHA-256 values.
+
+The portable and installer signature status must be stated as unsigned. SmartScreen guidance must explain the warning without telling users to disable platform security globally.
+
+## Publication gate
+
+Publication requires an explicit stop/go after all of the following are fixed and reviewed:
+
+- accepted source commit;
+- accepted workflow run;
+- accepted artifact digest;
+- physical report PASS and digest;
+- final asset names and checksums;
+- release notes and known limitations;
+- rollback and withdrawal procedure;
+- truthful website and GitHub channel wording.
+
+Creating this contract, passing CI or completing physical acceptance does not publish a release automatically.
+
+## Microsoft independence
+
+Partner Center verification may proceed separately. A later Microsoft Store package uses exact platform-issued identity and Store-specific acceptance.
+
+Microsoft delay does not block preparation or publication of an explicitly unsigned GitHub pre-release, and GitHub publication does not imply Store acceptance or signing.

--- a/docs/WINDOWS_PHYSICAL_ACCEPTANCE_GUIDED.md
+++ b/docs/WINDOWS_PHYSICAL_ACCEPTANCE_GUIDED.md
@@ -1,6 +1,8 @@
 # Metrora Windows physical acceptance — guided path
 
-This guide is a convenience layer over the authoritative R1.B.D protocol in `WINDOWS_PHYSICAL_ACCEPTANCE_R1BD.md`. It does not replace or weaken any candidate, repository, profile, sentinel, lifecycle or report verification.
+This guide is the convenience layer for the current Windows candidate acceptance process in [`WINDOWS_GITHUB_PRE_RELEASE_ACCEPTANCE_V1.md`](WINDOWS_GITHUB_PRE_RELEASE_ACCEPTANCE_V1.md). It does not replace or weaken any candidate, repository, profile, sentinel, lifecycle or report verification.
+
+The historical R1.B.D contract remains the authority for its accepted `0.9.19` evidence. Current candidates produce a version 2 report that records the exact migration baseline and candidate versions instead of reinterpreting the historical version 1 report.
 
 ## What remains manual
 
@@ -17,7 +19,8 @@ The guide fingerprints the local Windows profile without writing the username or
 - download the complete `metrora-windows-candidate-<commit>.zip` artifact produced from that same commit;
 - leave the ZIP intact, preferably in `Downloads`;
 - close every running Metrora process;
-- ensure the repository path can also be read by the dedicated Windows user.
+- ensure the repository path can also be read by the dedicated Windows user;
+- ensure the declared historical migration baseline commit is available in the local Git repository.
 
 Do not manually extract or launch anything from the artifact.
 
@@ -38,6 +41,7 @@ The guide:
 - calls the authoritative preparation script;
 - preserves and hashes the ZIP before bounded extraction;
 - reconstructs and verifies the canonical payload;
+- records the declared migration baseline in the closed acceptance context;
 - creates the sentinel and closed draft report;
 - launches the verified portable twice;
 - records P1 through the existing bounded recorder;
@@ -66,10 +70,10 @@ Open the shared directory shown by the first stage and double-click:
 CONTINUA-TEST-METRORA.cmd
 ```
 
-The guide refuses to continue when it detects the same profile used for P1. On the dedicated profile it invokes the unchanged authoritative scripts for:
+The guide refuses to continue when it detects the same profile used for P1. On the dedicated profile it invokes the authoritative scripts for:
 
 - P2 clean install, first launch, exact layout and identity checks, uninstall and sentinel preservation;
-- P3 local historical fixture build, upgrade, reinstall, explicit rollback, re-upgrade, uninstall, fixture removal and sentinel preservation;
+- P3 local declared-baseline fixture build, upgrade, reinstall, explicit rollback, re-upgrade, uninstall, fixture removal and sentinel preservation;
 - final closed-schema report generation and verification.
 
 The historical fixture remains local and is never uploaded or presented as a supported release.
@@ -82,10 +86,14 @@ A successful run opens the directory containing:
 METRORA-WINDOWS-PHYSICAL-ACCEPTANCE.json
 ```
 
+For current candidates, the report is version 2 and contains the exact historical baseline commit and version alongside the exact candidate source and version.
+
 The report contains no usernames, local paths, prompts, Workspace identifiers, keys, receipts or evidence contents.
 
 A failure stops the guide. It does not clean unknown state destructively, reinterpret a failed observation or convert a FAIL into PASS.
 
 ## Manual fallback
 
-The command-by-command protocol remains available in `WINDOWS_PHYSICAL_ACCEPTANCE_R1BD.md`. Both paths invoke the same underlying scripts and verifiers; the guided path only chooses the correct next stage and supplies validated paths.
+The current release-candidate boundary is defined in [`WINDOWS_GITHUB_PRE_RELEASE_ACCEPTANCE_V1.md`](WINDOWS_GITHUB_PRE_RELEASE_ACCEPTANCE_V1.md). The historical command-by-command R1.B.D protocol remains available in [`WINDOWS_PHYSICAL_ACCEPTANCE_R1BD.md`](WINDOWS_PHYSICAL_ACCEPTANCE_R1BD.md) for the evidence it originally governed.
+
+Both current paths invoke the same checked-in scripts and verifiers; the guided path only chooses the correct next stage and supplies validated paths.

--- a/release/1.0.0-rc.7/GITHUB_PRE_RELEASE.md
+++ b/release/1.0.0-rc.7/GITHUB_PRE_RELEASE.md
@@ -1,0 +1,88 @@
+# Metrora 1.0.0-rc.7 — GitHub pre-release record
+
+## Status
+
+**PREPARATION — NOT ACCEPTED — NOT PUBLISHED**
+
+This record prepares an unsigned Windows technical preview. It is not a stable release, signed package, Microsoft Store package or active update channel.
+
+## Target
+
+- Version: `1.0.0-rc.7`
+- Desktop build version: `1.0.0.7`
+- Platform: Windows x64
+- Channel: GitHub pre-release
+- Signature status: unsigned
+- Tag target: `v1.0.0-rc.7`
+
+The source commit, workflow run, artifact digests and physical report digest remain unset until one exact `main` candidate passes every required gate.
+
+## Planned release assets
+
+The accepted release bundle is expected to contain:
+
+- a verified portable ZIP derived from the accepted portable directory;
+- `Metrora-Setup-1.0.0-rc.7.exe` from the accepted candidate;
+- `SHA256SUMS.txt` for every published asset;
+- `RELEASE_MANIFEST.json`;
+- `PAYLOAD_MANIFEST.jsonl`;
+- `BUILD_ATTESTATION.json`;
+- `FORMAT_DERIVATION.json`;
+- `CANONICAL_PRODUCT_PAYLOAD.jsonl`;
+- `METRORA-WINDOWS-PHYSICAL-ACCEPTANCE.json`.
+
+No product binary may be rebuilt, patched or renamed ambiguously after physical acceptance.
+
+## Draft release notes
+
+Metrora is a local-first application for understanding AI-assisted development usage across supported tools, models, projects and sessions.
+
+This release candidate includes:
+
+- local collection across the registered provider integrations;
+- cost, token, cache, session, model, project and tool analysis;
+- date-effective historical pricing with explicit unavailable evidence;
+- local Optimize, Compare, Budget, Plan, Audit and Doctor workflows;
+- the desktop, CLI and local browser dashboard;
+- local personal Workspace evidence, recovery and export foundations;
+- verified Windows portable and NSIS derivation from one canonical payload;
+- state-preserving installation, migration, rollback and recovery checks.
+
+## Known limitations
+
+- The Windows installer and portable application are unsigned.
+- Windows SmartScreen may show a warning because no trusted publisher signature is attached.
+- Updates are manual; no automatic update channel is active.
+- This candidate is not Microsoft Store certified.
+- The release is Windows x64 only.
+- Android remains an experimental companion and is not part of this release.
+- macOS and Linux development sources do not imply accepted Metrora distributions.
+- Metrora must still distinguish observed, derived, estimated and unavailable evidence; not every provider exposes every metric.
+
+## Required acceptance
+
+- [ ] Freeze one reviewed `main` commit.
+- [ ] Dispatch `Metrora Windows Candidate` as `unsigned-release-candidate` for that commit.
+- [ ] Confirm all applicable CI and Windows jobs pass.
+- [ ] Download the complete candidate artifact without modification.
+- [ ] Verify candidate manifests and source binding.
+- [ ] Complete physical acceptance report v2 with PASS.
+- [ ] Record artifact, manifest and report SHA-256 values.
+- [ ] Derive final release assets without rebuilding product bytes.
+- [ ] Verify final asset checksums from a separate directory.
+- [ ] Review release notes, SmartScreen guidance and rollback wording.
+- [ ] Receive explicit publication authorization.
+- [ ] Create the tag and GitHub pre-release.
+- [ ] Update `metrora.eu` only after the GitHub release is live and verified.
+
+## Stop conditions
+
+Stop without publication when:
+
+- source, version, run or artifact authority is ambiguous;
+- any required automated gate fails or is stale;
+- physical acceptance is not PASS;
+- release assets differ from the accepted candidate;
+- checksums or manifests do not verify;
+- private data appears in metadata or reports;
+- wording implies signing, Store certification, stability or automatic updates that do not exist.

--- a/scripts/Complete-Metrora-Windows-Physical-Acceptance.ps1
+++ b/scripts/Complete-Metrora-Windows-Physical-Acceptance.ps1
@@ -30,41 +30,47 @@ $profiles = [ordered]@{
 
 $report = [ordered]@{
   kind = 'metrora.windows-physical-acceptance-report'
-  version = 1
+  version = [int]$context.version
   generatedAt = [DateTime]::UtcNow.ToString('yyyy-MM-ddTHH:mm:ss.fffZ')
   source = [ordered]@{
     repository = [string]$context.source.repository
     commit = [string]$context.source.commit
   }
-  candidate = [ordered]@{
-    artifactName = [string]$context.candidate.artifactName
-    artifactSha256 = [string]$context.candidate.artifactSha256
-    productVersion = [string]$context.candidate.productVersion
-    releaseManifestSha256 = [string]$context.candidate.releaseManifestSha256
-    formatManifestSha256 = [string]$context.candidate.formatManifestSha256
-  }
-  platform = [ordered]@{
-    edition = [string]$context.platform.edition
-    version = [string]$context.platform.version
-    build = [string]$context.platform.build
-    architecture = [string]$context.platform.architecture
-  }
-  profiles = $profiles
-  privacy = [ordered]@{
-    containsPrivatePaths = $false
-    containsUsernames = $false
-    containsPromptsOrResponses = $false
-    containsWorkspaceIdentifiers = $false
-    containsKeysOrEvidence = $false
-  }
-  limitations = @(
-    'unsigned-candidate'
-    'no-official-release'
-    'no-update-channel'
-    'single-windows-host'
-    'historical-fixture-local-only'
-  )
 }
+if ([int]$context.version -eq 2) {
+  $report.migrationBaseline = [ordered]@{
+    commit = [string]$context.migrationBaseline.commit
+    productVersion = [string]$context.migrationBaseline.productVersion
+  }
+}
+$report.candidate = [ordered]@{
+  artifactName = [string]$context.candidate.artifactName
+  artifactSha256 = [string]$context.candidate.artifactSha256
+  productVersion = [string]$context.candidate.productVersion
+  releaseManifestSha256 = [string]$context.candidate.releaseManifestSha256
+  formatManifestSha256 = [string]$context.candidate.formatManifestSha256
+}
+$report.platform = [ordered]@{
+  edition = [string]$context.platform.edition
+  version = [string]$context.platform.version
+  build = [string]$context.platform.build
+  architecture = [string]$context.platform.architecture
+}
+$report.profiles = $profiles
+$report.privacy = [ordered]@{
+  containsPrivatePaths = $false
+  containsUsernames = $false
+  containsPromptsOrResponses = $false
+  containsWorkspaceIdentifiers = $false
+  containsKeysOrEvidence = $false
+}
+$report.limitations = @(
+  'unsigned-candidate'
+  'no-official-release'
+  'no-update-channel'
+  'single-windows-host'
+  'historical-fixture-local-only'
+)
 
 $reportPath = Join-Path $acceptance 'METRORA-WINDOWS-PHYSICAL-ACCEPTANCE.json'
 Write-MetroraUtf8Json $reportPath $report

--- a/scripts/Complete-Metrora-Windows-Physical-Acceptance.ps1
+++ b/scripts/Complete-Metrora-Windows-Physical-Acceptance.ps1
@@ -41,15 +41,19 @@ if ([int]$context.version -eq 2) {
   $report.migrationBaseline = [ordered]@{
     commit = [string]$context.migrationBaseline.commit
     productVersion = [string]$context.migrationBaseline.productVersion
+    fileVersion = [string]$context.migrationBaseline.fileVersion
   }
 }
 $report.candidate = [ordered]@{
   artifactName = [string]$context.candidate.artifactName
   artifactSha256 = [string]$context.candidate.artifactSha256
   productVersion = [string]$context.candidate.productVersion
-  releaseManifestSha256 = [string]$context.candidate.releaseManifestSha256
-  formatManifestSha256 = [string]$context.candidate.formatManifestSha256
 }
+if ([int]$context.version -eq 2) {
+  $report.candidate.fileVersion = [string]$context.candidate.fileVersion
+}
+$report.candidate.releaseManifestSha256 = [string]$context.candidate.releaseManifestSha256
+$report.candidate.formatManifestSha256 = [string]$context.candidate.formatManifestSha256
 $report.platform = [ordered]@{
   edition = [string]$context.platform.edition
   version = [string]$context.platform.version

--- a/scripts/Prepare-Metrora-Windows-Physical-Acceptance.ps1
+++ b/scripts/Prepare-Metrora-Windows-Physical-Acceptance.ps1
@@ -19,6 +19,7 @@ Set-StrictMode -Version Latest
 
 $migrationBaselineCommit = '80c3a5a1a116a0bc2fd5352b9fee2afc58207f15'
 $migrationBaselineVersion = '0.9.19'
+$migrationBaselineFileVersion = '0.9.19'
 
 if ($ExpectedCommit -notmatch '^[a-f0-9]{40}$') {
   throw 'ExpectedCommit must be a full lowercase Git SHA-1'
@@ -72,6 +73,15 @@ if ([string]$preparation.productVersion -eq $migrationBaselineVersion) {
   throw 'physical candidate version must differ from the migration baseline version'
 }
 
+$candidateFileVersion = (& node (Join-Path $repository 'scripts\resolve-metrora-build-version.mjs') `
+  $preparation.productVersion 2>&1 | Out-String).Trim()
+if ($LASTEXITCODE -ne 0 -or $candidateFileVersion -notmatch '^[0-9]+\.[0-9]+\.[0-9]+(?:\.[0-9]+)?$') {
+  throw 'physical candidate file version could not be resolved from version authority'
+}
+if ($candidateFileVersion -eq $migrationBaselineFileVersion) {
+  throw 'physical candidate file version must differ from the migration baseline file version'
+}
+
 $platform = Get-MetroraWindowsPlatform
 if ($platform.architecture -ne 'x64') {
   throw "physical acceptance requires Windows x64, found $($platform.architecture)"
@@ -99,6 +109,7 @@ $context = [ordered]@{
   migrationBaseline = [ordered]@{
     commit = $migrationBaselineCommit
     productVersion = $migrationBaselineVersion
+    fileVersion = $migrationBaselineFileVersion
   }
   candidate = [ordered]@{
     directory = 'downloaded-candidate'
@@ -108,6 +119,7 @@ $context = [ordered]@{
     archiveEntryCount = [int]$extraction.EntryCount
     archiveUncompressedBytes = [int64]$extraction.UncompressedBytes
     productVersion = [string]$preparation.productVersion
+    fileVersion = $candidateFileVersion
     releaseManifestSha256 = [string]$preparation.releaseManifestSha256
     formatManifestSha256 = [string]$preparation.formatManifestSha256
     canonicalFileCount = [int]$preparation.canonicalFileCount
@@ -133,6 +145,7 @@ $report = [ordered]@{
     artifactName = $context.candidate.artifactName
     artifactSha256 = $context.candidate.artifactSha256
     productVersion = $context.candidate.productVersion
+    fileVersion = $context.candidate.fileVersion
     releaseManifestSha256 = $context.candidate.releaseManifestSha256
     formatManifestSha256 = $context.candidate.formatManifestSha256
   }

--- a/scripts/Prepare-Metrora-Windows-Physical-Acceptance.ps1
+++ b/scripts/Prepare-Metrora-Windows-Physical-Acceptance.ps1
@@ -17,10 +17,18 @@ Set-StrictMode -Version Latest
 . (Join-Path $PSScriptRoot 'windows-physical-context-lib.ps1')
 . (Join-Path $PSScriptRoot 'windows-physical-artifact-lib.ps1')
 
+$migrationBaselineCommit = '80c3a5a1a116a0bc2fd5352b9fee2afc58207f15'
+$migrationBaselineVersion = '0.9.19'
+
 if ($ExpectedCommit -notmatch '^[a-f0-9]{40}$') {
   throw 'ExpectedCommit must be a full lowercase Git SHA-1'
 }
 $repository = Assert-MetroraPhysicalRepositoryAuthority $RepositoryRoot $ExpectedCommit
+
+& git -C $repository cat-file -e "$migrationBaselineCommit`^{commit}"
+if ($LASTEXITCODE -ne 0) {
+  throw 'physical migration baseline commit is unavailable locally'
+}
 
 $archive = (Resolve-Path -LiteralPath $ArtifactArchive).Path
 if (-not (Test-Path -LiteralPath $archive -PathType Leaf)) {
@@ -60,6 +68,9 @@ $preparation = $preparationText | ConvertFrom-Json
 if ($preparation.status -ne 'pass' -or $preparation.sourceCommit -ne $ExpectedCommit) {
   throw 'physical candidate preparation returned an invalid authority'
 }
+if ([string]$preparation.productVersion -eq $migrationBaselineVersion) {
+  throw 'physical candidate version must differ from the migration baseline version'
+}
 
 $platform = Get-MetroraWindowsPlatform
 if ($platform.architecture -ne 'x64') {
@@ -80,10 +91,14 @@ $sentinelSha256 = Get-MetroraFileSha256 $sentinelPath
 
 $context = [ordered]@{
   kind = 'metrora.windows-physical-acceptance-context'
-  version = 1
+  version = 2
   source = [ordered]@{
     repository = 'maikolsiragusaa/metrora'
     commit = $ExpectedCommit
+  }
+  migrationBaseline = [ordered]@{
+    commit = $migrationBaselineCommit
+    productVersion = $migrationBaselineVersion
   }
   candidate = [ordered]@{
     directory = 'downloaded-candidate'
@@ -110,9 +125,10 @@ Get-MetroraPhysicalAcceptanceState $output $repository | Out-Null
 
 $report = [ordered]@{
   kind = 'metrora.windows-physical-acceptance-report'
-  version = 1
+  version = 2
   generatedAt = [DateTime]::UtcNow.ToString('yyyy-MM-ddTHH:mm:ss.fffZ')
   source = $context.source
+  migrationBaseline = $context.migrationBaseline
   candidate = [ordered]@{
     artifactName = $context.candidate.artifactName
     artifactSha256 = $context.candidate.artifactSha256
@@ -150,6 +166,7 @@ if ($LASTEXITCODE -ne 0) {
 [ordered]@{
   status = 'prepared'
   sourceCommit = $ExpectedCommit
+  migrationBaselineVersion = $migrationBaselineVersion
   productVersion = $context.candidate.productVersion
   canonicalFileCount = $context.candidate.canonicalFileCount
   archiveEntryCount = $context.candidate.archiveEntryCount

--- a/scripts/Test-Metrora-Windows-Physical-Migration.ps1
+++ b/scripts/Test-Metrora-Windows-Physical-Migration.ps1
@@ -20,8 +20,6 @@ if (-not $DedicatedProfileAcknowledged) {
   throw 'P3 requires an explicitly acknowledged dedicated Windows user profile'
 }
 
-$baselineCommit = '169992beef06f1f4cddc5dba6bce3b8991ce9fd4'
-$baselineVersion = '0.9.18'
 $state = Get-MetroraPhysicalAcceptanceState $AcceptanceDirectory $RepositoryRoot
 $acceptance = $state.Acceptance
 $repository = $state.Repository
@@ -29,6 +27,14 @@ $candidate = $state.Candidate
 $canonical = $state.Canonical
 $sentinelPath = $state.SentinelPath
 $context = $state.Context
+
+if ([int]$context.version -eq 2) {
+  $baselineCommit = [string]$context.migrationBaseline.commit
+  $baselineVersion = [string]$context.migrationBaseline.productVersion
+} else {
+  $baselineCommit = '169992beef06f1f4cddc5dba6bce3b8991ce9fd4'
+  $baselineVersion = '0.9.18'
+}
 
 & git -C $repository cat-file -e "$baselineCommit`^{commit}"
 if ($LASTEXITCODE -ne 0) {

--- a/scripts/Test-Metrora-Windows-Physical-Report-Runtime.ps1
+++ b/scripts/Test-Metrora-Windows-Physical-Report-Runtime.ps1
@@ -82,11 +82,13 @@ try {
     migrationBaseline = [ordered]@{
       commit = '80c3a5a1a116a0bc2fd5352b9fee2afc58207f15'
       productVersion = '0.9.19'
+      fileVersion = '0.9.19'
     }
     candidate = [ordered]@{
       artifactName = "metrora-windows-candidate-$commit.zip"
       artifactSha256 = $digest
       productVersion = '1.0.0-rc.7'
+      fileVersion = '1.0.0.7'
       releaseManifestSha256 = $digest
       formatManifestSha256 = $digest
     }
@@ -119,11 +121,11 @@ try {
         status = 'pass'
         transitions = @(
           'installed-0.9.19'
-          'upgraded-1.0.0-rc.7'
-          'reinstalled-1.0.0-rc.7'
+          'upgraded-1.0.0.7'
+          'reinstalled-1.0.0.7'
           'uninstalled-for-rollback'
           'rolled-back-0.9.19'
-          're-upgraded-1.0.0-rc.7'
+          're-upgraded-1.0.0.7'
           'uninstalled'
         )
         sentinelPreserved = $true

--- a/scripts/Test-Metrora-Windows-Physical-Report-Runtime.ps1
+++ b/scripts/Test-Metrora-Windows-Physical-Report-Runtime.ps1
@@ -73,16 +73,20 @@ try {
 
   $report = [ordered]@{
     kind = 'metrora.windows-physical-acceptance-report'
-    version = 1
+    version = 2
     generatedAt = [DateTime]::UtcNow.ToString('yyyy-MM-ddTHH:mm:ss.fffZ')
     source = [ordered]@{
       repository = 'maikolsiragusaa/metrora'
       commit = $commit
     }
+    migrationBaseline = [ordered]@{
+      commit = '80c3a5a1a116a0bc2fd5352b9fee2afc58207f15'
+      productVersion = '0.9.19'
+    }
     candidate = [ordered]@{
       artifactName = "metrora-windows-candidate-$commit.zip"
       artifactSha256 = $digest
-      productVersion = '0.9.19'
+      productVersion = '1.0.0-rc.7'
       releaseManifestSha256 = $digest
       formatManifestSha256 = $digest
     }
@@ -106,7 +110,7 @@ try {
         status = 'pass'
         registrationCount = 1
         shortcutCount = 1
-        cliVersion = '0.9.19'
+        cliVersion = '1.0.0-rc.7'
         firstLaunchPassed = $true
         uninstallPassed = $true
         sentinelPreserved = $true
@@ -114,12 +118,12 @@ try {
       migration = [ordered]@{
         status = 'pass'
         transitions = @(
-          'installed-0.9.18'
-          'upgraded-0.9.19'
-          'reinstalled-0.9.19'
+          'installed-0.9.19'
+          'upgraded-1.0.0-rc.7'
+          'reinstalled-1.0.0-rc.7'
           'uninstalled-for-rollback'
-          'rolled-back-0.9.18'
-          're-upgraded-0.9.19'
+          'rolled-back-0.9.19'
+          're-upgraded-1.0.0-rc.7'
           'uninstalled'
         )
         sentinelPreserved = $true

--- a/scripts/windows-physical-acceptance-report.mjs
+++ b/scripts/windows-physical-acceptance-report.mjs
@@ -24,6 +24,24 @@ export const EXPECTED_MIGRATION_TRANSITIONS = Object.freeze([
   'uninstalled',
 ])
 
+export function expectedMigrationTransitions(baselineVersion, candidateVersion) {
+  if (!semverPattern.test(baselineVersion) || !semverPattern.test(candidateVersion)) {
+    throw new Error('migration versions must be semantic versions')
+  }
+  if (baselineVersion === candidateVersion) {
+    throw new Error('migration baseline and candidate versions must differ')
+  }
+  return Object.freeze([
+    `installed-${baselineVersion}`,
+    `upgraded-${candidateVersion}`,
+    `reinstalled-${candidateVersion}`,
+    'uninstalled-for-rollback',
+    `rolled-back-${baselineVersion}`,
+    `re-upgraded-${candidateVersion}`,
+    'uninstalled',
+  ])
+}
+
 function assertObject(value, label) {
   if (!value || typeof value !== 'object' || Array.isArray(value)) {
     throw new Error(`${label} must be an object`)
@@ -167,7 +185,7 @@ function validateCleanProfile(profile, candidateVersion) {
   }
 }
 
-function validateMigrationProfile(profile) {
+function validateMigrationProfile(profile, expectedTransitions) {
   assertExactKeys(profile, [
     'status',
     'transitions',
@@ -182,7 +200,7 @@ function validateMigrationProfile(profile) {
   assertBoolean(profile.fixtureRemoved, 'profiles.migration.fixtureRemoved')
   if (profile.status === 'pass') {
     assertPassCondition(
-      JSON.stringify(profile.transitions) === JSON.stringify(EXPECTED_MIGRATION_TRANSITIONS),
+      JSON.stringify(profile.transitions) === JSON.stringify(expectedTransitions),
       'migration-profile PASS requires the complete declared transition sequence',
     )
     assertPassCondition(profile.sentinelPreserved, 'migration-profile PASS requires preserved sentinel')
@@ -196,8 +214,22 @@ function validateMigrationProfile(profile) {
   }
 }
 
+function validateMigrationBaseline(migrationBaseline) {
+  assertExactKeys(migrationBaseline, ['commit', 'productVersion'], 'migrationBaseline')
+  if (!gitSha1Pattern.test(migrationBaseline.commit)) {
+    throw new Error('migration baseline commit is invalid')
+  }
+  if (!semverPattern.test(migrationBaseline.productVersion)) {
+    throw new Error('migration baseline product version is invalid')
+  }
+}
+
 export function validateWindowsPhysicalAcceptanceReport(report, options = {}) {
-  assertExactKeys(report, [
+  assertObject(report, 'report')
+  if (report.kind !== 'metrora.windows-physical-acceptance-report' || ![1, 2].includes(report.version)) {
+    throw new Error('report kind or version is unsupported')
+  }
+  assertExactKeys(report, report.version === 1 ? [
     'kind',
     'version',
     'generatedAt',
@@ -207,10 +239,18 @@ export function validateWindowsPhysicalAcceptanceReport(report, options = {}) {
     'profiles',
     'privacy',
     'limitations',
+  ] : [
+    'kind',
+    'version',
+    'generatedAt',
+    'source',
+    'migrationBaseline',
+    'candidate',
+    'platform',
+    'profiles',
+    'privacy',
+    'limitations',
   ], 'report')
-  if (report.kind !== 'metrora.windows-physical-acceptance-report' || report.version !== 1) {
-    throw new Error('report kind or version is unsupported')
-  }
   if (typeof report.generatedAt !== 'string' || !timestampPattern.test(report.generatedAt)) {
     throw new Error('generatedAt must be a UTC timestamp')
   }
@@ -245,6 +285,16 @@ export function validateWindowsPhysicalAcceptanceReport(report, options = {}) {
     }
   }
 
+  const migrationTransitions = report.version === 1
+    ? EXPECTED_MIGRATION_TRANSITIONS
+    : (() => {
+        validateMigrationBaseline(report.migrationBaseline)
+        return expectedMigrationTransitions(
+          report.migrationBaseline.productVersion,
+          report.candidate.productVersion,
+        )
+      })()
+
   assertExactKeys(report.platform, ['edition', 'version', 'build', 'architecture'], 'platform')
   for (const field of ['edition', 'version', 'build', 'architecture']) {
     assertSafeText(report.platform[field], `platform.${field}`)
@@ -256,7 +306,7 @@ export function validateWindowsPhysicalAcceptanceReport(report, options = {}) {
   assertExactKeys(report.profiles, ['existing', 'clean', 'migration'], 'profiles')
   validateExistingProfile(report.profiles.existing)
   validateCleanProfile(report.profiles.clean, report.candidate.productVersion)
-  validateMigrationProfile(report.profiles.migration)
+  validateMigrationProfile(report.profiles.migration, migrationTransitions)
 
   assertExactKeys(report.privacy, [
     'containsPrivatePaths',

--- a/scripts/windows-physical-acceptance-report.mjs
+++ b/scripts/windows-physical-acceptance-report.mjs
@@ -1,6 +1,9 @@
+import { buildVersionFor } from './version-authority-lib.mjs'
+
 const sha256Pattern = /^[a-f0-9]{64}$/
 const gitSha1Pattern = /^[a-f0-9]{40}$/
 const semverPattern = /^[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?$/
+const fileVersionPattern = /^[0-9]+\.[0-9]+\.[0-9]+(?:\.[0-9]+)?$/
 const timestampPattern = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3})?Z$/
 const safeTextPattern = /^[^\\/\r\n\0]{1,160}$/
 const artifactNamePattern = /^[A-Za-z0-9][A-Za-z0-9._-]{0,195}\.zip$/
@@ -24,20 +27,20 @@ export const EXPECTED_MIGRATION_TRANSITIONS = Object.freeze([
   'uninstalled',
 ])
 
-export function expectedMigrationTransitions(baselineVersion, candidateVersion) {
-  if (!semverPattern.test(baselineVersion) || !semverPattern.test(candidateVersion)) {
-    throw new Error('migration versions must be semantic versions')
+export function expectedMigrationTransitions(baselineFileVersion, candidateFileVersion) {
+  if (!fileVersionPattern.test(baselineFileVersion) || !fileVersionPattern.test(candidateFileVersion)) {
+    throw new Error('migration file versions are invalid')
   }
-  if (baselineVersion === candidateVersion) {
-    throw new Error('migration baseline and candidate versions must differ')
+  if (baselineFileVersion === candidateFileVersion) {
+    throw new Error('migration baseline and candidate file versions must differ')
   }
   return Object.freeze([
-    `installed-${baselineVersion}`,
-    `upgraded-${candidateVersion}`,
-    `reinstalled-${candidateVersion}`,
+    `installed-${baselineFileVersion}`,
+    `upgraded-${candidateFileVersion}`,
+    `reinstalled-${candidateFileVersion}`,
     'uninstalled-for-rollback',
-    `rolled-back-${baselineVersion}`,
-    `re-upgraded-${candidateVersion}`,
+    `rolled-back-${baselineFileVersion}`,
+    `re-upgraded-${candidateFileVersion}`,
     'uninstalled',
   ])
 }
@@ -215,12 +218,15 @@ function validateMigrationProfile(profile, expectedTransitions) {
 }
 
 function validateMigrationBaseline(migrationBaseline) {
-  assertExactKeys(migrationBaseline, ['commit', 'productVersion'], 'migrationBaseline')
+  assertExactKeys(migrationBaseline, ['commit', 'productVersion', 'fileVersion'], 'migrationBaseline')
   if (!gitSha1Pattern.test(migrationBaseline.commit)) {
     throw new Error('migration baseline commit is invalid')
   }
   if (!semverPattern.test(migrationBaseline.productVersion)) {
     throw new Error('migration baseline product version is invalid')
+  }
+  if (!fileVersionPattern.test(migrationBaseline.fileVersion)) {
+    throw new Error('migration baseline file version is invalid')
   }
 }
 
@@ -263,10 +269,17 @@ export function validateWindowsPhysicalAcceptanceReport(report, options = {}) {
     throw new Error('report source commit does not match the expected commit')
   }
 
-  assertExactKeys(report.candidate, [
+  assertExactKeys(report.candidate, report.version === 1 ? [
     'artifactName',
     'artifactSha256',
     'productVersion',
+    'releaseManifestSha256',
+    'formatManifestSha256',
+  ] : [
+    'artifactName',
+    'artifactSha256',
+    'productVersion',
+    'fileVersion',
     'releaseManifestSha256',
     'formatManifestSha256',
   ], 'candidate')
@@ -279,6 +292,14 @@ export function validateWindowsPhysicalAcceptanceReport(report, options = {}) {
   if (!semverPattern.test(report.candidate.productVersion)) {
     throw new Error('candidate product version is invalid')
   }
+  if (report.version === 2) {
+    if (!fileVersionPattern.test(report.candidate.fileVersion)) {
+      throw new Error('candidate file version is invalid')
+    }
+    if (report.candidate.fileVersion !== buildVersionFor(report.candidate.productVersion)) {
+      throw new Error('candidate file version does not match version authority')
+    }
+  }
   for (const field of ['releaseManifestSha256', 'formatManifestSha256']) {
     if (!sha256Pattern.test(report.candidate[field])) {
       throw new Error(`candidate ${field} is invalid`)
@@ -290,8 +311,8 @@ export function validateWindowsPhysicalAcceptanceReport(report, options = {}) {
     : (() => {
         validateMigrationBaseline(report.migrationBaseline)
         return expectedMigrationTransitions(
-          report.migrationBaseline.productVersion,
-          report.candidate.productVersion,
+          report.migrationBaseline.fileVersion,
+          report.candidate.fileVersion,
         )
       })()
 

--- a/scripts/windows-physical-acceptance-report.node-test.mjs
+++ b/scripts/windows-physical-acceptance-report.node-test.mjs
@@ -87,11 +87,13 @@ function validReportV2() {
   report.migrationBaseline = {
     commit: baselineCommit,
     productVersion: '0.9.19',
+    fileVersion: '0.9.19',
   }
   report.candidate.productVersion = '1.0.0-rc.7'
+  report.candidate.fileVersion = '1.0.0.7'
   report.profiles.clean.cliVersion = '1.0.0-rc.7'
   report.profiles.migration.transitions = [
-    ...expectedMigrationTransitions('0.9.19', '1.0.0-rc.7'),
+    ...expectedMigrationTransitions('0.9.19', '1.0.0.7'),
   ]
   return report
 }
@@ -139,18 +141,18 @@ test('accepts a v2 report with explicit migration authority', () => {
 })
 
 test('derives v2 transitions from baseline and candidate versions', () => {
-  assert.deepEqual(expectedMigrationTransitions('0.9.19', '1.0.0-rc.7'), [
+  assert.deepEqual(expectedMigrationTransitions('0.9.19', '1.0.0.7'), [
     'installed-0.9.19',
-    'upgraded-1.0.0-rc.7',
-    'reinstalled-1.0.0-rc.7',
+    'upgraded-1.0.0.7',
+    'reinstalled-1.0.0.7',
     'uninstalled-for-rollback',
     'rolled-back-0.9.19',
-    're-upgraded-1.0.0-rc.7',
+    're-upgraded-1.0.0.7',
     'uninstalled',
   ])
 })
 
-test('rejects equal baseline and candidate versions', () => {
+test('rejects equal baseline and candidate file versions', () => {
   assert.throws(() => expectedMigrationTransitions('0.9.19', '0.9.19'), /must differ/)
 })
 
@@ -179,6 +181,12 @@ test('requires an explicit valid v2 migration baseline', () => {
   const invalid = validReportV2()
   invalid.migrationBaseline.commit = 'invalid'
   assert.throws(() => validateWindowsPhysicalAcceptanceReport(invalid), /baseline commit/)
+})
+
+test('rejects a candidate file version that contradicts version authority', () => {
+  const report = validReportV2()
+  report.candidate.fileVersion = '1.0.0.8'
+  assert.throws(() => validateWindowsPhysicalAcceptanceReport(report), /version authority/)
 })
 
 test('rejects path-shaped platform text', () => {

--- a/scripts/windows-physical-acceptance-report.node-test.mjs
+++ b/scripts/windows-physical-acceptance-report.node-test.mjs
@@ -3,13 +3,15 @@ import test from 'node:test'
 
 import {
   EXPECTED_MIGRATION_TRANSITIONS,
+  expectedMigrationTransitions,
   validateWindowsPhysicalAcceptanceReport,
 } from './windows-physical-acceptance-report.mjs'
 
 const commit = '4626c5bcc11352ada66131636d7a5f66cd4ad53b'
+const baselineCommit = '80c3a5a1a116a0bc2fd5352b9fee2afc58207f15'
 const digest = 'a'.repeat(64)
 
-function validReport() {
+function validReportV1() {
   return {
     kind: 'metrora.windows-physical-acceptance-report',
     version: 1,
@@ -79,6 +81,21 @@ function validReport() {
   }
 }
 
+function validReportV2() {
+  const report = validReportV1()
+  report.version = 2
+  report.migrationBaseline = {
+    commit: baselineCommit,
+    productVersion: '0.9.19',
+  }
+  report.candidate.productVersion = '1.0.0-rc.7'
+  report.profiles.clean.cliVersion = '1.0.0-rc.7'
+  report.profiles.migration.transitions = [
+    ...expectedMigrationTransitions('0.9.19', '1.0.0-rc.7'),
+  ]
+  return report
+}
+
 function setNotRunProfiles(report) {
   report.profiles.existing = {
     status: 'not-run',
@@ -111,13 +128,34 @@ function setNotRunProfiles(report) {
   }
 }
 
-test('accepts the complete sanitized physical acceptance report', () => {
-  const report = validReport()
+test('accepts the historical v1 physical acceptance report', () => {
+  const report = validReportV1()
   assert.equal(validateWindowsPhysicalAcceptanceReport(report, { expectedCommit: commit }), report)
 })
 
+test('accepts a v2 report with explicit migration authority', () => {
+  const report = validReportV2()
+  assert.equal(validateWindowsPhysicalAcceptanceReport(report, { expectedCommit: commit }), report)
+})
+
+test('derives v2 transitions from baseline and candidate versions', () => {
+  assert.deepEqual(expectedMigrationTransitions('0.9.19', '1.0.0-rc.7'), [
+    'installed-0.9.19',
+    'upgraded-1.0.0-rc.7',
+    'reinstalled-1.0.0-rc.7',
+    'uninstalled-for-rollback',
+    'rolled-back-0.9.19',
+    're-upgraded-1.0.0-rc.7',
+    'uninstalled',
+  ])
+})
+
+test('rejects equal baseline and candidate versions', () => {
+  assert.throws(() => expectedMigrationTransitions('0.9.19', '0.9.19'), /must differ/)
+})
+
 test('rejects a report bound to another source commit', () => {
-  const report = validReport()
+  const report = validReportV2()
   assert.throws(
     () => validateWindowsPhysicalAcceptanceReport(report, { expectedCommit: 'b'.repeat(40) }),
     /source commit/,
@@ -125,7 +163,7 @@ test('rejects a report bound to another source commit', () => {
 })
 
 test('requires a concrete ZIP artifact name and digest', () => {
-  const report = validReport()
+  const report = validReportV2()
   report.candidate.artifactName = 'metrora-windows-candidate'
   assert.throws(() => validateWindowsPhysicalAcceptanceReport(report), /ZIP name/)
   report.candidate.artifactName = `metrora-windows-candidate-${commit}.zip`
@@ -133,50 +171,60 @@ test('requires a concrete ZIP artifact name and digest', () => {
   assert.throws(() => validateWindowsPhysicalAcceptanceReport(report), /artifact digest/)
 })
 
+test('requires an explicit valid v2 migration baseline', () => {
+  const report = validReportV2()
+  delete report.migrationBaseline
+  assert.throws(() => validateWindowsPhysicalAcceptanceReport(report), /fields are invalid/)
+
+  const invalid = validReportV2()
+  invalid.migrationBaseline.commit = 'invalid'
+  assert.throws(() => validateWindowsPhysicalAcceptanceReport(invalid), /baseline commit/)
+})
+
 test('rejects path-shaped platform text', () => {
-  const report = validReport()
+  const report = validReportV2()
   report.platform.edition = 'C:\\Users\\private'
   assert.throws(() => validateWindowsPhysicalAcceptanceReport(report), /without paths/)
 })
 
 test('rejects private-data declarations', () => {
-  const report = validReport()
+  const report = validReportV2()
   report.privacy.containsWorkspaceIdentifiers = true
   assert.throws(() => validateWindowsPhysicalAcceptanceReport(report), /must remain false/)
 })
 
 test('rejects a passing existing profile with duplicate production', () => {
-  const report = validReport()
+  const report = validReportV2()
   report.profiles.existing.duplicateProductionCount = 1
   assert.throws(() => validateWindowsPhysicalAcceptanceReport(report), /duplicate production/)
 })
 
 test('rejects a passing clean profile with ambiguous registration authority', () => {
-  const report = validReport()
+  const report = validReportV2()
   report.profiles.clean.registrationCount = 2
   assert.throws(() => validateWindowsPhysicalAcceptanceReport(report), /one registration/)
 })
 
 test('rejects a passing clean profile with a different CLI version', () => {
-  const report = validReport()
-  report.profiles.clean.cliVersion = '0.9.18'
+  const report = validReportV2()
+  report.profiles.clean.cliVersion = '0.9.19'
   assert.throws(() => validateWindowsPhysicalAcceptanceReport(report), /current CLI version/)
 })
 
-test('rejects an incomplete passing migration sequence', () => {
-  const report = validReport()
-  report.profiles.migration.transitions.pop()
+test('rejects a v2 migration sequence for the wrong candidate', () => {
+  const report = validReportV2()
+  report.profiles.migration.transitions = [...EXPECTED_MIGRATION_TRANSITIONS]
   assert.throws(() => validateWindowsPhysicalAcceptanceReport(report), /complete declared transition/)
 })
 
 test('allows explicitly not-run profiles without manufacturing evidence', () => {
-  const report = validReport()
+  const report = validReportV2()
   setNotRunProfiles(report)
   assert.equal(validateWindowsPhysicalAcceptanceReport(report), report)
 })
 
 test('rejects evidence claims on not-run profiles', () => {
-  const report = validReport()
+  const report = validReportV2()
   setNotRunProfiles(report)
   report.profiles.existing.portableVerified = true
   assert.throws(() => validateWindowsPhysicalAcceptanceReport(report), /not-run forbids portable evidence/)
@@ -186,12 +234,12 @@ test('rejects evidence claims on not-run profiles', () => {
   assert.throws(() => validateWindowsPhysicalAcceptanceReport(report), /not-run requires zero registrations/)
 
   setNotRunProfiles(report)
-  report.profiles.migration.transitions = ['installed-0.9.18']
+  report.profiles.migration.transitions = ['installed-0.9.19']
   assert.throws(() => validateWindowsPhysicalAcceptanceReport(report), /not-run forbids transitions/)
 })
 
 test('rejects unknown fields rather than accepting future private content', () => {
-  const report = validReport()
+  const report = validReportV2()
   report.notes = 'private path or identifier could leak here'
   assert.throws(() => validateWindowsPhysicalAcceptanceReport(report), /fields are invalid/)
 })

--- a/scripts/windows-physical-context-lib.ps1
+++ b/scripts/windows-physical-context-lib.ps1
@@ -26,13 +26,13 @@ function Get-MetroraPhysicalAcceptanceState([string]$AcceptanceDirectory, [strin
     Assert-MetroraPhysicalContextKeys $context @('kind', 'version', 'source', 'candidate', 'platform', 'sentinel') 'context'
   } elseif ($contextVersion -eq 2) {
     Assert-MetroraPhysicalContextKeys $context @('kind', 'version', 'source', 'migrationBaseline', 'candidate', 'platform', 'sentinel') 'context'
-    Assert-MetroraPhysicalContextKeys $context.migrationBaseline @('commit', 'productVersion') 'context.migrationBaseline'
+    Assert-MetroraPhysicalContextKeys $context.migrationBaseline @('commit', 'productVersion', 'fileVersion') 'context.migrationBaseline'
   } else {
     throw 'physical acceptance context version is unsupported'
   }
 
   Assert-MetroraPhysicalContextKeys $context.source @('repository', 'commit') 'context.source'
-  Assert-MetroraPhysicalContextKeys $context.candidate @(
+  $candidateKeys = @(
     'directory',
     'archive',
     'artifactName',
@@ -44,7 +44,9 @@ function Get-MetroraPhysicalAcceptanceState([string]$AcceptanceDirectory, [strin
     'formatManifestSha256',
     'canonicalFileCount',
     'canonicalInventorySha256'
-  ) 'context.candidate'
+  )
+  if ($contextVersion -eq 2) { $candidateKeys += 'fileVersion' }
+  Assert-MetroraPhysicalContextKeys $context.candidate $candidateKeys 'context.candidate'
   Assert-MetroraPhysicalContextKeys $context.platform @('edition', 'version', 'build', 'architecture') 'context.platform'
   Assert-MetroraPhysicalContextKeys $context.sentinel @('file', 'sha256') 'context.sentinel'
 
@@ -63,7 +65,9 @@ function Get-MetroraPhysicalAcceptanceState([string]$AcceptanceDirectory, [strin
     if (
       $context.migrationBaseline.commit -notmatch '^[a-f0-9]{40}$' -or
       $context.migrationBaseline.productVersion -notmatch '^[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?$' -or
-      $context.migrationBaseline.productVersion -eq $context.candidate.productVersion
+      $context.migrationBaseline.fileVersion -notmatch '^[0-9]+\.[0-9]+\.[0-9]+(?:\.[0-9]+)?$' -or
+      $context.candidate.fileVersion -notmatch '^[0-9]+\.[0-9]+\.[0-9]+(?:\.[0-9]+)?$' -or
+      $context.migrationBaseline.fileVersion -eq $context.candidate.fileVersion
     ) {
       throw 'physical acceptance migration baseline authority is invalid'
     }

--- a/scripts/windows-physical-context-lib.ps1
+++ b/scripts/windows-physical-context-lib.ps1
@@ -20,8 +20,17 @@ function Get-MetroraPhysicalAcceptanceState([string]$AcceptanceDirectory, [strin
     throw 'physical acceptance context is missing'
   }
   $context = Get-Content -LiteralPath $contextPath -Raw | ConvertFrom-Json
+  $contextVersion = [int]$context.version
 
-  Assert-MetroraPhysicalContextKeys $context @('kind', 'version', 'source', 'candidate', 'platform', 'sentinel') 'context'
+  if ($contextVersion -eq 1) {
+    Assert-MetroraPhysicalContextKeys $context @('kind', 'version', 'source', 'candidate', 'platform', 'sentinel') 'context'
+  } elseif ($contextVersion -eq 2) {
+    Assert-MetroraPhysicalContextKeys $context @('kind', 'version', 'source', 'migrationBaseline', 'candidate', 'platform', 'sentinel') 'context'
+    Assert-MetroraPhysicalContextKeys $context.migrationBaseline @('commit', 'productVersion') 'context.migrationBaseline'
+  } else {
+    throw 'physical acceptance context version is unsupported'
+  }
+
   Assert-MetroraPhysicalContextKeys $context.source @('repository', 'commit') 'context.source'
   Assert-MetroraPhysicalContextKeys $context.candidate @(
     'directory',
@@ -41,7 +50,6 @@ function Get-MetroraPhysicalAcceptanceState([string]$AcceptanceDirectory, [strin
 
   if (
     $context.kind -ne 'metrora.windows-physical-acceptance-context' -or
-    $context.version -ne 1 -or
     $context.source.repository -ne 'maikolsiragusaa/metrora' -or
     $context.source.commit -notmatch '^[a-f0-9]{40}$' -or
     $context.candidate.directory -ne 'downloaded-candidate' -or
@@ -50,6 +58,17 @@ function Get-MetroraPhysicalAcceptanceState([string]$AcceptanceDirectory, [strin
   ) {
     throw 'physical acceptance context authority is invalid'
   }
+
+  if ($contextVersion -eq 2) {
+    if (
+      $context.migrationBaseline.commit -notmatch '^[a-f0-9]{40}$' -or
+      $context.migrationBaseline.productVersion -notmatch '^[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?$' -or
+      $context.migrationBaseline.productVersion -eq $context.candidate.productVersion
+    ) {
+      throw 'physical acceptance migration baseline authority is invalid'
+    }
+  }
+
   foreach ($digest in @(
     $context.candidate.artifactSha256,
     $context.candidate.releaseManifestSha256,


### PR DESCRIPTION
Advance the Windows distribution work without closing the broader distribution milestone.

## Purpose

Prepare the then-current `1.0.0-rc.7` source line for an explicitly unsigned Windows GitHub pre-release while keeping Store distribution as a separate channel.

This PR does **not** create a tag, publish a GitHub Release, submit a Store package, add signing authority or change product runtime behavior.

## What changed

- add the public GitHub pre-release acceptance contract and version-scoped preparation record;
- preserve historical physical-acceptance report verification;
- add report/context v2 with an explicit `0.9.19` migration baseline;
- distinguish public product version `1.0.0-rc.7` from Windows FileVersion `1.0.0.7`;
- derive lifecycle transition labels from the exact installed FileVersions verified by the Windows harness;
- update preparation, migration and finalization scripts without weakening the existing source-binding or privacy boundaries;
- update public release and distribution documentation;
- include the acceptance contract in the existing physical-acceptance CI guard.

## Validation

- modified report validator/tests passed;
- branch was based on the expected reviewed source line without divergence;
- GitHub Actions remained the integration authority for the complete Windows candidate lifecycle.

## Boundaries

No Store submission, stable publication or signing authority is introduced by this PR. Distribution actions remain separate from source integration.