### PR TITLE
docs(release): close out RC7 GitHub publication

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Understand where AI time, tokens and money go across tools, models, projects and sessions — without routing your work through another service.
 
-[Website](https://metrora.eu) · [Getting started](docs/GETTING_STARTED.md) · [Supported tools](docs/SUPPORTED_TOOLS.md) · [Documentation](docs/README.md)
+[Website](https://metrora.eu) · [Windows preview](https://github.com/maikolsiragusaa/metrora/releases/tag/v1.0.0-rc.7) · [Getting started](docs/GETTING_STARTED.md) · [Supported tools](docs/SUPPORTED_TOOLS.md) · [Documentation](docs/README.md)
 
 [![Metrora CI](https://github.com/maikolsiragusaa/metrora/actions/workflows/ci.yml/badge.svg)](https://github.com/maikolsiragusaa/metrora/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-E8590C.svg)](LICENSE)
@@ -14,7 +14,17 @@ Understand where AI time, tokens and money go across tools, models, projects and
 </div>
 
 > [!IMPORTANT]
-> Official desktop distribution is in preparation. Metrora does not yet have an official stable desktop release. The current public source line is `1.0.0-rc.7`; build and evaluate it from this canonical repository. Official artifacts will be announced through [metrora.eu](https://metrora.eu) and GitHub Releases only after the applicable distribution checks pass.
+> Metrora `1.0.0-rc.7` is available as an **unsigned Windows x64 technical preview**. It is not the stable `1.0.0` release, a signed package, a Microsoft Store package or an automatic update channel. Windows SmartScreen may show a warning. Verify `SHA256SUMS.txt` before running downloaded binaries.
+
+## Download the Windows technical preview
+
+Download the accepted installer or portable bundle from the [Metrora 1.0.0-rc.7 GitHub pre-release](https://github.com/maikolsiragusaa/metrora/releases/tag/v1.0.0-rc.7):
+
+- `Metrora-Setup-1.0.0-rc.7.exe` — unsigned Windows installer;
+- `Metrora-1.0.0-rc.7-Windows-x64-portable.zip` — portable Windows bundle;
+- `SHA256SUMS.txt` — checksums for the published payload assets.
+
+The published binaries were derived from one accepted candidate at commit `e158ee34e570161c778162be77629b3a4dbb74fe`, passed the documented automated and physical Windows acceptance, and remain subject to the limitations above. See the [version-scoped publication record](release/1.0.0-rc.7/GITHUB_PRE_RELEASE.md).
 
 ## What Metrora helps you understand
 
@@ -140,7 +150,7 @@ Historical API-equivalent pricing is date-effective and non-retroactive by defau
 
 | Surface | Role | Current status |
 | --- | --- | --- |
-| Desktop | Primary local analysis and configuration | Windows official distribution in preparation; development builds available from source |
+| Desktop | Primary local analysis and configuration | Unsigned Windows x64 technical preview available; stable and Microsoft Store distributions are not yet available |
 | CLI | Automation, inspection, export and keyboard-first analysis | Available from source |
 | Local web dashboard | Browser view served from the local machine | Available from source |
 | Android companion | Read-only local-network companion foundation | Experimental |

--- a/release/1.0.0-rc.7/GITHUB_PRE_RELEASE.md
+++ b/release/1.0.0-rc.7/GITHUB_PRE_RELEASE.md
@@ -2,42 +2,59 @@
 
 ## Status
 
-**PREPARATION — NOT ACCEPTED — NOT PUBLISHED**
+**ACCEPTED — PUBLISHED AS GITHUB PRE-RELEASE**
 
-This record prepares an unsigned Windows technical preview. It is not a stable release, signed package, Microsoft Store package or active update channel.
+Published on 2026-08-06 as an unsigned Windows x64 technical preview:
 
-## Target
+- release: [Metrora 1.0.0-rc.7 — Windows technical preview](https://github.com/maikolsiragusaa/metrora/releases/tag/v1.0.0-rc.7);
+- tag: `v1.0.0-rc.7`;
+- source commit: `e158ee34e570161c778162be77629b3a4dbb74fe`;
+- product version: `1.0.0-rc.7`;
+- Windows FileVersion: `1.0.0.7`;
+- platform: Windows x64;
+- signature status: unsigned;
+- update model: manual;
+- Microsoft Store status: not certified or published through the Store.
 
-- Version: `1.0.0-rc.7`
-- Desktop build version: `1.0.0.7`
-- Platform: Windows x64
-- Channel: GitHub pre-release
-- Signature status: unsigned
-- Tag target: `v1.0.0-rc.7`
+This is not the stable `1.0.0` release, a signed package or an automatic update channel.
 
-The source commit, workflow run, artifact digests and physical report digest remain unset until one exact `main` candidate passes every required gate.
+## Accepted authority
 
-## Planned release assets
+- Candidate workflow: [`Metrora Windows Candidate` run 31099518584](https://github.com/maikolsiragusaa/metrora/actions/runs/31099518584)
+- Candidate classification: `unsigned-release-candidate`
+- Candidate artifact: `metrora-windows-candidate-e158ee34e570161c778162be77629b3a4dbb74fe.zip`
+- Candidate artifact SHA-256: `f79bb8086d66a4ed462259de9d25fa0ed48945b219c3a79323eca7f86811221a`
+- Release manifest SHA-256: `4ff273ae06779ae39a806343b3ea295daf1754d041710a926f287de3d4456301`
+- Format derivation SHA-256: `28ce1f3f4daeb9b69fdbe3a0720da3bb7de2bf845ea1bb90a5916d176f71a81e`
+- Physical acceptance report SHA-256: `1242c7d700debb4a98bca0563740358f1bdd9a90c7cfff31fc85495028a7015a`
+- Physical acceptance result: PASS
+- Migration baseline: `0.9.19` at `80c3a5a1a116a0bc2fd5352b9fee2afc58207f15`
 
-The accepted release bundle is expected to contain:
+The accepted two-profile Windows report verified existing-profile preservation, clean installation and removal, and the complete `0.9.19` → `1.0.0.7` migration, reinstall, rollback and re-upgrade sequence. The sanitized report contains no usernames, private paths, prompts, responses, Workspace identifiers, keys or evidence contents.
 
-- a verified portable ZIP derived from the accepted portable directory;
-- `Metrora-Setup-1.0.0-rc.7.exe` from the accepted candidate;
-- `SHA256SUMS.txt` for every published asset;
-- `RELEASE_MANIFEST.json`;
-- `PAYLOAD_MANIFEST.jsonl`;
-- `BUILD_ATTESTATION.json`;
-- `FORMAT_DERIVATION.json`;
-- `CANONICAL_PRODUCT_PAYLOAD.jsonl`;
-- `METRORA-WINDOWS-PHYSICAL-ACCEPTANCE.json`.
+## Published assets
 
-No product binary may be rebuilt, patched or renamed ambiguously after physical acceptance.
+The GitHub pre-release contains these nine manually published assets plus GitHub's automatically generated source archives:
 
-## Draft release notes
+| Asset | SHA-256 |
+| --- | --- |
+| `Metrora-1.0.0-rc.7-Windows-x64-portable.zip` | `5806ad1e928f6cbf162470ff85fd16d6c900b5e74f51959ea74106bf1fafeacf` |
+| `Metrora-Setup-1.0.0-rc.7.exe` | `360e99a2b2a342e4db852b862cb6f69ba462a8d79a56158003d7050c9ccb7b30` |
+| `RELEASE_MANIFEST.json` | `4ff273ae06779ae39a806343b3ea295daf1754d041710a926f287de3d4456301` |
+| `PAYLOAD_MANIFEST.jsonl` | `5b94ecc64159acf1702d65a72c4d3770dceac8506ee4d20c8c69a3f67c8d57d9` |
+| `BUILD_ATTESTATION.json` | `df51faccd000b94738c1242af292edcee821f0fd5afe9c4768e72acf07795bdb` |
+| `FORMAT_DERIVATION.json` | `28ce1f3f4daeb9b69fdbe3a0720da3bb7de2bf845ea1bb90a5916d176f71a81e` |
+| `CANONICAL_PRODUCT_PAYLOAD.jsonl` | `bdcc6c6c2a0584e6c1aef5f6a9f50f0817b8518aaf9419d695d6f7fd1972de06` |
+| `METRORA-WINDOWS-PHYSICAL-ACCEPTANCE.json` | `1242c7d700debb4a98bca0563740358f1bdd9a90c7cfff31fc85495028a7015a` |
+| `SHA256SUMS.txt` | verify the listed payload hashes before running binaries |
+
+The installer and portable ZIP were derived from the accepted candidate without rebuilding or patching product bytes.
+
+## Included product boundary
 
 Metrora is a local-first application for understanding AI-assisted development usage across supported tools, models, projects and sessions.
 
-This release candidate includes:
+This candidate includes:
 
 - local collection across the registered provider integrations;
 - cost, token, cache, session, model, project and tool analysis;
@@ -51,38 +68,40 @@ This release candidate includes:
 ## Known limitations
 
 - The Windows installer and portable application are unsigned.
-- Windows SmartScreen may show a warning because no trusted publisher signature is attached.
+- Windows SmartScreen may show an unrecognized-app warning.
+- Do not disable Windows security globally; verify `SHA256SUMS.txt` and make a deliberate per-file decision.
 - Updates are manual; no automatic update channel is active.
 - This candidate is not Microsoft Store certified.
 - The release is Windows x64 only.
 - Android remains an experimental companion and is not part of this release.
 - macOS and Linux development sources do not imply accepted Metrora distributions.
-- Metrora must still distinguish observed, derived, estimated and unavailable evidence; not every provider exposes every metric.
+- Provider evidence varies; Metrora keeps observed, derived, estimated and unavailable values distinct.
 
-## Required acceptance
+## Completed acceptance
 
-- [ ] Freeze one reviewed `main` commit.
-- [ ] Dispatch `Metrora Windows Candidate` as `unsigned-release-candidate` for that commit.
-- [ ] Confirm all applicable CI and Windows jobs pass.
-- [ ] Download the complete candidate artifact without modification.
-- [ ] Verify candidate manifests and source binding.
-- [ ] Complete physical acceptance report v2 with PASS.
-- [ ] Record artifact, manifest and report SHA-256 values.
-- [ ] Derive final release assets without rebuilding product bytes.
-- [ ] Verify final asset checksums from a separate directory.
-- [ ] Review release notes, SmartScreen guidance and rollback wording.
-- [ ] Receive explicit publication authorization.
-- [ ] Create the tag and GitHub pre-release.
-- [ ] Update `metrora.eu` only after the GitHub release is live and verified.
+- [x] Freeze one reviewed `main` commit.
+- [x] Dispatch `Metrora Windows Candidate` as `unsigned-release-candidate` for that commit.
+- [x] Confirm all applicable CI and Windows jobs pass.
+- [x] Download the complete candidate artifact without modification.
+- [x] Verify candidate manifests and source binding.
+- [x] Complete physical acceptance report v2 with PASS.
+- [x] Record artifact, manifest and report SHA-256 values.
+- [x] Derive final release assets without rebuilding product bytes.
+- [x] Verify final asset checksums from a separate directory.
+- [x] Review release notes, SmartScreen guidance and rollback wording.
+- [x] Receive explicit publication authorization.
+- [x] Create tag `v1.0.0-rc.7` and the GitHub pre-release.
+- [x] Verify the live release, asset inventory and visible hashes.
+- [x] Publish truthful download access through `metrora.eu` after the GitHub release was live.
 
-## Stop conditions
+## Remaining gates
 
-Stop without publication when:
+This publication does not authorize:
 
-- source, version, run or artifact authority is ambiguous;
-- any required automated gate fails or is stale;
-- physical acceptance is not PASS;
-- release assets differ from the accepted candidate;
-- checksums or manifests do not verify;
-- private data appears in metadata or reports;
-- wording implies signing, Store certification, stability or automatic updates that do not exist.
+- promotion to stable `1.0.0`;
+- replacement or mutation of the published binaries;
+- an automatic update channel;
+- signing or Microsoft Store claims;
+- a Store package before exact Partner Center identity and Store-specific acceptance exist.
+
+A compromised asset, checksum mismatch, privacy defect or materially false release statement remains a withdrawal condition.

--- a/scripts/check-public-identity-boundary.mjs
+++ b/scripts/check-public-identity-boundary.mjs
@@ -36,7 +36,9 @@ const requiredFiles = {
     'Vensent™',
   ],
   'README.md': [
-    'Official desktop distribution is in preparation',
+    'Metrora `1.0.0-rc.7` is available as an **unsigned Windows x64 technical preview**',
+    'https://github.com/maikolsiragusaa/metrora/releases/tag/v1.0.0-rc.7',
+    'It is not the stable `1.0.0` release, a signed package, a Microsoft Store package or an automatic update channel',
     'Metrora is independently maintained',
     'Metrora™ — published by Vensent™',
   ],


### PR DESCRIPTION
## Summary

Close the public documentation gap after the verified publication of Metrora `v1.0.0-rc.7`.

- mark the version-scoped GitHub pre-release record as accepted and published;
- record the exact source, workflow, candidate, manifest, physical-report and release-asset hashes;
- mark the acceptance checklist complete;
- expose the Windows installer and portable preview directly from the README;
- preserve the unsigned, pre-release, SmartScreen, manual-update and non-Store boundaries;
- update the public-identity guard so the new truthful release markers remain mandatory.

## Authority

- source commit: `e158ee34e570161c778162be77629b3a4dbb74fe`
- tag: `v1.0.0-rc.7`
- workflow run: `31099518584`
- physical acceptance: PASS
- release: `https://github.com/maikolsiragusaa/metrora/releases/tag/v1.0.0-rc.7`

## Scope

Documentation plus its exact public-identity regression guard. No product code, product bytes, version, workflow, tag or release asset changes.

Merge authority remains with the Founder.