### PR TITLE
fix(store): refresh RC8 product identity and local state

### DIFF
--- a/.ci-staging-marker
+++ b/.ci-staging-marker
@@ -1,1 +1,0 @@
-temporary staging ref marker

--- a/.ci-staging-marker
+++ b/.ci-staging-marker
@@ -1,0 +1,1 @@
+temporary staging ref marker

--- a/.github/workflows/windows-store-package.yml
+++ b/.github/workflows/windows-store-package.yml
@@ -114,6 +114,16 @@ jobs:
             throw 'unexpected application identifier'
           }
 
+          $productVersion = [string](Get-Content -LiteralPath 'package.json' -Raw | ConvertFrom-Json).version
+          $productCore = $productVersion -replace '-rc\.\d+$', ''
+          if ($productCore -notmatch '^\d+\.\d+\.\d+$') {
+            throw 'product version cannot be mapped to the Store package version'
+          }
+          $expectedStoreVersion = "$productCore.0"
+          if ([string]$identity.Version -cne $expectedStoreVersion) {
+            throw "unexpected Store package version: expected $expectedStoreVersion, got $($identity.Version)"
+          }
+
           $capabilities = @($manifest.Package.Capabilities.ChildNodes | ForEach-Object { $_.GetAttribute('Name') })
           if ($capabilities.Count -ne 1 -or $capabilities[0] -cne 'runFullTrust') {
             throw 'unexpected capability set'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,30 @@
 
 This file records Metrora-originated public changes. Required upstream provenance and licence notices are maintained separately in [`UPSTREAM.md`](UPSTREAM.md), [`THIRD_PARTY_NOTICES.md`](THIRD_PARTY_NOTICES.md) and [`LICENSES/`](LICENSES/).
 
-## Unreleased — current source line `1.0.0-rc.7`
+## Unreleased — current source line `1.0.0-rc.8`
 
-The current version identifies public source under development. It is not a claim that an accepted, signed or published `rc.7` artifact exists.
+RC8 is the current source/pre-submission candidate. It is not yet a Microsoft Store submission, certification or publication.
+
+### Windows Store readiness
+
+- Added the assigned Microsoft Store AppX identity and a non-publishing x64 Store-package workflow with exact artifact/source binding.
+- Added bounded local AppX acceptance that test-signs only a copy, verifies launch/local collection/no-external-Node behavior and removes the temporary package/certificate/private key afterward.
+- Added Windows PowerShell 5.1-compatible physical-test platform detection.
+- Reconciled persisted Workspace endpoint software metadata to the current packaged Metrora/collector version without replacing endpoint identity, membership or evidence history.
+- Removed legacy product/version wording from the Store-facing About surface while retaining required upstream licence/provenance notices in their dedicated locations.
+- Clarified the distinction between product SemVer, desktop build version and Microsoft Store AppX package identity version.
+
+### Public identity and local paths
+
+- Made Metrora the canonical sync command/documentation surface while retaining the v1 inherited discovery route only as a compatibility wire identifier.
+- Removed inherited developer deployment identifiers from public sync documentation.
+- Made fresh config/sync state use canonical Metrora roots while adopting an existing Qovrion/CodeBurn root in place when necessary to avoid stranding user state.
+- Made sync credential identity Metrora-first with bounded legacy keychain adoption.
+- Hardened the existing public-identity check so legacy branding/version text cannot reappear in the Store-facing About surface.
+
+## `1.0.0-rc.7` — published unsigned Windows technical preview
+
+RC7 was published as an **unsigned Windows x64 GitHub technical preview**. It remains manually updated, is not Microsoft Store certified and is not the stable `1.0.0` release. Its release assets and evidence remain bound to their exact published source and are not rewritten by later source work.
 
 ### Product identity and public documentation
 
@@ -59,7 +80,7 @@ The current version identifies public source under development. It is not a clai
 - Validated clean installation, removal, upgrade, repair, controlled rollback, interruption recovery and user-owned state preservation.
 - Completed bounded physical Windows keyboard, scaling, theme, reduced-motion and Narrator acceptance for the unsigned engineering candidate.
 - Added physical-acceptance report v2 with an explicit migration baseline and candidate-derived transitions while preserving historical report v1 verification.
-- Added a public unsigned GitHub pre-release acceptance contract and version-scoped `1.0.0-rc.7` preparation record.
+- Added a public unsigned GitHub pre-release acceptance contract and version-scoped `1.0.0-rc.7` preparation/publication record.
 
 ## 0.9.19 — Metrora public source baseline
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -8,8 +8,9 @@ Metrora does not yet have an official stable desktop release. This document defi
 - Domain: **metrora.eu**
 - Repository: `maikolsiragusaa/metrora`
 - Canonical command: `metrora`
-- Current development version: `1.0.0-rc.7`
-- Current desktop build version: `1.0.0.7`
+- Current source candidate: `1.0.0-rc.8`
+- Current desktop build version: `1.0.0.8`
+- Latest published GitHub technical preview: `1.0.0-rc.7`
 
 Temporary compatibility commands are governed by the technical compatibility register. They are not release brands or names for new artifacts.
 
@@ -17,13 +18,23 @@ The root npm package is private and must not be published from this repository.
 
 ## Current engineering authority
 
-The active source line is `1.0.0-rc.7`, with desktop build metadata `1.0.0.7`. No artifact at this version is accepted, signed or published merely because the metadata exists.
+`1.0.0-rc.8` is the current **source/pre-submission candidate line**. Its metadata does not by itself make any artifact accepted, signed, submitted or published.
 
-The accepted Windows 0.9.19 candidate remains bound to reviewed public source, independently verifiable manifests and a sanitized physical-acceptance report.
+`1.0.0-rc.7` remains the latest published GitHub Windows technical preview. That channel is unsigned, manually updated and not Microsoft Store certified. Its source, release assets, manifests and checksums remain immutable historical publication evidence.
 
-It passed existing-state, clean-install and migration lifecycle validation. It remains unsigned engineering evidence and is not an official stable release.
+The Microsoft Store path is separate. Metrora has an assigned Store identity and a non-publishing AppX build/local-acceptance workflow, but no Store certification or publication is claimed until Microsoft has accepted the corresponding submission.
 
-Exact accepted source and artifact digests remain recorded in the applicable Windows acceptance contract and GitHub workflow record rather than repeated across general release guidance.
+Exact source commits and artifact digests belong in the applicable workflow/release acceptance evidence rather than being copied into general release guidance.
+
+## Version authorities
+
+Metrora deliberately separates three version forms:
+
+- product/source SemVer: `1.0.0-rc.8`;
+- desktop build version: `1.0.0.8`;
+- Microsoft Store AppX package identity version for the `1.0.0` line: `1.0.0.0`.
+
+The Store's four-component package identity is a platform contract and must not be confused with the desktop build counter or the SemVer pre-release label. See [`docs/VERSIONING.md`](docs/VERSIONING.md).
 
 ## Release responsibilities
 
@@ -62,20 +73,27 @@ Platform workflows add their own manifest, payload, installation, update, rollba
 
 An unsigned Windows GitHub pre-release is a technical-evaluation channel. It is separate from Microsoft Store signing and certification.
 
-The final candidate must come from an explicit `Metrora Windows Candidate` workflow dispatch on one exact reviewed `main` commit with classification `unsigned-release-candidate`. A pull-request merge ref, ordinary development artifact or local rebuild is not publication authority.
+The published `v1.0.0-rc.7` pre-release remains bound to its accepted source commit and release evidence. New source changes do not retroactively alter that release.
 
-Before a GitHub pre-release may be published:
+Any later GitHub pre-release must again come from one exact reviewed source commit and must pass the applicable candidate, artifact-binding and physical-acceptance boundaries before publication.
 
-1. all applicable repository and Windows workflow jobs pass for the exact commit;
-2. the complete downloaded candidate verifies against its source and format manifests;
-3. the guided two-profile physical acceptance produces a valid version 2 PASS report;
-4. release assets are derived from that accepted candidate without rebuilding or patching product bytes;
-5. final checksums, manifests, release notes, known limitations and rollback wording are reviewed;
-6. publication receives an explicit stop/go.
+The public acceptance contract is [`docs/WINDOWS_GITHUB_PRE_RELEASE_ACCEPTANCE_V1.md`](docs/WINDOWS_GITHUB_PRE_RELEASE_ACCEPTANCE_V1.md). The immutable RC7 publication record is [`release/1.0.0-rc.7/GITHUB_PRE_RELEASE.md`](release/1.0.0-rc.7/GITHUB_PRE_RELEASE.md).
 
-The public acceptance contract is [`docs/WINDOWS_GITHUB_PRE_RELEASE_ACCEPTANCE_V1.md`](docs/WINDOWS_GITHUB_PRE_RELEASE_ACCEPTANCE_V1.md). The version-scoped preparation record is [`release/1.0.0-rc.7/GITHUB_PRE_RELEASE.md`](release/1.0.0-rc.7/GITHUB_PRE_RELEASE.md).
+An unsigned GitHub pre-release must state that its portable/installer assets are unsigned, may trigger SmartScreen, require manual updates and are not Microsoft Store certified. It must not be presented as stable merely because GitHub represents it as a release object.
 
-A GitHub pre-release must state that portable and installer assets are unsigned, may trigger SmartScreen, require manual updates and are not Microsoft Store certified. It must not be presented as the stable release merely because GitHub labels it as a release object.
+## Microsoft Store pre-submission
+
+The Store candidate must be built from the exact reviewed source commit using the non-publishing Store workflow. Before Partner Center submission:
+
+1. the exact AppX artifact and workflow manifest must verify;
+2. Store identity, publisher, architecture, capabilities and package version must match reviewed configuration;
+3. the unsigned submission candidate must remain byte-identical to the workflow output;
+4. a separately test-signed copy may be used only for bounded local physical acceptance;
+5. local-test package/certificate/private-key material must be removed afterward;
+6. the sanitized local acceptance report must pass;
+7. submission requires an explicit stop/go after those checks.
+
+A passing local test is not Microsoft certification and does not authorize a publication claim.
 
 ## Versioning and notes
 
@@ -94,7 +112,7 @@ Every public release note states:
 
 ## Rollback
 
-Do not rewrite or replace a broadly distributed release under the same version. Publish a new patch version and retain the previous accepted artifact long enough to support rollback.
+Do not rewrite or replace a broadly distributed release under the same version. Publish a new version and retain the previous accepted artifact long enough to support rollback.
 
 Rollback preserves endpoint identity, OS-vault material, analytics, Workspace state, evidence, exports and user-owned local files according to the accepted migration contract.
 
@@ -112,4 +130,5 @@ Rollback preserves endpoint identity, OS-vault material, analytics, Workspace st
 - no protected credentials in untrusted pull requests;
 - no publication from an unverified local build;
 - no silent replacement of accepted artifacts;
-- no claim of an official release before the relevant channel passes acceptance.
+- no claim of Microsoft Store certification/publication before Microsoft actually accepts that channel;
+- no claim of an official stable release before the relevant channel passes acceptance.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -33,7 +33,11 @@ Security reports are welcome for:
 
 ## Release integrity
 
-Metrora does not yet publish official binaries. Signing, checksums, update channels, and store identities will be documented before an official release. Upstream CodeBurn artifacts are not Metrora releases.
+The latest public Windows technical preview is the **unsigned** GitHub pre-release `v1.0.0-rc.7`. Its release assets are bound to the published release evidence and checksums; it is not a signed stable channel, a Microsoft Store package, or an automatic update channel.
+
+Metrora also has an assigned Microsoft Store package identity and a reviewed non-publishing AppX build/local-acceptance path. That work is **pre-submission**: no Microsoft Store certification or publication is claimed by this repository until Microsoft has actually accepted and published the corresponding submission.
+
+Stable signing, Store publication, and any future update-channel claims must remain explicit and channel-specific. Upstream CodeBurn artifacts are not Metrora releases.
 
 ## Upstream reports
 

--- a/app/DISTRIBUTION.md
+++ b/app/DISTRIBUTION.md
@@ -7,8 +7,10 @@ This document defines the desktop packaging boundary. Platform-specific release 
 - Product: `Metrora`
 - Desktop app ID: `eu.metrora.desktop`
 - Website: `https://metrora.eu`
-- Current desktop version: `1.0.0-rc.7`
-- Current desktop build version: `1.0.0.7`
+- Current source/desktop candidate: `1.0.0-rc.8`
+- Current desktop build version: `1.0.0.8`
+- Latest published GitHub technical preview: `1.0.0-rc.7`
+- Current non-publishing Store AppX identity version: `1.0.0.0`
 
 Inherited names may remain only where required for compatibility or upstream provenance. They are not Metrora distribution names.
 
@@ -18,6 +20,8 @@ Packaged desktop builds include the required Metrora command-line runtime and do
 
 Packaging stages the current root runtime and copies it into Electron resources through `scripts/after-pack.cjs`. The packaged application uses this version-matched runtime before consulting any user-installed compatibility command.
 
+Persisted Workspace endpoint metadata is reconciled to the current packaged Metrora/collector version without replacing endpoint identity, Workspace membership or evidence history.
+
 ## Development packaging commands
 
 ```sh
@@ -26,10 +30,11 @@ npm --prefix app run package          # macOS
 npm --prefix app run package:arm64    # macOS arm64
 npm --prefix app run package:x64      # macOS x64
 npm --prefix app run package:win      # Windows NSIS x64
+npm --prefix app run package:store    # Windows AppX x64, non-publishing
 npm --prefix app run package:linux    # Linux AppImage, deb and rpm x64
 ```
 
-These commands create development or engineering artifacts. They do not by themselves create an official release.
+These commands create development or engineering artifacts. They do not by themselves create an official release or a Store submission.
 
 ## Official distribution requirements
 
@@ -39,7 +44,7 @@ An official desktop package must:
 - use exact Metrora product and publisher identity;
 - contain only declared product bytes and metadata;
 - preserve endpoint identity, Workspace state, secure-storage material and user-owned files;
-- state its exact version, format, platform and signature status;
+- state its exact product version, package version, format, platform and signature status;
 - remain independently traceable through checksums, manifests and provenance;
 - pass clean installation, first launch, update, rollback, removal and state-preservation acceptance;
 - keep private user data out of package metadata and reports.
@@ -49,6 +54,8 @@ An official desktop package must:
 ### Windows
 
 The development Windows installer is x64, per-user, assisted rather than one-click, non-destructive to application data on uninstall and named `Metrora-Setup-<version>.exe`.
+
+The Microsoft Store path builds an x64 AppX with the assigned Store identity and `runFullTrust`, without publishing it. The Store manifest's four-part package identity is separate from the desktop build counter; see [`../docs/VERSIONING.md`](../docs/VERSIONING.md).
 
 Unsigned engineering artifacts may trigger platform reputation warnings. Their signature status must remain explicit and they must not be represented as channel-certified packages.
 

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "metrora-desktop",
-  "version": "1.0.0-rc.7",
+  "version": "1.0.0-rc.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "metrora-desktop",
-      "version": "1.0.0-rc.7",
+      "version": "1.0.0-rc.8",
       "dependencies": {
         "@gsap/react": "^2.1.2",
         "gsap": "^3.15.0",

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "metrora-desktop",
   "private": true,
-  "version": "1.0.0-rc.7",
+  "version": "1.0.0-rc.8",
   "description": "Metrora Desktop — local-first AI usage intelligence",
   "main": "dist/electron/bootstrap.js",
   "scripts": {
@@ -141,7 +141,7 @@
       "maintainer": "Vensent (https://metrora.eu)",
       "executableName": "metrora"
     },
-    "buildVersion": "1.0.0.7"
+    "buildVersion": "1.0.0.8"
   },
   "homepage": "https://metrora.eu",
   "publisher": "Vensent",

--- a/app/renderer/components/AboutModal.test.tsx
+++ b/app/renderer/components/AboutModal.test.tsx
@@ -10,7 +10,7 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock('../lib/ipc', async orig => {
   const actual = await orig<typeof import('../lib/ipc')>()
-  return { ...actual, codeburn: { ...actual.codeburn, openExternal: mocks.openExternal } }
+  return { ...actual, metrora: { ...actual.metrora, openExternal: mocks.openExternal } }
 })
 
 const SOCIALS: SocialLink[] = [
@@ -32,13 +32,17 @@ describe('Metrora About modal', () => {
 
   afterEach(cleanup)
 
-  it('shows Metrora identity and the static no-update-channel status', () => {
+  it('shows only current Metrora distribution identity', () => {
     renderAbout()
 
     expect(screen.getByRole('dialog', { name: 'Metrora' })).toBeInTheDocument()
     expect(screen.getByText('Local-first intelligence for AI usage, cost and efficiency.')).toBeInTheDocument()
-    expect(screen.getByRole('status')).toHaveTextContent('does not yet publish an automatic update channel')
-    expect(screen.getByRole('status')).toHaveTextContent('never checks or downloads CodeBurn releases')
+    expect(screen.getByRole('status')).toHaveTextContent('active distribution channel')
+    expect(screen.getByRole('status')).toHaveTextContent('does not use a separate in-app updater')
+    expect(screen.getByText('Metrora · Published by Vensent')).toBeInTheDocument()
+    expect(screen.queryByText(/CodeBurn/i)).toBeNull()
+    expect(screen.queryByText(/Qovrion/i)).toBeNull()
+    expect(screen.queryByText(/0\.9\.19/)).toBeNull()
   })
 
   it('does not expose inherited update or download controls', () => {

--- a/app/renderer/components/AboutModal.tsx
+++ b/app/renderer/components/AboutModal.tsx
@@ -2,7 +2,7 @@ import { useEffect, type MouseEvent, type ReactNode } from 'react'
 
 import { version } from '../../package.json'
 import { BUILD_STAMP } from '../lib/build'
-import { codeburn } from '../lib/ipc'
+import { metrora } from '../lib/ipc'
 import { MetroraMark } from './MetroraMark'
 
 export type SocialLink = {
@@ -13,7 +13,7 @@ export type SocialLink = {
 
 function openExternal(event: MouseEvent<HTMLAnchorElement>, url: string): void {
   event.preventDefault()
-  void codeburn.openExternal(url)
+  void metrora.openExternal(url)
 }
 
 export function AboutModal({ socials, onClose }: { socials: SocialLink[]; onClose: () => void }) {
@@ -63,13 +63,13 @@ export function AboutModal({ socials, onClose }: { socials: SocialLink[]; onClos
             <div className="about-modal-section about-modal-updates">
               <div className="about-modal-section-title">Updates</div>
               <p className="about-modal-update-note" role="status">
-                Metrora does not yet publish an automatic update channel. This build never checks or downloads CodeBurn releases.
+                Updates are handled by the active distribution channel. This build does not use a separate in-app updater.
               </p>
             </div>
           </div>
         </div>
         <div className="about-modal-credit">
-          Independent Metrora build · Based on CodeBurn 0.9.19 under the MIT License
+          Metrora · Published by Vensent
         </div>
       </div>
     </div>

--- a/app/renderer/components/Splash.test.tsx
+++ b/app/renderer/components/Splash.test.tsx
@@ -2,10 +2,11 @@
 import { act, render } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-// The splash captures `codeburn` at import; mock it so a test can drive the
-// progress callback the splash subscribes with.
+// The splash captures the canonical Metrora bridge at import; mock both the
+// canonical export and compatibility alias with the same progress surface.
 let progressCb: ((event: unknown) => void) | undefined
 vi.mock('../lib/ipc', () => ({
+  metrora: { onProgress: (cb: (event: unknown) => void) => { progressCb = cb; return () => { progressCb = undefined } } },
   codeburn: { onProgress: (cb: (event: unknown) => void) => { progressCb = cb; return () => { progressCb = undefined } } },
   normalizeCliError: (err: unknown) => err,
 }))

--- a/app/renderer/components/Splash.tsx
+++ b/app/renderer/components/Splash.tsx
@@ -4,7 +4,7 @@ import { createPortal } from 'react-dom'
 import { ProviderLogo } from './ProviderLogo'
 import { MetroraMark } from './MetroraMark'
 import { motionClass, reducedMotion } from '../lib/motion'
-import { codeburn } from '../lib/ipc'
+import { metrora } from '../lib/ipc'
 import type { ScanProgressEvent } from '../lib/types'
 import { version } from '../../package.json'
 
@@ -73,7 +73,7 @@ function SplashStatus({ progress }: { progress: Progress }) {
   )
 }
 
-/** Full-window Metrora startup surface over the inherited local scan. */
+/** Full-window Metrora startup surface over the local scan. */
 export function Splash({ hasData, hasError }: { hasData: boolean; hasError: boolean }) {
   const [phase, setPhase] = useState<Phase>('lit')
   const [progress, setProgress] = useState<Progress>(EMPTY)
@@ -82,8 +82,8 @@ export function Splash({ hasData, hasError }: { hasData: boolean; hasError: bool
   const done = useRef(false)
 
   useEffect(() => {
-    if (!codeburn || typeof codeburn.onProgress !== 'function') return
-    return codeburn.onProgress(event => setProgress(previous => reduceProgress(previous, event)))
+    if (!metrora || typeof metrora.onProgress !== 'function') return
+    return metrora.onProgress(event => setProgress(previous => reduceProgress(previous, event)))
   }, [])
 
   useEffect(() => { if (progress.cold) setReveal(true) }, [progress.cold])

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -1,13 +1,15 @@
 # Getting started
 
-Metrora does not yet have an official stable desktop distribution. The supported public evaluation path is currently a clean build from this repository.
+Metrora does not yet have an official stable desktop distribution. You can evaluate it from source, or use the published **unsigned Windows x64 technical preview `v1.0.0-rc.7`** from GitHub Releases. RC7 is not signed, Microsoft Store certified, automatically updated or the stable `1.0.0` release.
+
+The repository's active source/pre-submission line may be newer than the latest published technical preview. Source builds must therefore be identified by their exact commit/version rather than treated as RC7 release assets.
 
 ## Requirements
 
-Use:
+For repository development and source evaluation use:
 
 - Git;
-- Node.js 22.15 or newer for repository development and validation;
+- Node.js 22.15 or newer;
 - npm;
 - at least one supported AI tool with local usage records.
 
@@ -140,15 +142,15 @@ npm --prefix app run typecheck
 npm --prefix app run build
 ```
 
-Development builds are not official signed releases. Windows is the first official desktop distribution target; the exact product and publisher identity, signing status and channel must be verified before an artifact is presented as official.
+Development builds are not official signed releases. Windows is the first official desktop distribution target. Metrora has an assigned Microsoft Store identity and a non-publishing AppX pre-submission path, but no Store certification/publication is claimed until Microsoft accepts a submission.
 
-See [Windows distribution](WINDOWS_DISTRIBUTION.md) and [`RELEASING.md`](../RELEASING.md).
+See [Windows distribution](WINDOWS_DISTRIBUTION.md), [Versioning authority](VERSIONING.md) and [`RELEASING.md`](../RELEASING.md).
 
 ## Local files and compatibility
 
 The canonical command is `metrora`. The former `qovrion` command and inherited `codeburn` command remain temporary compatibility aliases so existing local state, scripts and integrations can migrate without abrupt breakage.
 
-Some internal directories, environment variables and persisted identifiers also retain historical names. Their presence does not make them current product names or distribution channels.
+Fresh configuration paths use Metrora identity. Existing Qovrion/CodeBurn roots remain readable where required to avoid stranding user state. Some frozen v1 protocol fields, environment aliases and platform-specific integration identifiers also retain historical names; they are compatibility details, not current product names or distribution channels.
 
 Do not rename or delete compatibility state manually unless the relevant migration documentation explicitly instructs you to do so.
 

--- a/docs/VERSIONING.md
+++ b/docs/VERSIONING.md
@@ -1,16 +1,17 @@
 # Versioning authority
 
-Metrora uses semantic versioning for public product identity and a separate numeric build version where platform metadata requires one.
+Metrora uses semantic versioning for public product identity and separate numeric versions where desktop/platform packaging requires them.
 
 ## Current line
 
-- Public development version: `1.0.0-rc.7`
-- Desktop build version: `1.0.0.7`
+- Current source candidate: `1.0.0-rc.8`
+- Desktop build version: `1.0.0.8`
+- Latest published GitHub technical preview: `1.0.0-rc.7`
 - First intended stable release: `1.0.0`
 
 Changing metadata does not create an accepted artifact. Candidate identity always consists of the version, exact source commit, payload manifest and checksums, plus the applicable platform acceptance.
 
-## Mapping
+## Product and desktop build mapping
 
 For a candidate `MAJOR.MINOR.PATCH-rc.N`, the desktop build version is:
 
@@ -22,7 +23,23 @@ For a stable `MAJOR.MINOR.PATCH`, the desktop build version is:
 
 `MAJOR.MINOR.PATCH.10000`
 
-This keeps the stable build numerically above its release candidates while leaving room for later patch versions. Every numeric build-version component is limited to the Windows four-part version range.
+This keeps the stable desktop build numerically above its release candidates while leaving room for later patch versions. Every numeric build-version component remains inside the supported four-part range.
+
+## Microsoft Store package version
+
+The Microsoft Store AppX/MSIX manifest has a separate four-component package identity. For the Windows 10/11 Store package, Metrora uses:
+
+`MAJOR.MINOR.PATCH.0`
+
+The final component is `0` for the Store package contract. The SemVer pre-release suffix (`-rc.N`) is **not** encoded into the AppX identity version, and the desktop build counter (`MAJOR.MINOR.PATCH.N`) must not be presented as the Store package version.
+
+For the current `1.0.0` pre-submission line:
+
+- source/product candidate: `1.0.0-rc.8`;
+- desktop build version: `1.0.0.8`;
+- local/non-publishing Store AppX identity version: `1.0.0.0`.
+
+A locally validated `1.0.0.0` AppX does not mean that version has been submitted, certified or published. Once a package version is actually submitted to Microsoft, later Store updates must advance according to the Store's package-version rules rather than reusing an already submitted identity.
 
 ## Ordering
 
@@ -31,25 +48,24 @@ Metrora accepts only stable versions and numbered release candidates in the form
 - `MAJOR.MINOR.PATCH`
 - `MAJOR.MINOR.PATCH-rc.N`
 
-For the same core version, release candidates are ordered by `N` and the stable release sorts after every candidate. Release and migration tooling must use the shared authority in `scripts/version-authority-lib.mjs`; platform-native parsers that reject SemVer prerelease identifiers are not authoritative.
+For the same core version, release candidates are ordered by `N` and the stable release sorts after every candidate. Release and migration tooling must use the shared authority in `scripts/version-authority-lib.mjs`; platform-native parsers that reject SemVer prerelease identifiers are not authoritative for Metrora product ordering.
 
 ## Material candidate changes
 
 Advance `rc.N` whenever source changes can alter user-visible accounting, historical reconciliation, persisted-state interpretation, security or trust evidence, packaging, installation, migration, rollback or platform behavior.
 
-Parser and provider corrections that can change tokens, costs, calls, projects or other reported usage are material even when their code delta is small. They require a new source-bound candidate rather than reusing an artifact built from an earlier commit.
+Parser and provider corrections that can change tokens, costs, calls, projects or other reported usage are material even when their code delta is small. Persisted endpoint-software reconciliation is also material because it changes the interpretation/presentation of stored Workspace state.
 
 Documentation-only clarification, test-only determinism and other changes proven not to alter shipped behavior do not automatically require a new candidate. The applicable validation still follows the changed surface.
 
 ## Authorities
 
-The following values must agree:
+The following values must agree where they represent the same authority:
 
-- root `package.json`;
-- root `package-lock.json`;
-- desktop `app/package.json`;
-- desktop `app/package-lock.json`;
-- desktop `buildVersion` mapping;
+- root `package.json` and root `package-lock.json` — product SemVer;
+- desktop `app/package.json` and `app/package-lock.json` — product SemVer;
+- desktop `buildVersion` — desktop numeric build mapping;
+- Store AppX manifest — Store package-version mapping;
 - current-version declarations in `RELEASING.md`;
 - current desktop declarations in `app/DISTRIBUTION.md`;
 - current release-line declarations in this document and `docs/WINDOWS_DISTRIBUTION.md`.
@@ -62,6 +78,6 @@ CI executes the same check on pull requests and pushes to `main`.
 
 ## Historical evidence
 
-Historical version references are immutable evidence, not active version authorities. In particular, accepted 0.9.19 candidate reports, manifests, migration fixtures, provenance notices and changelog history must retain their original version and source binding.
+Historical version references are immutable evidence, not active version authorities. Published RC7 release records and accepted 0.9.19 candidate reports, manifests, migration fixtures, provenance notices and changelog history retain their original version/source binding.
 
 Never rename an old report or artifact to the current version, and never treat an accepted artifact as evidence for a later source commit.

--- a/docs/WINDOWS_DISTRIBUTION.md
+++ b/docs/WINDOWS_DISTRIBUTION.md
@@ -2,11 +2,15 @@
 
 ## Status
 
-Official Windows distribution is in preparation.
+Metrora does not yet have an official stable Windows release.
 
-The accepted 0.9.19 Windows artifacts remain unsigned engineering candidates used for validation. They are not an official release, signed package or active update channel.
+The latest public Windows technical preview is the **unsigned** GitHub pre-release `v1.0.0-rc.7`. It remains bound to its accepted source, manifests, checksums and publication evidence. It is not a signed stable package, a Microsoft Store package or an automatic update channel.
 
-The active source line is `1.0.0-rc.7`, with numeric desktop build version `1.0.0.7`. It does not have an accepted artifact yet and does not supersede the source-bound 0.9.19 evidence.
+The active source/pre-submission line is `1.0.0-rc.8`, with desktop build version `1.0.0.8`. RC8 exists because Store-readiness work changes persisted Workspace software metadata and Store-facing presentation; it cannot reuse RC7 product identity.
+
+Metrora has an assigned Microsoft Store identity and a reviewed non-publishing AppX workflow/local-test path. No Store submission, certification or publication is claimed until Microsoft actually accepts that channel.
+
+Historical 0.9.19 acceptance material remains immutable engineering evidence for its own source line only.
 
 ## Identity
 
@@ -15,6 +19,16 @@ An official distribution must use the exact product and publisher identity issue
 Identity values must never be guessed, copied from another project or patched into an artifact after the reviewed product build.
 
 Protected credentials and verification material remain outside untrusted public pull-request workflows.
+
+## Version boundary
+
+Windows uses multiple version authorities deliberately:
+
+- product/source candidate: `1.0.0-rc.8`;
+- desktop build version: `1.0.0.8`;
+- current non-publishing Microsoft Store AppX identity version: `1.0.0.0`.
+
+The Store AppX four-part identity is not the desktop build counter. See [Versioning authority](VERSIONING.md).
 
 ## Package requirements
 
@@ -29,13 +43,17 @@ An official Windows package must:
 - pass clean installation, first launch, update, removal and rollback acceptance;
 - keep private user data out of package metadata, reports and provenance.
 
-## Technical artifacts
-
-Portable and installer candidates may be published only as clearly labelled technical artifacts with their exact signature status, checksums and source binding.
+## GitHub technical preview
 
 An unsigned GitHub pre-release follows the separate source, candidate, physical and publication gates in [Windows GitHub pre-release acceptance v1](WINDOWS_GITHUB_PRE_RELEASE_ACCEPTANCE_V1.md).
 
-Technical artifacts must not be described as an official signed distribution or as equivalent to a channel-certified package.
+The existing RC7 release remains immutable. New RC8 Store-readiness changes do not retroactively modify or re-label those artifacts.
+
+## Microsoft Store pre-submission
+
+The Store workflow builds an unsigned AppX candidate and inspects its identity, architecture, capabilities and payload boundary without publishing it. A separate copy may be signed with a temporary local certificate only for physical acceptance.
+
+Before Partner Center submission, the exact source-bound candidate must pass the bounded local Store test and cleanup. A local PASS is pre-submission evidence only; it is not Microsoft certification.
 
 ## Acceptance gates
 

--- a/docs/sync/DEVELOPER.md
+++ b/docs/sync/DEVELOPER.md
@@ -1,215 +1,137 @@
-# Sync — Developer Documentation
+# Metrora sync — developer contract
 
-Architecture, protocol, server contract, and testing for `codeburn sync`.
+This document describes the current opt-in sync client, its v1 compatibility wire contract and its offline test boundaries. It is not a production-backend deployment guide.
 
-## Architecture
+## Client flow
 
-```
-Developer machine                          Remote backend
-──────────────────                         ──────────────
-~/.config/codeburn/sync.json  (config)
-~/.config/codeburn/.sync-token (credential)
-~/.cache/codeburn/sync-ledger.json (sent-ledger)
+```text
+Metrora client                              Configured remote endpoint
+──────────────                              ──────────────────────────
+config root/sync.json       (non-secret)
+credential backend          (refresh token)
+cache root/sync-ledger.json (sent ledger)
 
-codeburn sync push
+metrora sync push
   │
-  ├─ Read config → baseUrl, clientId, issuer, tracesPath
-  ├─ Read refresh token from OS store
-  ├─ POST {issuer}/oauth2/token (refresh_token grant) → access_token
-  ├─ Collect ParsedProviderCall[] for window
-  ├─ Filter against sent-ledger (only unsent calls)
-  ├─ Build OTLP/HTTP JSON payload
-  ├─ POST {baseUrl}{tracesPath} with Bearer token
-  ├─ On success → append deduplicationKeys to ledger
-  └─ Update lastSync in config
+  ├─ read endpoint configuration
+  ├─ refresh the OIDC access token
+  ├─ collect eligible local usage records for the requested window
+  ├─ subtract records already present in the sent-ledger
+  ├─ build OTLP/HTTP JSON
+  ├─ POST to the configured endpoint with a Bearer token
+  ├─ append successful record identities to the ledger
+  └─ update lastSync
 ```
 
-## Discovery Protocol
+Fresh installations use canonical Metrora config/cache roots. Existing Qovrion or CodeBurn roots are adopted in place when present so upgrades do not silently abandon state.
 
-### Server discovery document
+## Discovery protocol
 
-```
+The v1 protocol currently discovers endpoint metadata at:
+
+```text
 GET {baseUrl}/.well-known/codeburn-export.json
 ```
+
+The `codeburn-export.json` route name is a **frozen compatibility wire identifier**. It remains only to avoid breaking already compatible endpoints and must not be treated as current product branding.
+
+Example shape:
 
 ```json
 {
   "version": 1,
-  "issuer": "https://cognito-idp.us-west-2.amazonaws.com/us-west-2_XXXX",
-  "client_id": "70e6sgst2ju6ff9dnrmv4l1tcb",
+  "issuer": "https://auth.example.com",
+  "client_id": "example-client-id",
   "scopes": ["openid", "email"],
   "traces_path": "/v1/traces",
   "max_batch_size": 1000
 }
 ```
 
-| Field | Required | Default | Description |
+| Field | Required | Default | Meaning |
 |---|---|---|---|
-| `version` | No | `1` | Client rejects `version > 1` |
-| `issuer` | Yes | — | OIDC issuer URL. Client fetches `{issuer}/.well-known/openid-configuration` |
-| `client_id` | Yes | — | OAuth client ID for this deployment |
-| `scopes` | No | `["openid"]` | Scopes to request. `offline_access` added dynamically if IdP supports it |
-| `traces_path` | No | `/v1/traces` | Path for OTLP POST |
-| `max_batch_size` | No | `1000` | Max spans per HTTP request |
+| `version` | No | `1` | Client rejects versions newer than it understands. |
+| `issuer` | Yes | — | OIDC issuer URL. |
+| `client_id` | Yes | — | OAuth client ID for the deployment. |
+| `scopes` | No | `["openid"]` | Requested OIDC scopes. |
+| `traces_path` | No | `/v1/traces` | OTLP HTTP POST path. |
+| `max_batch_size` | No | `1000` | Maximum spans per request. |
 
-### Why not proxy `.well-known/openid-configuration`?
+Remote endpoint and issuer URLs must use HTTPS. Plain HTTP is accepted only for loopback development/testing.
 
-OIDC requires the `issuer` claim inside the discovery doc to match the URL it was fetched from. Serving Cognito's doc from a different domain violates this constraint. The `codeburn-export.json` doc decouples the metrics endpoint from the identity provider.
+## OIDC authentication
 
-## OIDC Authentication
+The client uses Authorization Code + PKCE:
 
-### Flow: Authorization Code + PKCE
+1. generate a random verifier and SHA-256 challenge;
+2. start a loopback callback listener on one of the reviewed fixed ports;
+3. open the authorization endpoint in the browser;
+4. validate the returned `state` and authorization code;
+5. exchange the code using the verifier;
+6. store the refresh token using the platform credential backend.
 
-1. Client generates `code_verifier` (32 random bytes, base64url) and `code_challenge` (SHA-256 of verifier, base64url)
-2. Client starts callback server on `127.0.0.1:19876` (fallback: 19877, 19878)
-3. Browser opens `{authorization_endpoint}?response_type=code&client_id=...&redirect_uri=http://127.0.0.1:{port}/callback&code_challenge=...&code_challenge_method=S256&state=...&scope=...`
-4. User logs in at IdP → IdP redirects to `http://127.0.0.1:{port}/callback?code=...&state=...`
-5. Callback server validates `state`, extracts `code`
-6. Client POSTs to `{token_endpoint}` with `grant_type=authorization_code`, `code`, `code_verifier`, `redirect_uri`, `client_id`
-7. IdP returns `access_token` + `refresh_token`
+On a later `metrora sync push`, the refresh token is exchanged for a current access token. An invalid/expired refresh grant stops the push and requires the user to run `metrora sync setup <url>` again.
 
-### Fixed ports
+## Credential boundary
 
-Cognito (and Okta) do exact string comparison on callback URLs. Ephemeral ports fail. We register three fixed ports: `19876`, `19877`, `19878`. The client tries in order, falling back if a port is in use.
+Supported storage backends are:
 
-RFC 8252 recommends `127.0.0.1` (IP literal) over `localhost` to avoid IPv6 `::1` resolution.
+| Platform | Preferred storage |
+|---|---|
+| macOS | Keychain |
+| Linux | libsecret, with permission-restricted file fallback |
+| Windows | DPAPI-protected local file |
 
-### Token refresh
+Canonical credential identity is `metrora-sync`. Existing Qovrion/CodeBurn keychain service entries can be adopted into the canonical service after a successful read. Legacy files remain readable through the shared config-root compatibility boundary.
 
-On every `sync push`:
-1. Read refresh token from OS store
-2. POST `{token_endpoint}` with `grant_type=refresh_token`
-3. Store whatever refresh token the server returns (handles rotation transparently)
-4. On `invalid_grant` → stop, prompt user to re-run `sync setup`
+Secrets are never written to `sync.json` or the sent-ledger.
 
-### Scope resolution
+## OTLP encoding
 
-- Request scopes from `codeburn-export.json`
-- Add `offline_access` only if `scopes_supported` in OIDC discovery includes it
-- Cognito rejects `offline_access` as `invalid_scope` — it issues refresh tokens without it
+The payload follows protobuf-JSON mapping for `ExportTraceServiceRequest`.
 
-## Credential Storage
+Deterministic span identity is derived from local record identity so retries remain stable:
 
-| Platform | Method | Implementation |
-|---|---|---|
-| macOS | Keychain | `security add-generic-password` / `find-generic-password` |
-| Linux | libsecret | `secret-tool store` / `secret-tool lookup` |
-| Windows | DPAPI | PowerShell `ConvertTo-SecureString` / `ConvertFrom-SecureString` |
-| Fallback | File | `~/.config/codeburn/.sync-token` with `0600` permissions |
-
-No native modules (`keytar` is archived). Shell out to OS CLIs. Fallback reported honestly in `sync status`.
-
-## OTLP Encoding
-
-Strict protobuf-JSON mapping of `ExportTraceServiceRequest`. lowerCamelCase fields, hex-encoded IDs, integer enums.
-
-### Span identity (deterministic)
-
-```
-span_id   = first 8 bytes of SHA-256(deduplicationKey) → hex (16 chars)
-trace_id  = first 16 bytes of SHA-256(sessionId)       → hex (32 chars)
+```text
+span_id  = first 8 bytes of SHA-256(deduplicationKey)
+trace_id = first 16 bytes of SHA-256(sessionId)
 ```
 
-Re-sends are byte-identical. Server-side dedup is defense-in-depth.
+The v1 payload may still contain inherited wire attribute names that are frozen for compatibility. Those identifiers are protocol details, not current UI/product names, and require a separately versioned migration before removal.
 
-### Resource attributes
+## Privacy boundary
 
-```json
-{
-  "resource": {
-    "attributes": [
-      { "key": "codeburn.device_id", "value": { "stringValue": "<SHA-256(hostname+username)[:16]>" } }
-    ]
-  }
-}
+The sync payload is metadata-oriented. It does not include prompt bodies, response bodies, source-code contents, diffs, shell-command text, API keys, secrets or unrestricted local paths.
+
+Identity for a remote deployment comes from the authenticated token; the client does not send a user's local account name as a dedicated identity field.
+
+## Sent-ledger
+
+`sync-ledger.json` records successfully sent deduplication keys. Push behavior is:
+
+```text
+selected local records
+  minus sent-ledger
+  = records eligible for this push
 ```
 
-### Span attributes
+Entries older than the supported retention window are pruned. A partially rejected OTLP batch is not ledgered as successful because the response does not identify exactly which spans were rejected; the batch can therefore retry with deterministic span IDs.
 
-```json
-{
-  "attributes": [
-    { "key": "ai.provider", "value": { "stringValue": "kiro" } },
-    { "key": "ai.model", "value": { "stringValue": "claude-sonnet-4-6" } },
-    { "key": "ai.input_tokens", "value": { "intValue": "12500" } },
-    { "key": "ai.output_tokens", "value": { "intValue": "3200" } },
-    { "key": "ai.cost_usd", "value": { "doubleValue": 0.085 } },
-    { "key": "ai.project", "value": { "stringValue": "my-app" } },
-    { "key": "ai.tools", "value": { "arrayValue": { "values": [{ "stringValue": "Edit" }] } } },
-    { "key": "ai.speed", "value": { "stringValue": "standard" } },
-    { "key": "ai.cost_estimated", "value": { "boolValue": true } }
-  ]
-}
-```
+HTTP 429 handling honors bounded `Retry-After` delays. Authentication or server failures stop the current push without falsely ledgering unsent records.
 
-## Sent-Ledger
+## Server contract
 
-Client-side deduplication source of truth at `~/.cache/codeburn/sync-ledger.json`.
+A compatible endpoint implements:
 
-Format: JSON array of `{ key: string, ts: string }` objects.
+1. `GET {baseUrl}/.well-known/codeburn-export.json` for the v1 discovery document;
+2. `POST {baseUrl}{traces_path}` accepting OTLP/HTTP JSON with Bearer authentication.
 
-**Push logic**: collect all calls in window → subtract ledger entries → send remainder → append to ledger on success.
+The server is responsible for validating tokens, applying its own authorization/retention policy and handling deterministic span IDs idempotently.
 
-**Pruning**: entries older than 6 months removed on every push.
-
-**Why not a watermark?** Timestamp watermarks silently skip late-arriving calls (long sessions, providers that update rows). The ledger is exact.
-
-### Partial success
-
-OTLP returns `partial_success.rejected_spans` in the response body. Because OTLP does not identify *which* spans were rejected, the client ledgers nothing for a partially-rejected batch — the entire batch retries on the next push. This is safe: span IDs are deterministic (derived from the deduplication key), so servers that store by span ID treat re-sent spans as idempotent upserts.
-
-### Rate limiting (429)
-
-A push runs to completion — there is no routine per-push cap (only a 50,000-call safety valve). Server rate limits are the intended brake:
-
-- On HTTP 429 the client honors `Retry-After` (delta-seconds or HTTP-date), capped at 120 seconds per wait, defaulting to 5 seconds when the header is absent
-- The same batch is retried up to 3 consecutive times; if the server is still rate-limiting after that, the push stops and the remaining (unledgered) calls are sent on the next push
-- On 401 or 5xx the push stops immediately with the same resume-on-next-push behavior
-
-### Server contract
-
-The backend must implement:
-
-1. `GET {baseUrl}/.well-known/codeburn-export.json` — returns the discovery doc (public, no auth)
-2. `POST {baseUrl}{traces_path}` — accepts OTLP/HTTP JSON with Bearer token
-   - Validate JWT (issued by the configured IdP)
-   - Derive developer identity from token's `sub` claim
-   - Accept `startTimeUnixNano` up to 6 months in the past
-   - Return standard OTLP response body
-
-No PII is included in the payload. The server derives identity solely from the authenticated token.
+Metrora does not ship or require a public hosted Community backend as part of this contract.
 
 ## Testing
 
-### Unit tests (`tests/sync.test.ts`)
+The repository's sync tests are expected to cover discovery parsing, PKCE helpers, callback validation, config read/write, token refresh behavior, sent-ledger semantics and loopback/mock-server flows without requiring a production endpoint.
 
-26 tests covering pure functions: discovery parsing, PKCE generation, auth URL construction, scope resolution, callback server, config read/write. No network, no browser.
-
-### Mock IdP e2e (`tests/sync-e2e.test.ts`)
-
-6 tests with a localhost mock IdP server. Exercises the full auth round-trip, token refresh, rotation, revocation — fully offline, runs in CI.
-
-### Headless browser e2e (`tests/sync-headless-e2e.test.ts`)
-
-1 test with Playwright headless Chromium against real Cognito. Proves the actual browser PKCE flow works including Cognito Hosted UI form submission and localhost redirect.
-
-**Developer-only** — requires:
-- Deployed test backend (CDK stack at `../codeburn-sync-backend/`)
-- Cognito user with confirmed password
-- Environment variables: `CODEBURN_SYNC_URL`, `CODEBURN_SYNC_EMAIL`, `CODEBURN_SYNC_PASSWORD`
-- Playwright Chromium installed (`PLAYWRIGHT_BROWSERS_PATH`)
-
-Skipped by default when env vars are not set. Never runs in CI.
-
-### Test CDK stack (`codeburn-sync-backend/`)
-
-Minimal AWS backend for the headless e2e test:
-- Cognito User Pool (PKCE, fixed callback ports)
-- HTTP API with JWT authorizer
-- Discovery Lambda (serves `codeburn-export.json`)
-- Ingest Lambda (logs OTLP spans to CloudWatch)
-
-Deploy: `npx cdk deploy --profile andklee-dev`
-Cost: ~$0/mo idle (pay-per-request)
-
-This is a **test fixture**, not a production reference. Any OIDC provider + OTLP-accepting endpoint satisfies the server contract.
+Tests that require external credentials or a live deployment are developer-controlled and must remain opt-in. Public documentation must not contain real deployment identifiers, private profiles, passwords, test-user credentials or production secrets.

--- a/docs/sync/README.md
+++ b/docs/sync/README.md
@@ -1,130 +1,103 @@
-# codeburn sync
+# Metrora sync
 
-Push your AI usage telemetry to a shared backend so teams can track adoption, budgets, and ROI across developers.
+`metrora sync` is an **explicit, opt-in** path for sending usage telemetry to a remote endpoint that you configure. It is not required for local Metrora use and it does not run automatically.
 
-Everything stays local-first: codeburn never sends data without your explicit action, and prompts/code are never included.
+Prompts, response bodies, source code, diffs, shell commands and secrets are not included in the sync payload.
 
-## Quick Start
+## Quick start
 
 ```bash
-# One-time setup (opens browser for login)
-codeburn sync setup https://metrics.your-team.com
+# One-time setup (opens a browser for login)
+metrora sync setup https://metrics.your-team.com
 
-# Push recent usage
-codeburn sync push
+# Push recent usage explicitly
+metrora sync push
 
-# Check status
-codeburn sync status
+# Check local sync status
+metrora sync status
 ```
 
 ## Commands
 
-### `codeburn sync setup <url>`
+### `metrora sync setup <url>`
 
-Configures sync with a remote endpoint. Opens your browser for a one-time OIDC login.
-
-```bash
-codeburn sync setup https://metrics.your-team.com
-```
-
-What happens:
-1. Fetches server configuration from `<url>/.well-known/codeburn-export.json`
-2. Opens your browser to the identity provider's login page
-3. After login, stores a refresh token securely in your OS keychain
-4. Saves the endpoint configuration (no secrets) to `~/.config/codeburn/sync.json`
-
-You only need to do this once. The token refreshes silently on every push.
-
-### `codeburn sync push`
-
-Sends unsent AI usage data to the configured endpoint.
+Configures one remote endpoint and performs an OIDC login.
 
 ```bash
-# Push unsent calls from the last 7 days (default)
-codeburn sync push
-
-# Push a larger window
-codeburn sync push --since 30d
-
-# Preview what would be sent
-codeburn sync push --dry-run
+metrora sync setup https://metrics.your-team.com
 ```
 
-### `codeburn sync status`
+The client:
 
-Shows the current sync configuration and authentication state.
+1. fetches the endpoint discovery document;
+2. opens the configured identity-provider login page;
+3. stores the refresh token using the platform credential backend;
+4. stores non-secret endpoint configuration in the Metrora config root.
 
-```
-Endpoint: https://metrics.your-team.com
-Traces path: /v1/traces
-Issuer: https://auth.your-team.com
-Auth: configured
-Token storage: keychain
-Last sync: 2h ago
-```
+Fresh installations use `~/.config/metrora` on platforms that follow the XDG-style layout. An existing Qovrion or CodeBurn config root is adopted in place rather than abandoned, so an upgrade does not silently lose configuration.
 
-### `codeburn sync logout`
+The v1 server contract still uses `/.well-known/codeburn-export.json` as a **frozen compatibility wire route**. That route name is not the product identity and must not be used for new UI, commands or branding.
 
-Removes stored credentials and revokes the token at the identity provider.
+### `metrora sync push`
+
+Sends only unsent usage records in the requested window to the configured endpoint.
 
 ```bash
-codeburn sync logout
+metrora sync push
+metrora sync push --since 30d
+metrora sync push --dry-run
 ```
 
-### `codeburn sync reset --confirm`
+No background scheduler or automatic Store upload is enabled by this command set.
 
-Clears the sent-ledger, causing the next push to re-send all data in the window. Use after a backend migration or if you suspect missing data.
+### `metrora sync status`
+
+Shows the configured endpoint, authentication state, credential-storage method and last successful push.
+
+### `metrora sync logout`
+
+Removes the local sync credential and endpoint configuration.
 
 ```bash
-codeburn sync reset --confirm
+metrora sync logout
 ```
 
-## What Gets Sent
+### `metrora sync reset --confirm`
 
-Each AI interaction becomes one OTLP span with these attributes:
+Clears the local sent-ledger. The next explicit push can therefore resend records in its selected window.
 
-| Field | Example | Description |
-|---|---|---|
-| `ai.provider` | `kiro`, `cursor`, `claude` | Which AI tool |
-| `ai.model` | `claude-sonnet-4-6` | Model used |
-| `ai.input_tokens` | `12500` | Prompt tokens |
-| `ai.output_tokens` | `3200` | Response tokens |
-| `ai.cost_usd` | `0.085` | Estimated cost |
-| `ai.project` | `my-app` | Project name |
-| `ai.tools` | `["Edit", "Bash"]` | Tools invoked |
+```bash
+metrora sync reset --confirm
+```
 
-A pseudonymous `device_id` distinguishes your machines without revealing hostnames.
+## What is sent
 
-### What is NOT sent
+Each eligible interaction is encoded as an OTLP span using metadata such as provider, model, token counts, cost attribution and project label when available. A pseudonymous device identifier distinguishes endpoints without transmitting the machine hostname as the identifier.
 
-- **Prompts** — your actual messages to AI are never included
-- **Code** — file contents, diffs, and paths stay local
-- **Bash commands** — may contain secrets, never sent
-- **Your name/email** — identity is derived server-side from your login token
+The sync payload does **not** include:
 
-There is no flag to override this. Privacy is structural, not configurable.
+- prompt or response bodies;
+- source-code contents or diffs;
+- shell-command text;
+- secrets or API keys;
+- unrestricted local paths.
 
-## Authentication
+This privacy boundary is structural; there is no command-line flag that turns those fields on.
 
-Sync uses standard OIDC (the same protocol as "Sign in with Google"). Your team's admin sets up the identity provider — you just click through the browser login once.
+## Authentication and local storage
 
-- **Token storage**: macOS Keychain, Windows Credential Manager, or Linux libsecret. Falls back to a `0600` file if no keychain is available.
-- **Token lifetime**: typically 30–90 days (set by your admin). You'll be prompted to re-login when it expires.
-- **Re-login**: run `codeburn sync setup <url>` again.
+Sync uses OIDC Authorization Code + PKCE. Credential handling is platform-specific:
 
-## FAQ
+- macOS: Keychain;
+- Linux: libsecret when available, otherwise a permission-restricted file fallback;
+- Windows: DPAPI-protected local credential storage.
 
-**Q: Does sync run automatically?**
-A: No. You run `codeburn sync push` when you want. A future version may offer opportunistic push (after each `codeburn report`), but it's always explicit.
+Fresh credential/config files use the canonical Metrora config root. Existing compatibility roots remain readable so upgrades do not strand credentials or settings.
 
-**Q: What if I push the same data twice?**
-A: Safe. A local sent-ledger tracks what's been sent. Re-pushing the same window doesn't create duplicates.
+## Operational behavior
 
-**Q: What if I'm offline for a week?**
-A: Next push catches up. The default window is 7 days; use `--since 30d` or `--since all` (up to 6 months) for longer gaps. A push runs to completion regardless of size — server rate limits (429) are waited out automatically.
+`metrora sync push` is idempotency-aware through a local sent-ledger. Successfully sent record identities are retained so an overlapping later push does not intentionally duplicate them. The ledger follows the canonical Metrora cache root on fresh installations and adopts an existing legacy cache root in place when present.
 
-**Q: Can my admin see my prompts?**
-A: No. Prompts are never included in the payload. The server only sees token counts, costs, model names, and project names.
+When the machine is offline, nothing is uploaded. A later explicit push can use a larger `--since` window to catch up.
 
-**Q: How do I stop syncing?**
-A: `codeburn sync logout` removes everything. Or just stop running `push`.
+For the versioned wire contract and test architecture, see [DEVELOPER.md](DEVELOPER.md).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "metrora",
-  "version": "1.0.0-rc.7",
+  "version": "1.0.0-rc.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "metrora",
-      "version": "1.0.0-rc.7",
+      "version": "1.0.0-rc.8",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metrora",
-  "version": "1.0.0-rc.7",
+  "version": "1.0.0-rc.8",
   "private": true,
   "description": "Metrora — local-first AI usage intelligence for tools, models, projects and sessions",
   "type": "module",

--- a/scripts/check-public-identity-boundary.mjs
+++ b/scripts/check-public-identity-boundary.mjs
@@ -42,6 +42,10 @@ const requiredFiles = {
     'Metrora is independently maintained',
     'Metrora™ — published by Vensent™',
   ],
+  'app/renderer/components/AboutModal.tsx': [
+    'Metrora · Published by Vensent',
+    'Updates are handled by the active distribution channel',
+  ],
   'CONTRIBUTING.md': [
     '## Public repository hygiene',
   ],
@@ -64,6 +68,22 @@ for (const [path, markers] of Object.entries(requiredFiles)) {
   }
 }
 
+const forbiddenStoreSurfaceMarkers = {
+  'app/renderer/components/AboutModal.tsx': [
+    'CodeBurn',
+    'Qovrion',
+    '0.9.19',
+  ],
+}
+
+for (const [path, markers] of Object.entries(forbiddenStoreSurfaceMarkers)) {
+  const text = readTrackedText(path)
+  for (const marker of markers) {
+    if (!text.includes(marker)) continue
+    findings.push({ path, line: 1, message: `legacy identity marker must not appear on the Store-facing surface: ${marker}` })
+  }
+}
+
 const rootLicense = readTrackedText('LICENSE')
 if (rootLicense.includes('AgentSeal')) {
   findings.push({
@@ -80,4 +100,4 @@ if (findings.length > 0) {
   process.exit(1)
 }
 
-console.log('Canonical public identity, licensing and contribution markers are present.')
+console.log('Canonical public identity, licensing, Store-facing and contribution markers are present.')

--- a/scripts/check-version-consistency.mjs
+++ b/scripts/check-version-consistency.mjs
@@ -25,15 +25,15 @@ if (appPackage.build?.buildVersion !== expectedBuildVersion) {
   fail(`desktop buildVersion is ${appPackage.build?.buildVersion}, expected ${expectedBuildVersion}`)
 }
 
-requireText('RELEASING.md', `- Current development version: \`${version}\``, 'development version')
+requireText('RELEASING.md', `- Current source candidate: \`${version}\``, 'source candidate')
 requireText('RELEASING.md', `- Current desktop build version: \`${expectedBuildVersion}\``, 'desktop build version')
-requireText('app/DISTRIBUTION.md', `- Current desktop version: \`${version}\``, 'desktop version')
+requireText('app/DISTRIBUTION.md', `- Current source/desktop candidate: \`${version}\``, 'desktop source candidate')
 requireText('app/DISTRIBUTION.md', `- Current desktop build version: \`${expectedBuildVersion}\``, 'desktop build version')
-requireText('docs/VERSIONING.md', `- Public development version: \`${version}\``, 'public development version')
+requireText('docs/VERSIONING.md', `- Current source candidate: \`${version}\``, 'public source candidate')
 requireText('docs/VERSIONING.md', `- Desktop build version: \`${expectedBuildVersion}\``, 'desktop build version')
 requireText(
   'docs/WINDOWS_DISTRIBUTION.md',
-  `The active source line is \`${version}\`, with numeric desktop build version \`${expectedBuildVersion}\`.`,
+  `The active source/pre-submission line is \`${version}\`, with desktop build version \`${expectedBuildVersion}\`.`,
   'Windows distribution version',
 )
 

--- a/scripts/windows-store-identity.node-test.mjs
+++ b/scripts/windows-store-identity.node-test.mjs
@@ -6,6 +6,7 @@ import { resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 const repositoryRoot = resolve(fileURLToPath(new URL('..', import.meta.url)))
+const rootPackage = JSON.parse(readFileSync(resolve(repositoryRoot, 'package.json'), 'utf8'))
 const desktopPackage = JSON.parse(readFileSync(resolve(repositoryRoot, 'app/package.json'), 'utf8'))
 const brandGenerator = readFileSync(resolve(repositoryRoot, 'scripts/generate-brand-assets.mjs'), 'utf8')
 
@@ -67,10 +68,19 @@ assert.equal(
   'the desktop build must not gain an implicit publication target',
 )
 
+assert.equal(desktopPackage.version, rootPackage.version, 'desktop and root product SemVer must match')
 assert.equal(
   desktopPackage.build?.buildVersion,
-  '1.0.0.7',
-  'the current Windows package version authority must remain 1.0.0.7',
+  '1.0.0.8',
+  'the current desktop build version authority must remain 1.0.0.8',
+)
+
+const productCore = rootPackage.version.replace(/-rc\.\d+$/, '')
+assert.match(productCore, /^\d+\.\d+\.\d+$/)
+assert.equal(
+  `${productCore}.0`,
+  '1.0.0.0',
+  'the current Microsoft Store AppX identity version mapping must remain 1.0.0.0',
 )
 
 for (const asset of [
@@ -82,4 +92,4 @@ for (const asset of [
   assert.ok(brandGenerator.includes(asset), `the deterministic brand generator must emit ${asset}`)
 }
 
-console.log('Windows Store package identity, assets and channel separation are valid.')
+console.log('Windows Store identity, version authorities, assets and channel separation are valid.')

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,8 +1,8 @@
 import { readFile, writeFile, mkdir, rename } from 'fs/promises'
 import { join } from 'path'
-import { homedir } from 'os'
 import { randomBytes } from 'crypto'
 import { PLAN_PROVIDERS } from './plans.js'
+import { getMetroraConfigDir } from './product-paths.js'
 
 export type PlanId = 'claude-pro' | 'claude-max' | 'claude-max-5x' | 'cursor-pro' | 'supergrok' | 'supergrok-heavy' | 'custom' | 'none'
 export type PlanProvider = 'claude' | 'codex' | 'cursor' | 'grok' | 'all'
@@ -19,6 +19,7 @@ export type PlanConfig = Omit<Plan, 'provider' | 'setAt'> & Partial<Pick<Plan, '
 export type PlanConfigMap = Partial<Record<PlanProvider, PlanConfig>>
 export type PlanMap = Partial<Record<PlanProvider, Plan>>
 
+// Historical type name retained as an internal source-compatibility alias.
 export type CodeburnConfig = {
   currency?: {
     code: string
@@ -53,7 +54,7 @@ export type CodeburnConfig = {
   // Absolute directory prefixes whose Claude Code sessions are routed through a
   // subscription-backed LLM proxy (e.g. GitHub Copilot via ANTHROPIC_BASE_URL;
   // tools like claude-code-over-github-copilot / claudegate). The JSONL records
-  // the underlying model name and no endpoint, so codeburn cannot auto-detect
+  // the underlying model name and no endpoint, so Metrora cannot auto-detect
   // proxying — the user declares it here, scoped by the project's canonical cwd.
   // Matching projects keep their full API-rate `totalCostUSD` (the billable /
   // would-be figure is never destroyed) but expose `totalProxiedCostUSD` so the
@@ -64,7 +65,7 @@ export type CodeburnConfig = {
 }
 
 function getConfigDir(): string {
-  return join(homedir(), '.config', 'codeburn')
+  return getMetroraConfigDir()
 }
 
 function getConfigPath(): string {

--- a/src/desktop-local-state-entry.ts
+++ b/src/desktop-local-state-entry.ts
@@ -1,10 +1,18 @@
 // Narrow runtime entry loaded by Electron's main process. It deliberately
 // exposes desktop-host initialization and public Workspace DTOs/actions;
 // raw private identity material never crosses into the renderer or an IPC response.
+import {
+  initializeDesktopWorkspaceRuntimeV1 as initializeDesktopWorkspaceRuntimeV1Base,
+} from './local-state/desktop-host.js'
+import type {
+  InitializedDesktopWorkspaceRuntimeV1,
+  InitializeDesktopWorkspaceRuntimeV1Options,
+} from './local-state/desktop-host.js'
+import { reconcileLocalWorkspaceSoftwareV1 } from './local-state/workspace-software-reconciliation.js'
+
 export {
   DesktopVaultUnavailableError,
   initializeDesktopLocalStateV1,
-  initializeDesktopWorkspaceRuntimeV1,
 } from './local-state/desktop-host.js'
 export type {
   DesktopSafeStorageProvider,
@@ -14,6 +22,20 @@ export type {
   InitializeDesktopLocalStateV1Options,
   InitializeDesktopWorkspaceRuntimeV1Options,
 } from './local-state/desktop-host.js'
+
+export async function initializeDesktopWorkspaceRuntimeV1(
+  input: InitializeDesktopWorkspaceRuntimeV1Options,
+): Promise<InitializedDesktopWorkspaceRuntimeV1> {
+  const initialized = await initializeDesktopWorkspaceRuntimeV1Base(input)
+  await reconcileLocalWorkspaceSoftwareV1({
+    endpointIdentity: initialized.endpoint,
+    metroraVersion: input.metroraVersion,
+    collectorVersion: input.collectorVersion,
+    ...(input.dataDir !== undefined ? { dataDir: input.dataDir } : {}),
+    ...(input.now !== undefined ? { now: input.now } : {}),
+  })
+  return initialized
+}
 
 export {
   DesktopReviewedProductionUnavailableError,
@@ -54,6 +76,14 @@ export type {
   LocalPersonalWorkspaceStateV1,
   LocalPersonalWorkspaceStoreOptions,
 } from './local-state/local-workspace.js'
+
+export {
+  reconcileLocalWorkspaceSoftwareV1,
+} from './local-state/workspace-software-reconciliation.js'
+export type {
+  ReconcileLocalWorkspaceSoftwareV1Options,
+  ReconcileLocalWorkspaceSoftwareV1Result,
+} from './local-state/workspace-software-reconciliation.js'
 
 export {
   inspectLocalWorkspaceProductionLifecycleV1,

--- a/src/local-state/workspace-software-reconciliation.test.ts
+++ b/src/local-state/workspace-software-reconciliation.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import {
+  createLocalPersonalWorkspaceV1,
+  loadLocalPersonalWorkspaceV1,
+} from './local-workspace.js'
+import type { LocalEndpointIdentityMetadataV1 } from './endpoint-identity.js'
+import { reconcileLocalWorkspaceSoftwareV1 } from './workspace-software-reconciliation.js'
+
+const roots: string[] = []
+const CREATED = '2026-08-01T12:00:00.000Z'
+const UPDATED = '2026-08-07T00:15:00.000Z'
+
+async function root(): Promise<string> {
+  const value = await mkdtemp(join(tmpdir(), 'metrora-workspace-software-'))
+  roots.push(value)
+  return value
+}
+
+function identity(): LocalEndpointIdentityMetadataV1 {
+  return {
+    kind: 'qovrion.local-endpoint-identity',
+    version: 1,
+    endpointId: 'ep_11111111-2222-4333-8444-555555555555',
+    generation: 1,
+    keyAlgorithm: 'ed25519',
+    publicKeySpkiBase64: Buffer.from('public-key-1').toString('base64'),
+    publicKeyFingerprintSha256: 'a'.repeat(64),
+    eventIdentityKeyVersion: 1,
+    createdAt: CREATED,
+    updatedAt: CREATED,
+  }
+}
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map(path => rm(path, { recursive: true, force: true })))
+})
+
+describe.sequential('local Workspace software reconciliation', () => {
+  it('updates stale software metadata without changing Workspace or endpoint identity', async () => {
+    const dataDir = await root()
+    const created = await createLocalPersonalWorkspaceV1({
+      dataDir,
+      endpointIdentity: identity(),
+      intent: {
+        workspace: { displayName: 'My workspace', slug: 'my-workspace' },
+        endpoint: {
+          displayName: 'This computer',
+          platform: { os: 'windows', architecture: 'x64' },
+          metroraVersion: '0.9.19',
+          collectorVersion: '0.9.19',
+          capabilities: ['collect', 'normalize', 'aggregate', 'serve-local-api'],
+        },
+      },
+      now: () => new Date(CREATED),
+      randomUUID: (() => {
+        let index = 0
+        return () => `00000000-0000-4000-8000-${String(++index).padStart(12, '0')}`
+      })(),
+    })
+
+    const result = await reconcileLocalWorkspaceSoftwareV1({
+      dataDir,
+      endpointIdentity: identity(),
+      metroraVersion: '1.0.0-rc.8',
+      collectorVersion: '1.0.0-rc.8',
+      now: () => new Date(UPDATED),
+    })
+
+    expect(result.outcome).toBe('updated')
+    const loaded = await loadLocalPersonalWorkspaceV1({ dataDir, endpointIdentity: identity() })
+    expect(loaded?.workspace).toEqual(created.state.workspace)
+    expect(loaded?.ownerMembership).toEqual(created.state.ownerMembership)
+    expect(loaded?.localSubjectId).toBe(created.state.localSubjectId)
+    expect(loaded?.endpoint.endpointId).toBe(created.state.endpoint.endpointId)
+    expect(loaded?.endpoint.identity).toEqual(created.state.endpoint.identity)
+    expect(loaded?.endpointIdentityGeneration).toBe(created.state.endpointIdentityGeneration)
+    expect(loaded?.endpoint.software).toEqual({
+      qovrionVersion: '1.0.0-rc.8',
+      collectorVersion: '1.0.0-rc.8',
+    })
+    expect(loaded?.endpoint.updatedAt).toBe(UPDATED)
+    expect(loaded?.endpoint.lastSeenAt).toBe(UPDATED)
+    expect(loaded?.updatedAt).toBe(UPDATED)
+  })
+
+  it('is a no-op when the persisted software metadata is already current', async () => {
+    const dataDir = await root()
+    await createLocalPersonalWorkspaceV1({
+      dataDir,
+      endpointIdentity: identity(),
+      intent: {
+        workspace: { displayName: 'My workspace', slug: 'my-workspace' },
+        endpoint: {
+          displayName: 'This computer',
+          platform: { os: 'windows', architecture: 'x64' },
+          metroraVersion: '1.0.0-rc.8',
+          collectorVersion: '1.0.0-rc.8',
+          capabilities: ['collect', 'normalize', 'aggregate', 'serve-local-api'],
+        },
+      },
+      now: () => new Date(CREATED),
+    })
+
+    const result = await reconcileLocalWorkspaceSoftwareV1({
+      dataDir,
+      endpointIdentity: identity(),
+      metroraVersion: '1.0.0-rc.8',
+      collectorVersion: '1.0.0-rc.8',
+      now: () => new Date(UPDATED),
+    })
+
+    expect(result.outcome).toBe('unchanged')
+    expect(result.state?.updatedAt).toBe(CREATED)
+    expect(result.state?.endpoint.updatedAt).toBe(CREATED)
+  })
+})

--- a/src/local-state/workspace-software-reconciliation.ts
+++ b/src/local-state/workspace-software-reconciliation.ts
@@ -1,0 +1,109 @@
+import { join } from 'node:path'
+import * as z from 'zod/v4'
+
+import { atomicWritePrivateFile, readOptionalPrivateFile } from './atomic-file.js'
+import {
+  defaultMetroraDataDir,
+  LocalEndpointIdentityMetadataV1Schema,
+  type LocalEndpointIdentityMetadataV1,
+} from './endpoint-identity.js'
+import {
+  loadLocalPersonalWorkspaceV1,
+  LocalPersonalWorkspaceStateV1Schema,
+  LocalWorkspaceRecoveryRequiredError,
+  type LocalPersonalWorkspaceStateV1,
+} from './local-workspace.js'
+import { withLocalStateLease } from './local-state-lease.js'
+
+const SoftwareVersionSchema = z.string().trim().min(1).max(64)
+const WORKSPACE_STATE_FILE = 'local-personal-workspace.v1.json'
+
+export type ReconcileLocalWorkspaceSoftwareV1Options = {
+  endpointIdentity: LocalEndpointIdentityMetadataV1
+  metroraVersion: string
+  collectorVersion: string
+  dataDir?: string
+  now?: () => Date
+}
+
+export type ReconcileLocalWorkspaceSoftwareV1Result = {
+  outcome: 'missing' | 'unchanged' | 'updated'
+  state?: LocalPersonalWorkspaceStateV1
+}
+
+/**
+ * Persist the software versions currently running on an already-enrolled local
+ * endpoint without minting a new Workspace, endpoint identity, membership or
+ * evidence chain. The frozen `qovrionVersion` field name remains a v1 wire
+ * compatibility detail; its value is always the current Metrora version.
+ */
+export async function reconcileLocalWorkspaceSoftwareV1(
+  input: ReconcileLocalWorkspaceSoftwareV1Options,
+): Promise<ReconcileLocalWorkspaceSoftwareV1Result> {
+  const endpointIdentity = LocalEndpointIdentityMetadataV1Schema.parse(input.endpointIdentity)
+  const metroraVersion = SoftwareVersionSchema.parse(input.metroraVersion)
+  const collectorVersion = SoftwareVersionSchema.parse(input.collectorVersion)
+  const dataDir = input.dataDir ?? defaultMetroraDataDir()
+  const now = input.now ?? (() => new Date())
+
+  // Reuse the existing loader as the identity-generation authority first. It
+  // performs any required identity reconciliation under the same Workspace lock.
+  const authoritative = await loadLocalPersonalWorkspaceV1({
+    dataDir,
+    endpointIdentity,
+    now,
+  })
+  if (!authoritative) return { outcome: 'missing' }
+
+  const workspaceDirectory = join(dataDir, 'workspace')
+  const statePath = join(workspaceDirectory, WORKSPACE_STATE_FILE)
+
+  return withLocalStateLease(workspaceDirectory, async () => {
+    const bytes = await readOptionalPrivateFile(statePath)
+    if (!bytes) return { outcome: 'missing' }
+
+    let stored: LocalPersonalWorkspaceStateV1
+    try {
+      stored = LocalPersonalWorkspaceStateV1Schema.parse(JSON.parse(Buffer.from(bytes).toString('utf-8')))
+    } catch (error) {
+      throw new LocalWorkspaceRecoveryRequiredError(
+        `local workspace state is invalid during software reconciliation: ${error instanceof Error ? error.message : String(error)}`,
+      )
+    }
+
+    if (
+      stored.endpoint.endpointId !== endpointIdentity.endpointId ||
+      stored.endpointIdentityGeneration !== endpointIdentity.generation ||
+      stored.endpoint.identity.publicKeyFingerprintSha256 !== endpointIdentity.publicKeyFingerprintSha256
+    ) {
+      throw new LocalWorkspaceRecoveryRequiredError(
+        'local workspace endpoint identity changed during software reconciliation',
+      )
+    }
+
+    if (
+      stored.endpoint.software.qovrionVersion === metroraVersion &&
+      stored.endpoint.software.collectorVersion === collectorVersion
+    ) {
+      return { outcome: 'unchanged', state: stored }
+    }
+
+    const updatedAt = now().toISOString()
+    const reconciled = LocalPersonalWorkspaceStateV1Schema.parse({
+      ...stored,
+      endpoint: {
+        ...stored.endpoint,
+        software: {
+          qovrionVersion: metroraVersion,
+          collectorVersion,
+        },
+        updatedAt,
+        lastSeenAt: updatedAt,
+      },
+      updatedAt,
+    })
+
+    await atomicWritePrivateFile(statePath, JSON.stringify(reconciled))
+    return { outcome: 'updated', state: reconciled }
+  })
+}

--- a/src/product-paths.test.ts
+++ b/src/product-paths.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { mkdirSync, mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { getMetroraCacheDir, getMetroraConfigDir } from './product-paths.js'
+
+const roots: string[] = []
+
+function root(): string {
+  const value = mkdtempSync(join(tmpdir(), 'metrora-product-paths-'))
+  roots.push(value)
+  return value
+}
+
+afterEach(() => {
+  for (const path of roots.splice(0)) rmSync(path, { recursive: true, force: true })
+})
+
+describe('Metrora product path authority', () => {
+  it('uses canonical Metrora roots for a fresh installation', () => {
+    const home = root()
+    expect(getMetroraConfigDir({}, home)).toBe(join(home, '.config', 'metrora'))
+    expect(getMetroraCacheDir({}, home)).toBe(join(home, '.cache', 'metrora'))
+  })
+
+  it('adopts existing legacy roots in place instead of abandoning user state', () => {
+    const home = root()
+    const oldConfig = join(home, '.config', 'codeburn')
+    const oldCache = join(home, '.cache', 'codeburn')
+    mkdirSync(oldConfig, { recursive: true })
+    mkdirSync(oldCache, { recursive: true })
+
+    expect(getMetroraConfigDir({}, home)).toBe(oldConfig)
+    expect(getMetroraCacheDir({}, home)).toBe(oldCache)
+  })
+
+  it('prefers canonical roots when both canonical and legacy data exist', () => {
+    const home = root()
+    const canonicalConfig = join(home, '.config', 'metrora')
+    const canonicalCache = join(home, '.cache', 'metrora')
+    mkdirSync(join(home, '.config', 'codeburn'), { recursive: true })
+    mkdirSync(join(home, '.cache', 'codeburn'), { recursive: true })
+    mkdirSync(canonicalConfig, { recursive: true })
+    mkdirSync(canonicalCache, { recursive: true })
+
+    expect(getMetroraConfigDir({}, home)).toBe(canonicalConfig)
+    expect(getMetroraCacheDir({}, home)).toBe(canonicalCache)
+  })
+
+  it('honors Metrora overrides before temporary compatibility aliases', () => {
+    const home = root()
+    expect(getMetroraConfigDir({
+      METRORA_CONFIG_DIR: '/canonical-config',
+      QOVRION_CONFIG_DIR: '/qovrion-config',
+      CODEBURN_CONFIG_DIR: '/legacy-config',
+    }, home)).toBe('/canonical-config')
+    expect(getMetroraCacheDir({
+      METRORA_CACHE_DIR: '/canonical-cache',
+      QOVRION_CACHE_DIR: '/qovrion-cache',
+      CODEBURN_CACHE_DIR: '/legacy-cache',
+    }, home)).toBe('/canonical-cache')
+  })
+
+  it('uses XDG bases without reintroducing a legacy product name', () => {
+    const home = root()
+    expect(getMetroraConfigDir({ XDG_CONFIG_HOME: '/xdg/config' }, home)).toBe('/xdg/config/metrora')
+    expect(getMetroraCacheDir({ XDG_CACHE_HOME: '/xdg/cache' }, home)).toBe('/xdg/cache/metrora')
+  })
+})

--- a/src/product-paths.ts
+++ b/src/product-paths.ts
@@ -20,8 +20,13 @@ function existingOrCanonical(canonical: string, legacy: string[]): string {
   return canonical
 }
 
+function standardBase(env: MetroraPathEnvironment, xdgName: string, home: string, fallback: string): string {
+  const xdg = env[xdgName]?.trim()
+  return xdg || join(home, fallback)
+}
+
 /**
- * New installations use ~/.config/metrora. Existing development-name or
+ * New installations use the Metrora config root. Existing development-name or
  * inherited roots remain readable in place until a separately reviewed data
  * migration can copy/merge them without risking user state.
  */
@@ -36,16 +41,17 @@ export function getMetroraConfigDir(
   ])
   if (explicit) return explicit
 
+  const base = standardBase(env, 'XDG_CONFIG_HOME', home, '.config')
   return existingOrCanonical(
-    join(home, '.config', 'metrora'),
-    [join(home, '.config', 'qovrion'), join(home, '.config', 'codeburn')],
+    join(base, 'metrora'),
+    [join(base, 'qovrion'), join(base, 'codeburn')],
   )
 }
 
 /**
- * New installations use ~/.cache/metrora. Explicit Metrora overrides win,
- * followed by temporary compatibility aliases; an existing legacy default is
- * adopted in place rather than abandoned, preserving durable history.
+ * New installations use the Metrora cache root. Explicit Metrora overrides
+ * win, followed by temporary compatibility aliases; an existing legacy default
+ * is adopted in place rather than abandoned, preserving durable history.
  */
 export function getMetroraCacheDir(
   env: MetroraPathEnvironment = process.env,
@@ -58,8 +64,9 @@ export function getMetroraCacheDir(
   ])
   if (explicit) return explicit
 
+  const base = standardBase(env, 'XDG_CACHE_HOME', home, '.cache')
   return existingOrCanonical(
-    join(home, '.cache', 'metrora'),
-    [join(home, '.cache', 'qovrion'), join(home, '.cache', 'codeburn')],
+    join(base, 'metrora'),
+    [join(base, 'qovrion'), join(base, 'codeburn')],
   )
 }

--- a/src/product-paths.ts
+++ b/src/product-paths.ts
@@ -1,0 +1,65 @@
+import { existsSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+
+export type MetroraPathEnvironment = NodeJS.ProcessEnv
+
+function firstExplicit(env: MetroraPathEnvironment, names: string[]): string | undefined {
+  for (const name of names) {
+    const value = env[name]?.trim()
+    if (value) return value
+  }
+  return undefined
+}
+
+function existingOrCanonical(canonical: string, legacy: string[]): string {
+  if (existsSync(canonical)) return canonical
+  for (const candidate of legacy) {
+    if (existsSync(candidate)) return candidate
+  }
+  return canonical
+}
+
+/**
+ * New installations use ~/.config/metrora. Existing development-name or
+ * inherited roots remain readable in place until a separately reviewed data
+ * migration can copy/merge them without risking user state.
+ */
+export function getMetroraConfigDir(
+  env: MetroraPathEnvironment = process.env,
+  home: string = homedir(),
+): string {
+  const explicit = firstExplicit(env, [
+    'METRORA_CONFIG_DIR',
+    'QOVRION_CONFIG_DIR',
+    'CODEBURN_CONFIG_DIR',
+  ])
+  if (explicit) return explicit
+
+  return existingOrCanonical(
+    join(home, '.config', 'metrora'),
+    [join(home, '.config', 'qovrion'), join(home, '.config', 'codeburn')],
+  )
+}
+
+/**
+ * New installations use ~/.cache/metrora. Explicit Metrora overrides win,
+ * followed by temporary compatibility aliases; an existing legacy default is
+ * adopted in place rather than abandoned, preserving durable history.
+ */
+export function getMetroraCacheDir(
+  env: MetroraPathEnvironment = process.env,
+  home: string = homedir(),
+): string {
+  const explicit = firstExplicit(env, [
+    'METRORA_CACHE_DIR',
+    'QOVRION_CACHE_DIR',
+    'CODEBURN_CACHE_DIR',
+  ])
+  if (explicit) return explicit
+
+  return existingOrCanonical(
+    join(home, '.cache', 'metrora'),
+    [join(home, '.cache', 'qovrion'), join(home, '.cache', 'codeburn')],
+  )
+}

--- a/src/sync/config.ts
+++ b/src/sync/config.ts
@@ -1,12 +1,14 @@
 /**
  * metrora sync — config file management.
  *
- * Stores non-secret sync configuration at ~/.config/codeburn/sync.json
+ * New installations store non-secret sync configuration under the canonical
+ * Metrora config root. Existing legacy roots are adopted in place by the shared
+ * product-path authority so upgrades do not silently lose configuration.
  */
 
 import { existsSync, mkdirSync, readFileSync, writeFileSync, unlinkSync } from 'fs'
 import { join } from 'path'
-import { homedir } from 'os'
+import { getMetroraConfigDir } from '../product-paths.js'
 
 export interface SyncConfig {
   baseUrl: string
@@ -17,7 +19,7 @@ export interface SyncConfig {
 }
 
 function configDir(): string {
-  return join(homedir(), '.config', 'codeburn')
+  return getMetroraConfigDir()
 }
 
 function configPath(): string {

--- a/src/sync/credentials.ts
+++ b/src/sync/credentials.ts
@@ -8,9 +8,10 @@
 import { execFileSync } from 'child_process'
 import { existsSync, mkdirSync, readFileSync, writeFileSync, unlinkSync, chmodSync } from 'fs'
 import { join } from 'path'
-import { homedir } from 'os'
+import { getMetroraConfigDir } from '../product-paths.js'
 
-const SERVICE_NAME = 'codeburn-sync'
+const SERVICE_NAME = 'metrora-sync'
+const LEGACY_SERVICE_NAMES = ['qovrion-sync', 'codeburn-sync'] as const
 const ACCOUNT_NAME = 'refresh-token'
 
 export type StorageMethod = 'keychain' | 'secret-tool' | 'dpapi' | 'file'
@@ -24,36 +25,50 @@ export interface CredentialStore {
 
 // --- macOS Keychain ---
 
+function readMacKeychain(service: string): string | null {
+  try {
+    const result = execFileSync(
+      'security',
+      ['find-generic-password', '-s', service, '-a', ACCOUNT_NAME, '-w'],
+      { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] },
+    )
+    return result.trim() || null
+  } catch {
+    return null
+  }
+}
+
+function deleteMacKeychain(service: string): void {
+  try {
+    execFileSync('security', ['delete-generic-password', '-s', service, '-a', ACCOUNT_NAME], { stdio: 'pipe' })
+  } catch { /* may not exist */ }
+}
+
 class KeychainStore implements CredentialStore {
   store(token: string): void {
-    // Delete existing first (add-generic-password fails if entry exists)
-    try {
-      execFileSync('security', ['delete-generic-password', '-s', SERVICE_NAME, '-a', ACCOUNT_NAME], { stdio: 'pipe' })
-    } catch { /* may not exist */ }
-
-    // Token passed as arg to execFileSync (no shell interpolation).
-    // Note: still briefly visible in process args on macOS; `security` has no
-    // stdin mode for -w with non-interactive use, so this is the best available.
+    deleteMacKeychain(SERVICE_NAME)
     execFileSync('security', ['add-generic-password', '-s', SERVICE_NAME, '-a', ACCOUNT_NAME, '-w', token], { stdio: 'pipe' })
   }
 
   retrieve(): string | null {
-    try {
-      const result = execFileSync(
-        'security',
-        ['find-generic-password', '-s', SERVICE_NAME, '-a', ACCOUNT_NAME, '-w'],
-        { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] }
-      )
-      return result.trim() || null
-    } catch {
-      return null
+    const canonical = readMacKeychain(SERVICE_NAME)
+    if (canonical) return canonical
+
+    for (const legacy of LEGACY_SERVICE_NAMES) {
+      const token = readMacKeychain(legacy)
+      if (!token) continue
+      // Adopt the credential into the canonical service while preserving the
+      // source entry until the canonical write succeeds.
+      this.store(token)
+      deleteMacKeychain(legacy)
+      return token
     }
+    return null
   }
 
   delete(): void {
-    try {
-      execFileSync('security', ['delete-generic-password', '-s', SERVICE_NAME, '-a', ACCOUNT_NAME], { stdio: 'pipe' })
-    } catch { /* may not exist */ }
+    deleteMacKeychain(SERVICE_NAME)
+    for (const legacy of LEGACY_SERVICE_NAMES) deleteMacKeychain(legacy)
   }
 
   method(): StorageMethod { return 'keychain' }
@@ -61,33 +76,51 @@ class KeychainStore implements CredentialStore {
 
 // --- Linux libsecret ---
 
+function readSecretTool(service: string): string | null {
+  try {
+    const result = execFileSync(
+      'secret-tool',
+      ['lookup', 'service', service, 'account', ACCOUNT_NAME],
+      { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] },
+    )
+    return result.trim() || null
+  } catch {
+    return null
+  }
+}
+
+function deleteSecretTool(service: string): void {
+  try {
+    execFileSync('secret-tool', ['clear', 'service', service, 'account', ACCOUNT_NAME], { stdio: 'pipe' })
+  } catch { /* may not exist */ }
+}
+
 class SecretToolStore implements CredentialStore {
   store(token: string): void {
-    // Token passed via stdin — never appears in argv or shell string
     execFileSync(
       'secret-tool',
       ['store', `--label=${SERVICE_NAME}`, 'service', SERVICE_NAME, 'account', ACCOUNT_NAME],
-      { input: token, stdio: ['pipe', 'pipe', 'pipe'] }
+      { input: token, stdio: ['pipe', 'pipe', 'pipe'] },
     )
   }
 
   retrieve(): string | null {
-    try {
-      const result = execFileSync(
-        'secret-tool',
-        ['lookup', 'service', SERVICE_NAME, 'account', ACCOUNT_NAME],
-        { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] }
-      )
-      return result.trim() || null
-    } catch {
-      return null
+    const canonical = readSecretTool(SERVICE_NAME)
+    if (canonical) return canonical
+
+    for (const legacy of LEGACY_SERVICE_NAMES) {
+      const token = readSecretTool(legacy)
+      if (!token) continue
+      this.store(token)
+      deleteSecretTool(legacy)
+      return token
     }
+    return null
   }
 
   delete(): void {
-    try {
-      execFileSync('secret-tool', ['clear', 'service', SERVICE_NAME, 'account', ACCOUNT_NAME], { stdio: 'pipe' })
-    } catch { /* may not exist */ }
+    deleteSecretTool(SERVICE_NAME)
+    for (const legacy of LEGACY_SERVICE_NAMES) deleteSecretTool(legacy)
   }
 
   method(): StorageMethod { return 'secret-tool' }
@@ -99,19 +132,19 @@ class DpapiStore implements CredentialStore {
   private filePath: string
 
   constructor() {
-    this.filePath = join(homedir(), '.config', 'codeburn', '.sync-token-dpapi')
+    this.filePath = join(getMetroraConfigDir(), '.sync-token-dpapi')
   }
 
   store(token: string): void {
-    // Token passed via environment variable — never in argv or command string
-    const ps = `$s = ConvertTo-SecureString $env:CODEBURN_SYNC_TOKEN -AsPlainText -Force; ConvertFrom-SecureString $s`
+    // Token passed via environment variable — never in argv or command string.
+    const ps = `$s = ConvertTo-SecureString $env:METRORA_SYNC_TOKEN -AsPlainText -Force; ConvertFrom-SecureString $s`
     const encrypted = execFileSync('powershell', ['-NoProfile', '-Command', ps], {
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
-      env: { ...process.env, CODEBURN_SYNC_TOKEN: token },
+      env: { ...process.env, METRORA_SYNC_TOKEN: token },
     }).trim()
 
-    const dir = join(homedir(), '.config', 'codeburn')
+    const dir = getMetroraConfigDir()
     mkdirSync(dir, { recursive: true })
     writeFileSync(this.filePath, encrypted, { mode: 0o600 })
   }
@@ -120,11 +153,11 @@ class DpapiStore implements CredentialStore {
     if (!existsSync(this.filePath)) return null
     try {
       const encrypted = readFileSync(this.filePath, 'utf-8').trim()
-      const ps = `$s = ConvertTo-SecureString $env:CODEBURN_SYNC_BLOB; [Runtime.InteropServices.Marshal]::PtrToStringAuto([Runtime.InteropServices.Marshal]::SecureStringToBSTR($s))`
+      const ps = `$s = ConvertTo-SecureString $env:METRORA_SYNC_BLOB; [Runtime.InteropServices.Marshal]::PtrToStringAuto([Runtime.InteropServices.Marshal]::SecureStringToBSTR($s))`
       const result = execFileSync('powershell', ['-NoProfile', '-Command', ps], {
         encoding: 'utf-8',
         stdio: ['pipe', 'pipe', 'pipe'],
-        env: { ...process.env, CODEBURN_SYNC_BLOB: encrypted },
+        env: { ...process.env, METRORA_SYNC_BLOB: encrypted },
       })
       return result.trim() || null
     } catch {
@@ -145,11 +178,11 @@ class FileStore implements CredentialStore {
   private filePath: string
 
   constructor() {
-    this.filePath = join(homedir(), '.config', 'codeburn', '.sync-token')
+    this.filePath = join(getMetroraConfigDir(), '.sync-token')
   }
 
   store(token: string): void {
-    const dir = join(homedir(), '.config', 'codeburn')
+    const dir = getMetroraConfigDir()
     mkdirSync(dir, { recursive: true })
     writeFileSync(this.filePath, token, { mode: 0o600 })
     // Ensure permissions (writeFile mode doesn't always work on existing files)
@@ -186,9 +219,12 @@ function isCommandAvailable(cmd: string): boolean {
 
 export function createCredentialStore(): CredentialStore {
   // Test/CI escape hatch: force the file store (respects $HOME, so tests
-  // can fully isolate with a temp HOME). Without this, darwin machines
-  // would hit the real login keychain during the offline test suite.
-  if (process.env.CODEBURN_SYNC_TOKEN_STORE === 'file') {
+  // can fully isolate with a temp HOME). Canonical env wins; legacy names stay
+  // accepted only as temporary compatibility aliases.
+  const forcedStore = process.env.METRORA_SYNC_TOKEN_STORE
+    ?? process.env.QOVRION_SYNC_TOKEN_STORE
+    ?? process.env.CODEBURN_SYNC_TOKEN_STORE
+  if (forcedStore === 'file') {
     return new FileStore()
   }
 
@@ -202,9 +238,9 @@ export function createCredentialStore(): CredentialStore {
 
   // Linux: try secret-tool, fall back to file
   if (isCommandAvailable('secret-tool')) {
-    // Also verify the keyring daemon is running
+    // Also verify the keyring daemon is running.
     try {
-      execFileSync('secret-tool', ['lookup', 'service', '__codeburn_probe__', 'account', '__probe__'], { stdio: 'pipe' })
+      execFileSync('secret-tool', ['lookup', 'service', '__metrora_probe__', 'account', '__probe__'], { stdio: 'pipe' })
       return new SecretToolStore()
     } catch (err) {
       // Exit code 1 = not found (keyring works). Other errors = keyring not running.

--- a/src/sync/discovery.ts
+++ b/src/sync/discovery.ts
@@ -1,7 +1,8 @@
 /**
  * metrora sync — discovery document parser.
  *
- * Fetches and validates {baseUrl}/.well-known/codeburn-export.json
+ * The v1 compatibility wire route remains {baseUrl}/.well-known/codeburn-export.json
+ * until a separately versioned protocol migration is available.
  */
 
 export interface CodeburnDiscoveryDoc {
@@ -55,7 +56,7 @@ export function parseDiscoveryDoc(raw: unknown): CodeburnDiscoveryDoc {
   const version = typeof doc.version === 'number' ? doc.version : 1
   if (version > SUPPORTED_VERSION) {
     throw new DiscoveryError(
-      `This endpoint requires metrora sync v${version}. Please update codeburn.`
+      `This endpoint requires metrora sync v${version}. Please update Metrora.`
     )
   }
 

--- a/src/sync/ledger.ts
+++ b/src/sync/ledger.ts
@@ -7,7 +7,7 @@
 
 import { existsSync, mkdirSync, readFileSync, writeFileSync, unlinkSync, renameSync } from 'fs'
 import { join } from 'path'
-import { homedir } from 'os'
+import { getMetroraCacheDir } from '../product-paths.js'
 
 export interface LedgerEntry {
   key: string  // deduplicationKey
@@ -17,10 +17,7 @@ export interface LedgerEntry {
 const SIX_MONTHS_MS = 180 * 24 * 60 * 60 * 1000
 
 function cacheDir(): string {
-  // Honor XDG_CACHE_HOME — the ledger is reconstructible state, not config
-  const xdg = process.env.XDG_CACHE_HOME
-  const base = xdg && xdg.trim() ? xdg : join(homedir(), '.cache')
-  return join(base, 'codeburn')
+  return getMetroraCacheDir()
 }
 
 function ledgerPath(): string {

--- a/tests/cli-budget.test.ts
+++ b/tests/cli-budget.test.ts
@@ -27,7 +27,7 @@ function runCli(args: string[], home: string) {
 }
 
 async function readConfig(home: string): Promise<{ budget?: { daily?: number; weekly?: number; monthly?: number } }> {
-  const raw = await readFile(join(home, '.config', 'codeburn', 'config.json'), 'utf-8')
+  const raw = await readFile(join(home, '.config', 'metrora', 'config.json'), 'utf-8')
   return JSON.parse(raw) as { budget?: { daily?: number; weekly?: number; monthly?: number } }
 }
 
@@ -51,7 +51,7 @@ function userLine(sessionId: string, timestamp: string): string {
     type: 'user',
     sessionId,
     timestamp,
-    cwd: '/tmp/codeburn-budget-app',
+    cwd: '/tmp/metrora-budget-app',
     message: { role: 'user', content: 'ship budget check' },
   })
 }
@@ -61,7 +61,7 @@ function assistantLine(sessionId: string, timestamp: string): string {
     type: 'assistant',
     sessionId,
     timestamp,
-    cwd: '/tmp/codeburn-budget-app',
+    cwd: '/tmp/metrora-budget-app',
     message: {
       id: `msg-${sessionId}`,
       type: 'message',
@@ -97,7 +97,7 @@ async function seedCurrentMonthSpend(home: string): Promise<void> {
 
 describe('metrora budget command', () => {
   it('saves, lists, and removes a monthly budget', async () => {
-    const home = await mkdtemp(join(tmpdir(), 'codeburn-cli-budget-'))
+    const home = await mkdtemp(join(tmpdir(), 'metrora-cli-budget-'))
     try {
       const set = runCli(['budget', '--monthly', '123.45'], home)
       expect(set.status, `stderr: ${set.stderr}`).toBe(0)
@@ -122,7 +122,7 @@ describe('metrora budget command', () => {
   }, CLI_TIMEOUT_MS)
 
   it('rejects an invalid amount without writing a budget', async () => {
-    const home = await mkdtemp(join(tmpdir(), 'codeburn-cli-budget-'))
+    const home = await mkdtemp(join(tmpdir(), 'metrora-cli-budget-'))
     try {
       const result = runCli(['budget', '--daily', '0'], home)
       expect(result.status).toBe(1)
@@ -137,7 +137,7 @@ describe('metrora budget command', () => {
   }, CLI_TIMEOUT_MS)
 
   it('exits 1 when the current month is over budget', async () => {
-    const home = await mkdtemp(join(tmpdir(), 'codeburn-cli-budget-'))
+    const home = await mkdtemp(join(tmpdir(), 'metrora-cli-budget-'))
     try {
       await seedCurrentMonthSpend(home)
       expect(runCli(['budget', '--monthly', '0.01'], home).status).toBe(0)
@@ -152,7 +152,7 @@ describe('metrora budget command', () => {
   }, CLI_TIMEOUT_MS)
 
   it('floors a 99.x percent budget check without reporting over', async () => {
-    const home = await mkdtemp(join(tmpdir(), 'codeburn-cli-budget-'))
+    const home = await mkdtemp(join(tmpdir(), 'metrora-cli-budget-'))
     try {
       await seedCurrentMonthSpend(home)
       expect(runCli(['budget', '--monthly', '4.52'], home).status).toBe(0)
@@ -168,8 +168,8 @@ describe('metrora budget command', () => {
   }, CLI_TIMEOUT_MS)
 
   it('exits 0 when the current month is under budget or no budget is configured', async () => {
-    const noneHome = await mkdtemp(join(tmpdir(), 'codeburn-cli-budget-'))
-    const underHome = await mkdtemp(join(tmpdir(), 'codeburn-cli-budget-'))
+    const noneHome = await mkdtemp(join(tmpdir(), 'metrora-cli-budget-'))
+    const underHome = await mkdtemp(join(tmpdir(), 'metrora-cli-budget-'))
     try {
       const none = runCli(['budget', '--check'], noneHome)
       expect(none.status).toBe(0)
@@ -189,7 +189,7 @@ describe('metrora budget command', () => {
   }, CLI_TIMEOUT_MS)
 
   it('keeps overview budget lines only on unfiltered overviews', async () => {
-    const home = await mkdtemp(join(tmpdir(), 'codeburn-cli-budget-'))
+    const home = await mkdtemp(join(tmpdir(), 'metrora-cli-budget-'))
     try {
       await seedCurrentMonthSpend(home)
       expect(runCli(['budget', '--monthly', '100000'], home).status).toBe(0)
@@ -214,7 +214,7 @@ describe('metrora budget command', () => {
   }, CLI_TIMEOUT_MS)
 
   it('uses the same weekly spend window for budget --check and overview -p week', async () => {
-    const home = await mkdtemp(join(tmpdir(), 'codeburn-cli-budget-'))
+    const home = await mkdtemp(join(tmpdir(), 'metrora-cli-budget-'))
     try {
       const weekStart = getDateRange('week').range.start
       await seedClaudeSpend(home, {

--- a/tests/cli-model-savings.test.ts
+++ b/tests/cli-model-savings.test.ts
@@ -22,13 +22,13 @@ function runCli(args: string[], home: string) {
 }
 
 function readConfig(home: string): Promise<Record<string, unknown>> {
-  return readFile(join(home, '.config', 'codeburn', 'config.json'), 'utf-8')
+  return readFile(join(home, '.config', 'metrora', 'config.json'), 'utf-8')
     .then(raw => JSON.parse(raw) as Record<string, unknown>)
 }
 
 describe('metrora model-savings command', () => {
   it('saves, lists, and removes a local-model savings mapping', async () => {
-    const home = await mkdtemp(join(tmpdir(), 'codeburn-cli-savings-'))
+    const home = await mkdtemp(join(tmpdir(), 'metrora-cli-savings-'))
     try {
       const set = runCli(['model-savings', 'llama3.1:8b', 'gpt-4o'], home)
       expect(set.status).toBe(0)
@@ -52,7 +52,7 @@ describe('metrora model-savings command', () => {
   }, CLI_TIMEOUT_MS)
 
   it('warns when the same model is also configured in modelAliases', async () => {
-    const home = await mkdtemp(join(tmpdir(), 'codeburn-cli-savings-'))
+    const home = await mkdtemp(join(tmpdir(), 'metrora-cli-savings-'))
     try {
       expect(runCli(['model-alias', 'llama3.1:8b', 'gpt-4o'], home).status).toBe(0)
       const set = runCli(['model-savings', 'llama3.1:8b', 'gpt-4o'], home)
@@ -64,7 +64,7 @@ describe('metrora model-savings command', () => {
   }, CLI_TIMEOUT_MS)
 
   it('rejects a remove for an unknown mapping', async () => {
-    const home = await mkdtemp(join(tmpdir(), 'codeburn-cli-savings-'))
+    const home = await mkdtemp(join(tmpdir(), 'metrora-cli-savings-'))
     try {
       const result = runCli(['model-savings', '--remove', 'unknown:1b'], home)
       expect(result.status).toBe(1)

--- a/tests/cli-plan.test.ts
+++ b/tests/cli-plan.test.ts
@@ -23,7 +23,7 @@ function runCli(args: string[], home: string) {
 
 describe('metrora plan command', () => {
   it('persists provider-keyed plans and clears on reset', async () => {
-    const home = await mkdtemp(join(tmpdir(), 'codeburn-cli-plan-'))
+    const home = await mkdtemp(join(tmpdir(), 'metrora-cli-plan-'))
 
     try {
       const setResult = runCli(['plan', 'set', 'claude-max'], home)
@@ -32,7 +32,7 @@ describe('metrora plan command', () => {
       const setCodexResult = runCli(['plan', 'set', 'custom', '--monthly-usd', '200', '--provider', 'codex'], home)
       expect(setCodexResult.status).toBe(0)
 
-      const configPath = join(home, '.config', 'codeburn', 'config.json')
+      const configPath = join(home, '.config', 'metrora', 'config.json')
       const configRaw = await readFile(configPath, 'utf-8')
       const config = JSON.parse(configRaw) as { plans?: { claude?: { id?: string; monthlyUsd?: number }; codex?: { id?: string; monthlyUsd?: number } } }
       expect(config.plans?.claude?.id).toBe('claude-max')
@@ -53,14 +53,14 @@ describe('metrora plan command', () => {
   }, CLI_PLAN_TIMEOUT_MS)
 
   it('resets one provider without removing other plans', async () => {
-    const home = await mkdtemp(join(tmpdir(), 'codeburn-cli-plan-'))
+    const home = await mkdtemp(join(tmpdir(), 'metrora-cli-plan-'))
 
     try {
       expect(runCli(['plan', 'set', 'claude-max'], home).status).toBe(0)
       expect(runCli(['plan', 'set', 'custom', '--monthly-usd', '200', '--provider', 'codex'], home).status).toBe(0)
       expect(runCli(['plan', 'reset', '--provider', 'codex'], home).status).toBe(0)
 
-      const configPath = join(home, '.config', 'codeburn', 'config.json')
+      const configPath = join(home, '.config', 'metrora', 'config.json')
       const configRaw = await readFile(configPath, 'utf-8')
       const config = JSON.parse(configRaw) as { plans?: { claude?: { id?: string }; codex?: unknown } }
       expect(config.plans?.claude?.id).toBe('claude-max')
@@ -71,13 +71,13 @@ describe('metrora plan command', () => {
   }, CLI_PLAN_TIMEOUT_MS)
 
   it('resets the all-provider plan without removing provider-specific plans', async () => {
-    const home = await mkdtemp(join(tmpdir(), 'codeburn-cli-plan-'))
+    const home = await mkdtemp(join(tmpdir(), 'metrora-cli-plan-'))
 
     try {
       expect(runCli(['plan', 'set', 'claude-max'], home).status).toBe(0)
       expect(runCli(['plan', 'reset', '--provider', 'all'], home).status).toBe(0)
 
-      const configPath = join(home, '.config', 'codeburn', 'config.json')
+      const configPath = join(home, '.config', 'metrora', 'config.json')
       const configRaw = await readFile(configPath, 'utf-8')
       const config = JSON.parse(configRaw) as { plans?: { claude?: { id?: string }; all?: unknown } }
       expect(config.plans?.claude?.id).toBe('claude-max')
@@ -88,7 +88,7 @@ describe('metrora plan command', () => {
   }, CLI_PLAN_TIMEOUT_MS)
 
   it('shows all configured plans as json', async () => {
-    const home = await mkdtemp(join(tmpdir(), 'codeburn-cli-plan-'))
+    const home = await mkdtemp(join(tmpdir(), 'metrora-cli-plan-'))
 
     try {
       expect(runCli(['plan', 'set', 'claude-max'], home).status).toBe(0)
@@ -107,7 +107,7 @@ describe('metrora plan command', () => {
   }, CLI_PLAN_TIMEOUT_MS)
 
   it('filters shown plans by provider', async () => {
-    const home = await mkdtemp(join(tmpdir(), 'codeburn-cli-plan-'))
+    const home = await mkdtemp(join(tmpdir(), 'metrora-cli-plan-'))
 
     try {
       expect(runCli(['plan', 'set', 'claude-max'], home).status).toBe(0)
@@ -125,7 +125,7 @@ describe('metrora plan command', () => {
   }, CLI_PLAN_TIMEOUT_MS)
 
   it('rejects all-provider scope for preset plans', async () => {
-    const home = await mkdtemp(join(tmpdir(), 'codeburn-cli-plan-'))
+    const home = await mkdtemp(join(tmpdir(), 'metrora-cli-plan-'))
 
     try {
       const result = runCli(['plan', 'set', 'claude-max', '--provider', 'all'], home)
@@ -137,7 +137,7 @@ describe('metrora plan command', () => {
   }, CLI_PLAN_TIMEOUT_MS)
 
   it('shows invalid reset-day value in error output', async () => {
-    const home = await mkdtemp(join(tmpdir(), 'codeburn-cli-plan-'))
+    const home = await mkdtemp(join(tmpdir(), 'metrora-cli-plan-'))
 
     try {
       const result = runCli(['plan', 'set', 'claude-max', '--reset-day', '99'], home)

--- a/tests/cli-price-override.test.ts
+++ b/tests/cli-price-override.test.ts
@@ -22,13 +22,13 @@ function runCli(args: string[], home: string) {
 }
 
 function readConfig(home: string): Promise<Record<string, unknown>> {
-  return readFile(join(home, '.config', 'codeburn', 'config.json'), 'utf-8')
+  return readFile(join(home, '.config', 'metrora', 'config.json'), 'utf-8')
     .then(raw => JSON.parse(raw) as Record<string, unknown>)
 }
 
 describe('metrora price-override command', () => {
   it('saves, lists, and removes a model price override', async () => {
-    const home = await mkdtemp(join(tmpdir(), 'codeburn-cli-price-override-'))
+    const home = await mkdtemp(join(tmpdir(), 'metrora-cli-price-override-'))
     try {
       const set = runCli([
         'price-override',
@@ -73,7 +73,7 @@ describe('metrora price-override command', () => {
   }, CLI_TIMEOUT_MS)
 
   it('rejects an invalid rate', async () => {
-    const home = await mkdtemp(join(tmpdir(), 'codeburn-cli-price-override-'))
+    const home = await mkdtemp(join(tmpdir(), 'metrora-cli-price-override-'))
     try {
       const result = runCli(['price-override', 'bad-rate-model', '--input', 'abc', '--output', '1'], home)
       expect(result.status).toBe(1)

--- a/tests/cli-proxy-path.test.ts
+++ b/tests/cli-proxy-path.test.ts
@@ -21,7 +21,7 @@ afterEach(async () => {
 })
 
 async function makeHome(): Promise<string> {
-  const home = await mkdtemp(join(tmpdir(), 'codeburn-proxy-cli-'))
+  const home = await mkdtemp(join(tmpdir(), 'metrora-proxy-cli-'))
   homes.push(home)
   return home
 }
@@ -35,12 +35,12 @@ function runCli(args: string[], home: string) {
   })
 }
 
-const configPath = (home: string) => join(home, '.config', 'codeburn', 'config.json')
+const configPath = (home: string) => join(home, '.config', 'metrora', 'config.json')
 async function readConfig(home: string): Promise<Record<string, unknown>> {
   return JSON.parse(await readFile(configPath(home), 'utf-8'))
 }
 async function writeConfig(home: string, obj: unknown): Promise<void> {
-  await mkdir(join(home, '.config', 'codeburn'), { recursive: true })
+  await mkdir(join(home, '.config', 'metrora'), { recursive: true })
   await writeFile(configPath(home), JSON.stringify(obj), 'utf-8')
 }
 

--- a/tests/setup/env-isolation.ts
+++ b/tests/setup/env-isolation.ts
@@ -1,28 +1,24 @@
 // Vitest setup file: isolates every test from the developer's shell environment.
 //
-// codeburn discovers sessions through a long list of provider-specific env
-// vars (CLAUDE_CONFIG_DIR, CODEX_HOME, CRUSH_GLOBAL_DATA, …) and via HOME /
-// XDG_* / APPDATA / LOCALAPPDATA. Without this file, any value set in the
-// developer's shell (e.g. CLAUDE_CONFIG_DIRS=/Users/me/.claude:…) bleeds into
-// fixture-based tests: the parser reads the developer's REAL sessions instead
-// of the temp-dir fixture, producing nonsense totals and false failures that
-// pass on a clean CI runner.
+// Metrora discovers sessions through a long list of provider-specific env vars
+// (CLAUDE_CONFIG_DIR, CODEX_HOME, CRUSH_GLOBAL_DATA, …) and via HOME / XDG_* /
+// APPDATA / LOCALAPPDATA. Without this file, values set in the developer's shell
+// can bleed into fixture-based tests and make them read real local state.
 //
 // What this file does:
 //   1. Mints an empty sandbox temp dir once per worker.
-//   2. REDIRECTED vars (HOME / XDG_* / APPDATA / LOCALAPPDATA) point at the
-//      sandbox so any fallback to homedir() / platform defaults lands in an
-//      empty filesystem.
-//   3. CLEARED vars (every provider's explicit override) are deleted so a test
-//      that does NOT set one gets "unconfigured" rather than the dev's value.
-//   4. PRESERVED vars (PATH, COLUMNS, …) are snapshotted from the dev's shell
-//      and restored every test. We can't wipe them - Node uses PATH for spawn
-//      and module resolution, terminal code uses COLUMNS - but a test that
-//      mutates them shouldn't leak the change into the next test.
-//   5. Re-asserts the above before EVERY test (global beforeEach), so a test
-//      that mutates an env var doesn't leak its value into the next test.
-//      Tests can freely set process.env['HOME'] = customDir without saving the
-//      previous value - the next test gets a fresh sandbox baseline.
+//   2. REDIRECTED home/platform roots point at the sandbox so ordinary platform
+//      defaults land in an empty filesystem.
+//   3. XDG roots and explicit product/provider overrides are CLEARED. This is
+//      deliberate: tests that replace HOME must be able to exercise that home's
+//      canonical defaults instead of silently inheriting one worker-wide XDG
+//      root. A test that specifically covers XDG behavior sets that variable in
+//      its own beforeEach/test body.
+//   4. PRESERVED vars (PATH, COLUMNS, …) are snapshotted from the developer's
+//      shell and restored every test. We cannot wipe them because Node uses PATH
+//      for spawn/module resolution and terminal code reads COLUMNS.
+//   5. Re-asserts the above before EVERY test, so mutations do not leak into the
+//      next test.
 //
 // CAVEAT: env vars set in a test file's beforeAll() get overwritten by this
 // file's beforeEach before each test runs. Use beforeEach (not beforeAll) when
@@ -33,19 +29,28 @@ import { tmpdir } from 'os'
 import { join } from 'path'
 import { beforeEach } from 'vitest'
 
-const sandbox = mkdtempSync(join(tmpdir(), 'codeburn-test-env-'))
+const sandbox = mkdtempSync(join(tmpdir(), 'metrora-test-env-'))
 
 const REDIRECTED = [
   'HOME',
-  'XDG_CONFIG_HOME',
-  'XDG_DATA_HOME',
-  'XDG_CACHE_HOME',
-  'XDG_STATE_HOME',
   'APPDATA',
   'LOCALAPPDATA',
 ] as const
 
 const CLEARED = [
+  // Platform roots: leave unset unless the individual test is exercising XDG.
+  'XDG_CONFIG_HOME',
+  'XDG_DATA_HOME',
+  'XDG_CACHE_HOME',
+  'XDG_STATE_HOME',
+  // Canonical and compatibility product roots. No developer shell override may
+  // leak into tests; individual compatibility tests set these explicitly.
+  'METRORA_CONFIG_DIR',
+  'QOVRION_CONFIG_DIR',
+  'CODEBURN_CONFIG_DIR',
+  'METRORA_CACHE_DIR',
+  'QOVRION_CACHE_DIR',
+  'CODEBURN_CACHE_DIR',
   // Provider session-discovery dirs
   'CLAUDE_CONFIG_DIR',
   'CLAUDE_CONFIG_DIRS',
@@ -65,8 +70,7 @@ const CLEARED = [
   'VIBE_HOME',
   'WARP_DB_PATH',
   'ZS_DATA_DIR',
-  // codeburn override dirs / paths
-  'CODEBURN_CACHE_DIR',
+  // Compatibility collector/cache overrides
   'CODEBURN_COPILOT_JETBRAINS_DIR',
   'CODEBURN_COPILOT_OTEL_DB',
   'CODEBURN_COPILOT_SESSION_STATE_DIR',
@@ -74,7 +78,7 @@ const CLEARED = [
   'CODEBURN_DESKTOP_SESSIONS_DIR',
   'CODEBURN_MUX_DIR',
   'CODEBURN_ANTIGRAVITY_SETTINGS_PATH',
-  // codeburn behavior toggles (set by the dev to tweak local runs)
+  // Compatibility behavior toggles (set by developers to tweak local runs)
   'CODEBURN_COPILOT_DISABLE_OTEL',
   'CODEBURN_TZ',
   'CODEBURN_VERBOSE',
@@ -84,13 +88,13 @@ const CLEARED = [
   'KIMI_MODEL_NAME',
   'AI_GATEWAY_API_KEY',
   'VERCEL_OIDC_TOKEN',
-  // Read by detectBashBloat - a dev's real shell limit must not bleed in
+  // Read by detectBashBloat - a developer's real shell limit must not bleed in
   'BASH_MAX_OUTPUT_LENGTH',
 ] as const
 
-// Snapshotted from the dev's shell and restored every test. These can't be
-// wiped (Node needs PATH for spawn / module resolution, dashboard/table layout
-// reads COLUMNS) but a test that mutates them shouldn't leak.
+// Snapshotted from the developer's shell and restored every test. These cannot
+// be wiped (Node needs PATH for spawn/module resolution; dashboard/table layout
+// reads COLUMNS), but a test mutation must not leak into the next test.
 const PRESERVED = ['PATH', 'COLUMNS'] as const
 const preservedSnapshot = new Map<string, string | undefined>()
 for (const key of PRESERVED) preservedSnapshot.set(key, process.env[key])
@@ -103,10 +107,9 @@ function applyIsolation(): void {
     if (original === undefined) delete process.env[key]
     else process.env[key] = original
   }
-  // Pin the timezone so date grouping is deterministic regardless of the dev's
-  // shell TZ. Clearing it is not enough (Node falls back to the OS zone); a
-  // non-UTC TZ would otherwise shift day buckets versus a clean CI runner. A
-  // test that needs a specific zone can still set process.env.TZ in beforeEach.
+  // Pin the timezone so date grouping is deterministic regardless of the
+  // developer's shell timezone. A test that needs another zone can still set
+  // process.env.TZ in its own beforeEach.
   process.env.TZ = 'UTC'
 }
 

--- a/tests/sync-ledger-otlp.test.ts
+++ b/tests/sync-ledger-otlp.test.ts
@@ -130,6 +130,7 @@ describe('buildOtlpPayload', () => {
     const payload = buildOtlpPayload([makeCallWithSession()])
 
     expect(payload.resourceSpans).toHaveLength(1)
+    // Protocol attribute retained for backward-compatible remote ingestion.
     expect(payload.resourceSpans[0]!.resource.attributes).toEqual([
       { key: 'codeburn.device_id', value: { stringValue: expect.stringMatching(/^[0-9a-f]{16}$/) } },
     ])
@@ -235,10 +236,10 @@ describe('ledger', () => {
   const originalHome = process.env.HOME
 
   beforeEach(async () => {
-    tmpDir = await mkdtemp(join(tmpdir(), 'codeburn-ledger-'))
+    tmpDir = await mkdtemp(join(tmpdir(), 'metrora-ledger-'))
     process.env.HOME = tmpDir
-    // env-isolation.ts redirects XDG_CACHE_HOME to a per-worker sandbox shared
-    // across tests — the ledger honors XDG, so point it at the per-test dir.
+    // Pin XDG cache to this test's own root. Global isolation deliberately
+    // clears XDG roots so custom HOME tests do not share worker-wide state.
     process.env.XDG_CACHE_HOME = join(tmpDir, '.cache')
   })
 
@@ -308,7 +309,7 @@ describe('ledger', () => {
     expect(clearLedger()).toBe(0)
   })
 
-  it('corrupt ledger file reads as empty (crash-safe recovery)', async () => {
+  it('adopts a corrupt legacy ledger path and fails safe to empty', async () => {
     const { readLedger } = await import('../src/sync/ledger.js')
     const { mkdirSync, writeFileSync } = await import('fs')
     const { join } = await import('path')
@@ -323,12 +324,12 @@ describe('ledger', () => {
     const { existsSync } = await import('fs')
     const { join } = await import('path')
     writeLedger([{ key: 'a', ts: '2026-07-01T00:00:00Z' }])
-    const dir = join(process.env.HOME!, '.cache', 'codeburn')
+    const dir = join(process.env.HOME!, '.cache', 'metrora')
     expect(existsSync(join(dir, 'sync-ledger.json'))).toBe(true)
     expect(existsSync(join(dir, 'sync-ledger.json.tmp'))).toBe(false)
   })
 
-  it('honors XDG_CACHE_HOME when set', async () => {
+  it('honors XDG_CACHE_HOME with the canonical Metrora directory', async () => {
     const { writeLedger, readLedger } = await import('../src/sync/ledger.js')
     const { existsSync } = await import('fs')
     const { join } = await import('path')
@@ -337,7 +338,7 @@ describe('ledger', () => {
     process.env.XDG_CACHE_HOME = xdgDir
     try {
       writeLedger([{ key: 'xdg-entry', ts: '2026-07-01T00:00:00Z' }])
-      expect(existsSync(join(xdgDir, 'codeburn', 'sync-ledger.json'))).toBe(true)
+      expect(existsSync(join(xdgDir, 'metrora', 'sync-ledger.json'))).toBe(true)
       expect(readLedger().map(e => e.key)).toEqual(['xdg-entry'])
     } finally {
       if (original === undefined) delete process.env.XDG_CACHE_HOME

--- a/tests/sync.test.ts
+++ b/tests/sync.test.ts
@@ -1,17 +1,15 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
-import { mkdtemp, rm, writeFile, readFile, mkdir } from 'fs/promises'
+import { mkdtemp, rm, readFile } from 'fs/promises'
 import { join } from 'path'
 import { tmpdir } from 'os'
-import { createServer, type Server } from 'http'
 
-import { parseDiscoveryDoc, DiscoveryError } from '../src/sync/discovery.js'
+import { parseDiscoveryDoc } from '../src/sync/discovery.js'
 import {
   generatePkce,
   buildAuthUrl,
   resolveScopes,
   startCallbackServer,
   renderCallbackPage,
-  CALLBACK_PORTS,
 } from '../src/sync/auth.js'
 
 // ── Discovery Doc Parser ──────────────────────────────────────────────
@@ -36,7 +34,7 @@ describe('parseDiscoveryDoc', () => {
 
   it('rejects version > 1', () => {
     expect(() => parseDiscoveryDoc({ version: 2, issuer: 'https://idp.example', client_id: 'y' }))
-      .toThrow('Please update codeburn')
+      .toThrow('Please update Metrora')
   })
 
   it('rejects missing issuer', () => {
@@ -171,13 +169,8 @@ describe('startCallbackServer', () => {
   it('accepts valid callback with matching state', async () => {
     const state = 'test-state-123'
     const { promise, ready } = startCallbackServer(state, 5000, [0])
-
-    // Wait for server to bind
     const port = await ready
-
-    // Simulate IdP callback
     await fetch(`http://127.0.0.1:${port}/callback?code=auth-code-xyz&state=${state}`)
-
     const result = await promise
     expect(result.code).toBe('auth-code-xyz')
   }, 10000)
@@ -186,20 +179,15 @@ describe('startCallbackServer', () => {
     const state = 'correct-state'
     const { promise, ready } = startCallbackServer(state, 5000, [0])
     const port = await ready
-
-    // Send with wrong state — server stays running
     const resp = await fetch(`http://127.0.0.1:${port}/callback?code=xxx&state=wrong-state`)
     expect(resp.status).toBe(400)
-
-    // Now send correct one
     await fetch(`http://127.0.0.1:${port}/callback?code=real-code&state=${state}`)
     const result = await promise
     expect(result.code).toBe('real-code')
   }, 10000)
 
   it('times out after configured duration', async () => {
-    const { promise } = startCallbackServer('state', 300, [0]) // 300ms timeout
-
+    const { promise } = startCallbackServer('state', 300, [0])
     await expect(promise).rejects.toThrow('timed out')
   }, 5000)
 })
@@ -211,7 +199,7 @@ describe('syncConfig', () => {
   const originalHome = process.env.HOME
 
   beforeEach(async () => {
-    tmpDir = await mkdtemp(join(tmpdir(), 'codeburn-sync-config-'))
+    tmpDir = await mkdtemp(join(tmpdir(), 'metrora-sync-config-'))
     process.env.HOME = tmpDir
   })
 
@@ -221,7 +209,6 @@ describe('syncConfig', () => {
   })
 
   it('writes and reads config', async () => {
-    // Dynamically import to pick up new HOME
     const { writeSyncConfig, readSyncConfig } = await import('../src/sync/config.js')
 
     writeSyncConfig({
@@ -253,7 +240,7 @@ describe('syncConfig', () => {
       issuer: 'https://idp.test.com',
     })
 
-    const raw = await readFile(join(tmpDir, '.config', 'codeburn', 'sync.json'), 'utf-8')
+    const raw = await readFile(join(tmpDir, '.config', 'metrora', 'sync.json'), 'utf-8')
     expect(raw).not.toContain('token')
     expect(raw).not.toContain('secret')
     expect(raw).not.toContain('password')


### PR DESCRIPTION
## Summary

- advance the active source/desktop candidate to `1.0.0-rc.8` / `1.0.0.8` while keeping the Store AppX identity version distinct
- reconcile persisted Workspace endpoint software metadata without replacing endpoint identity, membership, or evidence history
- remove stale product/version presentation from current desktop surfaces
- make new config/cache/sync state use canonical Metrora paths while preserving non-destructive compatibility with existing local state
- align Store, release, security, sync, and distribution documentation with the current published-vs-pre-submission boundary
- strengthen existing identity/version checks without adding a new CI gate

## Boundary

This PR does not submit, certify, sign for distribution, or publish a Microsoft Store package. Existing published release evidence remains immutable.