### PR TITLE
fix(antigravity): complete source discovery and durable accounting

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -3042,22 +3042,19 @@ async function parseProviderSources(
         const canonicalCalls = await Promise.all(providerCalls.map(canonicalizeProviderCallProject))
         const turns = providerCallsToCachedTurns(canonicalCalls)
 
-        // Store/merge parsed turns into the cache.
-        // Durable providers use a union-by-deduplicationKey merge: existing turns
-        // are NEVER deleted (preserves data for spans pruned from the DB), and
-        // only turns whose dedup keys are not already cached are appended.
-        // Non-durable providers keep the original overwrite-or-append behaviour.
+        // Durable sources retain absent fresh calls; Antigravity fresh native
+        // identities replace stale values on source rewrites.
         if (provider.durableSources) {
-          const existingEntry = section.files[source.path]
-          if (existingEntry) {
-            const existingKeys = new Set(
-              existingEntry.turns.flatMap(t => t.calls.map(c => c.deduplicationKey))
-            )
-            const newTurns = turns.filter(t =>
-              t.calls.every(c => !existingKeys.has(c.deduplicationKey))
-            )
-            existingEntry.turns = [...existingEntry.turns, ...newTurns]
-            existingEntry.fingerprint = fp
+            const existingEntry = section.files[source.path]
+            if (existingEntry) {
+              if (provider.durableFreshWins) {
+                const freshKeys = new Set(turns.flatMap(t => t.calls.map(c => c.deduplicationKey)))
+                existingEntry.turns = existingEntry.turns.map(t => ({ ...t, calls: t.calls.filter(c => !freshKeys.has(c.deduplicationKey)) })).filter(t => t.calls.length > 0)
+              }
+              const existingKeys = new Set(existingEntry.turns.flatMap(t => t.calls.map(c => c.deduplicationKey)))
+              const newTurns = turns.filter(t => t.calls.every(c => !existingKeys.has(c.deduplicationKey)))
+              existingEntry.turns = [...existingEntry.turns, ...newTurns]
+              existingEntry.fingerprint = fp
           } else {
             section.files[source.path] = { fingerprint: fp, mcpInventory: [], turns }
           }

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -2791,11 +2791,11 @@ function getOrCreateProviderSection(cache: SessionCache, provider: string): Prov
   const existing = cache.providers[provider]
   if (existing && existing.envFingerprint === envFp) return existing
   const section: ProviderSection = { envFingerprint: envFp, files: {} }
-  // Durable sources may lose authority without disappearing from disk, so
-  // carry every prior entry through a fingerprint change and dedupe fresh calls.
-  if (existing && DURABLE_PROVIDER_NAMES.has(provider)) {
+  // A fingerprint change re-parses every present source. Durable providers
+  // carry only entries whose source was pruned and cannot be re-derived.
+  if (existing && (existing.durable || DURABLE_PROVIDER_NAMES.has(provider))) {
     for (const [path, file] of Object.entries(existing.files)) {
-      section.files[path] = file
+      if (!existsSync(path)) section.files[path] = file
     }
   }
   cache.providers[provider] = section
@@ -2951,9 +2951,7 @@ async function parseProviderSources(
   const provider = await getProvider(providerName)
   if (!provider) return []
 
-  const priorSection = diskCache.providers[providerName]
   const section = getOrCreateProviderSection(diskCache, providerName)
-  const forceReparse = diskCache.complete !== true || priorSection?.envFingerprint !== section.envFingerprint
   const allDiscoveredFiles = new Set<string>()
   const servedSources = [...sources]
 
@@ -2981,7 +2979,7 @@ async function parseProviderSources(
     // A cached parse failure at this same fingerprint stays skipped — don't
     // re-read a file that already threw and hasn't changed. It re-parses only
     // when the file changes (then `reconcileFile` reports non-'unchanged').
-    if (cached && (readOnly || (!forceReparse && action.action === 'unchanged' && (cached.failed || !cachedFileNeedsProviderReparse(providerName, source.path, cached))))) {
+    if (cached && (readOnly || (action.action === 'unchanged' && (cached.failed || !cachedFileNeedsProviderReparse(providerName, source.path, cached))))) {
       unchangedSources.push({ source, cached })
     } else if (!readOnly) {
       changedSources.push({ source, fp })
@@ -3118,10 +3116,10 @@ async function parseProviderSources(
     }
   }
 
-  // Durable providers retain 90-day history by default; providers whose local
-  // source is the durable record may opt out.
-  if (!readOnly && provider.durableSources && provider.durableHistoryRetentionDays !== null) {
-    const cutoffMs = Date.now() - (provider.durableHistoryRetentionDays ?? 90) * 24 * 60 * 60 * 1000
+  // 90-day age-out for durable providers: remove entries whose newest call is
+  // older than 90 days so the detailed cache remains bounded.
+  if (!readOnly && provider.durableSources) {
+    const cutoffMs = Date.now() - 90 * 24 * 60 * 60 * 1000
     for (const [cachedPath, cachedFile] of Object.entries(section.files)) {
       const newestTs = cachedFile.turns
         .flatMap(t => t.calls)

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -2791,16 +2791,11 @@ function getOrCreateProviderSection(cache: SessionCache, provider: string): Prov
   const existing = cache.providers[provider]
   if (existing && existing.envFingerprint === envFp) return existing
   const section: ProviderSection = { envFingerprint: envFp, files: {} }
-  // A fingerprint change (env override or parse-version bump) must re-parse
-  // every present source, but for durable providers the cache is the ONLY
-  // remaining record of usage whose source rows were already pruned (OTel
-  // orphans). Discarding those with the section would permanently erase
-  // month-to-date history that cannot be re-derived, so carry forward exactly
-  // the entries whose source no longer exists; everything present on disk is
-  // dropped and re-parsed under the new fingerprint.
+  // Durable sources may lose authority without disappearing from disk, so
+  // carry every prior entry through a fingerprint change and dedupe fresh calls.
   if (existing && DURABLE_PROVIDER_NAMES.has(provider)) {
     for (const [path, file] of Object.entries(existing.files)) {
-      if (!existsSync(path)) section.files[path] = file
+      section.files[path] = file
     }
   }
   cache.providers[provider] = section
@@ -2956,7 +2951,9 @@ async function parseProviderSources(
   const provider = await getProvider(providerName)
   if (!provider) return []
 
+  const priorSection = diskCache.providers[providerName]
   const section = getOrCreateProviderSection(diskCache, providerName)
+  const forceReparse = diskCache.complete !== true || priorSection?.envFingerprint !== section.envFingerprint
   const allDiscoveredFiles = new Set<string>()
   const servedSources = [...sources]
 
@@ -2984,7 +2981,7 @@ async function parseProviderSources(
     // A cached parse failure at this same fingerprint stays skipped — don't
     // re-read a file that already threw and hasn't changed. It re-parses only
     // when the file changes (then `reconcileFile` reports non-'unchanged').
-    if (cached && (readOnly || (action.action === 'unchanged' && (cached.failed || !cachedFileNeedsProviderReparse(providerName, source.path, cached))))) {
+    if (cached && (readOnly || (!forceReparse && action.action === 'unchanged' && (cached.failed || !cachedFileNeedsProviderReparse(providerName, source.path, cached))))) {
       unchangedSources.push({ source, cached })
     } else if (!readOnly) {
       changedSources.push({ source, fp })
@@ -3121,10 +3118,10 @@ async function parseProviderSources(
     }
   }
 
-  // 90-day age-out for durable providers: remove entries whose newest call is
-  // older than 90 days so the cache doesn't grow unboundedly over time.
-  if (!readOnly && provider.durableSources) {
-    const cutoffMs = Date.now() - 90 * 24 * 60 * 60 * 1000
+  // Durable providers retain 90-day history by default; providers whose local
+  // source is the durable record may opt out.
+  if (!readOnly && provider.durableSources && provider.durableHistoryRetentionDays !== null) {
+    const cutoffMs = Date.now() - (provider.durableHistoryRetentionDays ?? 90) * 24 * 60 * 60 * 1000
     for (const [cachedPath, cachedFile] of Object.entries(section.files)) {
       const newestTs = cachedFile.turns
         .flatMap(t => t.calls)

--- a/src/providers/antigravity-source-discovery.ts
+++ b/src/providers/antigravity-source-discovery.ts
@@ -1,0 +1,101 @@
+import { readdir, stat } from 'fs/promises'
+import { basename, join } from 'path'
+import { homedir } from 'os'
+
+import type { ProbeRoot, SessionSource } from './types.js'
+
+export type AntigravityConversationRoot = {
+  dir: string
+  project: string
+  extensions: readonly string[]
+}
+
+function conversationRoots(): readonly AntigravityConversationRoot[] {
+  const home = homedir()
+  return [
+    { dir: join(home, '.gemini', 'antigravity', 'conversations'), project: 'antigravity', extensions: ['.pb', '.db'] },
+    { dir: join(home, '.gemini', 'antigravity', 'implicit'), project: 'antigravity', extensions: ['.pb'] },
+    { dir: join(home, '.gemini', 'antigravity-cli', 'conversations'), project: 'antigravity-cli', extensions: ['.pb', '.db'] },
+    { dir: join(home, '.gemini', 'antigravity-cli', 'implicit'), project: 'antigravity-cli', extensions: ['.pb'] },
+    { dir: join(home, '.gemini', 'antigravity-ide', 'conversations'), project: 'antigravity-ide', extensions: ['.pb', '.db'] },
+    { dir: join(home, '.gemini', 'antigravity-ide', 'implicit'), project: 'antigravity-ide', extensions: ['.pb'] },
+  ]
+}
+
+export function antigravityCascadeIdFromPath(path: string): string {
+  return basename(path).replace(/\.(pb|db)$/i, '')
+}
+
+function isImplicitRoot(path: string): boolean {
+  return path.replace(/\\/g, '/').replace(/\/+$/, '').toLowerCase().endsWith('/implicit')
+}
+
+// Native cascade identity is authoritative: direct SQLite beats protobuf,
+// non-implicit roots beat mirrors, and root order breaks remaining ties.
+function compareSourceAuthority(
+  left: { source: { path: string }; rootIndex: number },
+  right: { source: { path: string }; rootIndex: number },
+): number {
+  const leftPath = left.source.path
+  const rightPath = right.source.path
+  const leftDb = leftPath.toLowerCase().endsWith('.db')
+  const rightDb = rightPath.toLowerCase().endsWith('.db')
+  if (leftDb !== rightDb) return leftDb ? -1 : 1
+
+  const leftImplicit = leftPath.replace(/\\/g, '/').includes('/implicit/')
+  const rightImplicit = rightPath.replace(/\\/g, '/').includes('/implicit/')
+  if (leftImplicit !== rightImplicit) return leftImplicit ? 1 : -1
+
+  return left.rootIndex - right.rootIndex
+}
+
+function isConversationFile(file: string, extensions: readonly string[]): boolean {
+  const lowerFile = file.toLowerCase()
+  return extensions.some(ext => lowerFile.endsWith(ext))
+}
+
+export async function discoverAntigravitySources(
+  statusLinePath: string,
+  roots?: readonly AntigravityConversationRoot[],
+): Promise<SessionSource[]> {
+  const includeStatusLineEvents = roots === undefined
+  const effectiveRoots = roots ?? conversationRoots()
+  const selected = new Map<string, { source: SessionSource; rootIndex: number }>()
+
+  for (let rootIndex = 0; rootIndex < effectiveRoots.length; rootIndex++) {
+    const root = effectiveRoots[rootIndex]!
+    let files: string[]
+    try { files = await readdir(root.dir) } catch { continue }
+
+    for (const file of files.sort()) {
+      if (!isConversationFile(file, root.extensions)) continue
+      const path = join(root.dir, file)
+      const sourceStat = await stat(path).catch(() => null)
+      if (!sourceStat?.isFile()) continue
+      const source = { path, project: root.project, provider: 'antigravity' }
+      const candidate = { source, rootIndex }
+      const cascadeId = antigravityCascadeIdFromPath(path)
+      const prior = selected.get(cascadeId)
+      if (!prior || compareSourceAuthority(candidate, prior) < 0) selected.set(cascadeId, candidate)
+    }
+  }
+
+  const sources = [...selected.values()].map(candidate => candidate.source)
+  if (!includeStatusLineEvents) return sources
+
+  const statusLineStat = await stat(statusLinePath).catch(() => null)
+  if (statusLineStat?.isFile()) {
+    sources.push({ path: statusLinePath, project: 'antigravity-cli', provider: 'antigravity' })
+  }
+  return sources
+}
+
+export function antigravityProbeRoots(statusLinePath: string): ProbeRoot[] {
+  return [
+    ...conversationRoots().map(root => ({
+      path: root.dir,
+      label: isImplicitRoot(root.dir) ? 'implicit' : 'conversations',
+    })),
+    { path: statusLinePath, label: 'statusline' },
+  ]
+}

--- a/src/providers/antigravity-source-discovery.ts
+++ b/src/providers/antigravity-source-discovery.ts
@@ -2,7 +2,7 @@ import { readdir, stat } from 'fs/promises'
 import { basename, join } from 'path'
 import { homedir } from 'os'
 
-import type { ProbeRoot, SessionSource } from './types.js'
+import type { ProbeRoot, SessionSource, SessionSourceLocator } from './types.js'
 
 export type AntigravityConversationRoot = {
   dir: string
@@ -33,8 +33,8 @@ function isImplicitRoot(path: string): boolean {
 // Native cascade identity is authoritative: direct SQLite beats protobuf,
 // non-implicit roots beat mirrors, and root order breaks remaining ties.
 function compareSourceAuthority(
-  left: { source: { path: string }; rootIndex: number },
-  right: { source: { path: string }; rootIndex: number },
+  left: { source: SessionSourceLocator; rootIndex: number },
+  right: { source: SessionSourceLocator; rootIndex: number },
 ): number {
   const leftPath = left.source.path
   const rightPath = right.source.path
@@ -60,7 +60,7 @@ export async function discoverAntigravitySources(
 ): Promise<SessionSource[]> {
   const includeStatusLineEvents = roots === undefined
   const effectiveRoots = roots ?? conversationRoots()
-  const selected = new Map<string, { source: SessionSource; rootIndex: number }>()
+  const grouped = new Map<string, Array<{ source: SessionSourceLocator; rootIndex: number }>>()
 
   for (let rootIndex = 0; rootIndex < effectiveRoots.length; rootIndex++) {
     const root = effectiveRoots[rootIndex]!
@@ -75,12 +75,16 @@ export async function discoverAntigravitySources(
       const source = { path, project: root.project, provider: 'antigravity' }
       const candidate = { source, rootIndex }
       const cascadeId = antigravityCascadeIdFromPath(path)
-      const prior = selected.get(cascadeId)
-      if (!prior || compareSourceAuthority(candidate, prior) < 0) selected.set(cascadeId, candidate)
+      grouped.set(cascadeId, [...(grouped.get(cascadeId) ?? []), candidate])
     }
   }
 
-  const sources = [...selected.values()].map(candidate => candidate.source)
+  const sources = [...grouped.values()].map(candidates => {
+    const ordered = candidates.sort(compareSourceAuthority)
+    const canonical = ordered[0]!.source
+    const alternateLocators = ordered.slice(1).map(candidate => candidate.source)
+    return alternateLocators.length > 0 ? { ...canonical, alternateLocators } : canonical
+  })
   if (!includeStatusLineEvents) return sources
 
   const statusLineStat = await stat(statusLinePath).catch(() => null)
@@ -88,6 +92,10 @@ export async function discoverAntigravitySources(
     sources.push({ path: statusLinePath, project: 'antigravity-cli', provider: 'antigravity' })
   }
   return sources
+}
+
+export function antigravitySourceLocators(source: SessionSource): SessionSourceLocator[] {
+  return [source, ...(source.alternateLocators ?? [])]
 }
 
 export function antigravityProbeRoots(statusLinePath: string): ProbeRoot[] {

--- a/src/providers/antigravity.ts
+++ b/src/providers/antigravity.ts
@@ -1311,7 +1311,7 @@ export function createAntigravityProvider(): Provider {
   return {
     name: 'antigravity',
     displayName: 'Antigravity',
-    durableSources: true,
+    durableSources: true, durableFreshWins: true,
 
     modelDisplayName(model: string): string {
       return modelDisplayNames[model] ?? model

--- a/src/providers/antigravity.ts
+++ b/src/providers/antigravity.ts
@@ -1,14 +1,19 @@
-import { readdir, readFile, mkdir, stat, open, rename, unlink } from 'fs/promises'
+import { readFile, mkdir, stat, open, rename, unlink } from 'fs/promises'
 import { execFile } from 'child_process'
 import { randomBytes } from 'crypto'
 import { basename, join } from 'path'
-import { homedir } from 'os'
 import { fileURLToPath } from 'url'
 import https from 'https'
 import { calculateCost } from '../models.js'
 import { isSqliteAvailable, isSqliteBusyError, openDatabase } from '../sqlite.js'
 import { ExpiringServerDiscoveryCache, runWithSingleServerRediscovery } from './antigravity-server-recovery.js'
 import type { Provider, SessionSource, SessionParser, ParsedProviderCall } from './types.js'
+import {
+  antigravityCascadeIdFromPath,
+  antigravityProbeRoots,
+  discoverAntigravitySources,
+  type AntigravityConversationRoot,
+} from './antigravity-source-discovery.js'
 import { getMetroraCacheDir } from '../product-paths.js'
 import {
   buildCallsFromGeneratorMetadata,
@@ -19,44 +24,7 @@ import {
 } from './antigravity-accounting.js'
 export { buildCallsFromGeneratorMetadata, reconcileAntigravityStatusLineCalls } from './antigravity-accounting.js'
 export type { AntigravityCacheEnrichment, GeneratorMetadata } from './antigravity-accounting.js'
-type AntigravityConversationRoot = {
-  dir: string
-  project: string
-  extensions: readonly string[]
-}
-
-// Computed on each call rather than frozen at module load so discovery honors
-// the current home directory (env overrides in tests, and any runtime change).
-function conversationRoots(): readonly AntigravityConversationRoot[] {
-  const home = homedir()
-  return [
-    {
-      dir: join(home, '.gemini', 'antigravity', 'conversations'),
-      project: 'antigravity',
-      extensions: ['.pb', '.db'],
-    },
-    {
-      dir: join(home, '.gemini', 'antigravity-cli', 'conversations'),
-      project: 'antigravity-cli',
-      extensions: ['.pb', '.db'],
-    },
-    {
-      dir: join(home, '.gemini', 'antigravity-cli', 'implicit'),
-      project: 'antigravity-cli',
-      extensions: ['.pb'],
-    },
-    {
-      dir: join(home, '.gemini', 'antigravity-ide', 'conversations'),
-      project: 'antigravity-ide',
-      extensions: ['.pb', '.db'],
-    },
-    {
-      dir: join(home, '.gemini', 'antigravity-ide', 'implicit'),
-      project: 'antigravity-ide',
-      extensions: ['.pb'],
-    },
-  ]
-}
+export { antigravityCascadeIdFromPath }
 const CACHE_VERSION = 6
 const PREVIOUS_CACHE_VERSION = 5
 
@@ -298,21 +266,12 @@ async function loadCache(): Promise<AntigravityCache> {
   return memCache
 }
 
-async function flushCache(liveCascadeIds?: Set<string>): Promise<void> {
+async function flushCache(_liveCascadeIds?: Set<string>): Promise<void> {
   if (!memCache) return
-  // If the caller supplied liveCascadeIds, we must run the eviction step
-  // even when no cascade was added or updated this run; otherwise deleted
-  // .pb files would persist in the cache forever once it stops getting
-  // dirty writes. Mark the cache dirty when an eviction happens so the
-  // file write below proceeds.
-  if (liveCascadeIds) {
-    for (const id of Object.keys(memCache.cascades)) {
-      if (!liveCascadeIds.has(id)) {
-        delete memCache.cascades[id]
-        cacheDirty = true
-      }
-    }
-  }
+  // The result cache is the provider-level durable evidence for cascades whose
+  // source file is later pruned or temporarily unavailable. Never evict by the
+  // current discovery set: the session/daily caches can still rehydrate these
+  // calls without a live server, and their first-seen timestamps must survive.
   if (!cacheDirty) return
   try {
 
@@ -845,15 +804,6 @@ function usageDelta(current: StatusLineEvent['usage'], previous: StatusLineEvent
   }
 }
 
-export function antigravityCascadeIdFromPath(path: string): string {
-  return basename(path).replace(/\.(pb|db)$/i, '')
-}
-
-function isConversationFile(file: string, extensions: readonly string[]): boolean {
-  const lowerFile = file.toLowerCase()
-  return extensions.some(ext => lowerFile.endsWith(ext))
-}
-
 export function isAntigravityStatusLineEventsPath(path: string): boolean {
   return path === getAntigravityStatusLineEventsPath()
 }
@@ -861,45 +811,7 @@ export function isAntigravityStatusLineEventsPath(path: string): boolean {
 export async function discoverAntigravitySessionSources(
   roots?: readonly AntigravityConversationRoot[],
 ): Promise<SessionSource[]> {
-  // The statusline JSONL is a synthetic source only appended for the real
-  // default roots, not when a caller passes an explicit (test) root set.
-  const includeStatusLineEvents = roots === undefined
-  const effectiveRoots = roots ?? conversationRoots()
-  const sources: SessionSource[] = []
-  for (const root of effectiveRoots) {
-    let files: string[]
-    try {
-      files = await readdir(root.dir)
-    } catch {
-      continue
-    }
-
-    for (const file of files.sort()) {
-      if (!isConversationFile(file, root.extensions)) continue
-      const path = join(root.dir, file)
-      const s = await stat(path).catch(() => null)
-      if (!s?.isFile()) continue
-      sources.push({
-        path,
-        project: root.project,
-        provider: 'antigravity',
-      })
-    }
-  }
-
-  if (includeStatusLineEvents) {
-    const statusLinePath = getAntigravityStatusLineEventsPath()
-    const statusLineStat = await stat(statusLinePath).catch(() => null)
-    if (statusLineStat?.isFile()) {
-      sources.push({
-        path: statusLinePath,
-        project: 'antigravity-cli',
-        provider: 'antigravity',
-      })
-    }
-  }
-
-  return sources
+  return discoverAntigravitySources(getAntigravityStatusLineEventsPath(), roots)
 }
 
 function parseStatusLinePayload(input: unknown): StatusLineEvent | null {
@@ -1343,6 +1255,8 @@ export function createAntigravityProvider(): Provider {
   return {
     name: 'antigravity',
     displayName: 'Antigravity',
+    durableSources: true,
+    durableHistoryRetentionDays: null,
 
     modelDisplayName(model: string): string {
       return modelDisplayNames[model] ?? model
@@ -1350,6 +1264,10 @@ export function createAntigravityProvider(): Provider {
 
     toolDisplayName(rawTool: string): string {
       return rawTool
+    },
+
+    async probeRoots() {
+      return antigravityProbeRoots(getAntigravityStatusLineEventsPath())
     },
 
     async discoverSessions(): Promise<SessionSource[]> {

--- a/src/providers/antigravity.ts
+++ b/src/providers/antigravity.ts
@@ -7,10 +7,11 @@ import https from 'https'
 import { calculateCost } from '../models.js'
 import { isSqliteAvailable, isSqliteBusyError, openDatabase } from '../sqlite.js'
 import { ExpiringServerDiscoveryCache, runWithSingleServerRediscovery } from './antigravity-server-recovery.js'
-import type { Provider, SessionSource, SessionParser, ParsedProviderCall } from './types.js'
+import type { Provider, SessionSource, SessionSourceLocator, SessionParser, ParsedProviderCall } from './types.js'
 import {
   antigravityCascadeIdFromPath,
   antigravityProbeRoots,
+  antigravitySourceLocators,
   discoverAntigravitySources,
   type AntigravityConversationRoot,
 } from './antigravity-source-discovery.js'
@@ -99,6 +100,12 @@ type AntigravityCache = {
   cascades: Record<string, CachedCascade>
 }
 
+type AntigravityRpcData = { metadata: GeneratorMetadata[]; modelMap: ModelMap }
+export type AntigravityRpcDataOverride = (
+  appDataDir: 'antigravity' | 'antigravity-cli' | 'antigravity-ide',
+  cascadeId: string,
+) => Promise<AntigravityRpcData | null>
+
 type ProtoField = {
   number: number
   wireType: number
@@ -121,6 +128,7 @@ const cachedModelMaps = new Map<string, ModelMap>()
 let memCache: AntigravityCache | null = null
 let memCachePath = ''
 let cacheDirty = false
+let rpcDataOverride: AntigravityRpcDataOverride | null = null
 let httpsAgent: https.Agent | undefined
 const protoTextDecoder = new TextDecoder('utf-8', { fatal: false })
 
@@ -266,12 +274,18 @@ async function loadCache(): Promise<AntigravityCache> {
   return memCache
 }
 
-async function flushCache(_liveCascadeIds?: Set<string>): Promise<void> {
+async function flushCache(liveCascadeIds?: Set<string>): Promise<void> {
   if (!memCache) return
-  // The result cache is the provider-level durable evidence for cascades whose
-  // source file is later pruned or temporarily unavailable. Never evict by the
-  // current discovery set: the session/daily caches can still rehydrate these
-  // calls without a live server, and their first-seen timestamps must survive.
+  // Keep detailed result-cache retention bounded by the live cascade set. The
+  // durable session/daily caches preserve older orphan history.
+  if (liveCascadeIds) {
+    for (const id of Object.keys(memCache.cascades)) {
+      if (!liveCascadeIds.has(id)) {
+        delete memCache.cascades[id]
+        cacheDirty = true
+      }
+    }
+  }
   if (!cacheDirty) return
   try {
 
@@ -496,10 +510,11 @@ async function getModelMap(server: ServerInfo): Promise<ModelMap> {
   return {}
 }
 
-async function fetchCascadeRpcData(
+async function fetchCascadeRpcDataForAppDataDir(
   appDataDir: 'antigravity' | 'antigravity-cli' | 'antigravity-ide',
   cascadeId: string,
-): Promise<{ metadata: GeneratorMetadata[]; modelMap: ModelMap } | null> {
+): Promise<AntigravityRpcData | null> {
+  if (rpcDataOverride) return rpcDataOverride(appDataDir, cascadeId)
   return runWithSingleServerRediscovery({
     detect: () => detectServer(appDataDir),
     invalidate: server => invalidateServer(appDataDir, server),
@@ -511,6 +526,21 @@ async function fetchCascadeRpcData(
       return { metadata, modelMap }
     },
   })
+}
+
+async function fetchCascadeRpcData(
+  locators: readonly SessionSourceLocator[],
+  cascadeId: string,
+): Promise<AntigravityRpcData | null> {
+  const tried = new Set<string>()
+  for (const locator of locators) {
+    const appDataDir = antigravityAppDataDirFromSourcePath(locator.path)
+    if (tried.has(appDataDir)) continue
+    tried.add(appDataDir)
+    const data = await fetchCascadeRpcDataForAppDataDir(appDataDir, cascadeId)
+    if (data?.metadata.length) return data
+  }
+  return null
 }
 
 function readProtoVarint(data: Uint8Array, startOffset: number): ProtoVarint | null {
@@ -1008,13 +1038,19 @@ export function shouldReparseAntigravitySource(path: string, cachedTurnCount: nu
   return isAntigravityStatusLineEventsPath(path)
 }
 
-async function findCascadeSource(cascadeId: string): Promise<SessionSource | null> {
+async function findCascadeLocators(cascadeId: string): Promise<SessionSourceLocator[]> {
   const sources = await discoverAntigravitySessionSources()
-  return sources.find(source => {
-    const lower = source.path.replace(/\\/g, '/').toLowerCase()
-    return (lower.includes('/.gemini/antigravity-cli/') || lower.includes('/.gemini/antigravity-ide/')) &&
-      antigravityCascadeIdFromPath(source.path) === cascadeId
-  }) ?? null
+  const locators: SessionSourceLocator[] = []
+  for (const source of sources) {
+    for (const locator of antigravitySourceLocators(source)) {
+      const lower = locator.path.replace(/\\/g, '/').toLowerCase()
+      if (
+        (lower.includes('/.gemini/antigravity-cli/') || lower.includes('/.gemini/antigravity-ide/')) &&
+        antigravityCascadeIdFromPath(locator.path) === cascadeId
+      ) locators.push(locator)
+    }
+  }
+  return locators
 }
 
 export async function snapshotAntigravityStatusLinePayload(input: unknown): Promise<boolean> {
@@ -1022,30 +1058,36 @@ export async function snapshotAntigravityStatusLinePayload(input: unknown): Prom
   if (!event) return false
 
   const cascadeId = event.conversationId
-  const source = await findCascadeSource(cascadeId)
-  if (!source) return false
+  const locators = await findCascadeLocators(cascadeId)
+  if (locators.length === 0) return false
 
-  const s = await stat(source.path).catch(() => null)
-  if (!s) return false
+  let sourceStat: Awaited<ReturnType<typeof stat>> | null = null
+  for (const locator of locators) {
+    const candidateStat = await stat(locator.path).catch(() => null)
+    if (!candidateStat) continue
+    sourceStat ??= candidateStat
+  }
+  if (!sourceStat) return false
 
   const cache = await loadCache()
   const cached = cache.cascades[cascadeId]
   if (
     cached?.parserVersion === CACHE_VERSION &&
-    cached.mtimeMs === s.mtimeMs && cached.sizeBytes === s.size && cached.calls.length > 0
+    cached.mtimeMs === sourceStat.mtimeMs && cached.sizeBytes === sourceStat.size &&
+    cached.calls.length > 0
   ) {
     return true
   }
 
-  const rpcData = await fetchCascadeRpcData(antigravityAppDataDirFromSourcePath(source.path), cascadeId)
+  const rpcData = await fetchCascadeRpcData(locators, cascadeId)
   if (!rpcData) return false
 
   const snapshotCalls = buildCallsFromGeneratorMetadata(cascadeId, rpcData.metadata, rpcData.modelMap)
-  assignStableTimestamps(snapshotCalls, cached?.calls, new Date(s.mtimeMs).toISOString())
+  assignStableTimestamps(snapshotCalls, cached?.calls, new Date(sourceStat.mtimeMs).toISOString())
   cache.cascades[cascadeId] = {
     parserVersion: CACHE_VERSION,
-    mtimeMs: s.mtimeMs,
-    sizeBytes: s.size,
+    mtimeMs: sourceStat.mtimeMs,
+    sizeBytes: sourceStat.size,
     calls: snapshotCalls,
   }
   cacheDirty = true
@@ -1150,6 +1192,8 @@ function createParser(source: SessionSource, seenKeys: Set<string>): SessionPars
       }
 
       const cascadeId = antigravityCascadeIdFromPath(source.path)
+      const locators = antigravitySourceLocators(source)
+      const isDbSource = source.path.toLowerCase().endsWith('.db')
       const cache = await loadCache()
 
       const s = await stat(source.path).catch(() => null)
@@ -1159,10 +1203,10 @@ function createParser(source: SessionSource, seenKeys: Set<string>): SessionPars
       const fallbackTimestamp = new Date(s.mtimeMs).toISOString()
 
       const cached = cache.cascades[cascadeId]
-      if (
-        cached?.parserVersion === CACHE_VERSION &&
+      const cacheMatchesSource = cached !== undefined &&
+        cached.parserVersion === CACHE_VERSION &&
         cached.mtimeMs === s.mtimeMs && cached.sizeBytes === s.size && cached.calls.length > 0
-      ) {
+      if (cacheMatchesSource && (!isDbSource || locators.length === 1)) {
         for (const call of cached.calls) {
           applyAntigravityProject(call, source, projectPath)
           if (seenKeys.has(call.deduplicationKey)) continue
@@ -1195,7 +1239,19 @@ function createParser(source: SessionSource, seenKeys: Set<string>): SessionPars
         return
       }
 
-      const rpcData = await fetchCascadeRpcData(antigravityAppDataDirFromSourcePath(source.path), cascadeId)
+      // A DB with no local usage must still expose alternate PB locators to
+      // RPC. Only use its old result cache after those routes have been tried.
+      if (cacheMatchesSource && locators.length === 1) {
+        for (const call of cached.calls) {
+          applyAntigravityProject(call, source, projectPath)
+          if (seenKeys.has(call.deduplicationKey)) continue
+          seenKeys.add(call.deduplicationKey)
+          yield withFallbackTimestamp(call, fallbackTimestamp)
+        }
+        return
+      }
+
+      const rpcData = await fetchCascadeRpcData(locators, cascadeId)
       if (!rpcData) {
         if (cached) {
           for (const call of cached.calls) {
@@ -1256,7 +1312,6 @@ export function createAntigravityProvider(): Provider {
     name: 'antigravity',
     displayName: 'Antigravity',
     durableSources: true,
-    durableHistoryRetentionDays: null,
 
     modelDisplayName(model: string): string {
       return modelDisplayNames[model] ?? model
@@ -1288,6 +1343,11 @@ export function resetAntigravityMemoryCacheForTests(): void {
   memCache = null
   memCachePath = ''
   cacheDirty = false
+  rpcDataOverride = null
+}
+
+export function setAntigravityRpcDataForTests(override: AntigravityRpcDataOverride | null): void {
+  rpcDataOverride = override
 }
 
 export const antigravity = createAntigravityProvider()

--- a/src/providers/types.ts
+++ b/src/providers/types.ts
@@ -97,6 +97,9 @@ export type Provider = {
   // are never evicted, and orphaned entries (paths no longer discovered) are
   // kept and included in query-time aggregation so the monthly total never drops.
   durableSources?: boolean
+  // Fresh derivation for a present durable source replaces cached calls with the
+  // same native identity while retaining cached calls absent from that derivation.
+  durableFreshWins?: boolean
   modelDisplayName(model: string): string
   toolDisplayName(rawTool: string): string
   discoverSessions(): Promise<SessionSource[]>

--- a/src/providers/types.ts
+++ b/src/providers/types.ts
@@ -93,6 +93,9 @@ export type Provider = {
   // are never evicted, and orphaned entries (paths no longer discovered) are
   // kept and included in query-time aggregation so the monthly total never drops.
   durableSources?: boolean
+  // `undefined` keeps the existing 90-day durable-cache retention. `null`
+  // disables age-out for providers whose local history is the durable record.
+  durableHistoryRetentionDays?: number | null
   modelDisplayName(model: string): string
   toolDisplayName(rawTool: string): string
   discoverSessions(): Promise<SessionSource[]>

--- a/src/providers/types.ts
+++ b/src/providers/types.ts
@@ -2,14 +2,18 @@ import type { DateRange, ToolCall } from '../types.js'
 import type { ReasoningLevel, ReasoningLevelSource } from '../reasoning-level.js'
 import type { CostAssignmentV1 } from '../pricing/cost-assignment.js'
 
-export type SessionSource = {
+export type SessionSourceLocator = {
   path: string
   project: string
   provider: string
+}
+
+export type SessionSource = SessionSourceLocator & {
   sourceId?: string
   sourceLabel?: string
   sourcePath?: string
   sourceKind?: 'claude-config' | 'claude-desktop'
+  alternateLocators?: readonly SessionSourceLocator[]
 }
 
 export type SessionParser = {
@@ -93,9 +97,6 @@ export type Provider = {
   // are never evicted, and orphaned entries (paths no longer discovered) are
   // kept and included in query-time aggregation so the monthly total never drops.
   durableSources?: boolean
-  // `undefined` keeps the existing 90-day durable-cache retention. `null`
-  // disables age-out for providers whose local history is the durable record.
-  durableHistoryRetentionDays?: number | null
   modelDisplayName(model: string): string
   toolDisplayName(rawTool: string): string
   discoverSessions(): Promise<SessionSource[]>

--- a/src/session-cache.ts
+++ b/src/session-cache.ts
@@ -211,7 +211,7 @@ export const PROVIDER_ENV_VARS: Record<string, string[]> = {
 
 // Names of providers whose cache entries are never evicted when source files
 // disappear — they are preserved so month-to-date totals never drop.
-export const DURABLE_PROVIDER_NAMES: ReadonlySet<string> = new Set(['copilot'])
+export const DURABLE_PROVIDER_NAMES: ReadonlySet<string> = new Set(['copilot', 'antigravity'])
 
 // Estimated-cost surfacing (#639): providers that set `costIsEstimated` carry a
 // `-est-cost` suffix (or a new entry) so their already-cached sessions reparse
@@ -251,7 +251,7 @@ export const PROVIDER_PARSE_VERSIONS: Record<string, string> = {
   'roo-code': 'worktree-project-grouping-v1',
   zerostack: 'cumulative-session-v1-provider-provenance-estimated-cost-v2',
   warp: 'worktree-project-grouping-v1-est-cost',
-  antigravity: 'worktree-project-grouping-v6-provider-reasoning-filter-usage-accounting-v2',
+  antigravity: 'worktree-project-grouping-v6-provider-reasoning-filter-usage-accounting-v2-source-union-v1-durable-v1',
   // OpenCode keeps valid usage in archived root/child sessions. The parser
   // must scan the complete SQLite session tree, not only active sessions.
   opencode: 'sqlite-session-tree-v2-provider-id-v1-free-route-v1-route-cost-v1',
@@ -504,14 +504,14 @@ async function adoptPriorCache(version: number): Promise<SessionCache | null> {
       if (rawFiles && typeof rawFiles === 'object' && !Array.isArray(rawFiles)) {
         for (const [path, file] of Object.entries(rawFiles as Record<string, unknown>)) {
           if (!validateCachedFile(file)) continue
-          const durable = (section as Record<string, unknown>)['durable'] === true
-          if (!existsSync(path) && (file.prLinks?.length || durable)) files[path] = file
+          const durable = (section as Record<string, unknown>)['durable'] === true || DURABLE_PROVIDER_NAMES.has(provider)
+          if ((durable || !existsSync(path)) && (file.prLinks?.length || durable)) files[path] = file
         }
       }
       migrated.providers[provider] = {
         envFingerprint: computeEnvFingerprint(provider),
         files,
-        ...((section as Record<string, unknown>)['durable'] ? { durable: true } : {}),
+        ...((section as Record<string, unknown>)['durable'] || DURABLE_PROVIDER_NAMES.has(provider) ? { durable: true } : {}),
       }
     }
     return migrated

--- a/src/session-cache.ts
+++ b/src/session-cache.ts
@@ -217,8 +217,8 @@ export const DURABLE_PROVIDER_NAMES: ReadonlySet<string> = new Set(['copilot', '
 // `-est-cost` suffix (or a new entry) so their already-cached sessions reparse
 // once and the flag lands, instead of silently reading as measured. Copilot
 // needs no suffix: the cli-shutdown-cost-v1 bump below already forces its one
-// re-parse, which lands the flag too, and durable orphans now survive
-// fingerprint changes (the carry-forward in getOrCreateProviderSection).
+// re-parse, which lands the flag too. Durable orphans survive fingerprint
+// changes through the present-source check in the parser.
 export const PROVIDER_PARSE_VERSIONS: Record<string, string> = {
   // rich-session-capture-v1: parse-time capture of per-turn gitBranch, per-call
   // LOC deltas / interruptions / userModified / toolErrors, and session-level
@@ -505,7 +505,7 @@ async function adoptPriorCache(version: number): Promise<SessionCache | null> {
         for (const [path, file] of Object.entries(rawFiles as Record<string, unknown>)) {
           if (!validateCachedFile(file)) continue
           const durable = (section as Record<string, unknown>)['durable'] === true || DURABLE_PROVIDER_NAMES.has(provider)
-          if ((durable || !existsSync(path)) && (file.prLinks?.length || durable)) files[path] = file
+          if (!existsSync(path) && (file.prLinks?.length || durable)) files[path] = file
         }
       }
       migrated.providers[provider] = {

--- a/tests/parser-antigravity-timestamp.test.ts
+++ b/tests/parser-antigravity-timestamp.test.ts
@@ -20,6 +20,43 @@ type TestDb = {
   close(): void
 }
 
+type CachedCallSnapshot = { deduplicationKey: string; usage: { inputTokens: number } }
+type CachedSnapshot = {
+  envFingerprint?: string
+  file?: {
+    fingerprint: unknown
+    turns: Array<{ timestamp: string; calls: CachedCallSnapshot[] }>
+  }
+}
+
+function encodeVarint(value: number | bigint): Buffer {
+  let remaining = BigInt(value)
+  const bytes: number[] = []
+  do {
+    const low = Number(remaining & 0x7fn)
+    remaining >>= 7n
+    bytes.push(low | (remaining > 0n ? 0x80 : 0))
+  } while (remaining > 0n)
+  return Buffer.from(bytes)
+}
+
+function encodeProtoBytes(fieldNumber: number, value: Uint8Array | string): Buffer {
+  const data = typeof value === 'string' ? Buffer.from(value) : Buffer.from(value)
+  return Buffer.concat([encodeVarint((BigInt(fieldNumber) << 3n) | 2n), encodeVarint(data.length), data])
+}
+
+function encodeProtoVarint(fieldNumber: number, value: number): Buffer {
+  return Buffer.concat([encodeVarint(BigInt(fieldNumber) << 3n), encodeVarint(value)])
+}
+
+function sqliteUsageRow(idx: number, responseId: string, inputTokens: number, outputTokens: number): { idx: number; hex: string } {
+  const usage = Buffer.concat([
+    encodeProtoVarint(1, inputTokens), encodeProtoVarint(3, outputTokens), encodeProtoBytes(11, responseId),
+  ])
+  const chatModel = Buffer.concat([encodeProtoBytes(4, usage), encodeProtoBytes(19, 'gemini-3-pro')])
+  return { idx, hex: encodeProtoBytes(1, chatModel).toString('hex') }
+}
+
 function createGenMetadataDb(dbPath: string, fixture: Fixture): void {
   const { DatabaseSync: Database } = requireForTest('node:sqlite')
   const db = new Database(dbPath) as TestDb
@@ -40,10 +77,21 @@ function createGenMetadataDb(dbPath: string, fixture: Fixture): void {
 }
 
 async function cachedAntigravityTurns(cacheDir: string, dbPath: string): Promise<Array<{ timestamp: string }>> {
+  return (await cachedAntigravitySnapshot(dbPath)).file?.turns ?? []
+}
+
+async function cachedAntigravitySnapshot(dbPath: string): Promise<CachedSnapshot> {
   const saved = JSON.parse(await readFile(sessionCachePath(), 'utf-8')) as {
-    providers: Record<string, { files: Record<string, { turns: Array<{ timestamp: string }> }> }>
+    providers: Record<string, { envFingerprint?: string; files: Record<string, CachedSnapshot['file']> }>
   }
-  return saved.providers['antigravity']?.files[dbPath]?.turns ?? []
+  const provider = saved.providers['antigravity']
+  return { envFingerprint: provider?.envFingerprint, file: provider?.files[dbPath] }
+}
+
+function summarizeCachedCalls(snapshot: CachedSnapshot): Array<{ key: string; input: number }> {
+  return (snapshot.file?.turns ?? [])
+    .flatMap(turn => turn.calls.map(call => ({ key: call.deduplicationKey, input: call.usage.inputTokens })))
+    .sort((a, b) => a.key.localeCompare(b.key))
 }
 
 let home: string
@@ -149,6 +197,71 @@ describe('Antigravity timestamp stability across .db rewrites', () => {
       ),
     )
     expect(todayKeys).toHaveLength(0)
+  })
+
+  it('lets fresh native usage replace stale durable usage after an ordinary DB rewrite', async () => {
+    if (!isSqliteAvailable()) return
+
+    const conversationId = 'durable-rewrite-cascade'
+    const conversationsDir = join(home, '.gemini', 'antigravity-ide', 'conversations')
+    await mkdir(conversationsDir, { recursive: true })
+    const dbPath = join(conversationsDir, `${conversationId}.db`)
+    const wideRange: DateRange = {
+      start: new Date('2026-01-01T00:00:00.000Z'),
+      end: new Date('2026-12-31T23:59:59.999Z'),
+    }
+
+    createGenMetadataDb(dbPath, {
+      conversationId,
+      rows: [sqliteUsageRow(0, 'K', 100, 1), sqliteUsageRow(1, 'B', 50, 1)],
+    })
+    const firstSeen = new Date('2026-07-02T03:04:05.000Z')
+    await utimes(dbPath, firstSeen, firstSeen)
+
+    await parseAllSessions(wideRange, 'antigravity')
+    const first = await cachedAntigravitySnapshot(dbPath)
+    expect(summarizeCachedCalls(first)).toEqual([
+      { key: `antigravity:${conversationId}:B`, input: 50 },
+      { key: `antigravity:${conversationId}:K`, input: 100 },
+    ])
+    expect(first.envFingerprint).toBeDefined()
+    expect(first.file).toBeDefined()
+
+    clearSessionCache()
+    await rm(dbPath)
+    createGenMetadataDb(dbPath, {
+      conversationId,
+      rows: [sqliteUsageRow(0, 'K', 120, 1), sqliteUsageRow(1, 'C', 30, 1)],
+    })
+    const rewritten = new Date('2026-07-07T08:09:10.000Z')
+    await utimes(dbPath, rewritten, rewritten)
+
+    const secondProjects = await parseAllSessions(wideRange, 'antigravity')
+    const second = await cachedAntigravitySnapshot(dbPath)
+    expect(second.envFingerprint).toBe(first.envFingerprint)
+    expect(second.file?.fingerprint).not.toEqual(first.file?.fingerprint)
+    expect(summarizeCachedCalls(second)).toEqual([
+      { key: `antigravity:${conversationId}:B`, input: 50 },
+      { key: `antigravity:${conversationId}:C`, input: 30 },
+      { key: `antigravity:${conversationId}:K`, input: 120 },
+    ])
+    expect(summarizeCachedCalls(second).reduce((sum, call) => sum + call.input, 0)).toBe(200)
+
+    const summarizeProjects = (projects: typeof secondProjects) => projects.flatMap(project =>
+      project.sessions.flatMap(session =>
+        session.turns.flatMap(turn => turn.assistantCalls.map(call => ({
+          key: call.deduplicationKey, input: call.usage.inputTokens,
+        }))),
+      ),
+    ).sort((a, b) => a.key.localeCompare(b.key))
+    expect(summarizeProjects(secondProjects)).toEqual(summarizeCachedCalls(second))
+
+    clearSessionCache()
+    const thirdProjects = await parseAllSessions(wideRange, 'antigravity')
+    const third = await cachedAntigravitySnapshot(dbPath)
+    expect(summarizeCachedCalls(third)).toEqual(summarizeCachedCalls(second))
+    expect(summarizeProjects(thirdProjects)).toEqual(summarizeProjects(secondProjects))
+    expect(new Set(summarizeCachedCalls(third).map(call => call.key)).size).toBe(3)
   })
 
   it('preserves durable orphan usage after source pruning and a cache fingerprint change', async () => {

--- a/tests/parser-antigravity-timestamp.test.ts
+++ b/tests/parser-antigravity-timestamp.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, readFile, rm, utimes } from 'fs/promises'
+import { mkdir, mkdtemp, readFile, rm, utimes, writeFile } from 'fs/promises'
 import { tmpdir } from 'os'
 import { join } from 'path'
 import { createRequire } from 'node:module'
@@ -149,5 +149,53 @@ describe('Antigravity timestamp stability across .db rewrites', () => {
       ),
     )
     expect(todayKeys).toHaveLength(0)
+  })
+
+  it('preserves durable orphan usage after source pruning and a cache fingerprint change', async () => {
+    if (!isSqliteAvailable()) return
+
+    const fixture = JSON.parse(await readFile(
+      new URL('./fixtures/antigravity-cli-current/gen-metadata.json', import.meta.url),
+      'utf-8',
+    )) as Fixture
+    const conversationsDir = join(home, '.gemini', 'antigravity-ide', 'conversations')
+    await mkdir(conversationsDir, { recursive: true })
+    const dbPath = join(conversationsDir, `${fixture.conversationId}.db`)
+    createGenMetadataDb(dbPath, fixture)
+
+    const wideRange: DateRange = {
+      start: new Date('2026-01-01T00:00:00.000Z'),
+      end: new Date('2026-12-31T23:59:59.999Z'),
+    }
+
+    const firstProjects = await parseAllSessions(wideRange, 'antigravity')
+    const firstKeys = firstProjects.flatMap(project =>
+      project.sessions.flatMap(session =>
+        session.turns.flatMap(turn => turn.assistantCalls.map(call => call.deduplicationKey)),
+      ),
+    )
+    expect(firstKeys.length).toBeGreaterThan(0)
+
+    const saved = JSON.parse(await readFile(sessionCachePath(), 'utf-8')) as {
+      providers: Record<string, { envFingerprint: string; durable?: boolean }>
+    }
+    saved.providers['antigravity']!.envFingerprint = 'stale-antigravity-fingerprint'
+    await writeFile(sessionCachePath(), JSON.stringify(saved))
+    await rm(dbPath)
+
+    clearSessionCache()
+    const secondProjects = await parseAllSessions(wideRange, 'antigravity')
+    const secondKeys = secondProjects.flatMap(project =>
+      project.sessions.flatMap(session =>
+        session.turns.flatMap(turn => turn.assistantCalls.map(call => call.deduplicationKey)),
+      ),
+    )
+
+    expect(secondKeys).toEqual(firstKeys)
+    expect((await cachedAntigravityTurns(cacheDir, dbPath)).length).toBeGreaterThan(0)
+    const migrated = JSON.parse(await readFile(sessionCachePath(), 'utf-8')) as {
+      providers: Record<string, { durable?: boolean }>
+    }
+    expect(migrated.providers['antigravity']?.durable).toBe(true)
   })
 })

--- a/tests/parser-antigravity-timestamp.test.ts
+++ b/tests/parser-antigravity-timestamp.test.ts
@@ -91,8 +91,8 @@ describe('Antigravity timestamp stability across .db rewrites', () => {
     createGenMetadataDb(dbPath, fixture)
 
     // The fixture row carries no ChatStartMetadata.created_at, so the call
-    // inherits the file mtime as its first-seen fallback. Pin it to January.
-    const firstSeen = new Date('2026-01-02T03:04:05.000Z')
+    // inherits the file mtime as its first-seen fallback. Pin it to July.
+    const firstSeen = new Date('2026-07-02T03:04:05.000Z')
     await utimes(dbPath, firstSeen, firstSeen)
 
     const wideRange: DateRange = {
@@ -116,30 +116,30 @@ describe('Antigravity timestamp stability across .db rewrites', () => {
     // source is cleared and reparsed, but the dedup key must retain its
     // first-seen time rather than jumping to the new mtime.
     clearSessionCache()
-    const rewritten = new Date('2026-06-07T08:09:10.000Z')
+    const rewritten = new Date('2026-07-07T08:09:10.000Z')
     await utimes(dbPath, rewritten, rewritten)
     await parseAllSessions(wideRange, 'antigravity')
     const afterRewrite = await cachedAntigravityTurns(cacheDir, dbPath)
     expect(afterRewrite[0]!.timestamp).toBe(firstTs)
     expect(Math.abs(new Date(afterRewrite[0]!.timestamp).getTime() - rewritten.getTime())).toBeGreaterThan(1000)
 
-    // Date-range consequence: a January-only range still includes the call
-    // after the June rewrite, because its timestamp stayed in January.
+    // Date-range consequence: the first-seen month still includes the call
+    // after the July rewrite, because its timestamp stayed in early July.
     clearSessionCache()
-    const januaryRange: DateRange = {
-      start: new Date('2026-01-01T00:00:00.000Z'),
-      end: new Date('2026-01-31T23:59:59.999Z'),
+    const firstSeenMonthRange: DateRange = {
+      start: new Date('2026-07-01T00:00:00.000Z'),
+      end: new Date('2026-07-31T23:59:59.999Z'),
     }
-    const januaryProjects = await parseAllSessions(januaryRange, 'antigravity')
-    const januaryKeys = januaryProjects.flatMap(project =>
+    const firstSeenMonthProjects = await parseAllSessions(firstSeenMonthRange, 'antigravity')
+    const firstSeenMonthKeys = firstSeenMonthProjects.flatMap(project =>
       project.sessions.flatMap(session =>
         session.turns.flatMap(turn => turn.assistantCalls.map(call => call.deduplicationKey)),
       ),
     )
-    expect(januaryKeys.length).toBeGreaterThan(0)
+    expect(firstSeenMonthKeys.length).toBeGreaterThan(0)
 
-    // `today` must NOT include the call: first-seen is January, not "now",
-    // even though the file mtime was rewritten to June (and wall-clock is later).
+    // `today` must NOT include the call: first-seen is in July, not "now",
+    // even though the file mtime was rewritten within July.
     clearSessionCache()
     const { range: todayRange } = getDateRange('today')
     const todayProjects = await parseAllSessions(todayRange, 'antigravity')

--- a/tests/parser.test.ts
+++ b/tests/parser.test.ts
@@ -14,7 +14,7 @@ import { createRequire } from 'node:module'
 
 import { isSqliteAvailable } from '../src/sqlite.js'
 import { clearSessionCache, parseAllSessions } from '../src/parser.js'
-import { loadCache, saveCache, sessionCachePath } from '../src/session-cache.js'
+import { loadCache, PROVIDER_PARSE_VERSIONS, saveCache, sessionCachePath } from '../src/session-cache.js'
 import type { SessionSource, SessionParser, ParsedProviderCall } from '../src/providers/types.js'
 
 // ── Synthetic provider state ───────────────────────────────────────────────
@@ -171,6 +171,14 @@ function totalOutput(projects: Awaited<ReturnType<typeof parseAllSessions>>): nu
     .flatMap(s => s.turns)
     .flatMap(t => t.assistantCalls)
     .reduce((s, c) => s + c.usage.outputTokens, 0)
+}
+
+function totalInput(projects: Awaited<ReturnType<typeof parseAllSessions>>): number {
+  return projects
+    .flatMap(p => p.sessions)
+    .flatMap(s => s.turns)
+    .flatMap(t => t.assistantCalls)
+    .reduce((s, c) => s + c.usage.inputTokens, 0)
 }
 
 // ── Common env setup ──────────────────────────────────────────────────────
@@ -432,31 +440,96 @@ describe('(f) durable orphans survive a parse-version bump', () => {
     vi.stubEnv('METRORA_COPILOT_DISABLE_OTEL', '1')
     vi.stubEnv('METRORA_COPILOT_WS_STORAGE_DIR', join(tmpHome, 'no-ws'))
 
-    // Parse once so the session is cached, then prune the source: the cache
-    // entry becomes a durable orphan (its only record).
+    // Parse once so the session is cached, then rewrite the still-present
+    // source with corrected usage. A fingerprint bump must replace its key.
     const eventsPath = await createJsonlSession(sessionStateDir, 'sess-bump', 200)
     const before = totalOutput(await parseAllSessions(undefined, 'copilot'))
     expect(before).toBe(200)
-    await unlink(eventsPath)
-    clearSessionCache()
 
     // Simulate the fingerprint a PREVIOUS release computed (any mismatching
     // value takes the same code path as a real parse-version bump).
     const { readFile, writeFile: writeFileFs } = await import('fs/promises')
     const cachePath = sessionCachePath()
-    const disk = JSON.parse(await readFile(cachePath, 'utf-8')) as { providers: Record<string, { envFingerprint: string }> }
-    expect(disk.providers['copilot']).toBeDefined()
-    disk.providers['copilot']!.envFingerprint = '0000000000000000'
-    await writeFileFs(cachePath, JSON.stringify(disk), 'utf-8')
+    const setStaleFingerprint = async (): Promise<void> => {
+      const disk = JSON.parse(await readFile(cachePath, 'utf-8')) as { providers: Record<string, { envFingerprint: string }> }
+      expect(disk.providers['copilot']).toBeDefined()
+      disk.providers['copilot']!.envFingerprint = '0000000000000000'
+      await writeFileFs(cachePath, JSON.stringify(disk), 'utf-8')
+    }
+
+    await createJsonlSession(sessionStateDir, 'sess-bump', 240)
+    clearSessionCache()
+    await setStaleFingerprint()
+    expect(totalOutput(await parseAllSessions(undefined, 'copilot'))).toBe(240)
+
+    // Delete the source (simulates VS Code / CLI pruning it): the corrected
+    // entry becomes a durable orphan (its only record).
+    await unlink(eventsPath)
+    clearSessionCache()
+    await setStaleFingerprint()
 
     // First parse after the "upgrade": the orphan must still be counted and
     // must survive in the rewritten cache, not be erased with the section.
     const after = totalOutput(await parseAllSessions(undefined, 'copilot'))
-    expect(after).toBe(200)
+    expect(after).toBe(240)
 
     clearSessionCache()
     const again = totalOutput(await parseAllSessions(undefined, 'copilot'))
-    expect(again).toBe(200)
+    expect(again).toBe(240)
+  })
+})
+
+describe('(h) fresh durable accounting wins over carried entries on a parser bump', () => {
+  it('replaces a present K=100 source with K=120 while retaining a missing orphan', async () => {
+    const fileA = join(tmpHome, 'synth-authority-a.txt')
+    const fileB = join(tmpHome, 'synth-authority-orphan.txt')
+    await writeFile(fileA, 'source-a')
+    await writeFile(fileB, 'source-b')
+
+    const call = (deduplicationKey: string, inputTokens: number): ParsedProviderCall => ({
+      provider: 'test-synthetic', model: 'gpt-4o',
+      inputTokens, outputTokens: 1,
+      cacheCreationInputTokens: 0, cacheReadInputTokens: 0,
+      cachedInputTokens: 0, reasoningTokens: 0, webSearchRequests: 0,
+      costUSD: 0.001, tools: [], bashCommands: [],
+      timestamp: '2026-08-01T00:00:00.000Z', speed: 'standard',
+      deduplicationKey, userMessage: '', sessionId: deduplicationKey,
+    })
+
+    _synthDurable = true
+    _synthSources = [{ path: fileA, project: 'test', provider: 'test-synthetic' }]
+    _synthYields = [call('K', 100)]
+    expect(totalInput(await parseAllSessions(undefined, 'test-synthetic'))).toBe(100)
+
+    // Add a second physical source so its usage is cached under a distinct
+    // path, then remove that source before the parser fingerprint changes.
+    _synthSources = [
+      { path: fileA, project: 'test', provider: 'test-synthetic' },
+      { path: fileB, project: 'test', provider: 'test-synthetic' },
+    ]
+    _synthYields = [call('ORPHAN', 7)]
+    clearSessionCache()
+    expect(totalInput(await parseAllSessions(undefined, 'test-synthetic'))).toBe(107)
+
+    await unlink(fileB)
+    _synthSources = [{ path: fileA, project: 'test', provider: 'test-synthetic' }]
+    _synthYields = [call('K', 120)]
+    const previousVersion = PROVIDER_PARSE_VERSIONS['test-synthetic']
+    PROVIDER_PARSE_VERSIONS['test-synthetic'] = `${previousVersion ?? 'v1'}-bump`
+    try {
+      clearSessionCache()
+      const projects = await parseAllSessions(undefined, 'test-synthetic')
+      expect(totalInput(projects)).toBe(127)
+      const calls = projects.flatMap(project => project.sessions)
+        .flatMap(session => session.turns)
+        .flatMap(turn => turn.assistantCalls)
+      expect(calls.filter(c => c.deduplicationKey === 'K')).toHaveLength(1)
+      expect(calls.find(c => c.deduplicationKey === 'K')!.usage.inputTokens).toBe(120)
+      expect(calls.find(c => c.deduplicationKey === 'ORPHAN')!.usage.inputTokens).toBe(7)
+    } finally {
+      if (previousVersion === undefined) delete PROVIDER_PARSE_VERSIONS['test-synthetic']
+      else PROVIDER_PARSE_VERSIONS['test-synthetic'] = previousVersion
+    }
   })
 })
 

--- a/tests/providers/antigravity.test.ts
+++ b/tests/providers/antigravity.test.ts
@@ -406,6 +406,63 @@ describe('antigravity provider helpers', () => {
     await rm(tempHome, { recursive: true, force: true })
   })
 
+  it('unions real roots by native cascade identity and exposes the same roots to doctor', async () => {
+    const tempHome = await mkdtemp(join(tmpdir(), 'metrora-antigravity-root-union-'))
+    const cacheDir = join(tempHome, 'cache')
+    const previousHome = process.env['HOME']
+    const previousUserProfile = process.env['USERPROFILE']
+    const previousCacheDir = process.env['METRORA_CACHE_DIR']
+
+    try {
+      process.env['HOME'] = tempHome
+      process.env['USERPROFILE'] = tempHome
+      process.env['METRORA_CACHE_DIR'] = cacheDir
+
+      const appConversations = join(tempHome, '.gemini', 'antigravity', 'conversations')
+      const appImplicit = join(tempHome, '.gemini', 'antigravity', 'implicit')
+      const ideConversations = join(tempHome, '.gemini', 'antigravity-ide', 'conversations')
+      const ideImplicit = join(tempHome, '.gemini', 'antigravity-ide', 'implicit')
+      await Promise.all([
+        mkdir(appConversations, { recursive: true }),
+        mkdir(appImplicit, { recursive: true }),
+        mkdir(ideConversations, { recursive: true }),
+        mkdir(ideImplicit, { recursive: true }),
+      ])
+
+      // The SQLite source is authoritative over a same-ID protobuf copy.
+      await writeFile(join(appConversations, 'shared-cascade.pb'), '')
+      await writeFile(join(ideConversations, 'shared-cascade.db'), '')
+      // Identical implicit mirrors collapse to one native cascade as well.
+      await writeFile(join(appImplicit, 'implicit-cascade.pb'), '')
+      await writeFile(join(ideImplicit, 'implicit-cascade.pb'), '')
+
+      const sources = await discoverAntigravitySessionSources()
+      expect(sources.filter(source => antigravityCascadeIdFromPath(source.path) === 'shared-cascade')).toEqual([
+        { path: join(ideConversations, 'shared-cascade.db'), project: 'antigravity-ide', provider: 'antigravity' },
+      ])
+      expect(sources.filter(source => antigravityCascadeIdFromPath(source.path) === 'implicit-cascade')).toEqual([
+        { path: join(appImplicit, 'implicit-cascade.pb'), project: 'antigravity', provider: 'antigravity' },
+      ])
+
+      const roots = await createAntigravityProvider().probeRoots?.()
+      expect(roots?.map(root => root.label)).toEqual([
+        'conversations', 'implicit',
+        'conversations', 'implicit',
+        'conversations', 'implicit',
+        'statusline',
+      ])
+      expect(roots?.at(-1)?.path).toBe(join(cacheDir, 'antigravity-statusline.jsonl'))
+    } finally {
+      if (previousHome === undefined) delete process.env['HOME']
+      else process.env['HOME'] = previousHome
+      if (previousUserProfile === undefined) delete process.env['USERPROFILE']
+      else process.env['USERPROFILE'] = previousUserProfile
+      if (previousCacheDir === undefined) delete process.env['METRORA_CACHE_DIR']
+      else process.env['METRORA_CACHE_DIR'] = previousCacheDir
+      await rm(tempHome, { recursive: true, force: true })
+    }
+  })
+
   it('displays Gemini 3.5 Flash thinking variants as the base model', () => {
     const provider = createAntigravityProvider()
 
@@ -864,6 +921,18 @@ describe('antigravity provider helpers', () => {
               userMessage: '', sessionId: fixture.conversationId,
             }],
           },
+          orphanedCascade: {
+            mtimeMs: 0,
+            sizeBytes: 0,
+            calls: [{
+              provider: 'antigravity', model: 'gemini-3.6-flash', inputTokens: 2, outputTokens: 1,
+              cacheCreationInputTokens: 0, cacheReadInputTokens: 0, cachedInputTokens: 0,
+              reasoningTokens: 0, webSearchRequests: 0, costUSD: 0, tools: [], bashCommands: [],
+              timestamp: '2026-08-01T00:00:00.000Z', speed: 'standard',
+              deduplicationKey: 'antigravity:orphanedCascade:response', userMessage: '',
+              sessionId: 'orphanedCascade',
+            }],
+          },
         },
       }))
 
@@ -879,6 +948,7 @@ describe('antigravity provider helpers', () => {
         version: 6,
         cascades: { [fixture.conversationId]: { parserVersion: 6 } },
       })
+      expect(migrated.cascades.orphanedCascade.calls).toHaveLength(1)
 
       resetAntigravityMemoryCacheForTests()
       const second = await collectAntigravityCalls(source)

--- a/tests/providers/antigravity.test.ts
+++ b/tests/providers/antigravity.test.ts
@@ -21,9 +21,11 @@ import {
   reconcileAntigravityStatusLineCalls,
   recordAntigravityStatusLinePayload,
   resetAntigravityMemoryCacheForTests,
+  setAntigravityRpcDataForTests,
+  snapshotAntigravityStatusLinePayload,
   shouldReparseAntigravitySource,
 } from '../../src/providers/antigravity.js'
-import type { ParsedProviderCall } from '../../src/providers/types.js'
+import type { ParsedProviderCall, SessionSource } from '../../src/providers/types.js'
 
 const requireForTest = createRequire(import.meta.url)
 
@@ -57,11 +59,26 @@ function createCurrentAntigravityCliDb(dbPath: string, fixture: CurrentCliFixtur
   }
 }
 
-async function collectAntigravityCalls(source: { path: string; project: string; provider: string }): Promise<ParsedProviderCall[]> {
+async function collectAntigravityCalls(source: SessionSource): Promise<ParsedProviderCall[]> {
   const parser = createAntigravityProvider().createSessionParser(source, new Set())
   const calls: ParsedProviderCall[] = []
   for await (const call of parser.parse()) calls.push(call)
   return calls
+}
+
+function rpcData(responseId: string) {
+  return {
+    metadata: [{
+      chatModel: {
+        model: 'gemini-3-pro',
+        usage: {
+          model: 'gemini-3-pro', inputTokens: '10', outputTokens: '4',
+          apiProvider: 'google', responseId,
+        },
+      },
+    }],
+    modelMap: {},
+  }
 }
 
 describe('antigravity provider helpers', () => {
@@ -438,10 +455,16 @@ describe('antigravity provider helpers', () => {
 
       const sources = await discoverAntigravitySessionSources()
       expect(sources.filter(source => antigravityCascadeIdFromPath(source.path) === 'shared-cascade')).toEqual([
-        { path: join(ideConversations, 'shared-cascade.db'), project: 'antigravity-ide', provider: 'antigravity' },
+        {
+          path: join(ideConversations, 'shared-cascade.db'), project: 'antigravity-ide', provider: 'antigravity',
+          alternateLocators: [{ path: join(appConversations, 'shared-cascade.pb'), project: 'antigravity', provider: 'antigravity' }],
+        },
       ])
       expect(sources.filter(source => antigravityCascadeIdFromPath(source.path) === 'implicit-cascade')).toEqual([
-        { path: join(appImplicit, 'implicit-cascade.pb'), project: 'antigravity', provider: 'antigravity' },
+        {
+          path: join(appImplicit, 'implicit-cascade.pb'), project: 'antigravity', provider: 'antigravity',
+          alternateLocators: [{ path: join(ideImplicit, 'implicit-cascade.pb'), project: 'antigravity-ide', provider: 'antigravity' }],
+        },
       ])
 
       const roots = await createAntigravityProvider().probeRoots?.()
@@ -453,6 +476,173 @@ describe('antigravity provider helpers', () => {
       ])
       expect(roots?.at(-1)?.path).toBe(join(cacheDir, 'antigravity-statusline.jsonl'))
     } finally {
+      if (previousHome === undefined) delete process.env['HOME']
+      else process.env['HOME'] = previousHome
+      if (previousUserProfile === undefined) delete process.env['USERPROFILE']
+      else process.env['USERPROFILE'] = previousUserProfile
+      if (previousCacheDir === undefined) delete process.env['METRORA_CACHE_DIR']
+      else process.env['METRORA_CACHE_DIR'] = previousCacheDir
+      await rm(tempHome, { recursive: true, force: true })
+    }
+  })
+
+  it('keeps alternate PB locators and falls back across appDataDir without double counting', async () => {
+    const tempHome = await mkdtemp(join(tmpdir(), 'metrora-antigravity-rpc-locators-'))
+    const previousHome = process.env['HOME']
+    const previousUserProfile = process.env['USERPROFILE']
+    const previousCacheDir = process.env['METRORA_CACHE_DIR']
+    const cacheDir = join(tempHome, 'cache')
+
+    try {
+      process.env['HOME'] = tempHome
+      process.env['USERPROFILE'] = tempHome
+      process.env['METRORA_CACHE_DIR'] = cacheDir
+      const appDir = join(tempHome, '.gemini', 'antigravity', 'conversations')
+      const ideDir = join(tempHome, '.gemini', 'antigravity-ide', 'conversations')
+      await mkdir(appDir, { recursive: true })
+      await mkdir(ideDir, { recursive: true })
+
+      for (const id of ['pb-fallback', 'pb-both', 'pb-blocked']) {
+        await writeFile(join(appDir, `${id}.pb`), '')
+        await writeFile(join(ideDir, `${id}.pb`), '')
+      }
+
+      const roots = [
+        { dir: appDir, project: 'antigravity', extensions: ['.pb'] as const },
+        { dir: ideDir, project: 'antigravity-ide', extensions: ['.pb'] as const },
+      ]
+      const discovered = await discoverAntigravitySessionSources(roots)
+      const fallbackSource = discovered.find(source => antigravityCascadeIdFromPath(source.path) === 'pb-fallback')!
+      expect(fallbackSource.alternateLocators).toEqual([{
+        path: join(ideDir, 'pb-fallback.pb'), project: 'antigravity-ide', provider: 'antigravity',
+      }])
+
+      const attempts: string[] = []
+      setAntigravityRpcDataForTests(async (appDataDir, cascadeId) => {
+        attempts.push(`${cascadeId}:${appDataDir}`)
+        if (cascadeId === 'pb-fallback') {
+          return appDataDir === 'antigravity-ide' ? rpcData('fallback-response') : null
+        }
+        if (cascadeId === 'pb-both') return rpcData('both-response')
+        return null
+      })
+
+      const fallbackCalls = await collectAntigravityCalls(fallbackSource)
+      expect(fallbackCalls).toHaveLength(1)
+      expect(fallbackCalls[0]!.deduplicationKey).toBe('antigravity:pb-fallback:fallback-response')
+      expect(attempts).toEqual(['pb-fallback:antigravity', 'pb-fallback:antigravity-ide'])
+
+      attempts.length = 0
+      const bothSource = discovered.find(source => antigravityCascadeIdFromPath(source.path) === 'pb-both')!
+      const bothCalls = await collectAntigravityCalls(bothSource)
+      expect(bothCalls).toHaveLength(1)
+      expect(attempts).toEqual(['pb-both:antigravity'])
+
+      attempts.length = 0
+      const blockedSource = discovered.find(source => antigravityCascadeIdFromPath(source.path) === 'pb-blocked')!
+      expect(await collectAntigravityCalls(blockedSource)).toEqual([])
+      expect(attempts).toEqual(['pb-blocked:antigravity', 'pb-blocked:antigravity-ide'])
+    } finally {
+      resetAntigravityMemoryCacheForTests()
+      if (previousHome === undefined) delete process.env['HOME']
+      else process.env['HOME'] = previousHome
+      if (previousUserProfile === undefined) delete process.env['USERPROFILE']
+      else process.env['USERPROFILE'] = previousUserProfile
+      if (previousCacheDir === undefined) delete process.env['METRORA_CACHE_DIR']
+      else process.env['METRORA_CACHE_DIR'] = previousCacheDir
+      await rm(tempHome, { recursive: true, force: true })
+    }
+  })
+
+  it('keeps SQLite primary and uses an alternate RPC locator when the DB has no usage', async () => {
+    if (!isSqliteAvailable()) return
+
+    const tempHome = await mkdtemp(join(tmpdir(), 'metrora-antigravity-db-rpc-'))
+    const previousCacheDir = process.env['METRORA_CACHE_DIR']
+    process.env['METRORA_CACHE_DIR'] = join(tempHome, 'cache')
+    const appDir = join(tempHome, '.gemini', 'antigravity', 'conversations')
+    const ideDir = join(tempHome, '.gemini', 'antigravity-ide', 'conversations')
+
+    try {
+      await mkdir(appDir, { recursive: true })
+      await mkdir(ideDir, { recursive: true })
+      const fixture = JSON.parse(await readFile(
+        new URL('../fixtures/antigravity-cli-current/gen-metadata.json', import.meta.url),
+        'utf-8',
+      )) as CurrentCliFixture
+      const primaryDb = join(appDir, `${fixture.conversationId}.db`)
+      createCurrentAntigravityCliDb(primaryDb, fixture)
+      await writeFile(join(ideDir, `${fixture.conversationId}.pb`), '')
+
+      const emptyId = 'empty-db-rpc-fallback'
+      const emptyDb = join(appDir, `${emptyId}.db`)
+      createCurrentAntigravityCliDb(emptyDb, { conversationId: emptyId, rows: [] })
+      await writeFile(join(ideDir, `${emptyId}.pb`), '')
+      const roots = [
+        { dir: appDir, project: 'antigravity', extensions: ['.db'] as const },
+        { dir: ideDir, project: 'antigravity-ide', extensions: ['.pb'] as const },
+      ]
+      const sources = await discoverAntigravitySessionSources(roots)
+      const primarySource = sources.find(source => antigravityCascadeIdFromPath(source.path) === fixture.conversationId)!
+      const emptySource = sources.find(source => antigravityCascadeIdFromPath(source.path) === emptyId)!
+      const attempts: string[] = []
+
+      setAntigravityRpcDataForTests(async (appDataDir, cascadeId) => {
+        attempts.push(`${cascadeId}:${appDataDir}`)
+        return cascadeId === emptyId && appDataDir === 'antigravity-ide'
+          ? rpcData('empty-db-rpc-response')
+          : null
+      })
+
+      const primaryCalls = await collectAntigravityCalls(primarySource)
+      expect(primaryCalls).toHaveLength(1)
+      expect(primaryCalls[0]!.deduplicationKey).toContain(`${fixture.conversationId}:fixture-response-1`)
+      expect(attempts).toEqual([])
+
+      const emptyCalls = await collectAntigravityCalls(emptySource)
+      expect(emptyCalls).toHaveLength(1)
+      expect(emptyCalls[0]!.deduplicationKey).toBe(`antigravity:${emptyId}:empty-db-rpc-response`)
+      expect(attempts).toEqual([`${emptyId}:antigravity`, `${emptyId}:antigravity-ide`])
+    } finally {
+      resetAntigravityMemoryCacheForTests()
+      if (previousCacheDir === undefined) delete process.env['METRORA_CACHE_DIR']
+      else process.env['METRORA_CACHE_DIR'] = previousCacheDir
+      await rm(tempHome, { recursive: true, force: true })
+    }
+  })
+
+  it('finds an IDE alternate locator for the statusline snapshot path', async () => {
+    const tempHome = await mkdtemp(join(tmpdir(), 'metrora-antigravity-statusline-locator-'))
+    const previousHome = process.env['HOME']
+    const previousUserProfile = process.env['USERPROFILE']
+    const previousCacheDir = process.env['METRORA_CACHE_DIR']
+    const cacheDir = join(tempHome, 'cache')
+
+    try {
+      process.env['HOME'] = tempHome
+      process.env['USERPROFILE'] = tempHome
+      process.env['METRORA_CACHE_DIR'] = cacheDir
+      const appDir = join(tempHome, '.gemini', 'antigravity', 'conversations')
+      const ideDir = join(tempHome, '.gemini', 'antigravity-ide', 'conversations')
+      await mkdir(appDir, { recursive: true })
+      await mkdir(ideDir, { recursive: true })
+      await writeFile(join(appDir, 'statusline-shared.pb'), '')
+      await writeFile(join(ideDir, 'statusline-shared.pb'), '')
+
+      const attempts: string[] = []
+      setAntigravityRpcDataForTests(async appDataDir => {
+        attempts.push(appDataDir)
+        return appDataDir === 'antigravity-ide' ? rpcData('statusline-response') : null
+      })
+
+      expect(await snapshotAntigravityStatusLinePayload({
+        conversation_id: 'statusline-shared',
+        model: 'gemini-3-pro',
+        context_window: { current_usage: { input_tokens: 10, output_tokens: 4 } },
+      })).toBe(true)
+      expect(attempts).toEqual(['antigravity-ide'])
+    } finally {
+      resetAntigravityMemoryCacheForTests()
       if (previousHome === undefined) delete process.env['HOME']
       else process.env['HOME'] = previousHome
       if (previousUserProfile === undefined) delete process.env['USERPROFILE']
@@ -948,7 +1138,7 @@ describe('antigravity provider helpers', () => {
         version: 6,
         cascades: { [fixture.conversationId]: { parserVersion: 6 } },
       })
-      expect(migrated.cascades.orphanedCascade.calls).toHaveLength(1)
+      expect(migrated.cascades.orphanedCascade).toBeUndefined()
 
       resetAntigravityMemoryCacheForTests()
       const second = await collectAntigravityCalls(source)


### PR DESCRIPTION
## Summary

- discover Antigravity conversation and implicit roots as one native cascade identity while retaining alternate physical locators for safe RPC fallback
- keep direct SQLite usage authoritative, fall back across matching app/CLI/IDE RPC routes when local usage is unavailable, and avoid duplicate accounting
- preserve durable history when sources are pruned while allowing fresh present-source accounting to replace stale values for the same native generation identity
- keep detailed cache retention bounded and preserve stable timestamps across source rewrites
- expose the same Antigravity roots through the existing doctor/probe contract

## Validation

- 222 focused Antigravity/parser/session-cache/Copilot regression tests passed
- TypeScript typecheck passed
- source-size ratchet passed
- `git diff --check` passed

No release, tag, packaging, or workflow behavior is changed by this PR.