### PR TITLE
build(store): establish exact Metrora AppX identity

### DIFF
--- a/.github/workflows/windows-store-package.yml
+++ b/.github/workflows/windows-store-package.yml
@@ -46,7 +46,7 @@ jobs:
           node-version: '22.15.0'
           cache: npm
 
-      - name: Validate exact Store identity and channel separation
+      - name: Validate Store identity and channel separation
         run: node scripts/windows-store-identity.node-test.mjs
 
       - name: Install core dependencies
@@ -58,7 +58,7 @@ jobs:
       - name: Build unsigned AppX candidate without publication
         run: npm --prefix app run package:store
 
-      - name: Inspect package manifest, assets, and signature boundary
+      - name: Inspect package boundary
         id: inspect
         shell: pwsh
         run: |
@@ -84,31 +84,31 @@ jobs:
           $application = $manifest.Package.Applications.Application
 
           if ($identity.Name -cne 'Vensent.Metrora') {
-            throw "unexpected Identity.Name: $($identity.Name)"
+            throw 'unexpected package identity name'
           }
           if ($identity.Publisher -cne 'CN=BC955F81-5099-4C27-A7A6-FF611BAACC3F') {
-            throw "unexpected Identity.Publisher: $($identity.Publisher)"
+            throw 'unexpected package publisher'
           }
           if ($identity.ProcessorArchitecture -cne 'x64') {
-            throw "unexpected package architecture: $($identity.ProcessorArchitecture)"
+            throw 'unexpected package architecture'
           }
           if ([string]$properties.PublisherDisplayName -cne 'Vensent') {
-            throw "unexpected PublisherDisplayName: $($properties.PublisherDisplayName)"
+            throw 'unexpected publisher display name'
           }
           if ([string]$properties.DisplayName -cne 'Metrora') {
-            throw "unexpected package DisplayName: $($properties.DisplayName)"
+            throw 'unexpected package display name'
           }
           if ($application.Id -cne 'eu.metrora.desktop') {
-            throw "unexpected application Id: $($application.Id)"
+            throw 'unexpected application identifier'
           }
 
           $capabilities = @($manifest.Package.Capabilities.ChildNodes | ForEach-Object { $_.GetAttribute('Name') })
           if ($capabilities.Count -ne 1 -or $capabilities[0] -cne 'runFullTrust') {
-            throw "unexpected capability set: $($capabilities -join ', ')"
+            throw 'unexpected capability set'
           }
 
           if (Test-Path -LiteralPath (Join-Path $unpacked 'AppxSignature.p7x')) {
-            throw 'the pre-submission Store candidate must remain unsigned'
+            throw 'the pre-submission candidate must remain unsigned'
           }
 
           Add-Type -AssemblyName System.Drawing
@@ -120,7 +120,7 @@ jobs:
             $image = [System.Drawing.Image]::FromFile($matches[0].FullName)
             try {
               if ($image.Width -ne $width -or $image.Height -ne $height) {
-                throw "$name has $($image.Width)x$($image.Height), expected ${width}x${height}"
+                throw "$name has unexpected dimensions"
               }
             } finally {
               $image.Dispose()
@@ -135,7 +135,6 @@ jobs:
           $candidateDirectory = Join-Path $PWD 'app\release\Metrora-Windows-Store-Candidate'
           New-Item -ItemType Directory -Path $candidateDirectory -Force | Out-Null
           Copy-Item -LiteralPath $package.FullName -Destination $candidateDirectory -Force
-          Copy-Item -LiteralPath $manifestPath -Destination (Join-Path $candidateDirectory 'AppxManifest.xml') -Force
 
           $hash = (Get-FileHash -LiteralPath $package.FullName -Algorithm SHA256).Hash.ToLowerInvariant()
           $summary = [ordered]@{
@@ -145,12 +144,6 @@ jobs:
             sha256 = $hash
             packageVersion = [string]$identity.Version
             architecture = [string]$identity.ProcessorArchitecture
-            identityName = [string]$identity.Name
-            publisher = [string]$identity.Publisher
-            publisherDisplayName = [string]$properties.PublisherDisplayName
-            applicationId = [string]$application.Id
-            packageFamilyName = 'Vensent.Metrora_1xcj95baterfy'
-            storeId = '9NXSZFQSBBDX'
             signed = $false
             submitted = $false
             published = $false
@@ -178,7 +171,5 @@ jobs:
 
           - Artifact: `${{ steps.inspect.outputs.artifact_name }}`
           - SHA-256: `${{ steps.inspect.outputs.sha256 }}`
-          - Identity: `Vensent.Metrora`
-          - Publisher: `CN=BC955F81-5099-4C27-A7A6-FF611BAACC3F`
           - State: unsigned, not submitted, not published
           "@ >> $env:GITHUB_STEP_SUMMARY

--- a/.github/workflows/windows-store-package.yml
+++ b/.github/workflows/windows-store-package.yml
@@ -102,7 +102,7 @@ jobs:
             throw "unexpected application Id: $($application.Id)"
           }
 
-          $capabilities = @($manifest.Package.Capabilities.ChildNodes | ForEach-Object { $_.Name })
+          $capabilities = @($manifest.Package.Capabilities.ChildNodes | ForEach-Object { $_.GetAttribute('Name') })
           if ($capabilities.Count -ne 1 -or $capabilities[0] -cne 'runFullTrust') {
             throw "unexpected capability set: $($capabilities -join ', ')"
           }

--- a/.github/workflows/windows-store-package.yml
+++ b/.github/workflows/windows-store-package.yml
@@ -1,0 +1,184 @@
+name: Metrora Windows Store Package
+
+on:
+  workflow_dispatch:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review, converted_to_draft]
+    paths:
+      - '.github/workflows/windows-store-package.yml'
+      - 'app/package.json'
+      - 'app/package-lock.json'
+      - 'scripts/generate-brand-assets.mjs'
+      - 'scripts/windows-store-identity.node-test.mjs'
+      - 'docs/WINDOWS_STORE_IDENTITY_V1.md'
+      - 'package.json'
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/windows-store-package.yml'
+      - 'app/package.json'
+      - 'app/package-lock.json'
+      - 'scripts/generate-brand-assets.mjs'
+      - 'scripts/windows-store-identity.node-test.mjs'
+      - 'docs/WINDOWS_STORE_IDENTITY_V1.md'
+      - 'package.json'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: metrora-windows-store-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  package:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    name: Build and inspect non-publishing AppX candidate
+    runs-on: windows-latest
+    timeout-minutes: 45
+    env:
+      CSC_IDENTITY_AUTO_DISCOVERY: 'false'
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22.15.0'
+          cache: npm
+
+      - name: Validate exact Store identity and channel separation
+        run: node scripts/windows-store-identity.node-test.mjs
+
+      - name: Install core dependencies
+        run: npm ci --no-audit --no-fund
+
+      - name: Install desktop dependencies
+        run: npm --prefix app ci --no-audit --no-fund
+
+      - name: Build unsigned AppX candidate without publication
+        run: npm --prefix app run package:store
+
+      - name: Inspect package manifest, assets, and signature boundary
+        id: inspect
+        shell: pwsh
+        run: |
+          $packages = @(Get-ChildItem -LiteralPath 'app\release' -File -Filter '*.appx')
+          if ($packages.Count -ne 1) {
+            throw "expected exactly one AppX package, found $($packages.Count)"
+          }
+
+          $package = $packages[0]
+          $archive = Join-Path $env:RUNNER_TEMP 'metrora-store-candidate.zip'
+          $unpacked = Join-Path $env:RUNNER_TEMP 'metrora-store-candidate'
+          Copy-Item -LiteralPath $package.FullName -Destination $archive -Force
+          Expand-Archive -LiteralPath $archive -DestinationPath $unpacked -Force
+
+          $manifestPath = Join-Path $unpacked 'AppxManifest.xml'
+          if (-not (Test-Path -LiteralPath $manifestPath)) {
+            throw 'AppxManifest.xml is missing from the candidate'
+          }
+
+          [xml]$manifest = Get-Content -LiteralPath $manifestPath -Raw
+          $identity = $manifest.Package.Identity
+          $properties = $manifest.Package.Properties
+          $application = $manifest.Package.Applications.Application
+
+          if ($identity.Name -cne 'Vensent.Metrora') {
+            throw "unexpected Identity.Name: $($identity.Name)"
+          }
+          if ($identity.Publisher -cne 'CN=BC955F81-5099-4C27-A7A6-FF611BAACC3F') {
+            throw "unexpected Identity.Publisher: $($identity.Publisher)"
+          }
+          if ($identity.ProcessorArchitecture -cne 'x64') {
+            throw "unexpected package architecture: $($identity.ProcessorArchitecture)"
+          }
+          if ([string]$properties.PublisherDisplayName -cne 'Vensent') {
+            throw "unexpected PublisherDisplayName: $($properties.PublisherDisplayName)"
+          }
+          if ([string]$properties.DisplayName -cne 'Metrora') {
+            throw "unexpected package DisplayName: $($properties.DisplayName)"
+          }
+          if ($application.Id -cne 'eu.metrora.desktop') {
+            throw "unexpected application Id: $($application.Id)"
+          }
+
+          $capabilities = @($manifest.Package.Capabilities.ChildNodes | ForEach-Object { $_.Name })
+          if ($capabilities.Count -ne 1 -or $capabilities[0] -cne 'runFullTrust') {
+            throw "unexpected capability set: $($capabilities -join ', ')"
+          }
+
+          if (Test-Path -LiteralPath (Join-Path $unpacked 'AppxSignature.p7x')) {
+            throw 'the pre-submission Store candidate must remain unsigned'
+          }
+
+          Add-Type -AssemblyName System.Drawing
+          function Assert-PngDimensions([string]$name, [int]$width, [int]$height) {
+            $matches = @(Get-ChildItem -LiteralPath $unpacked -Recurse -File -Filter $name)
+            if ($matches.Count -ne 1) {
+              throw "expected one $name asset, found $($matches.Count)"
+            }
+            $image = [System.Drawing.Image]::FromFile($matches[0].FullName)
+            try {
+              if ($image.Width -ne $width -or $image.Height -ne $height) {
+                throw "$name has $($image.Width)x$($image.Height), expected ${width}x${height}"
+              }
+            } finally {
+              $image.Dispose()
+            }
+          }
+
+          Assert-PngDimensions 'StoreLogo.png' 50 50
+          Assert-PngDimensions 'Square44x44Logo.png' 44 44
+          Assert-PngDimensions 'Square150x150Logo.png' 150 150
+          Assert-PngDimensions 'Wide310x150Logo.png' 310 150
+
+          $candidateDirectory = Join-Path $PWD 'app\release\Metrora-Windows-Store-Candidate'
+          New-Item -ItemType Directory -Path $candidateDirectory -Force | Out-Null
+          Copy-Item -LiteralPath $package.FullName -Destination $candidateDirectory -Force
+          Copy-Item -LiteralPath $manifestPath -Destination (Join-Path $candidateDirectory 'AppxManifest.xml') -Force
+
+          $hash = (Get-FileHash -LiteralPath $package.FullName -Algorithm SHA256).Hash.ToLowerInvariant()
+          $summary = [ordered]@{
+            schemaVersion = 1
+            sourceCommit = $env:GITHUB_SHA
+            artifactName = $package.Name
+            sha256 = $hash
+            packageVersion = [string]$identity.Version
+            architecture = [string]$identity.ProcessorArchitecture
+            identityName = [string]$identity.Name
+            publisher = [string]$identity.Publisher
+            publisherDisplayName = [string]$properties.PublisherDisplayName
+            applicationId = [string]$application.Id
+            packageFamilyName = 'Vensent.Metrora_1xcj95baterfy'
+            storeId = '9NXSZFQSBBDX'
+            signed = $false
+            submitted = $false
+            published = $false
+          }
+          $summary | ConvertTo-Json -Depth 4 | Set-Content -LiteralPath (Join-Path $candidateDirectory 'STORE_PACKAGE_MANIFEST.json') -Encoding utf8NoBOM
+
+          "artifact_name=$($package.Name)" >> $env:GITHUB_OUTPUT
+          "sha256=$hash" >> $env:GITHUB_OUTPUT
+
+      - name: Upload short-lived Store candidate
+        uses: actions/upload-artifact@v4
+        with:
+          name: metrora-windows-store-${{ github.sha }}
+          path: app/release/Metrora-Windows-Store-Candidate
+          if-no-files-found: error
+          include-hidden-files: true
+          compression-level: 6
+          retention-days: 14
+
+      - name: Summarize candidate boundary
+        shell: pwsh
+        run: |
+          @"
+          ## Metrora Windows Store candidate
+
+          - Artifact: `${{ steps.inspect.outputs.artifact_name }}`
+          - SHA-256: `${{ steps.inspect.outputs.sha256 }}`
+          - Identity: `Vensent.Metrora`
+          - Publisher: `CN=BC955F81-5099-4C27-A7A6-FF611BAACC3F`
+          - State: unsigned, not submitted, not published
+          "@ >> $env:GITHUB_STEP_SUMMARY

--- a/app/package.json
+++ b/app/package.json
@@ -18,7 +18,7 @@
     "package:arm64": "npm run stage-cli && npm run build && electron-builder --mac --arm64",
     "package:x64": "npm run stage-cli && npm run build && electron-builder --mac --x64",
     "package:win": "npm run stage-cli && npm run build && electron-builder --win",
-    "package:store": "npm run stage-cli && npm run build && electron-builder --win appx --x64",
+    "package:store": "npm run stage-cli && npm run build && electron-builder --win appx --x64 --publish never",
     "package:linux": "npm run stage-cli && npm run build && electron-builder --linux"
   },
   "dependencies": {

--- a/app/package.json
+++ b/app/package.json
@@ -18,6 +18,7 @@
     "package:arm64": "npm run stage-cli && npm run build && electron-builder --mac --arm64",
     "package:x64": "npm run stage-cli && npm run build && electron-builder --mac --x64",
     "package:win": "npm run stage-cli && npm run build && electron-builder --win",
+    "package:store": "npm run stage-cli && npm run build && electron-builder --win appx --x64",
     "package:linux": "npm run stage-cli && npm run build && electron-builder --linux"
   },
   "dependencies": {
@@ -102,6 +103,17 @@
       "perMachine": false,
       "deleteAppDataOnUninstall": false,
       "artifactName": "Metrora-Setup-${version}.${ext}"
+    },
+    "appx": {
+      "applicationId": "eu.metrora.desktop",
+      "identityName": "Vensent.Metrora",
+      "publisher": "CN=BC955F81-5099-4C27-A7A6-FF611BAACC3F",
+      "publisherDisplayName": "Vensent",
+      "displayName": "Metrora",
+      "artifactName": "Metrora-${version}-Windows-Store-${arch}.${ext}",
+      "capabilities": [
+        "runFullTrust"
+      ]
     },
     "linux": {
       "target": [

--- a/docs/README.md
+++ b/docs/README.md
@@ -36,6 +36,7 @@ Component references in this section explain bounded implementation responsibili
 ## Distribution and releases
 
 - [Windows distribution](WINDOWS_DISTRIBUTION.md) — canonical current Windows package, identity and publication boundary.
+- [Windows Store package identity v1](WINDOWS_STORE_IDENTITY_V1.md) — exact Partner Center identity and separate AppX/MSIX build boundary.
 - [Windows release candidate v1](WINDOWS_RELEASE_CANDIDATE_V1.md) — unsigned candidate manifest and independent verification contract.
 - [Windows format derivation v1](WINDOWS_FORMAT_DERIVATION_V1.md) — one-payload portable and installer derivation.
 - [Windows clean install v1](WINDOWS_CLEAN_INSTALL_V1.md) — isolated NSIS installation and state-preservation contract.

--- a/docs/WINDOWS_STORE_IDENTITY_V1.md
+++ b/docs/WINDOWS_STORE_IDENTITY_V1.md
@@ -1,0 +1,81 @@
+# Windows Store package identity v1
+
+**Status:** product name reserved / package identity fixed / not submitted  
+**Authority date:** 2026-08-06  
+**Store product name:** Metrora
+
+## Purpose
+
+Record the public Microsoft Store identity assigned to Metrora and bind the separate AppX/MSIX build target to those exact values.
+
+This document does not authorize a Partner Center submission, Microsoft certification, publication, stable `1.0.0`, or any change to the already published unsigned GitHub `1.0.0-rc.7` artifacts.
+
+## Manifest identity
+
+The Store package manifest must contain these exact values:
+
+```text
+Package/Identity/Name: Vensent.Metrora
+Package/Identity/Publisher: CN=BC955F81-5099-4C27-A7A6-FF611BAACC3F
+Package/Properties/PublisherDisplayName: Vensent
+```
+
+Case, punctuation and spacing are part of the identity and must not be normalized or replaced.
+
+The package application identifier remains:
+
+```text
+eu.metrora.desktop
+```
+
+The user-visible product name remains:
+
+```text
+Metrora
+```
+
+## Assigned Store identifiers
+
+```text
+Package Family Name: Vensent.Metrora_1xcj95baterfy
+Store ID: 9NXSZFQSBBDX
+```
+
+The Store deep link and Web Store URL are not yet live. They must not be advertised until Partner Center exposes them after publication.
+
+The Package SID is intentionally not recorded here. Metrora does not currently use Windows Push Notification Services, and the SID is not required by the package manifest or ordinary Store submission.
+
+## Build boundary
+
+The Store candidate is built separately from the existing NSIS technical-preview channel:
+
+```text
+npm --prefix app run package:store
+```
+
+The command builds an x64 AppX package with:
+
+- the exact Store identity above;
+- `runFullTrust`, required for the existing local desktop behavior;
+- no automatic submission or publication configuration;
+- an artifact name distinct from the NSIS installer.
+
+The existing command remains authoritative for the unsigned GitHub/technical-user installer:
+
+```text
+npm --prefix app run package:win
+```
+
+Neither channel inherits the signature or certification status of the other.
+
+## Current limitations
+
+The Store target is packaging-ready only. It is not yet:
+
+- accepted by physical Store-specific validation;
+- submitted to Partner Center;
+- certified or signed by Microsoft;
+- published through the Microsoft Store;
+- an automatic update for existing NSIS or portable installations.
+
+A Store package must pass manifest and inventory validation, clean installation, launch, local collector discovery, state-preservation, update, uninstall, channel-coexistence and rollback checks before submission or publication authorization.

--- a/docs/WINDOWS_STORE_IDENTITY_V1.md
+++ b/docs/WINDOWS_STORE_IDENTITY_V1.md
@@ -1,81 +1,35 @@
 # Windows Store package identity v1
 
-**Status:** product name reserved / package identity fixed / not submitted  
-**Authority date:** 2026-08-06  
-**Store product name:** Metrora
+**Status:** identity assigned / packaging only / not submitted
 
 ## Purpose
 
-Record the public Microsoft Store identity assigned to Metrora and bind the separate AppX/MSIX build target to those exact values.
+Define the separate Windows Store packaging boundary for Metrora.
 
-This document does not authorize a Partner Center submission, Microsoft certification, publication, stable `1.0.0`, or any change to the already published unsigned GitHub `1.0.0-rc.7` artifacts.
+The exact manifest values are maintained in the reviewed desktop build configuration. They must match Partner Center byte-for-byte and must not be duplicated across public documentation.
 
-## Manifest identity
-
-The Store package manifest must contain these exact values:
-
-```text
-Package/Identity/Name: Vensent.Metrora
-Package/Identity/Publisher: CN=BC955F81-5099-4C27-A7A6-FF611BAACC3F
-Package/Properties/PublisherDisplayName: Vensent
-```
-
-Case, punctuation and spacing are part of the identity and must not be normalized or replaced.
-
-The package application identifier remains:
-
-```text
-eu.metrora.desktop
-```
-
-The user-visible product name remains:
-
-```text
-Metrora
-```
-
-## Assigned Store identifiers
-
-```text
-Package Family Name: Vensent.Metrora_1xcj95baterfy
-Store ID: 9NXSZFQSBBDX
-```
-
-The Store deep link and Web Store URL are not yet live. They must not be advertised until Partner Center exposes them after publication.
-
-The Package SID is intentionally not recorded here. Metrora does not currently use Windows Push Notification Services, and the SID is not required by the package manifest or ordinary Store submission.
+This document does not authorize submission, certification, publication, stable `1.0.0`, or any change to the already published GitHub `1.0.0-rc.7` artifacts.
 
 ## Build boundary
 
-The Store candidate is built separately from the existing NSIS technical-preview channel:
+The Store candidate is built separately from the existing NSIS channel:
 
 ```text
 npm --prefix app run package:store
 ```
 
-The command builds an x64 AppX package with:
+The command produces one non-publishing x64 AppX candidate with the assigned Store identity and the required full-trust desktop capability.
 
-- the exact Store identity above;
-- `runFullTrust`, required for the existing local desktop behavior;
-- no automatic submission or publication configuration;
-- an artifact name distinct from the NSIS installer.
-
-The existing command remains authoritative for the unsigned GitHub/technical-user installer:
+The existing technical-user installer remains separate:
 
 ```text
 npm --prefix app run package:win
 ```
 
-Neither channel inherits the signature or certification status of the other.
+Neither channel inherits the signature, certification or publication status of the other.
 
 ## Current limitations
 
-The Store target is packaging-ready only. It is not yet:
+The Store target is packaging-ready only. It is not submitted, certified, signed by Microsoft, published, or an automatic update for existing installations.
 
-- accepted by physical Store-specific validation;
-- submitted to Partner Center;
-- certified or signed by Microsoft;
-- published through the Microsoft Store;
-- an automatic update for existing NSIS or portable installations.
-
-A Store package must pass manifest and inventory validation, clean installation, launch, local collector discovery, state-preservation, update, uninstall, channel-coexistence and rollback checks before submission or publication authorization.
+Store-specific acceptance and separate publication authorization remain required.

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "build:cli": "tsup && node -e \"const fs=require('fs'); fs.copyFileSync('src/cli.ts','dist/cli.js'); fs.chmodSync('dist/cli.js',0o755)\"",
     "build:dash": "cd dash && npm install --no-audit --no-fund --silent && npm run build",
     "dev": "NODE_OPTIONS=--no-deprecation tsx src/cli.ts",
-    "identity:public:check": "node scripts/check-public-identity-boundary.mjs",
+    "identity:public:check": "node scripts/check-public-identity-boundary.mjs && node scripts/windows-store-identity.node-test.mjs",
     "pricing:docs": "tsx scripts/generate-pricing-history.ts",
     "pricing:docs:check": "tsx scripts/generate-pricing-history.ts --check",
     "test": "vitest",

--- a/scripts/generate-brand-assets.mjs
+++ b/scripts/generate-brand-assets.mjs
@@ -30,6 +30,32 @@ function chunk(type, data) {
   return Buffer.concat([length, typeBuffer, data, checksum])
 }
 
+function encodePng(width, height, pixels) {
+  if (pixels.length !== width * height * 4) {
+    throw new Error(`unexpected RGBA buffer length for ${width}x${height}`)
+  }
+
+  const raw = Buffer.alloc((width * 4 + 1) * height)
+  for (let y = 0; y < height; y += 1) {
+    const rowOffset = y * (width * 4 + 1)
+    raw[rowOffset] = 0
+    pixels.copy(raw, rowOffset + 1, y * width * 4, (y + 1) * width * 4)
+  }
+
+  const ihdr = Buffer.alloc(13)
+  ihdr.writeUInt32BE(width, 0)
+  ihdr.writeUInt32BE(height, 4)
+  ihdr[8] = 8
+  ihdr[9] = 6
+
+  return Buffer.concat([
+    Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]),
+    chunk('IHDR', ihdr),
+    chunk('IDAT', deflateSync(raw, { level: 9 })),
+    chunk('IEND', Buffer.alloc(0)),
+  ])
+}
+
 function insideRoundedSquare(x, y, size, radius) {
   const left = radius
   const right = size - radius - 1
@@ -57,7 +83,7 @@ function fillRect(pixels, size, x, y, width, height, color) {
   }
 }
 
-function createIcon(size = 1024) {
+function createIconPixels(size) {
   const pixels = Buffer.alloc(size * size * 4)
   const radius = Math.round(size * 0.2266)
 
@@ -81,35 +107,40 @@ function createIcon(size = 1024) {
     fillRect(pixels, size, x * scale, y * scale, width * scale, height * scale, COLORS.paper)
   }
 
-  const raw = Buffer.alloc((size * 4 + 1) * size)
-  for (let y = 0; y < size; y += 1) {
-    const rowOffset = y * (size * 4 + 1)
-    raw[rowOffset] = 0
-    pixels.copy(raw, rowOffset + 1, y * size * 4, (y + 1) * size * 4)
-  }
-
-  const ihdr = Buffer.alloc(13)
-  ihdr.writeUInt32BE(size, 0)
-  ihdr.writeUInt32BE(size, 4)
-  ihdr[8] = 8
-  ihdr[9] = 6
-
-  return Buffer.concat([
-    Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]),
-    chunk('IHDR', ihdr),
-    chunk('IDAT', deflateSync(raw, { level: 9 })),
-    chunk('IEND', Buffer.alloc(0)),
-  ])
+  return pixels
 }
 
-const icon = createIcon(1024)
+function createIcon(size) {
+  return encodePng(size, size, createIconPixels(size))
+}
+
+function createWideIcon(width = 310, height = 150, markSize = 112) {
+  const pixels = Buffer.alloc(width * height * 4)
+  const mark = createIconPixels(markSize)
+  const offsetX = Math.floor((width - markSize) / 2)
+  const offsetY = Math.floor((height - markSize) / 2)
+
+  for (let y = 0; y < markSize; y += 1) {
+    const sourceStart = y * markSize * 4
+    const targetStart = ((offsetY + y) * width + offsetX) * 4
+    mark.copy(pixels, targetStart, sourceStart, sourceStart + markSize * 4)
+  }
+
+  return encodePng(width, height, pixels)
+}
+
+const canonicalIcon = createIcon(1024)
 const outputs = [
-  resolve(ROOT, 'app/build/icon.png'),
-  resolve(ROOT, 'assets/menubar-logo.png'),
+  [resolve(ROOT, 'app/build/icon.png'), canonicalIcon],
+  [resolve(ROOT, 'assets/menubar-logo.png'), canonicalIcon],
+  [resolve(ROOT, 'app/build/appx/StoreLogo.png'), createIcon(50)],
+  [resolve(ROOT, 'app/build/appx/Square44x44Logo.png'), createIcon(44)],
+  [resolve(ROOT, 'app/build/appx/Square150x150Logo.png'), createIcon(150)],
+  [resolve(ROOT, 'app/build/appx/Wide310x150Logo.png'), createWideIcon()],
 ]
 
-for (const output of outputs) {
+for (const [output, bytes] of outputs) {
   mkdirSync(dirname(output), { recursive: true })
-  writeFileSync(output, icon)
+  writeFileSync(output, bytes)
   console.log(`Generated ${output.replace(`${ROOT}/`, '')}`)
 }

--- a/scripts/windows-store-identity.node-test.mjs
+++ b/scripts/windows-store-identity.node-test.mjs
@@ -6,8 +6,9 @@ import { resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 const repositoryRoot = resolve(fileURLToPath(new URL('..', import.meta.url)))
-const desktopPackagePath = resolve(repositoryRoot, 'app/package.json')
-const desktopPackage = JSON.parse(readFileSync(desktopPackagePath, 'utf8'))
+const desktopPackage = JSON.parse(readFileSync(resolve(repositoryRoot, 'app/package.json'), 'utf8'))
+const brandGenerator = readFileSync(resolve(repositoryRoot, 'scripts/generate-brand-assets.mjs'), 'utf8')
+const identityDocument = readFileSync(resolve(repositoryRoot, 'docs/WINDOWS_STORE_IDENTITY_V1.md'), 'utf8')
 
 const expected = Object.freeze({
   applicationId: 'eu.metrora.desktop',
@@ -20,8 +21,8 @@ const expected = Object.freeze({
 
 assert.equal(
   desktopPackage.scripts?.['package:store'],
-  'npm run stage-cli && npm run build && electron-builder --win appx --x64',
-  'the Store build must remain an explicit x64 AppX target',
+  'npm run stage-cli && npm run build && electron-builder --win appx --x64 --publish never',
+  'the Store build must remain an explicit non-publishing x64 AppX target',
 )
 
 assert.equal(
@@ -73,4 +74,29 @@ assert.equal(
   'the current Windows package version authority must remain 1.0.0.7',
 )
 
-console.log('Windows Store package identity and channel separation are valid.')
+for (const asset of [
+  'app/build/appx/StoreLogo.png',
+  'app/build/appx/Square44x44Logo.png',
+  'app/build/appx/Square150x150Logo.png',
+  'app/build/appx/Wide310x150Logo.png',
+]) {
+  assert.ok(brandGenerator.includes(asset), `the deterministic brand generator must emit ${asset}`)
+}
+
+for (const marker of [
+  'Package/Identity/Name: Vensent.Metrora',
+  'Package/Identity/Publisher: CN=BC955F81-5099-4C27-A7A6-FF611BAACC3F',
+  'Package/Properties/PublisherDisplayName: Vensent',
+  'Package Family Name: Vensent.Metrora_1xcj95baterfy',
+  'Store ID: 9NXSZFQSBBDX',
+]) {
+  assert.ok(identityDocument.includes(marker), `the Store identity document must include ${marker}`)
+}
+
+assert.equal(
+  identityDocument.includes('S-1-15-2-'),
+  false,
+  'the Package SID must not be copied into the public identity document',
+)
+
+console.log('Windows Store package identity, assets and channel separation are valid.')

--- a/scripts/windows-store-identity.node-test.mjs
+++ b/scripts/windows-store-identity.node-test.mjs
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const repositoryRoot = resolve(fileURLToPath(new URL('..', import.meta.url)))
+const desktopPackagePath = resolve(repositoryRoot, 'app/package.json')
+const desktopPackage = JSON.parse(readFileSync(desktopPackagePath, 'utf8'))
+
+const expected = Object.freeze({
+  applicationId: 'eu.metrora.desktop',
+  identityName: 'Vensent.Metrora',
+  publisher: 'CN=BC955F81-5099-4C27-A7A6-FF611BAACC3F',
+  publisherDisplayName: 'Vensent',
+  displayName: 'Metrora',
+  artifactName: 'Metrora-${version}-Windows-Store-${arch}.${ext}',
+})
+
+assert.equal(
+  desktopPackage.scripts?.['package:store'],
+  'npm run stage-cli && npm run build && electron-builder --win appx --x64',
+  'the Store build must remain an explicit x64 AppX target',
+)
+
+assert.equal(
+  desktopPackage.scripts?.['package:win'],
+  'npm run stage-cli && npm run build && electron-builder --win',
+  'the existing Windows packaging command must remain unchanged',
+)
+
+assert.deepEqual(
+  desktopPackage.build?.win?.target,
+  [{ target: 'nsis', arch: ['x64'] }],
+  'the GitHub/technical-user Windows channel must remain the NSIS x64 target',
+)
+
+assert.equal(
+  desktopPackage.build?.nsis?.artifactName,
+  'Metrora-Setup-${version}.${ext}',
+  'the accepted NSIS artifact name must remain unchanged',
+)
+
+const appx = desktopPackage.build?.appx
+assert.ok(appx && typeof appx === 'object', 'an AppX configuration is required')
+
+for (const [field, value] of Object.entries(expected)) {
+  assert.equal(appx[field], value, `AppX ${field} must match the reviewed Store authority`)
+}
+
+assert.deepEqual(
+  appx.capabilities,
+  ['runFullTrust'],
+  'the Store package must declare only the currently required full-trust capability',
+)
+
+assert.equal(
+  Object.hasOwn(appx, 'publish'),
+  false,
+  'the build configuration must not submit or publish to Partner Center',
+)
+
+assert.equal(
+  Object.hasOwn(desktopPackage.build, 'publish'),
+  false,
+  'the desktop build must not gain an implicit publication target',
+)
+
+assert.equal(
+  desktopPackage.build?.buildVersion,
+  '1.0.0.7',
+  'the current Windows package version authority must remain 1.0.0.7',
+)
+
+console.log('Windows Store package identity and channel separation are valid.')

--- a/scripts/windows-store-identity.node-test.mjs
+++ b/scripts/windows-store-identity.node-test.mjs
@@ -8,7 +8,6 @@ import { fileURLToPath } from 'node:url'
 const repositoryRoot = resolve(fileURLToPath(new URL('..', import.meta.url)))
 const desktopPackage = JSON.parse(readFileSync(resolve(repositoryRoot, 'app/package.json'), 'utf8'))
 const brandGenerator = readFileSync(resolve(repositoryRoot, 'scripts/generate-brand-assets.mjs'), 'utf8')
-const identityDocument = readFileSync(resolve(repositoryRoot, 'docs/WINDOWS_STORE_IDENTITY_V1.md'), 'utf8')
 
 const expected = Object.freeze({
   applicationId: 'eu.metrora.desktop',
@@ -82,21 +81,5 @@ for (const asset of [
 ]) {
   assert.ok(brandGenerator.includes(asset), `the deterministic brand generator must emit ${asset}`)
 }
-
-for (const marker of [
-  'Package/Identity/Name: Vensent.Metrora',
-  'Package/Identity/Publisher: CN=BC955F81-5099-4C27-A7A6-FF611BAACC3F',
-  'Package/Properties/PublisherDisplayName: Vensent',
-  'Package Family Name: Vensent.Metrora_1xcj95baterfy',
-  'Store ID: 9NXSZFQSBBDX',
-]) {
-  assert.ok(identityDocument.includes(marker), `the Store identity document must include ${marker}`)
-}
-
-assert.equal(
-  identityDocument.includes('S-1-15-2-'),
-  false,
-  'the Package SID must not be copied into the public identity document',
-)
 
 console.log('Windows Store package identity, assets and channel separation are valid.')


### PR DESCRIPTION
## Summary

Add a separate non-publishing Windows Store package target bound to the assigned Store package identity.

- preserve the existing NSIS/GitHub channel unchanged;
- generate the required AppX assets from the canonical brand source;
- validate package identity, architecture, capabilities, signature boundary and asset dimensions;
- upload only a short-lived candidate artifact for review.

## Boundaries

No Store submission, certification, signing, publication, stable release, website change, credential, private verification material or runtime behavior change is included.

Source integration and any later Store distribution action remain separate decisions.