### PR TITLE
fix(windows): support Windows PowerShell platform detection

### DIFF
--- a/.github/workflows/windows-physical-acceptance.yml
+++ b/.github/workflows/windows-physical-acceptance.yml
@@ -99,3 +99,7 @@ jobs:
       - name: Exercise Store local-test helpers
         shell: pwsh
         run: ./scripts/Test-Metrora-Windows-Store-Local-Test-Runtime.ps1 -RepositoryRoot $PWD
+
+      - name: Exercise Store helpers under Windows PowerShell 5.1
+        shell: powershell
+        run: ./scripts/Test-Metrora-Windows-Store-Local-Test-Runtime.ps1 -RepositoryRoot $PWD

--- a/scripts/Test-Metrora-Windows-Store-Local-Test-Runtime.ps1
+++ b/scripts/Test-Metrora-Windows-Store-Local-Test-Runtime.ps1
@@ -8,6 +8,16 @@ Set-StrictMode -Version Latest
 $repository = (Resolve-Path -LiteralPath $RepositoryRoot).Path
 . (Join-Path $repository 'scripts\windows-store-local-test-lib.ps1')
 
+$platform = Get-MetroraWindowsPlatform
+if (
+  [string]::IsNullOrWhiteSpace([string]$platform.edition) -or
+  [string]::IsNullOrWhiteSpace([string]$platform.version) -or
+  [string]::IsNullOrWhiteSpace([string]$platform.build) -or
+  @('x86', 'x64', 'arm', 'arm64', 'ia64') -notcontains [string]$platform.architecture
+) {
+  throw 'Windows platform runtime detection returned unexpected values'
+}
+
 $temporary = Join-Path $env:TEMP "metrora-store-runtime-$([Guid]::NewGuid().ToString('N'))"
 New-Item -ItemType Directory -Path $temporary -Force | Out-Null
 try {

--- a/scripts/windows-physical-acceptance-lib.ps1
+++ b/scripts/windows-physical-acceptance-lib.ps1
@@ -33,11 +33,22 @@ function Get-MetroraWindowsPlatform {
   if ([Environment]::OSVersion.Platform -ne [PlatformID]::Win32NT) {
     throw 'physical Windows acceptance must run on Windows'
   }
+
   $operatingSystem = Get-CimInstance -ClassName Win32_OperatingSystem
-  $architecture = switch ([Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString()) {
-    'X64' { 'x64' }
-    default { $_.ToLowerInvariant() }
+  $processor = @(Get-CimInstance -ClassName Win32_Processor | Select-Object -First 1)
+  if ($processor.Count -ne 1) {
+    throw 'physical Windows acceptance could not determine processor architecture'
   }
+
+  $architecture = switch ([int]$processor[0].Architecture) {
+    0 { 'x86' }
+    5 { 'arm' }
+    6 { 'ia64' }
+    9 { 'x64' }
+    12 { 'arm64' }
+    default { "unknown-$([int]$processor[0].Architecture)" }
+  }
+
   return [ordered]@{
     edition = [string]$operatingSystem.Caption
     version = [string]$operatingSystem.Version


### PR DESCRIPTION
Fix the physical Store acceptance helper on Windows PowerShell 5.1 by deriving the native Windows architecture from Win32_Processor instead of RuntimeInformation.OSArchitecture. Exercise the platform helper in the Store runtime test and retain a Windows PowerShell 5.1 regression step on the existing Windows runner.

No package, Store identity, product runtime, submission, or publication behavior changes.