### PR TITLE
fix(copilot): preserve source provenance and rehydrate history

### DIFF
--- a/src/daily-cache-core.ts
+++ b/src/daily-cache-core.ts
@@ -5,6 +5,7 @@ import { join } from 'path'
 import type { DateRange, ProjectSummary } from './types.js'
 import { getMetroraCacheDir } from './product-paths.js'
 import { emptyModelStats, mergeModelStats, sanitizeModels } from './daily-cache-model-detail.js'
+// v18: Copilot accounting changed; v17 history is adopted untrusted, re-derived where sources survive, and carried otherwise.
 // Bumped to 16: historical per-call cost assignments. Surviving source days
 // re-derive under immutable date-effective settlements; sourceless provider
 // slices continue to carry forward losslessly from v15.
@@ -61,7 +62,7 @@ import { emptyModelStats, mergeModelStats, sanitizeModels } from './daily-cache-
 // that older binaries skipped. v8 added local-model savings to the daily
 // rollup; the `savingsConfigHash` field is invalidated separately when the
 // user changes their `localModelSavings` mapping.
-export const DAILY_CACHE_VERSION = 17
+export const DAILY_CACHE_VERSION = 18
 const MIN_SUPPORTED_VERSION = 15
 // Version-suffixed so different binaries each own a distinct file and never
 // clobber an incompatible schema. Bumping the version mints a fresh filename;
@@ -302,9 +303,8 @@ export function migratedFrom(parsed: { version: number; lastComputedDate: string
       ? parsed.lastComputedDate
       : null,
     days: migrateDays(parsed.days),
-    // Only a cache explicitly marked complete stays trusted; one written before
-    // the marker existed reads false and is re-backfilled once.
-    complete: parsed.complete === true,
+    // Older schemas carry history but are never complete-authoritative.
+    complete: parsed.version === DAILY_CACHE_VERSION && parsed.complete === true,
   }
 }
 

--- a/src/daily-cache.ts
+++ b/src/daily-cache.ts
@@ -41,7 +41,10 @@ async function readTrust(path: string): Promise<{ version: number; trusted: bool
 }
 
 function supportsActiveTrust(version: number): boolean {
-  return version === core.DAILY_CACHE_VERSION || version === core.DAILY_CACHE_VERSION - 1
+  // The immediately previous envelope is an adoptable baseline, not active
+  // authority: Copilot accounting changed in v18 and must re-derive surviving
+  // sources before its watermark becomes trusted again.
+  return version === core.DAILY_CACHE_VERSION
 }
 
 async function readPersistedTrust(): Promise<boolean> {
@@ -74,7 +77,7 @@ export function emptyCache(savingsConfigHash = ''): DailyCache {
 
 export async function loadDailyCache(): Promise<DailyCache> {
   // Read before the core migration/adoption path sanitizes unknown fields, then
-  // re-persist a trusted stamp when that path minted the active v16 envelope.
+  // re-persist a trusted stamp when that path minted the active envelope.
   const watermarkTrusted = await readPersistedTrust()
   const cache = withTrust(await core.loadDailyCache(), watermarkTrusted)
   if (watermarkTrusted) {

--- a/src/local-state/canonical-history-parity-observer.test.ts
+++ b/src/local-state/canonical-history-parity-observer.test.ts
@@ -1,7 +1,7 @@
 import { createHash } from 'node:crypto'
 import { describe, expect, it, vi } from 'vitest'
 
-import type { DailyCache, DailyEntry } from '../daily-cache.js'
+import { DAILY_CACHE_VERSION, type DailyCache, type DailyEntry } from '../daily-cache.js'
 import type { CachedCall, CachedFile, SessionCache } from '../session-cache.js'
 import { projectCanonicalHistoryReadV1 } from './canonical-history-read-projection.js'
 import {
@@ -128,7 +128,7 @@ function day(): DailyEntry {
 
 function dailyCache(days: DailyEntry[] = [day()]): DailyCache {
   return {
-    version: 17,
+    version: DAILY_CACHE_VERSION,
     savingsConfigHash: 'test',
     tzKey: 'UTC',
     lastComputedDate: '2026-08-01',

--- a/src/providers/copilot.ts
+++ b/src/providers/copilot.ts
@@ -690,56 +690,34 @@ function inferTranscriptModel(lines: string[]): string {
   return openaiCount >= anthropicCount ? 'copilot-openai-auto' : 'copilot-anthropic-auto'
 }
 
-// ---------------------------------------------------------------------------
-// JSONL parser (handles both regular session-state events and VS Code
-// transcript format via session.start { producer: 'copilot-agent' })
-// ---------------------------------------------------------------------------
+// JSONL parser for CLI session-state and VS Code transcripts.
 
 function createJsonlParser(
   source: SessionSource,
-  seenKeys: Set<string>
+  seenKeys: Set<string>,
+  isTranscript: boolean,
 ): SessionParser {
   return {
     async *parse(): AsyncGenerator<ParsedProviderCall> {
       const content = await readSessionFile(source.path)
       if (!content) return
-      const sessionId = basename(dirname(source.path))
+      // CLI uses <sessionId>/events.jsonl; transcripts use transcripts/<sessionId>.jsonl.
+      const sessionId = isTranscript
+        ? basename(source.path, '.jsonl')
+        : basename(dirname(source.path))
       const lines = content.split('\n').filter((l) => l.trim())
 
-      // Detect VS Code transcript format: the first session.start event has
-      // { producer: 'copilot-agent' } and no outputTokens in messages.
-      let isTranscript = false
       let currentModel = ''
       let pendingUserMessage = ''
-      // Track the active subagent for this session (from subagent.selected events).
-      // Resets when a new subagent is selected.
+      // Track the active subagent; reset when a new one is selected.
       let currentSubagentType: string | undefined
 
-      // First pass: detect format and infer transcript model if needed.
-      for (const line of lines) {
-        try {
-          const ev = JSON.parse(line) as CopilotEvent
-          if (ev.type === 'session.start') {
-            const data = ev.data as SessionStartData & { producer?: string }
-            if (data.producer === 'copilot-agent') {
-              isTranscript = true
-            }
-            break
-          }
-          if (ev.type === 'session.model_change') break // regular format
-        } catch {
-          continue
-        }
-      }
-
       if (isTranscript) {
+        // Tool-call-id inference seeds legacy transcript models only.
         currentModel = inferTranscriptModel(lines)
-        if (!currentModel) return // no toolCallIds to infer model from
       }
 
-      // Shutdown rollups may lack their own timestamp; remember the last
-      // stamped event so the supplementary call is never left with an empty
-      // timestamp, which the date-range filters silently drop.
+      // Use the last stamped event when a shutdown has no timestamp.
       let lastEventTimestamp = ''
 
       for (const line of lines) {
@@ -774,18 +752,8 @@ function createJsonlParser(
         }
 
         if (event.type === 'session.shutdown') {
-          // The Copilot CLI writes a per-model token/cost rollup here at
-          // shutdown: the only place a CLI session records input, cache-read
-          // and cache-write tokens (assistant.message events carry output
-          // only). VS Code transcripts never carry this rollup, so this path
-          // is gated to the CLI (non-transcript) format, leaving VS Code,
-          // JetBrains and OTel sources untouched.
-          //
-          // We emit one supplementary call per model carrying ONLY the
-          // input/cache tokens the per-turn events lack; output is excluded so
-          // the assistant.message output (and its cost) is not double-counted.
-          // Combined with the per-turn output cost, this yields the full,
-          // CLI-measured session cost.
+          // CLI shutdowns carry input/cache/reasoning; transcripts do not. Keep
+          // output on assistant.message so it is not counted twice.
           if (isTranscript) continue
           const shutdownData = event.data as SessionShutdownData
           const modelMetrics = shutdownData.modelMetrics
@@ -802,25 +770,20 @@ function createJsonlParser(
             const cacheReadTokens = numberOrZero(usage['cacheReadTokens'])
             const cacheWriteTokens = numberOrZero(usage['cacheWriteTokens'])
             const reasoningTokens = numberOrZero(usage['reasoningTokens'])
-            // usage.inputTokens is cache-INCLUSIVE (input + cache_read +
-            // cache_write). calculateCost expects the uncached input alone with
-            // cache tokens billed separately, so subtract the cache components.
-            // Clamp at 0 in case a future schema reports input non-inclusively.
+            // inputTokens is cache-inclusive; calculateCost receives uncached input.
             const inputTokens = Math.max(
               0,
               numberOrZero(usage['inputTokens']) - cacheReadTokens - cacheWriteTokens
             )
 
-            // Nothing this call would add over the per-turn events, so skip it
-            // to avoid an empty $0 row (output is intentionally excluded).
+            // Skip empty supplementary rows (output is intentionally excluded).
             if (inputTokens === 0 && cacheReadTokens === 0 && cacheWriteTokens === 0 && reasoningTokens === 0) continue
 
             const dedupKey = `copilot:${sessionId}:shutdown:${model}`
             if (seenKeys.has(dedupKey)) continue
             seenKeys.add(dedupKey)
 
-            // Tokens are real counts written by the CLI, so this cost is
-            // measured, not char-estimated: costIsEstimated is false.
+            // CLI-written token counts are measured, not char-estimated.
             const costUSD = calculateCost(model, inputTokens, 0, cacheWriteTokens, cacheReadTokens, 0)
 
             yield {
@@ -1836,6 +1799,12 @@ interface JsonlSessionSource extends SessionSource {
   sourceType: 'jsonl'
 }
 
+// A VS Code workspaceStorage transcript. Distinct from 'jsonl' (CLI
+// session-state) so classification rides provenance, not file contents.
+interface TranscriptSessionSource extends SessionSource {
+  sourceType: 'transcript'
+}
+
 interface ChatSessionSource extends SessionSource {
   sourceType: 'chatsession'
 }
@@ -1867,6 +1836,10 @@ function isOtelSource(source: SessionSource): source is OTelSessionSource {
 
 function isChatSessionSource(source: SessionSource): source is ChatSessionSource {
   return (source as ChatSessionSource).sourceType === 'chatsession'
+}
+
+function isTranscriptSource(source: SessionSource): source is TranscriptSessionSource {
+  return (source as TranscriptSessionSource).sourceType === 'transcript'
 }
 
 function isJetBrainsSource(source: SessionSource): source is JetBrainsSessionSource {
@@ -2241,8 +2214,8 @@ async function discoverEmptyWindowChatSessions(
  */
 async function discoverTranscriptSessions(
   workspaceStorageDirs: string[]
-): Promise<JsonlSessionSource[]> {
-  const sources: JsonlSessionSource[] = []
+): Promise<TranscriptSessionSource[]> {
+  const sources: TranscriptSessionSource[] = []
 
   for (const wsDir of workspaceStorageDirs) {
     let hashDirs: string[]
@@ -2274,7 +2247,7 @@ async function discoverTranscriptSessions(
           path: join(transcriptsDir, file),
           project,
           provider: 'copilot',
-          sourceType: 'jsonl',
+          sourceType: 'transcript',
         })
       }
     }
@@ -2417,7 +2390,7 @@ export function createCopilotProvider(
       if (isJetBrainsSource(source)) {
         return createJetBrainsParser(source, seenKeys)
       }
-      return createJsonlParser(source, seenKeys)
+      return createJsonlParser(source, seenKeys, isTranscriptSource(source))
     },
   }
 }

--- a/src/session-cache.ts
+++ b/src/session-cache.ts
@@ -237,7 +237,7 @@ export const PROVIDER_PARSE_VERSIONS: Record<string, string> = {
   codex: 'mcp-attribution-v5-est-cost-active-timing-mcp-wait-rich-capture-v1-cross-provider-pr-v1-reasoning-attribution-v1-pricing-context-tags-v1',
   cursor: 'composer-anchored-crediting-v1-est-cost',
   'cursor-agent': 'workspaceless-transcript-v2-estimated-cost',
-  copilot: 'cli-shutdown-cost-v2-preserve-observed-reasoning-cache',
+  copilot: 'cli-shutdown-cost-v3-source-provenance',
   goose: 'sqlite-session-v1-provider-provenance',
   grok: 'estimated-cost-v1',
   hermes: 'reasoning-output-accounting-v2-provider-provenance-cost-semantics-v2',

--- a/tests/codex-daily-cache-v17-migration.test.ts
+++ b/tests/codex-daily-cache-v17-migration.test.ts
@@ -43,7 +43,7 @@ function day(
 beforeEach(async () => {
   vi.useFakeTimers()
   vi.setSystemTime(new Date('2026-08-05T12:00:00Z'))
-  cacheDir = await mkdtemp(join(tmpdir(), 'codex-v17-cache-'))
+  cacheDir = await mkdtemp(join(tmpdir(), 'daily-v18-cache-'))
   previousCacheDir = process.env['METRORA_CACHE_DIR']
   previousTz = process.env['TZ']
   process.env['METRORA_CACHE_DIR'] = cacheDir
@@ -59,12 +59,12 @@ afterEach(async () => {
   await rm(cacheDir, { recursive: true, force: true })
 })
 
-describe('Codex daily-cache v17 migration', () => {
+describe('daily-cache v18 migration', () => {
   it('re-derives surviving Codex days and carries sourceless history losslessly and idempotently', async () => {
-    expect(DAILY_CACHE_VERSION).toBe(17)
+    expect(DAILY_CACHE_VERSION).toBe(18)
     await mkdir(cacheDir, { recursive: true })
-    const v16 = {
-      version: 16,
+    const v17 = {
+      version: 17,
       savingsConfigHash: 'settled-config',
       tzKey: 'UTC',
       lastComputedDate: '2026-08-04',
@@ -97,10 +97,10 @@ describe('Codex daily-cache v17 migration', () => {
         }),
       ],
     }
-    await writeFile(join(cacheDir, 'daily-cache.v16.json'), JSON.stringify(v16))
+    await writeFile(join(cacheDir, 'daily-cache.v17.json'), JSON.stringify(v17))
 
     const adopted = await loadDailyCache()
-    expect(adopted.version).toBe(17)
+    expect(adopted.version).toBe(18)
     expect(adopted.complete).toBe(false)
     expect(adopted.days).toHaveLength(2)
 
@@ -160,8 +160,8 @@ describe('Codex daily-cache v17 migration', () => {
     expect(parses).toBe(1)
     expect(again).toEqual(migrated)
 
-    const persisted = JSON.parse(await readFile(join(cacheDir, 'daily-cache.v17.json'), 'utf-8'))
-    expect(persisted.version).toBe(17)
+    const persisted = JSON.parse(await readFile(join(cacheDir, 'daily-cache.v18.json'), 'utf-8'))
+    expect(persisted.version).toBe(18)
     expect(persisted.days.find((entry: DailyEntry) => entry.date === '2026-08-03').cost).toBe(12.345678)
   })
 

--- a/tests/copilot-daily-cache-v18-migration.test.ts
+++ b/tests/copilot-daily-cache-v18-migration.test.ts
@@ -1,0 +1,167 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { existsSync } from 'fs'
+import { mkdir, readFile, rm, writeFile } from 'fs/promises'
+import { tmpdir } from 'os'
+import { join } from 'path'
+
+import type { DateRange, ProjectSummary } from '../src/types.js'
+import {
+  DAILY_CACHE_VERSION,
+  currentTzKey,
+  dailyCachePath,
+  ensureCacheHydrated,
+  type DailyEntry,
+  type ProviderDaySlice,
+} from '../src/daily-cache.js'
+
+let root: string
+
+function slice(cost: number, calls: number, extra: Partial<ProviderDaySlice> = {}): ProviderDaySlice {
+  return { cost, calls, savingsUSD: 0, ...extra }
+}
+
+function day(date: string, providers: Record<string, ProviderDaySlice>): DailyEntry {
+  const values = Object.values(providers)
+  const sum = (key: keyof ProviderDaySlice): number => values.reduce((total, value) => total + (Number(value[key]) || 0), 0)
+  return {
+    date,
+    cost: sum('cost'),
+    savingsUSD: sum('savingsUSD'),
+    calls: sum('calls'),
+    sessions: sum('sessions'),
+    inputTokens: sum('inputTokens'),
+    outputTokens: sum('outputTokens'),
+    ...(sum('reasoningTokens') > 0 ? { reasoningTokens: sum('reasoningTokens') } : {}),
+    cacheReadTokens: sum('cacheReadTokens'),
+    cacheWriteTokens: sum('cacheWriteTokens'),
+    editTurns: sum('editTurns'),
+    oneShotTurns: sum('oneShotTurns'),
+    models: {},
+    categories: {},
+    providers,
+  }
+}
+
+async function writeV17(days: DailyEntry[]): Promise<void> {
+  await writeFile(join(root, 'daily-cache.v17.json'), JSON.stringify({
+    version: 17,
+    savingsConfigHash: 'cfg',
+    tzKey: currentTzKey(),
+    lastComputedDate: '2026-08-02',
+    complete: true,
+    watermarkTrusted: true,
+    days,
+  }), 'utf-8')
+}
+
+beforeEach(async () => {
+  vi.useFakeTimers()
+  vi.setSystemTime(new Date('2026-08-03T12:00:00.000Z'))
+  root = join(tmpdir(), `metrora-copilot-daily-v18-${Math.random().toString(36).slice(2)}`)
+  process.env['METRORA_CACHE_DIR'] = root
+  await mkdir(root, { recursive: true })
+})
+
+afterEach(async () => {
+  vi.useRealTimers()
+  if (existsSync(root)) await rm(root, { recursive: true, force: true })
+})
+
+describe('Copilot daily-cache v18 NEVER-LOSE migration', () => {
+  it('re-derives a surviving Copilot slice and carries an unrelated orphan once', async () => {
+    expect(DAILY_CACHE_VERSION).toBe(18)
+    const date = '2026-07-30'
+    const staleCopilot = slice(90, 9, { sessions: 1, inputTokens: 900, outputTokens: 90 })
+    const orphanClaude = slice(7, 1, { sessions: 1, inputTokens: 70, outputTokens: 7 })
+    await writeV17([day(date, { copilot: staleCopilot, claude: orphanClaude })])
+
+    const freshCopilot = slice(12, 2, { sessions: 1, inputTokens: 120, outputTokens: 12 })
+    let parses = 0
+    const parseSessions = async (_range: DateRange): Promise<ProjectSummary[]> => {
+      parses++
+      return []
+    }
+    const migrated = await ensureCacheHydrated(parseSessions, () => [day(date, { copilot: freshCopilot })], 'cfg', () => true)
+    const migratedDay = migrated.days.find(entry => entry.date === date)!
+
+    expect(parses).toBe(1)
+    expect(migrated.version).toBe(18)
+    expect(migrated.complete).toBe(true)
+    expect(migrated.watermarkTrusted).toBe(true)
+    expect(migratedDay.providers.copilot).toEqual(freshCopilot)
+    expect(migratedDay.providers.claude).toEqual(orphanClaude)
+    expect(migratedDay.carried).toBe(true)
+    expect(migratedDay.calls).toBe(3)
+    expect(migratedDay.cost).toBe(19)
+    expect(migratedDay.inputTokens).toBe(190)
+    expect(migratedDay.outputTokens).toBe(19)
+
+    const again = await ensureCacheHydrated(parseSessions, () => [], 'cfg', () => true)
+    expect(parses).toBe(1)
+    expect(again.days.find(entry => entry.date === date)!.calls).toBe(3)
+    expect(JSON.parse(await readFile(dailyCachePath(), 'utf-8')).version).toBe(18)
+  })
+
+  it('carries a sourceless Copilot slice exactly and does not create a historical zero', async () => {
+    const date = '2026-07-29'
+    const prior = slice(17.5, 63, {
+      sessions: 5,
+      inputTokens: 0,
+      outputTokens: 1_174_967,
+      models: { 'gpt-5.4': { calls: 63, cost: 17.5, savingsUSD: 0, inputTokens: 0, outputTokens: 1_174_967, cacheReadTokens: 0, cacheWriteTokens: 0 } },
+    })
+    await writeV17([day(date, { copilot: prior })])
+
+    let parses = 0
+    const out = await ensureCacheHydrated(
+      async (_range: DateRange): Promise<ProjectSummary[]> => { parses++; return [] },
+      () => [],
+      'cfg',
+      () => true,
+    )
+    const carriedDay = out.days.find(entry => entry.date === date)!
+
+    expect(parses).toBe(1)
+    expect(carriedDay.providers.copilot).toEqual(prior)
+    expect(carriedDay.calls).toBe(63)
+    expect(carriedDay.outputTokens).toBe(1_174_967)
+    expect(carriedDay.cost).toBe(17.5)
+    expect(carriedDay.carried).toBe(true)
+    expect(out.complete).toBe(true)
+    expect(out.watermarkTrusted).toBe(true)
+
+    await ensureCacheHydrated(async () => { parses++; return [] }, () => [], 'cfg', () => true)
+    expect(parses).toBe(1)
+  })
+
+  it('keeps v17 untrusted until a parse is genuinely authoritative', async () => {
+    const date = '2026-07-28'
+    const prior = slice(30, 3, { sessions: 1, outputTokens: 300 })
+    const fresh = slice(4, 1, { sessions: 1, inputTokens: 40, outputTokens: 4 })
+    await writeV17([day(date, { copilot: prior })])
+
+    let authoritative = false
+    let parses = 0
+    const parseSessions = async (_range: DateRange): Promise<ProjectSummary[]> => {
+      parses++
+      return []
+    }
+    const aggregate = () => authoritative ? [day(date, { copilot: fresh })] : []
+
+    const degraded = await ensureCacheHydrated(parseSessions, aggregate, 'cfg', () => authoritative)
+    expect(parses).toBe(1)
+    expect(degraded.complete).toBe(false)
+    expect(degraded.watermarkTrusted).toBe(false)
+    expect(degraded.days.find(entry => entry.date === date)!.providers.copilot).toEqual(prior)
+
+    authoritative = true
+    const recovered = await ensureCacheHydrated(parseSessions, aggregate, 'cfg', () => authoritative)
+    expect(parses).toBe(2)
+    expect(recovered.complete).toBe(true)
+    expect(recovered.watermarkTrusted).toBe(true)
+    expect(recovered.days.find(entry => entry.date === date)!.providers.copilot).toEqual(fresh)
+
+    await ensureCacheHydrated(parseSessions, aggregate, 'cfg', () => authoritative)
+    expect(parses).toBe(2)
+  })
+})

--- a/tests/daily-cache-trusted-adoption.test.ts
+++ b/tests/daily-cache-trusted-adoption.test.ts
@@ -57,14 +57,15 @@ describe('trusted watermark envelope propagation', () => {
     expect((await loadDailyCache()).watermarkTrusted).toBe(true)
   })
 
-  it('durably preserves a trusted stamp while migrating a supported active envelope', async () => {
+  it('does not trust a v17 envelope before the v18 accounting re-derive', async () => {
     await writeFile(dailyCachePath(), JSON.stringify(envelope({ version: DAILY_CACHE_VERSION - 1 })), 'utf-8')
 
     const loaded = await loadDailyCache()
     expect(loaded.version).toBe(DAILY_CACHE_VERSION)
-    expect(loaded.watermarkTrusted).toBe(true)
-    expect(await persistedTrust()).toBe(true)
-    expect((await loadDailyCache()).watermarkTrusted).toBe(true)
+    expect(loaded.complete).toBe(false)
+    expect(loaded.watermarkTrusted).toBe(false)
+    expect(await persistedTrust()).toBeUndefined()
+    expect((await loadDailyCache()).watermarkTrusted).toBe(false)
   })
 
   it('never transfers trust from an unsupported active envelope to an adopted cache', async () => {

--- a/tests/providers/copilot.test.ts
+++ b/tests/providers/copilot.test.ts
@@ -346,7 +346,7 @@ describe('copilot provider - JSONL parsing', () => {
       }),
     ])
 
-    const source = { path: eventsPath, project: 'test', provider: 'copilot' }
+    const source = { path: eventsPath, project: 'test', provider: 'copilot', sourceType: 'transcript' }
     const calls: ParsedProviderCall[] = []
     for await (const call of copilot.createSessionParser(source, new Set()).parse()) calls.push(call)
 
@@ -365,7 +365,7 @@ describe('copilot provider - JSONL parsing', () => {
       }),
     ])
 
-    const source = { path: eventsPath, project: 'test', provider: 'copilot' }
+    const source = { path: eventsPath, project: 'test', provider: 'copilot', sourceType: 'transcript' }
     const calls: ParsedProviderCall[] = []
     for await (const call of copilot.createSessionParser(source, new Set()).parse()) calls.push(call)
 
@@ -394,7 +394,7 @@ describe('copilot provider - JSONL parsing', () => {
       }),
     ])
 
-    const source = { path: eventsPath, project: 'test', provider: 'copilot' }
+    const source = { path: eventsPath, project: 'test', provider: 'copilot', sourceType: 'transcript' }
     const calls: ParsedProviderCall[] = []
     for await (const call of copilot.createSessionParser(source, new Set()).parse()) calls.push(call)
 
@@ -414,12 +414,32 @@ describe('copilot provider - JSONL parsing', () => {
       }),
     ])
 
-    const source = { path: eventsPath, project: 'test', provider: 'copilot' }
+    const source = { path: eventsPath, project: 'test', provider: 'copilot', sourceType: 'transcript' }
     const calls: ParsedProviderCall[] = []
     for await (const call of copilot.createSessionParser(source, new Set()).parse()) calls.push(call)
 
     expect(calls).toHaveLength(1)
     expect(calls[0]!.tools).toEqual(['mcp__github_mcp_server__list_issues', 'Read'])
+  })
+
+  it('uses the discovered transcript filename as its session identity', async () => {
+    const transcriptDir = join(tmpDir, 'transcripts')
+    await mkdir(transcriptDir, { recursive: true })
+    const eventsPath = join(transcriptDir, 'session-by-filename.jsonl')
+    await writeFile(eventsPath, [
+      transcriptSessionStart('payload-session-id'),
+      transcriptAssistantMessage({ messageId: 'msg-1', content: 'done', toolCallIds: ['call_abc'] }),
+    ].join('\n') + '\n')
+
+    const calls = await collectCalls({
+      path: eventsPath,
+      project: 'test',
+      provider: 'copilot',
+      sourceType: 'transcript',
+    })
+
+    expect(calls).toHaveLength(1)
+    expect(calls[0]!.sessionId).toBe('session-by-filename')
   })
 })
 
@@ -430,6 +450,36 @@ describe('copilot provider - session.shutdown token/cost rollup', () => {
 
   afterEach(async () => {
     await rm(tmpDir, { recursive: true, force: true })
+  })
+
+  it('uses discovered CLI provenance even when producer is copilot-agent', async () => {
+    const eventsPath = await createSessionDir('sess-cli-provenance', [
+      JSON.stringify({
+        type: 'session.start',
+        timestamp: '2026-04-15T10:00:00Z',
+        data: { sessionId: 'sess-cli-provenance', producer: 'copilot-agent', selectedModel: 'claude-sonnet-4-5' },
+      }),
+      assistantMessage({ messageId: 'msg-1', outputTokens: 345 }),
+      shutdownEvent({
+        modelMetrics: {
+          'claude-sonnet-4-5': { inputTokens: 71282, outputTokens: 345, cacheReadTokens: 35495, cacheWriteTokens: 35783, reasoningTokens: 31 },
+        },
+      }),
+    ])
+
+    const calls = await collectCalls({
+      path: eventsPath,
+      project: 'myproject',
+      provider: 'copilot',
+      sourceType: 'jsonl',
+    })
+
+    expect(calls).toHaveLength(2)
+    expect(calls.find(c => c.deduplicationKey.includes(':shutdown:'))).toBeDefined()
+    expect(calls.reduce((sum, call) => sum + call.outputTokens, 0)).toBe(345)
+    expect(calls.reduce((sum, call) => sum + call.inputTokens, 0)).toBe(4)
+    expect(calls.reduce((sum, call) => sum + call.cacheReadInputTokens, 0)).toBe(35495)
+    expect(calls.reduce((sum, call) => sum + call.cacheCreationInputTokens, 0)).toBe(35783)
   })
 
   it('reads input/cache tokens and measured cost from session.shutdown', async () => {
@@ -620,7 +670,7 @@ describe('copilot provider - session.shutdown token/cost rollup', () => {
         },
       }),
     ])
-    const source = { path: eventsPath, project: 'test', provider: 'copilot' }
+    const source = { path: eventsPath, project: 'test', provider: 'copilot', sourceType: 'transcript' }
     const calls = await collectCalls(source)
 
     // Only the transcript assistant call; the shutdown rollup is CLI-only.
@@ -880,6 +930,7 @@ describe('copilot provider - discoverSessions', () => {
     expect(sessions).toHaveLength(1)
     expect(sessions[0]!.project).toBe('myapp')
     expect(sessions[0]!.path).toContain('session-1.jsonl')
+    expect((sessions[0] as { sourceType?: string }).sourceType).toBe('transcript')
   })
 
   it('includes VSCodium workspaceStorage paths on all supported platforms', () => {


### PR DESCRIPTION
## Summary

- classify Copilot CLI session-state and VS Code transcript sources from discovery provenance instead of payload producer fields;
- keep assistant-message output accounting separate from CLI shutdown input/cache/reasoning accounting to avoid double counting;
- use source-native transcript session identity;
- bump the daily cache envelope to v18 so surviving Copilot history is re-derived under the corrected accounting while sourceless historical slices remain carried forward losslessly;
- preserve durable orphan history and existing pricing semantics.

## Validation

Focused Copilot, daily-cache, carry-forward, trust and session-cache regressions pass, together with root typecheck, source-size ratchet and `git diff --check`.

No release, tag or manual Candidate action is included.