### PR TITLE
fix(accounting): reconcile source completeness and durable history

### DIFF
--- a/src/codex-cache.ts
+++ b/src/codex-cache.ts
@@ -16,7 +16,10 @@ import { getMetroraCacheDir } from './product-paths.js'
 // v8: persist native MCP timing and compact invocation attribution.
 // v9: persist explicit per-call reasoning attribution from turn_context.
 // v10: reprice raw Codex model ids carrying numeric context-capacity tags.
-const CODEX_CACHE_VERSION = 10
+// v11: legacy session_meta.payload.id is a native session identity fallback.
+// Reparse any surviving result-cache entries so their session identity cannot
+// remain pinned to the pre-v11 admission/identity contract.
+const CODEX_CACHE_VERSION = 11
 const CACHE_FILE = 'codex-results.json'
 
 type FileFingerprint = { mtimeMs: number; sizeBytes: number }

--- a/src/contracts/v1/collector-provenance.ts
+++ b/src/contracts/v1/collector-provenance.ts
@@ -77,7 +77,7 @@ export type IdentityProvenanceV1 = z.infer<typeof IdentityProvenanceSchema>
 export type CollectorCostProvenanceV1 = z.infer<typeof CollectorCostProvenanceSchema>
 export type CollectorProvenanceProfileV1 = z.infer<typeof CollectorProvenanceProfileV1Schema>
 
-const CLAUDE_PARSER_VERSION = 'advisor-usage-v1-skills-rich-capture-v1-cross-provider-pr-v1'
+const CLAUDE_PARSER_VERSION = 'advisor-usage-v1-skills-rich-capture-v1-cross-provider-pr-v1-native-id-reconciliation-v1'
 const CODEX_PARSER_VERSION = 'mcp-attribution-v5-est-cost-active-timing-mcp-wait-rich-capture-v1-cross-provider-pr-v1-reasoning-attribution-v1-pricing-context-tags-v1'
 const GEMINI_PARSER_VERSION = 'message-token-ledger-v1'
 const ZED_PARSER_VERSION = 'sqlite-zstd-ledger-v1-model-provider-v1'

--- a/src/daily-cache-config.ts
+++ b/src/daily-cache-config.ts
@@ -1,11 +1,11 @@
 import { getLocalModelSavingsConfigHash, getPriceOverridesConfigHash } from './models.js'
 import { runtimeHistoricalPricingCacheKeyV1 } from './pricing/runtime-cost-assignment.js'
-import { PROVIDER_PARSE_VERSIONS } from './session-cache.js'
 import {
   CODEX_LEGACY_SESSION_META_AUTHORITY,
+  COPILOT_CHAT_JOURNAL_AUTHORITY,
   ensureCodexLegacySessionMetaAuthority,
-} from './providers/codex-model-provider.js'
-import { COPILOT_CHAT_JOURNAL_AUTHORITY } from './providers/copilot-chat-journal.js'
+} from './provider-parse-authorities.js'
+import { PROVIDER_PARSE_VERSIONS } from './session-cache.js'
 
 /** Hashes every authority that can change a durable daily/model projection. */
 export function getDailyCacheConfigHash(): string {

--- a/src/daily-cache-config.ts
+++ b/src/daily-cache-config.ts
@@ -2,6 +2,8 @@ import { getLocalModelSavingsConfigHash, getPriceOverridesConfigHash } from './m
 import { runtimeHistoricalPricingCacheKeyV1 } from './pricing/runtime-cost-assignment.js'
 import { PROVIDER_PARSE_VERSIONS } from './session-cache.js'
 
+const COPILOT_CHAT_JOURNAL_AUTHORITY = 'current-chat-journal-v2'
+
 /** Hashes every authority that can change a durable daily/model projection. */
 export function getDailyCacheConfigHash(): string {
   const savingsHash = getLocalModelSavingsConfigHash()
@@ -12,6 +14,7 @@ export function getDailyCacheConfigHash(): string {
   return `historicalPricing=${runtimeHistoricalPricingCacheKeyV1()}`
     + `\u0002clineCollector=${PROVIDER_PARSE_VERSIONS['cline'] ?? ''}`
     + `\u0002copilotCollector=${PROVIDER_PARSE_VERSIONS['copilot'] ?? ''}`
+    + `\u0002copilotJournal=${COPILOT_CHAT_JOURNAL_AUTHORITY}`
     + `\u0002antigravityCollector=${PROVIDER_PARSE_VERSIONS['antigravity'] ?? ''}`
     + `\u0002opencodeCollector=${PROVIDER_PARSE_VERSIONS['opencode'] ?? ''}`
     + `\u0002modelIdentity=v3`

--- a/src/daily-cache-config.ts
+++ b/src/daily-cache-config.ts
@@ -2,6 +2,8 @@ import { getLocalModelSavingsConfigHash, getPriceOverridesConfigHash } from './m
 import { runtimeHistoricalPricingCacheKeyV1 } from './pricing/runtime-cost-assignment.js'
 import { PROVIDER_PARSE_VERSIONS } from './session-cache.js'
 
+const COPILOT_CHAT_JOURNAL_AUTHORITY = 'current-chat-journal-v2'
+
 /** Hashes every authority that can change a durable daily/model projection. */
 export function getDailyCacheConfigHash(): string {
   const savingsHash = getLocalModelSavingsConfigHash()
@@ -12,6 +14,8 @@ export function getDailyCacheConfigHash(): string {
   return `historicalPricing=${runtimeHistoricalPricingCacheKeyV1()}`
     + `\u0002clineCollector=${PROVIDER_PARSE_VERSIONS['cline'] ?? ''}`
     + `\u0002codexCollector=legacy-session-meta-v1`
+    + `\u0002copilotCollector=${PROVIDER_PARSE_VERSIONS['copilot'] ?? ''}`
+    + `\u0002copilotJournal=${COPILOT_CHAT_JOURNAL_AUTHORITY}`
     + `\u0002antigravityCollector=${PROVIDER_PARSE_VERSIONS['antigravity'] ?? ''}`
     + `\u0002opencodeCollector=${PROVIDER_PARSE_VERSIONS['opencode'] ?? ''}`
     + `\u0002modelIdentity=v3`

--- a/src/daily-cache-config.ts
+++ b/src/daily-cache-config.ts
@@ -1,14 +1,11 @@
 import { getLocalModelSavingsConfigHash, getPriceOverridesConfigHash } from './models.js'
 import { runtimeHistoricalPricingCacheKeyV1 } from './pricing/runtime-cost-assignment.js'
 import { PROVIDER_PARSE_VERSIONS } from './session-cache.js'
+import {
+  CODEX_LEGACY_SESSION_META_AUTHORITY,
+  ensureCodexLegacySessionMetaAuthority,
+} from './providers/codex-model-provider.js'
 import { COPILOT_CHAT_JOURNAL_AUTHORITY } from './providers/copilot-chat-journal.js'
-
-const CODEX_LEGACY_SESSION_META_AUTHORITY = 'legacy-session-meta-v1'
-
-function extendAuthority(base: string | undefined, authority: string): string {
-  if (!base) return authority
-  return base.includes(authority) ? base : `${base}-${authority}`
-}
 
 /** Hashes every authority that can change a durable daily/model projection. */
 export function getDailyCacheConfigHash(): string {
@@ -17,10 +14,10 @@ export function getDailyCacheConfigHash(): string {
   const accountingHash = overridesHash
     ? `localModelSavings=${savingsHash}\u0002priceOverrides=${overridesHash}`
     : savingsHash
-  const codexCollector = extendAuthority(
-    PROVIDER_PARSE_VERSIONS['codex'],
-    CODEX_LEGACY_SESSION_META_AUTHORITY,
-  )
+  const codexCollector = ensureCodexLegacySessionMetaAuthority()
+  if (!codexCollector.includes(CODEX_LEGACY_SESSION_META_AUTHORITY)) {
+    throw new Error('Codex legacy session-meta authority was not installed')
+  }
   return `historicalPricing=${runtimeHistoricalPricingCacheKeyV1()}`
     + `\u0002clineCollector=${PROVIDER_PARSE_VERSIONS['cline'] ?? ''}`
     + `\u0002codexCollector=${codexCollector}`

--- a/src/daily-cache-config.ts
+++ b/src/daily-cache-config.ts
@@ -13,6 +13,7 @@ export function getDailyCacheConfigHash(): string {
     : savingsHash
   return `historicalPricing=${runtimeHistoricalPricingCacheKeyV1()}`
     + `\u0002clineCollector=${PROVIDER_PARSE_VERSIONS['cline'] ?? ''}`
+    + `\u0002codexCollector=legacy-session-meta-v1`
     + `\u0002copilotCollector=${PROVIDER_PARSE_VERSIONS['copilot'] ?? ''}`
     + `\u0002copilotJournal=${COPILOT_CHAT_JOURNAL_AUTHORITY}`
     + `\u0002antigravityCollector=${PROVIDER_PARSE_VERSIONS['antigravity'] ?? ''}`

--- a/src/daily-cache-config.ts
+++ b/src/daily-cache-config.ts
@@ -11,6 +11,7 @@ export function getDailyCacheConfigHash(): string {
     : savingsHash
   return `historicalPricing=${runtimeHistoricalPricingCacheKeyV1()}`
     + `\u0002clineCollector=${PROVIDER_PARSE_VERSIONS['cline'] ?? ''}`
+    + `\u0002codexCollector=legacy-session-meta-v1`
     + `\u0002antigravityCollector=${PROVIDER_PARSE_VERSIONS['antigravity'] ?? ''}`
     + `\u0002opencodeCollector=${PROVIDER_PARSE_VERSIONS['opencode'] ?? ''}`
     + `\u0002modelIdentity=v3`

--- a/src/daily-cache-config.ts
+++ b/src/daily-cache-config.ts
@@ -11,6 +11,7 @@ export function getDailyCacheConfigHash(): string {
     : savingsHash
   return `historicalPricing=${runtimeHistoricalPricingCacheKeyV1()}`
     + `\u0002clineCollector=${PROVIDER_PARSE_VERSIONS['cline'] ?? ''}`
+    + `\u0002copilotCollector=${PROVIDER_PARSE_VERSIONS['copilot'] ?? ''}`
     + `\u0002antigravityCollector=${PROVIDER_PARSE_VERSIONS['antigravity'] ?? ''}`
     + `\u0002opencodeCollector=${PROVIDER_PARSE_VERSIONS['opencode'] ?? ''}`
     + `\u0002modelIdentity=v3`

--- a/src/daily-cache-config.ts
+++ b/src/daily-cache-config.ts
@@ -3,7 +3,9 @@ import { runtimeHistoricalPricingCacheKeyV1 } from './pricing/runtime-cost-assig
 import {
   CODEX_LEGACY_SESSION_META_AUTHORITY,
   COPILOT_CHAT_JOURNAL_AUTHORITY,
+  COPILOT_CLI_RESUME_AUTHORITY,
   ensureCodexLegacySessionMetaAuthority,
+  getProviderEnvConfigHash,
 } from './provider-parse-authorities.js'
 import { PROVIDER_PARSE_VERSIONS } from './session-cache.js'
 
@@ -19,10 +21,12 @@ export function getDailyCacheConfigHash(): string {
     throw new Error('Codex legacy session-meta authority was not installed')
   }
   return `historicalPricing=${runtimeHistoricalPricingCacheKeyV1()}`
+    + `\u0002providerEnv=${getProviderEnvConfigHash()}`
     + `\u0002clineCollector=${PROVIDER_PARSE_VERSIONS['cline'] ?? ''}`
     + `\u0002codexCollector=${codexCollector}`
     + `\u0002copilotCollector=${PROVIDER_PARSE_VERSIONS['copilot'] ?? ''}`
     + `\u0002copilotJournal=${COPILOT_CHAT_JOURNAL_AUTHORITY}`
+    + `\u0002copilotCliResume=${COPILOT_CLI_RESUME_AUTHORITY}`
     + `\u0002antigravityCollector=${PROVIDER_PARSE_VERSIONS['antigravity'] ?? ''}`
     + `\u0002opencodeCollector=${PROVIDER_PARSE_VERSIONS['opencode'] ?? ''}`
     + `\u0002modelIdentity=v3`

--- a/src/daily-cache-config.ts
+++ b/src/daily-cache-config.ts
@@ -1,8 +1,14 @@
 import { getLocalModelSavingsConfigHash, getPriceOverridesConfigHash } from './models.js'
 import { runtimeHistoricalPricingCacheKeyV1 } from './pricing/runtime-cost-assignment.js'
 import { PROVIDER_PARSE_VERSIONS } from './session-cache.js'
+import { COPILOT_CHAT_JOURNAL_AUTHORITY } from './providers/copilot-chat-journal.js'
 
-const COPILOT_CHAT_JOURNAL_AUTHORITY = 'current-chat-journal-v2'
+const CODEX_LEGACY_SESSION_META_AUTHORITY = 'legacy-session-meta-v1'
+
+function extendAuthority(base: string | undefined, authority: string): string {
+  if (!base) return authority
+  return base.includes(authority) ? base : `${base}-${authority}`
+}
 
 /** Hashes every authority that can change a durable daily/model projection. */
 export function getDailyCacheConfigHash(): string {
@@ -11,9 +17,13 @@ export function getDailyCacheConfigHash(): string {
   const accountingHash = overridesHash
     ? `localModelSavings=${savingsHash}\u0002priceOverrides=${overridesHash}`
     : savingsHash
+  const codexCollector = extendAuthority(
+    PROVIDER_PARSE_VERSIONS['codex'],
+    CODEX_LEGACY_SESSION_META_AUTHORITY,
+  )
   return `historicalPricing=${runtimeHistoricalPricingCacheKeyV1()}`
     + `\u0002clineCollector=${PROVIDER_PARSE_VERSIONS['cline'] ?? ''}`
-    + `\u0002codexCollector=legacy-session-meta-v1`
+    + `\u0002codexCollector=${codexCollector}`
     + `\u0002copilotCollector=${PROVIDER_PARSE_VERSIONS['copilot'] ?? ''}`
     + `\u0002copilotJournal=${COPILOT_CHAT_JOURNAL_AUTHORITY}`
     + `\u0002antigravityCollector=${PROVIDER_PARSE_VERSIONS['antigravity'] ?? ''}`

--- a/src/daily-cache-config.ts
+++ b/src/daily-cache-config.ts
@@ -22,6 +22,7 @@ export function getDailyCacheConfigHash(): string {
   }
   return `historicalPricing=${runtimeHistoricalPricingCacheKeyV1()}`
     + `\u0002providerEnv=${getProviderEnvConfigHash()}`
+    + `\u0002claudeCollector=${PROVIDER_PARSE_VERSIONS['claude'] ?? ''}`
     + `\u0002clineCollector=${PROVIDER_PARSE_VERSIONS['cline'] ?? ''}`
     + `\u0002codexCollector=${codexCollector}`
     + `\u0002copilotCollector=${PROVIDER_PARSE_VERSIONS['copilot'] ?? ''}`

--- a/src/daily-cache-core.ts
+++ b/src/daily-cache-core.ts
@@ -64,6 +64,10 @@ import { emptyModelStats, mergeModelStats, sanitizeModels } from './daily-cache-
 // user changes their `localModelSavings` mapping.
 export const DAILY_CACHE_VERSION = 18
 const MIN_SUPPORTED_VERSION = 15
+// A durable source is allowed to outlive the bounded detailed session cache.
+// This marker makes the first run after that contract change an explicit,
+// one-time reconciliation rather than relying on the ordinary 365-day poll.
+export const DURABLE_HISTORY_AUTHORITY = 'materialize-before-evict-v1'
 // Version-suffixed so different binaries each own a distinct file and never
 // clobber an incompatible schema. Bumping the version mints a fresh filename;
 // adoptOlderDailyCaches then unions days out of every previous file (including
@@ -157,6 +161,10 @@ export type DailyCache = {
   /// (same self-heal as `savingsConfigHash`). Absent on caches written before
   /// this field existed → not treated as a mismatch (no gratuitous rebuild).
   tzKey?: string
+  /// Durable-source evidence was materialized into the daily ledger under this
+  /// authority. Absent on pre-remediation caches, which triggers one wide
+  /// reconciliation when the caller opts into the authority.
+  durableHistoryAuthority?: string
   lastComputedDate: string | null
   days: DailyEntry[]
   /// True only once the full backfill window has been hydrated from a COMPLETE
@@ -190,7 +198,15 @@ export function emptyCache(savingsConfigHash = ''): DailyCache {
   return { version: DAILY_CACHE_VERSION, savingsConfigHash, tzKey: currentTzKey(), lastComputedDate: null, days: [], complete: false }
 }
 
-export function isMigratableCache(parsed: unknown): parsed is { version: number; lastComputedDate: string | null; savingsConfigHash?: string; tzKey?: string; days: Record<string, unknown>[]; complete?: boolean } {
+export function isMigratableCache(parsed: unknown): parsed is {
+  version: number
+  lastComputedDate: string | null
+  savingsConfigHash?: string
+  tzKey?: string
+  durableHistoryAuthority?: string
+  days: Record<string, unknown>[]
+  complete?: boolean
+} {
   if (!parsed || typeof parsed !== 'object') return false
   const c = parsed as Partial<DailyCache>
   if (typeof c.version !== 'number') return false
@@ -294,11 +310,22 @@ export function migrateDays(days: Record<string, unknown>[]): DailyEntry[] {
     }))
 }
 
-export function migratedFrom(parsed: { version: number; lastComputedDate: string | null; savingsConfigHash?: string; tzKey?: string; days: Record<string, unknown>[]; complete?: boolean }): DailyCache {
+export function migratedFrom(parsed: {
+  version: number
+  lastComputedDate: string | null
+  savingsConfigHash?: string
+  tzKey?: string
+  durableHistoryAuthority?: string
+  days: Record<string, unknown>[]
+  complete?: boolean
+}): DailyCache {
   return {
     version: DAILY_CACHE_VERSION,
     savingsConfigHash: parsed.savingsConfigHash ?? '',
     tzKey: parsed.tzKey,
+    ...(typeof parsed.durableHistoryAuthority === 'string'
+      ? { durableHistoryAuthority: parsed.durableHistoryAuthority }
+      : {}),
     lastComputedDate: typeof parsed.lastComputedDate === 'string' && DATE_KEY_RE.test(parsed.lastComputedDate)
       ? parsed.lastComputedDate
       : null,
@@ -327,7 +354,15 @@ export async function loadDailyCache(): Promise<DailyCache> {
   return adoptOlderDailyCaches()
 }
 
-type AdoptableCache = { version: number; lastComputedDate?: string | null; savingsConfigHash?: string; tzKey?: string; days: Record<string, unknown>[]; complete?: boolean }
+type AdoptableCache = {
+  version: number
+  lastComputedDate?: string | null
+  savingsConfigHash?: string
+  tzKey?: string
+  durableHistoryAuthority?: string
+  days: Record<string, unknown>[]
+  complete?: boolean
+}
 
 function isAdoptableCache(parsed: unknown): parsed is AdoptableCache {
   if (!parsed || typeof parsed !== 'object') return false
@@ -447,6 +482,9 @@ export function addNewDays(cache: DailyCache, incoming: DailyEntry[], newestDate
     version: DAILY_CACHE_VERSION,
     savingsConfigHash: cache.savingsConfigHash,
     tzKey: cache.tzKey,
+    ...(typeof cache.durableHistoryAuthority === 'string'
+      ? { durableHistoryAuthority: cache.durableHistoryAuthority }
+      : {}),
     lastComputedDate: nextLast,
     days: applyRetention(merged, newestDate),
     complete: cache.complete,
@@ -622,6 +660,13 @@ export const BACKFILL_DAYS = 365
 // well under 100 ms on the polling path.
 export const DAILY_CACHE_RETENTION_DAYS = 3650
 
+export type CacheHydrationOptions = {
+  /// Opt into the durable-source materialization contract. The first run with
+  /// a new authority scans the full durable daily-retention horizon; subsequent
+  /// runs return to BACKFILL_DAYS.
+  durableHistoryAuthority?: string
+}
+
 export function toDateString(date: Date): string {
   return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`
 }
@@ -640,6 +685,7 @@ export async function ensureCacheHydrated(
   /// So the backfill is only marked `complete` when this returns true. Defaults
   /// to a trusting `true` for callers that don't (or can't) supply it.
   sessionComplete: () => boolean = () => true,
+  options: CacheHydrationOptions = {},
 ): Promise<DailyCache> {
   const now = new Date()
   const todayStart = new Date(now.getFullYear(), now.getMonth(), now.getDate())
@@ -648,6 +694,9 @@ export async function ensureCacheHydrated(
 
   return withDailyCacheLock(async () => {
     let c = await loadDailyCache()
+    const durableHistoryAuthority = options.durableHistoryAuthority
+    const historyAuthorityChanged = durableHistoryAuthority !== undefined
+      && c.durableHistoryAuthority !== durableHistoryAuthority
 
     // Drop any cached entry dated today or later BEFORE anything else can
     // carry it forward. The cache only ever stores complete past days (up to
@@ -679,9 +728,10 @@ export async function ensureCacheHydrated(
     // into permanently lost history.
     const tzKey = currentTzKey()
     const tzChanged = c.tzKey !== undefined && c.tzKey !== tzKey
-    if (c.savingsConfigHash !== savingsConfigHash || c.complete !== true || tzChanged) {
+    if (c.savingsConfigHash !== savingsConfigHash || c.complete !== true || tzChanged || historyAuthorityChanged) {
       const baseline = c.days
-      const backfillStart = new Date(now.getFullYear(), now.getMonth(), now.getDate() - BACKFILL_DAYS)
+      const horizonDays = historyAuthorityChanged ? DAILY_CACHE_RETENTION_DAYS : BACKFILL_DAYS
+      const backfillStart = new Date(now.getFullYear(), now.getMonth(), now.getDate() - horizonDays)
       let freshDays: DailyEntry[] = []
       if (backfillStart.getTime() <= yesterdayEnd.getTime()) {
         freshDays = aggregateDays(await parseSessions({ start: backfillStart, end: yesterdayEnd }))
@@ -698,6 +748,11 @@ export async function ensureCacheHydrated(
         version: DAILY_CACHE_VERSION,
         savingsConfigHash,
         tzKey,
+        ...(durableHistoryAuthority !== undefined && parseWasComplete
+          ? { durableHistoryAuthority }
+          : typeof c.durableHistoryAuthority === 'string'
+            ? { durableHistoryAuthority: c.durableHistoryAuthority }
+            : {}),
         lastComputedDate: yesterdayStr,
         days: applyRetention(merged, yesterdayStr),
         complete: parseWasComplete,

--- a/src/daily-cache-tz-reconcile.ts
+++ b/src/daily-cache-tz-reconcile.ts
@@ -28,6 +28,17 @@ function hasSliceData(slice: ProviderDaySlice): boolean {
     || num(slice.oneShotTurns) > 0
 }
 
+function hasModelData(model: ModelDayStats): boolean {
+  return model.calls > 0
+    || model.cost > 0
+    || num(model.savingsUSD) > 0
+    || model.inputTokens > 0
+    || model.outputTokens > 0
+    || num(model.reasoningTokens) > 0
+    || model.cacheReadTokens > 0
+    || model.cacheWriteTokens > 0
+}
+
 function subtractModelStats(base: ModelDayStats, sub: ModelDayStats): ModelDayStats | null {
   const calls = Math.max(0, base.calls - num(sub.calls))
   const cost = Math.max(0, base.cost - num(sub.cost))
@@ -185,6 +196,24 @@ function projectDelta(base: ProjectDayStats, reduced: ProjectDayStats | undefine
   }
 }
 
+function refreshModelSourceProviders(day: DailyEntry, modelName: string): void {
+  const aggregate = Object.hasOwn(day.models, modelName) ? day.models[modelName] : undefined
+  if (!aggregate) return
+
+  let hasSliceEvidence = false
+  const providers: string[] = []
+  for (const [provider, slice] of Object.entries(day.providers)) {
+    if (!slice.models || !Object.hasOwn(slice.models, modelName)) continue
+    hasSliceEvidence = true
+    const stats = slice.models[modelName]
+    if (stats && hasModelData(stats)) providers.push(provider)
+  }
+  if (!hasSliceEvidence) return
+
+  if (providers.length > 0) aggregate.sourceProviders = [...new Set(providers)].sort()
+  else delete aggregate.sourceProviders
+}
+
 function subtractSliceFromDay(day: DailyEntry, provider: string, sub: ProviderDaySlice): void {
   const current = Object.hasOwn(day.providers, provider) ? day.providers[provider] : undefined
   if (!current) return
@@ -212,6 +241,7 @@ function subtractSliceFromDay(day: DailyEntry, provider: string, sub: ProviderDa
     const next = subtractModelStats(day.models[name]!, removed)
     if (next) setOwn(day.models, name, next)
     else delete day.models[name]
+    refreshModelSourceProviders(day, name)
   }
 
   for (const [name, stats] of Object.entries(current.categories ?? {})) {

--- a/src/daily-cache-tz-reconcile.ts
+++ b/src/daily-cache-tz-reconcile.ts
@@ -1,0 +1,318 @@
+import {
+  mergeDayEntries,
+  type CategoryDayStats,
+  type DailyEntry,
+  type ModelDayStats,
+  type ProjectDayStats,
+  type ProviderDaySlice,
+} from './daily-cache-core.js'
+
+function num(value: number | undefined): number {
+  return typeof value === 'number' && Number.isFinite(value) ? value : 0
+}
+
+function setOwn<T>(target: Record<string, T>, key: string, value: T): void {
+  Object.defineProperty(target, key, { value, enumerable: true, writable: true, configurable: true })
+}
+
+function hasSliceData(slice: ProviderDaySlice): boolean {
+  return slice.cost > 0
+    || slice.calls > 0
+    || num(slice.savingsUSD) > 0
+    || num(slice.inputTokens) > 0
+    || num(slice.outputTokens) > 0
+    || num(slice.reasoningTokens) > 0
+    || num(slice.cacheReadTokens) > 0
+    || num(slice.cacheWriteTokens) > 0
+    || num(slice.editTurns) > 0
+    || num(slice.oneShotTurns) > 0
+}
+
+function subtractModelStats(base: ModelDayStats, sub: ModelDayStats): ModelDayStats | null {
+  const calls = Math.max(0, base.calls - num(sub.calls))
+  const cost = Math.max(0, base.cost - num(sub.cost))
+  const savingsUSD = Math.max(0, num(base.savingsUSD) - num(sub.savingsUSD))
+  const inputTokens = Math.max(0, base.inputTokens - num(sub.inputTokens))
+  const outputTokens = Math.max(0, base.outputTokens - num(sub.outputTokens))
+  const reasoningTokens = Math.max(0, num(base.reasoningTokens) - num(sub.reasoningTokens))
+  const cacheReadTokens = Math.max(0, base.cacheReadTokens - num(sub.cacheReadTokens))
+  const cacheWriteTokens = Math.max(0, base.cacheWriteTokens - num(sub.cacheWriteTokens))
+
+  if (
+    calls === 0 && cost === 0 && savingsUSD === 0
+    && inputTokens === 0 && outputTokens === 0 && reasoningTokens === 0
+    && cacheReadTokens === 0 && cacheWriteTokens === 0
+  ) return null
+
+  return {
+    calls,
+    cost,
+    savingsUSD,
+    inputTokens,
+    outputTokens,
+    ...(base.reasoningTokens !== undefined || sub.reasoningTokens !== undefined ? { reasoningTokens } : {}),
+    cacheReadTokens,
+    cacheWriteTokens,
+    ...(base.modelProvider ? { modelProvider: base.modelProvider } : {}),
+    ...(base.sourceProviders?.length ? { sourceProviders: [...base.sourceProviders] } : {}),
+  }
+}
+
+function subtractModels(
+  base: Record<string, ModelDayStats> | undefined,
+  sub: Record<string, ModelDayStats> | undefined,
+): Record<string, ModelDayStats> | undefined {
+  if (!base) return undefined
+  const out: Record<string, ModelDayStats> = {}
+  for (const [name, stats] of Object.entries(base)) {
+    const reduced = sub && Object.hasOwn(sub, name) ? subtractModelStats(stats, sub[name]!) : structuredClone(stats)
+    if (reduced) setOwn(out, name, reduced)
+  }
+  return Object.keys(out).length > 0 ? out : undefined
+}
+
+function subtractCategoryStats(base: CategoryDayStats, sub: CategoryDayStats): CategoryDayStats | null {
+  const turns = Math.max(0, base.turns - num(sub.turns))
+  const cost = Math.max(0, base.cost - num(sub.cost))
+  const savingsUSD = Math.max(0, num(base.savingsUSD) - num(sub.savingsUSD))
+  const editTurns = Math.max(0, base.editTurns - num(sub.editTurns))
+  const oneShotTurns = Math.max(0, base.oneShotTurns - num(sub.oneShotTurns))
+  if (turns === 0 && cost === 0 && savingsUSD === 0 && editTurns === 0 && oneShotTurns === 0) return null
+  return { turns, cost, savingsUSD, editTurns, oneShotTurns }
+}
+
+function subtractCategories(
+  base: Record<string, CategoryDayStats> | undefined,
+  sub: Record<string, CategoryDayStats> | undefined,
+): Record<string, CategoryDayStats> | undefined {
+  if (!base) return undefined
+  const out: Record<string, CategoryDayStats> = {}
+  for (const [name, stats] of Object.entries(base)) {
+    const reduced = sub && Object.hasOwn(sub, name) ? subtractCategoryStats(stats, sub[name]!) : structuredClone(stats)
+    if (reduced) setOwn(out, name, reduced)
+  }
+  return Object.keys(out).length > 0 ? out : undefined
+}
+
+function subtractProjectStats(base: ProjectDayStats, sub: ProjectDayStats): ProjectDayStats | null {
+  const cost = Math.max(0, base.cost - num(sub.cost))
+  const calls = Math.max(0, base.calls - num(sub.calls))
+  const savingsUSD = Math.max(0, num(base.savingsUSD) - num(sub.savingsUSD))
+  const sessions = Math.max(0, num(base.sessions) - num(sub.sessions))
+  if (cost === 0 && calls === 0 && savingsUSD === 0 && sessions === 0) return null
+  return { cost, calls, savingsUSD, sessions, ...(base.path ? { path: base.path } : {}) }
+}
+
+function subtractProjects(
+  base: Record<string, ProjectDayStats> | undefined,
+  sub: Record<string, ProjectDayStats> | undefined,
+): Record<string, ProjectDayStats> | undefined {
+  if (!base) return undefined
+  const out: Record<string, ProjectDayStats> = {}
+  for (const [name, stats] of Object.entries(base)) {
+    const reduced = sub && Object.hasOwn(sub, name) ? subtractProjectStats(stats, sub[name]!) : structuredClone(stats)
+    if (reduced) setOwn(out, name, reduced)
+  }
+  return Object.keys(out).length > 0 ? out : undefined
+}
+
+function subtractSlice(base: ProviderDaySlice, sub: ProviderDaySlice): ProviderDaySlice | null {
+  const calls = Math.max(0, base.calls - num(sub.calls))
+  const cost = Math.max(0, base.cost - num(sub.cost))
+  const savingsUSD = Math.max(0, num(base.savingsUSD) - num(sub.savingsUSD))
+  const sessions = Math.max(0, num(base.sessions) - num(sub.sessions))
+  const inputTokens = Math.max(0, num(base.inputTokens) - num(sub.inputTokens))
+  const outputTokens = Math.max(0, num(base.outputTokens) - num(sub.outputTokens))
+  const reasoningTokens = Math.max(0, num(base.reasoningTokens) - num(sub.reasoningTokens))
+  const cacheReadTokens = Math.max(0, num(base.cacheReadTokens) - num(sub.cacheReadTokens))
+  const cacheWriteTokens = Math.max(0, num(base.cacheWriteTokens) - num(sub.cacheWriteTokens))
+  const editTurns = Math.max(0, num(base.editTurns) - num(sub.editTurns))
+  const oneShotTurns = Math.max(0, num(base.oneShotTurns) - num(sub.oneShotTurns))
+  const models = subtractModels(base.models, sub.models)
+  const categories = subtractCategories(base.categories, sub.categories)
+  const projects = subtractProjects(base.projects, sub.projects)
+
+  const out: ProviderDaySlice = {
+    calls,
+    cost,
+    savingsUSD,
+    ...(base.sessions !== undefined || sub.sessions !== undefined ? { sessions } : {}),
+    ...(base.inputTokens !== undefined || sub.inputTokens !== undefined ? { inputTokens } : {}),
+    ...(base.outputTokens !== undefined || sub.outputTokens !== undefined ? { outputTokens } : {}),
+    ...(base.reasoningTokens !== undefined || sub.reasoningTokens !== undefined ? { reasoningTokens } : {}),
+    ...(base.cacheReadTokens !== undefined || sub.cacheReadTokens !== undefined ? { cacheReadTokens } : {}),
+    ...(base.cacheWriteTokens !== undefined || sub.cacheWriteTokens !== undefined ? { cacheWriteTokens } : {}),
+    ...(base.editTurns !== undefined || sub.editTurns !== undefined ? { editTurns } : {}),
+    ...(base.oneShotTurns !== undefined || sub.oneShotTurns !== undefined ? { oneShotTurns } : {}),
+    ...(models ? { models } : {}),
+    ...(categories ? { categories } : {}),
+    ...(projects ? { projects } : {}),
+  }
+  return hasSliceData(out) || num(out.sessions) > 0 ? out : null
+}
+
+function modelDelta(base: ModelDayStats, reduced: ModelDayStats | undefined): ModelDayStats {
+  return {
+    calls: Math.max(0, base.calls - num(reduced?.calls)),
+    cost: Math.max(0, base.cost - num(reduced?.cost)),
+    savingsUSD: Math.max(0, num(base.savingsUSD) - num(reduced?.savingsUSD)),
+    inputTokens: Math.max(0, base.inputTokens - num(reduced?.inputTokens)),
+    outputTokens: Math.max(0, base.outputTokens - num(reduced?.outputTokens)),
+    ...(base.reasoningTokens !== undefined || reduced?.reasoningTokens !== undefined
+      ? { reasoningTokens: Math.max(0, num(base.reasoningTokens) - num(reduced?.reasoningTokens)) }
+      : {}),
+    cacheReadTokens: Math.max(0, base.cacheReadTokens - num(reduced?.cacheReadTokens)),
+    cacheWriteTokens: Math.max(0, base.cacheWriteTokens - num(reduced?.cacheWriteTokens)),
+  }
+}
+
+function categoryDelta(base: CategoryDayStats, reduced: CategoryDayStats | undefined): CategoryDayStats {
+  return {
+    turns: Math.max(0, base.turns - num(reduced?.turns)),
+    cost: Math.max(0, base.cost - num(reduced?.cost)),
+    savingsUSD: Math.max(0, num(base.savingsUSD) - num(reduced?.savingsUSD)),
+    editTurns: Math.max(0, base.editTurns - num(reduced?.editTurns)),
+    oneShotTurns: Math.max(0, base.oneShotTurns - num(reduced?.oneShotTurns)),
+  }
+}
+
+function projectDelta(base: ProjectDayStats, reduced: ProjectDayStats | undefined): ProjectDayStats {
+  return {
+    cost: Math.max(0, base.cost - num(reduced?.cost)),
+    calls: Math.max(0, base.calls - num(reduced?.calls)),
+    savingsUSD: Math.max(0, num(base.savingsUSD) - num(reduced?.savingsUSD)),
+    sessions: Math.max(0, num(base.sessions) - num(reduced?.sessions)),
+  }
+}
+
+function subtractSliceFromDay(day: DailyEntry, provider: string, sub: ProviderDaySlice): void {
+  const current = Object.hasOwn(day.providers, provider) ? day.providers[provider] : undefined
+  if (!current) return
+  const reduced = subtractSlice(current, sub)
+  if (reduced) setOwn(day.providers, provider, reduced)
+  else delete day.providers[provider]
+
+  day.cost = Math.max(0, day.cost - (current.cost - num(reduced?.cost)))
+  day.calls = Math.max(0, day.calls - (current.calls - num(reduced?.calls)))
+  day.savingsUSD = Math.max(0, day.savingsUSD - (num(current.savingsUSD) - num(reduced?.savingsUSD)))
+  day.sessions = Math.max(0, day.sessions - (num(current.sessions) - num(reduced?.sessions)))
+  day.inputTokens = Math.max(0, day.inputTokens - (num(current.inputTokens) - num(reduced?.inputTokens)))
+  day.outputTokens = Math.max(0, day.outputTokens - (num(current.outputTokens) - num(reduced?.outputTokens)))
+  if (day.reasoningTokens !== undefined || current.reasoningTokens !== undefined || reduced?.reasoningTokens !== undefined) {
+    day.reasoningTokens = Math.max(0, num(day.reasoningTokens) - (num(current.reasoningTokens) - num(reduced?.reasoningTokens)))
+  }
+  day.cacheReadTokens = Math.max(0, day.cacheReadTokens - (num(current.cacheReadTokens) - num(reduced?.cacheReadTokens)))
+  day.cacheWriteTokens = Math.max(0, day.cacheWriteTokens - (num(current.cacheWriteTokens) - num(reduced?.cacheWriteTokens)))
+  day.editTurns = Math.max(0, day.editTurns - (num(current.editTurns) - num(reduced?.editTurns)))
+  day.oneShotTurns = Math.max(0, day.oneShotTurns - (num(current.oneShotTurns) - num(reduced?.oneShotTurns)))
+
+  for (const [name, stats] of Object.entries(current.models ?? {})) {
+    if (!Object.hasOwn(day.models, name)) continue
+    const removed = modelDelta(stats, reduced?.models?.[name])
+    const next = subtractModelStats(day.models[name]!, removed)
+    if (next) setOwn(day.models, name, next)
+    else delete day.models[name]
+  }
+
+  for (const [name, stats] of Object.entries(current.categories ?? {})) {
+    if (!Object.hasOwn(day.categories, name)) continue
+    const removed = categoryDelta(stats, reduced?.categories?.[name])
+    const next = subtractCategoryStats(day.categories[name]!, removed)
+    if (next) setOwn(day.categories, name, next)
+    else delete day.categories[name]
+  }
+
+  if (day.projects) {
+    for (const [name, stats] of Object.entries(current.projects ?? {})) {
+      if (!Object.hasOwn(day.projects, name)) continue
+      const removed = projectDelta(stats, reduced?.projects?.[name])
+      const next = subtractProjectStats(day.projects[name]!, removed)
+      if (next) setOwn(day.projects, name, next)
+      else delete day.projects[name]
+    }
+  }
+}
+
+function hasPositiveDayContent(day: DailyEntry): boolean {
+  return day.cost > 0
+    || day.calls > 0
+    || day.savingsUSD > 0
+    || day.sessions > 0
+    || day.inputTokens > 0
+    || day.outputTokens > 0
+    || num(day.reasoningTokens) > 0
+    || day.cacheReadTokens > 0
+    || day.cacheWriteTokens > 0
+    || day.editTurns > 0
+    || day.oneShotTurns > 0
+    || Object.keys(day.providers).length > 0
+    || Object.keys(day.models).length > 0
+    || Object.keys(day.categories).length > 0
+    || Object.keys(day.projects ?? {}).length > 0
+}
+
+function buildSubtraction(days: DailyEntry[]): Map<string, Map<string, ProviderDaySlice>> {
+  const out = new Map<string, Map<string, ProviderDaySlice>>()
+  for (const day of days) {
+    const providers = new Map<string, ProviderDaySlice>()
+    for (const [provider, slice] of Object.entries(day.providers)) providers.set(provider, slice)
+    if (providers.size > 0) out.set(day.date, providers)
+  }
+  return out
+}
+
+function addFreshPlaceholdersToResiduals(baseline: DailyEntry[], freshDays: DailyEntry[]): void {
+  const freshByDate = new Map(freshDays.map(day => [day.date, day]))
+  for (const day of baseline) {
+    const fresh = freshByDate.get(day.date)
+    if (!fresh) continue
+    for (const [provider, residual] of Object.entries(day.providers)) {
+      const placeholder = Object.hasOwn(fresh.providers, provider) ? fresh.providers[provider] : undefined
+      if (!placeholder || hasSliceData(placeholder) || num(placeholder.sessions) === 0) continue
+
+      residual.sessions = num(residual.sessions) + num(placeholder.sessions)
+      if (!residual.projects || !placeholder.projects) continue
+      for (const [name, project] of Object.entries(placeholder.projects)) {
+        if (!Object.hasOwn(residual.projects, name)) continue
+        residual.projects[name]!.sessions += num(project.sessions)
+      }
+    }
+  }
+}
+
+/**
+ * Remove from the old-timezone baseline exactly the usage still present in the
+ * fresh parse when that same parse is bucketed under the OLD timezone. The
+ * remainder is genuinely source-gone carried history; the removed portion is
+ * the same evidence that moved across midnight and will be emitted by the fresh
+ * current-timezone aggregation.
+ *
+ * This is intentionally a pre-merge transform. It lets Metrora keep the mature
+ * generic NEVER-LOSE merge untouched while fixing timezone rebucketing, and it
+ * preserves Metrora-only reasoning/model-provider/source-provider provenance.
+ */
+export function mergeTimezoneRebucketedDays(
+  freshDays: DailyEntry[],
+  baseline: DailyEntry[],
+  freshUnderOldTimezone: DailyEntry[],
+): DailyEntry[] {
+  const subtraction = buildSubtraction(freshUnderOldTimezone)
+  const adjusted: DailyEntry[] = []
+
+  for (const sourceDay of baseline) {
+    const day = structuredClone(sourceDay)
+    const perProvider = subtraction.get(day.date)
+    if (perProvider) {
+      for (const [provider, sub] of perProvider) subtractSliceFromDay(day, provider, sub)
+    }
+    if (hasPositiveDayContent(day)) adjusted.push(day)
+  }
+
+  // Generic merge max-dedupes placeholder session counts. After subtraction the
+  // residual sessions are known-distinct source-gone sessions, so fold the fresh
+  // placeholder counts into the residual slice before handing it to that merge;
+  // its existing `residual - placeholder` arithmetic then adds exactly the
+  // genuine residual instead of clamping one session away.
+  addFreshPlaceholdersToResiduals(adjusted, freshDays)
+  return mergeDayEntries(freshDays, adjusted, true)
+}

--- a/src/daily-cache.ts
+++ b/src/daily-cache.ts
@@ -148,6 +148,15 @@ export async function ensureCacheHydrated(
     const todayStr = core.toDateString(now)
     const tzKey = core.currentTzKey()
     const tzChanged = cache.tzKey !== undefined && cache.tzKey !== tzKey
+    const accountingChanged = cache.savingsConfigHash !== savingsConfigHash
+
+    // A timezone rebucket can be reconciled losslessly only when the baseline
+    // and the fresh projection share the same accounting authority. If both
+    // authorities change in one run, the old-day cost cannot be subtracted
+    // from the new-day cost without inventing a cross-authority monetary
+    // delta. Keep the old cache untouched and require the caller to retry
+    // after the two invalidations have been serialized.
+    if (tzChanged && accountingChanged) return cache
 
     // On ordinary runs an accidental/current-day cache row is discarded because
     // live parsing owns today. During a timezone migration, however, a day that
@@ -180,7 +189,7 @@ export async function ensureCacheHydrated(
       }
     }
 
-    if (cache.savingsConfigHash !== savingsConfigHash || cache.complete !== true || tzChanged) {
+    if (accountingChanged || cache.complete !== true || tzChanged) {
       const baseline = cache.days
       const priorWatermark = cache.lastComputedDate
       const backfillStart = new Date(now.getFullYear(), now.getMonth(), now.getDate() - core.BACKFILL_DAYS)

--- a/src/daily-cache.ts
+++ b/src/daily-cache.ts
@@ -4,6 +4,7 @@ import { dirname, join } from 'path'
 import { isSessionHydrationComplete } from './parser.js'
 import { currentSessionSnapshotCompleteness } from './session-snapshot-completeness.js'
 import type { DateRange, ProjectSummary } from './types.js'
+import { aggregateProjectsIntoDays, dateKeyInTz } from './day-aggregator.js'
 import { mergeTimezoneRebucketedDays } from './daily-cache-tz-reconcile.js'
 import * as core from './daily-cache-core.js'
 
@@ -133,7 +134,8 @@ export async function ensureCacheHydrated(
   aggregateDays: (projects: ProjectSummary[]) => core.DailyEntry[],
   savingsConfigHash: string = '',
   sessionComplete: () => boolean = () => true,
-  aggregateDaysInTz?: (projects: ProjectSummary[], tz: string) => core.DailyEntry[],
+  aggregateDaysInTz: (projects: ProjectSummary[], tz: string) => core.DailyEntry[] =
+    (projects, tz) => aggregateProjectsIntoDays(projects, iso => dateKeyInTz(iso, tz)),
 ): Promise<DailyCache> {
   const now = new Date()
   const todayStart = new Date(now.getFullYear(), now.getMonth(), now.getDate())
@@ -193,7 +195,6 @@ export async function ensureCacheHydrated(
         && tzChanged
         && cache.savingsConfigHash === savingsConfigHash
         && cache.tzKey !== undefined
-        && aggregateDaysInTz
       ) {
         const wideProjects = await parseSessions({ start: backfillStart, end: now })
         const wideParseWasComplete = await parseIsAuthoritative(sessionComplete, allowDegradedSourceReconciliation)

--- a/src/daily-cache.ts
+++ b/src/daily-cache.ts
@@ -146,8 +146,17 @@ export async function ensureCacheHydrated(
   return core.withDailyCacheLock(async () => {
     let cache = await loadDailyCache()
     const todayStr = core.toDateString(now)
+    const tzKey = core.currentTzKey()
+    const tzChanged = cache.tzKey !== undefined && cache.tzKey !== tzKey
 
-    if (cache.days.some(day => day.date >= todayStr)) {
+    // On ordinary runs an accidental/current-day cache row is discarded because
+    // live parsing owns today. During a timezone migration, however, a day that
+    // was FINALIZED as yesterday in the old timezone can have the same date as
+    // today's new-timezone label (for example a large westward offset change).
+    // Dropping it here would bypass NEVER-LOSE carry semantics and permanently
+    // erase sourceless history before the old/new timezone reconciliation sees
+    // it. Keep the complete old baseline intact whenever tzKey changes.
+    if (!tzChanged && cache.days.some(day => day.date >= todayStr)) {
       const days = cache.days.filter(day => day.date < todayStr)
       const lastComputedDate = days.length > 0 ? days[days.length - 1]!.date : null
       cache = { ...cache, days, lastComputedDate }
@@ -171,8 +180,6 @@ export async function ensureCacheHydrated(
       }
     }
 
-    const tzKey = core.currentTzKey()
-    const tzChanged = cache.tzKey !== undefined && cache.tzKey !== tzKey
     if (cache.savingsConfigHash !== savingsConfigHash || cache.complete !== true || tzChanged) {
       const baseline = cache.days
       const priorWatermark = cache.lastComputedDate

--- a/src/daily-cache.ts
+++ b/src/daily-cache.ts
@@ -136,6 +136,7 @@ export async function ensureCacheHydrated(
   sessionComplete: () => boolean = () => true,
   aggregateDaysInTz: (projects: ProjectSummary[], tz: string) => core.DailyEntry[] =
     (projects, tz) => aggregateProjectsIntoDays(projects, iso => dateKeyInTz(iso, tz)),
+  options: core.CacheHydrationOptions = {},
 ): Promise<DailyCache> {
   const now = new Date()
   const todayStart = new Date(now.getFullYear(), now.getMonth(), now.getDate())
@@ -149,14 +150,46 @@ export async function ensureCacheHydrated(
     const tzKey = core.currentTzKey()
     const tzChanged = cache.tzKey !== undefined && cache.tzKey !== tzKey
     const accountingChanged = cache.savingsConfigHash !== savingsConfigHash
+    const durableHistoryAuthority = options.durableHistoryAuthority
+    const historyAuthorityChanged = durableHistoryAuthority !== undefined
+      && cache.durableHistoryAuthority !== durableHistoryAuthority
 
-    // A timezone rebucket can be reconciled losslessly only when the baseline
-    // and the fresh projection share the same accounting authority. If both
-    // authorities change in one run, the old-day cost cannot be subtracted
-    // from the new-day cost without inventing a cross-authority monetary
-    // delta. Keep the old cache untouched and require the caller to retry
-    // after the two invalidations have been serialized.
-    if (tzChanged && accountingChanged) return cache
+    // Serialize simultaneous invalidations. First re-derive the accounting
+    // authority while retaining the old timezone, then persist that intermediate
+    // state. The next run sees accounting=B/tz=A and can perform the lossless
+    // timezone rebucket under one accounting authority. This avoids subtracting
+    // old-money from new-money while still guaranteeing finite progress.
+    if (tzChanged && accountingChanged) {
+      const baseline = cache.days
+      const horizonDays = historyAuthorityChanged ? core.DAILY_CACHE_RETENTION_DAYS : core.BACKFILL_DAYS
+      const backfillStart = new Date(now.getFullYear(), now.getMonth(), now.getDate() - horizonDays)
+      let freshDays: core.DailyEntry[] = []
+      if (backfillStart.getTime() <= yesterdayEnd.getTime() && cache.tzKey !== undefined) {
+        const projects = await parseSessions({ start: backfillStart, end: yesterdayEnd })
+        freshDays = aggregateDaysInTz(projects, cache.tzKey)
+      }
+      const parseWasComplete = await parseIsAuthoritative(sessionComplete, allowDegradedSourceReconciliation)
+      // If the parse is partial, keep A/A completely intact and retry this same
+      // first phase. In particular, do not publish a B/A intermediate state from
+      // an undercounted snapshot.
+      if (!parseWasComplete) return cache
+
+      cache = withTrust({
+        version: core.DAILY_CACHE_VERSION,
+        savingsConfigHash,
+        tzKey: cache.tzKey,
+        ...(durableHistoryAuthority !== undefined
+          ? { durableHistoryAuthority }
+          : typeof cache.durableHistoryAuthority === 'string'
+            ? { durableHistoryAuthority: cache.durableHistoryAuthority }
+            : {}),
+        lastComputedDate: yesterdayStr,
+        days: applyRetention(core.mergeDayEntries(freshDays, baseline, true), yesterdayStr),
+        complete: true,
+      }, true)
+      await saveDailyCache(cache)
+      return cache
+    }
 
     // On ordinary runs an accidental/current-day cache row is discarded because
     // live parsing owns today. During a timezone migration, however, a day that
@@ -189,10 +222,11 @@ export async function ensureCacheHydrated(
       }
     }
 
-    if (accountingChanged || cache.complete !== true || tzChanged) {
+    if (accountingChanged || cache.complete !== true || tzChanged || historyAuthorityChanged) {
       const baseline = cache.days
       const priorWatermark = cache.lastComputedDate
-      const backfillStart = new Date(now.getFullYear(), now.getMonth(), now.getDate() - core.BACKFILL_DAYS)
+      const horizonDays = historyAuthorityChanged ? core.DAILY_CACHE_RETENTION_DAYS : core.BACKFILL_DAYS
+      const backfillStart = new Date(now.getFullYear(), now.getMonth(), now.getDate() - horizonDays)
       let freshDays: core.DailyEntry[] = []
       if (backfillStart.getTime() <= yesterdayEnd.getTime()) {
         freshDays = aggregateDays(await parseSessions({ start: backfillStart, end: yesterdayEnd }))
@@ -234,6 +268,11 @@ export async function ensureCacheHydrated(
         version: core.DAILY_CACHE_VERSION,
         savingsConfigHash,
         tzKey,
+        ...(durableHistoryAuthority !== undefined && parseWasComplete
+          ? { durableHistoryAuthority }
+          : typeof cache.durableHistoryAuthority === 'string'
+            ? { durableHistoryAuthority: cache.durableHistoryAuthority }
+            : {}),
         lastComputedDate: parseWasComplete ? yesterdayStr : priorWatermark,
         days: applyRetention(days, yesterdayStr),
         complete: parseWasComplete,

--- a/src/daily-cache.ts
+++ b/src/daily-cache.ts
@@ -4,6 +4,7 @@ import { dirname, join } from 'path'
 import { isSessionHydrationComplete } from './parser.js'
 import { currentSessionSnapshotCompleteness } from './session-snapshot-completeness.js'
 import type { DateRange, ProjectSummary } from './types.js'
+import { mergeTimezoneRebucketedDays } from './daily-cache-tz-reconcile.js'
 import * as core from './daily-cache-core.js'
 
 export * from './daily-cache-core.js'
@@ -132,6 +133,7 @@ export async function ensureCacheHydrated(
   aggregateDays: (projects: ProjectSummary[]) => core.DailyEntry[],
   savingsConfigHash: string = '',
   sessionComplete: () => boolean = () => true,
+  aggregateDaysInTz?: (projects: ProjectSummary[], tz: string) => core.DailyEntry[],
 ): Promise<DailyCache> {
   const now = new Date()
   const todayStart = new Date(now.getFullYear(), now.getMonth(), now.getDate())
@@ -177,10 +179,39 @@ export async function ensureCacheHydrated(
       if (backfillStart.getTime() <= yesterdayEnd.getTime()) {
         freshDays = aggregateDays(await parseSessions({ start: backfillStart, end: yesterdayEnd }))
       }
-      const parseWasComplete = await parseIsAuthoritative(sessionComplete, allowDegradedSourceReconciliation)
-      const days = parseWasComplete
-        ? core.mergeDayEntries(freshDays, baseline, true)
-        : core.mergeDayEntries(baseline, freshDays, false)
+      let parseWasComplete = await parseIsAuthoritative(sessionComplete, allowDegradedSourceReconciliation)
+      let days: core.DailyEntry[]
+
+      // A timezone change is not a pricing/source change: the same physical
+      // usage can simply cross a local-midnight boundary. Re-aggregate a WIDE
+      // copy of the same parse under the cache's old timezone and subtract that
+      // evidence from carried baseline slices before the normal NEVER-LOSE
+      // merge. Without this step, a rebucketed turn can survive on its old day
+      // as carried history and also appear on its new day.
+      if (
+        parseWasComplete
+        && tzChanged
+        && cache.savingsConfigHash === savingsConfigHash
+        && cache.tzKey !== undefined
+        && aggregateDaysInTz
+      ) {
+        const wideProjects = await parseSessions({ start: backfillStart, end: now })
+        const wideParseWasComplete = await parseIsAuthoritative(sessionComplete, allowDegradedSourceReconciliation)
+        if (wideParseWasComplete) {
+          const freshUnderOldTimezone = aggregateDaysInTz(wideProjects, cache.tzKey)
+          days = mergeTimezoneRebucketedDays(freshDays, baseline, freshUnderOldTimezone)
+        } else {
+          // The subtraction must never be built from a partial wide snapshot.
+          // Preserve the baseline as authority and leave the cache incomplete so
+          // the next run retries the migration rather than freezing a guess.
+          parseWasComplete = false
+          days = core.mergeDayEntries(baseline, freshDays, false)
+        }
+      } else {
+        days = parseWasComplete
+          ? core.mergeDayEntries(freshDays, baseline, true)
+          : core.mergeDayEntries(baseline, freshDays, false)
+      }
 
       cache = withTrust({
         version: core.DAILY_CACHE_VERSION,

--- a/src/day-aggregator.ts
+++ b/src/day-aggregator.ts
@@ -55,6 +55,27 @@ export function dateKey(iso: string): string {
   return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
 }
 
+/** Bucket an ISO timestamp under an explicit IANA timezone. */
+export function dateKeyInTz(iso: string, tz: string): string {
+  const date = new Date(iso)
+  if (Number.isNaN(date.getTime())) return dateKey(iso)
+  const parts = new Intl.DateTimeFormat('en-CA', {
+    timeZone: tz,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).formatToParts(date)
+  let year = ''
+  let month = ''
+  let day = ''
+  for (const part of parts) {
+    if (part.type === 'year') year = part.value
+    else if (part.type === 'month') month = part.value
+    else if (part.type === 'day') day = part.value
+  }
+  return year && month && day ? `${year}-${month}-${day}` : dateKey(iso)
+}
+
 function emptySlice(): ProviderDaySlice {
   return {
     calls: 0, cost: 0, savingsUSD: 0,
@@ -63,7 +84,10 @@ function emptySlice(): ProviderDaySlice {
   }
 }
 
-export function aggregateProjectsIntoDays(projects: ProjectSummary[]): DailyEntry[] {
+export function aggregateProjectsIntoDays(
+  projects: ProjectSummary[],
+  dateKeyFn: (iso: string) => string = dateKey,
+): DailyEntry[] {
   const byDate = new Map<string, DailyEntry>()
   const ensure = (date: string): DailyEntry => {
     let d = byDate.get(date)
@@ -90,7 +114,7 @@ export function aggregateProjectsIntoDays(projects: ProjectSummary[]): DailyEntr
 
   for (const project of projects) {
     for (const session of project.sessions) {
-      const sessionDate = dateKey(session.firstTimestamp)
+      const sessionDate = dateKeyFn(session.firstTimestamp)
       const sessionDay = ensure(sessionDate)
       sessionDay.sessions += 1
       ensureProject(sessionDay, session.project, project.projectPath).sessions += 1
@@ -112,7 +136,7 @@ export function aggregateProjectsIntoDays(projects: ProjectSummary[]): DailyEntr
         // bucketed per-call by each call's own timestamp, so a midnight-
         // straddling turn split across two days and history.daily / the provider
         // breakdown never reconciled to current.cost (a constant offset).
-        const turnDate = dateKey(turn.timestamp || turn.assistantCalls[0]!.timestamp)
+        const turnDate = dateKeyFn(turn.timestamp || turn.assistantCalls[0]!.timestamp)
         const turnDay = ensure(turnDate)
 
         const editTurns = turn.hasEdits ? 1 : 0

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -1,21 +1,14 @@
 import { existsSync } from 'fs'
-import { readFile } from 'fs/promises'
-import { dirname, join } from 'path'
+import { dirname } from 'path'
 
-import { Chalk } from 'chalk'
-
-import { getClaudeConfigDirs } from './providers/claude.js'
-import { getAllProviders } from './providers/index.js'
+import { allProviderNames, getAllProviders, safeDiscoverSessions } from './providers/index.js'
+import { emptyCache, loadCache, PROVIDER_ENV_VARS, type SessionCache } from './session-cache.js'
 import type { Provider } from './providers/types.js'
-import {
-  PROVIDER_ENV_VARS,
-  PROVIDER_PARSE_VERSIONS,
-  loadCache,
-  type SessionCache,
-} from './session-cache.js'
-import { renderTable } from './text-table.js'
 
-// ── Types ──────────────────────────────────────────────────────────────
+export type DoctorEnvOverride = {
+  name: string
+  value: string
+}
 
 export type DoctorProbePath = {
   path: string
@@ -23,58 +16,21 @@ export type DoctorProbePath = {
   exists: boolean
 }
 
-export type DoctorEnvOverride = {
-  name: string
-  value: string
-}
-
-export type DoctorStatus = 'ok' | 'empty' | 'errors' | 'error' | 'network'
-
 export type DoctorProviderReport = {
   provider: string
   displayName: string
-  status: DoctorStatus
-  /** Directories/dbs the provider scans, with existence checked (may be empty
-   *  for providers that do not expose probeRoots). */
+  status: 'ok' | 'empty' | 'error'
+  discoveredSources: number
+  sampledCalls: number
   probePaths: DoctorProbePath[]
-  /** Env overrides that are actually set for this provider. */
   envOverrides: DoctorEnvOverride[]
-  parseVersion?: string
-  /** Session sources discovered (candidate files/dbs). */
-  candidatesFound: number
-  /** How many discovered sources we attempted to parse (bounded sample). */
-  sampled: number
-  parsedOk: number
-  parseFailed: number
-  /** True when we sampled fewer sources than were discovered. */
-  bounded: boolean
-  /** Files cached for this provider in session-cache.json. */
-  cachedFiles: number
-  /** Cached entries flagged as parse failures. */
-  cachedFailed: number
-  /** One-line human verdict. */
   verdict: string
-  /** Message when the provider itself threw (status 'error'). */
   error?: string
-}
-
-export type ClaudeRetentionNote = {
-  /// Effective transcript retention in days. Claude Code deletes session
-  /// files older than cleanupPeriodDays at startup; 30 is its default when
-  /// the setting is absent.
-  effectiveDays: number
-  /// True when cleanupPeriodDays is explicitly set in settings.json.
-  configured: boolean
-  settingsPath: string
 }
 
 export type DoctorReport = {
   generatedAt: string
   providers: DoctorProviderReport[]
-  /// Present when the Claude provider is in the report and a config dir was
-  /// found. Surfaced because deleted transcripts are unrecoverable: daily
-  /// totals survive in Metrora's cache, but per-session detail does not.
-  claudeRetention?: ClaudeRetentionNote
 }
 
 export type CollectDoctorOptions = {
@@ -99,10 +55,22 @@ const PARSE_CALL_CAP = 500
 // (readdir/stat only) still runs, so session counts stay meaningful.
 const PARSE_SPAWNS = new Set(['antigravity'])
 
-// Metrora's own cache location: listed in PROVIDER_ENV_VARS for cache
-// fingerprinting, but it is not a discovery path, so it must never be blamed
-// in a NOTHING FOUND hint.
-const NON_DISCOVERY_ENV_VARS = new Set(['METRORA_CACHE_DIR'])
+// Declared env inputs that change parsing/accounting but not where discovery
+// looks. They belong in the cache fingerprint, but must never be blamed for a
+// NOTHING FOUND result.
+const NON_DISCOVERY_ENV_VARS = new Set([
+  'METRORA_CACHE_DIR',
+  'METRORA_CURSOR_MAX_BUBBLES',
+  'KIMI_MODEL_NAME',
+])
+
+// Windows supplies these to ordinary processes, so they move discovery roots
+// and must be fingerprinted but do not represent deliberate user overrides.
+const AMBIENT_ENV_VARS = new Set(['APPDATA', 'LOCALAPPDATA'])
+
+// Credential presence is useful diagnostic state; the value is a live secret
+// and must never reach text or JSON doctor output.
+const SECRET_ENV_VARS = new Set(['AI_GATEWAY_API_KEY', 'VERCEL_OIDC_TOKEN'])
 
 // ── Collect (pure, testable) ─────────────────────────────────────────────
 
@@ -110,8 +78,11 @@ function collectEnvOverrides(providerName: string): DoctorEnvOverride[] {
   const vars = PROVIDER_ENV_VARS[providerName] ?? []
   const out: DoctorEnvOverride[] = []
   for (const name of vars) {
+    if (AMBIENT_ENV_VARS.has(name)) continue
     const value = process.env[name]
-    if (value !== undefined && value !== '') out.push({ name, value })
+    if (value !== undefined && value !== '') {
+      out.push(SECRET_ENV_VARS.has(name) ? { name, value: '<set>' } : { name, value })
+    }
   }
   return out
 }
@@ -168,277 +139,137 @@ function emptyVerdict(
   // With an override set, a missing probed path is the likely culprit; name it
   // so the row itself points at the misconfiguration (Details lists them all).
   if (hasOverride) {
-    return missing.length > 0
-      ? `NOTHING FOUND (override ${overrideNames} set; ${missing[0]!.path} does not exist)`
-      : `NOTHING FOUND (override ${overrideNames} set; ${present[0]!.path} holds no sessions)`
+    if (missing.length > 0) return `NOTHING FOUND (override ${overrideNames} set; ${missing[0]!.path} does not exist)`
+    return `NOTHING FOUND (override ${overrideNames} set; probed path exists but holds no sessions)`
   }
-  // No override. If every probed path is missing, the tool is likely not
-  // installed; if some exist, the data dir is there but empty (no history).
-  return present.length === 0
-    ? `NOTHING FOUND (${missing[0]!.path} does not exist; tool likely not installed)`
-    : `NOTHING FOUND (${present[0]!.path} exists but holds no sessions; no history yet)`
+  if (present.length > 0) return `NOTHING FOUND (${present[0]!.path} exists but holds no sessions; no history yet)`
+  return `NOTHING FOUND (${missing[0]?.path ?? 'probed path'} does not exist; tool likely not installed)`
 }
 
-async function collectOneProvider(
-  provider: Provider,
-  cache: SessionCache,
-  sampleLimit: number,
-): Promise<DoctorProviderReport> {
-  const base: DoctorProviderReport = {
-    provider: provider.name,
-    displayName: provider.displayName,
-    status: 'ok',
-    probePaths: [],
-    envOverrides: collectEnvOverrides(provider.name),
-    parseVersion: PROVIDER_PARSE_VERSIONS[provider.name],
-    candidatesFound: 0,
-    sampled: 0,
-    parsedOk: 0,
-    parseFailed: 0,
-    bounded: false,
-    cachedFiles: 0,
-    cachedFailed: 0,
-    verdict: '',
+function okVerdict(discoveredSources: number, sampledCalls: number): string {
+  if (sampledCalls > 0) return `OK (${pluralSessions(discoveredSources)}, sampled ${sampledCalls.toLocaleString('en-US')} calls)`
+  return `OK (${pluralSessions(discoveredSources)} discovered)`
+}
+
+async function sampleProvider(provider: Provider, sources: Awaited<ReturnType<typeof safeDiscoverSessions>>, limit: number): Promise<number> {
+  if (PARSE_SPAWNS.has(provider.name)) return 0
+  let calls = 0
+  const seen = new Set<string>()
+  for (const source of sources.slice(0, limit)) {
+    const parser = provider.createSessionParser(source, seen)
+    for await (const _call of parser.parse()) {
+      calls++
+      if (calls >= PARSE_CALL_CAP) return calls
+    }
   }
-
-  const section = cache.providers[provider.name]
-  if (section) {
-    const files = Object.values(section.files)
-    base.cachedFiles = files.length
-    base.cachedFailed = files.filter(f => f.failed).length
-  }
-
-  // Any single provider throwing (probe, discovery, or a parser) must never
-  // crash doctor or blank the other rows: catch and report it as an ERROR row.
-  try {
-    base.probePaths = await collectProbePaths(provider)
-
-    const sources = await provider.discoverSessions()
-    base.candidatesFound = sources.length
-    if (base.probePaths.length === 0) {
-      base.probePaths = derivePathsFromSources(sources.map(s => s.path))
-    }
-
-    // Network providers fetch on parse; doctor runs offline, so we never parse
-    // them. Discovery for the one network provider is offline (it only checks
-    // for a configured API key), so the count above still means something.
-    if (provider.network) {
-      base.status = 'network'
-      base.verdict = base.candidatesFound > 0
-        ? `NETWORK (${base.candidatesFound} source configured; parse skipped offline)`
-        : 'NETWORK (not configured; no API key)'
-      return base
-    }
-
-    if (sources.length > 0 && PARSE_SPAWNS.has(provider.name)) {
-      base.status = 'ok'
-      base.verdict = `OK (${pluralSessions(sources.length)}; parse sample skipped, provider probes live processes)`
-      return base
-    }
-
-    if (sources.length > 0) {
-      const sample = sources.slice(0, sampleLimit)
-      base.bounded = sample.length < sources.length
-      const seenKeys = new Set<string>()
-      for (const source of sample) {
-        base.sampled++
-        try {
-          const parser = provider.createSessionParser(source, seenKeys)
-          let n = 0
-          for await (const _call of parser.parse()) {
-            if (++n >= PARSE_CALL_CAP) break
-          }
-          base.parsedOk++
-        } catch {
-          base.parseFailed++
-        }
-      }
-    }
-
-    if (base.parseFailed > 0) {
-      base.status = 'errors'
-      base.verdict = `ERRORS (${base.parseFailed}/${base.sampled} sampled file${base.sampled === 1 ? '' : 's'} failed to parse)`
-    } else if (base.candidatesFound === 0) {
-      base.status = 'empty'
-      base.verdict = emptyVerdict(base.probePaths, base.envOverrides)
-    } else {
-      base.status = 'ok'
-      base.verdict = `OK (${pluralSessions(base.candidatesFound)})`
-    }
-  } catch (err) {
-    base.status = 'error'
-    base.error = err instanceof Error ? err.message : String(err)
-    base.verdict = `ERROR (${base.error})`
-  }
-
-  return base
+  return calls
 }
 
 export async function collectDoctorReport(
-  providerFilter?: string,
+  providerName = 'all',
   opts: CollectDoctorOptions = {},
 ): Promise<DoctorReport> {
-  const all = opts.providers ?? await getAllProviders()
-  const filtered = providerFilter && providerFilter !== 'all'
-    ? all.filter(p => p.name === providerFilter)
-    : all
-  const cache = opts.cache ?? await loadCache()
-  const sampleLimit = opts.sampleLimit ?? DEFAULT_SAMPLE_LIMIT
+  const providers = opts.providers ?? await getAllProviders()
+  const cache = opts.cache ?? (await loadCache().catch(() => null) ?? emptyCache())
+  const sampleLimit = Math.max(0, opts.sampleLimit ?? DEFAULT_SAMPLE_LIMIT)
+  const selected = providerName === 'all'
+    ? providers
+    : providers.filter(p => p.name === providerName)
 
-  // Doctor promises to be strictly read-only, but sample-parsing drives real
-  // provider parsers, and cursor's writes its results cache to disk before its
-  // first yield. The flag tells cache writers to stand down for this process
-  // while doctor collects; restored afterwards so long-lived embedders (tests,
-  // MCP) keep normal behavior.
-  const prevSuppress = process.env['METRORA_SUPPRESS_CACHE_WRITES']
-  process.env['METRORA_SUPPRESS_CACHE_WRITES'] = '1'
-  try {
-    const providers: DoctorProviderReport[] = []
-    for (const provider of filtered) {
-      providers.push(await collectOneProvider(provider, cache, sampleLimit))
-    }
-    providers.sort((a, b) => (a.displayName < b.displayName ? -1 : a.displayName > b.displayName ? 1 : 0))
-
-    const report: DoctorReport = { generatedAt: new Date().toISOString(), providers }
-    if (providers.some(p => p.provider === 'claude')) {
-      const retention = await collectClaudeRetention()
-      if (retention) report.claudeRetention = retention
-    }
-    return report
-  } finally {
-    if (prevSuppress === undefined) delete process.env['METRORA_SUPPRESS_CACHE_WRITES']
-    else process.env['METRORA_SUPPRESS_CACHE_WRITES'] = prevSuppress
+  if (providerName !== 'all' && !allProviderNames().includes(providerName) && selected.length === 0) {
+    return { generatedAt: new Date().toISOString(), providers: [] }
   }
-}
 
-// Claude Code's documented default when cleanupPeriodDays is absent.
-const CLAUDE_DEFAULT_CLEANUP_DAYS = 30
-// Below this, long-horizon views depend entirely on Metrora's daily cache;
-// the doctor line turns into a warning.
-const CLAUDE_RETENTION_WARN_DAYS = 365
-
-async function collectClaudeRetention(): Promise<ClaudeRetentionNote | undefined> {
-  for (const dir of await getClaudeConfigDirs()) {
-    const settingsPath = join(dir, 'settings.json')
-    let raw: string
+  const rows: DoctorProviderReport[] = []
+  for (const provider of selected) {
     try {
-      raw = await readFile(settingsPath, 'utf-8')
-    } catch {
-      continue
-    }
-    try {
-      const parsed: unknown = JSON.parse(raw)
-      const days = (parsed as Record<string, unknown> | null)?.['cleanupPeriodDays']
-      if (typeof days === 'number' && Number.isFinite(days)) {
-        return { effectiveDays: days, configured: true, settingsPath }
-      }
-      return { effectiveDays: CLAUDE_DEFAULT_CLEANUP_DAYS, configured: false, settingsPath }
-    } catch {
-      // Unparseable settings: report the default; Claude Code would apply it too.
-      return { effectiveDays: CLAUDE_DEFAULT_CLEANUP_DAYS, configured: false, settingsPath }
+      const sources = await safeDiscoverSessions(provider)
+      let probePaths = await collectProbePaths(provider)
+      if (probePaths.length === 0 && sources.length > 0) probePaths = derivePathsFromSources(sources.map(s => s.path))
+      const envOverrides = collectEnvOverrides(provider.name)
+      const sampledCalls = sampleLimit > 0 && sources.length > 0
+        ? await sampleProvider(provider, sources, sampleLimit)
+        : 0
+      const status: DoctorProviderReport['status'] = sources.length > 0 ? 'ok' : 'empty'
+      rows.push({
+        provider: provider.name,
+        displayName: provider.displayName,
+        status,
+        discoveredSources: sources.length,
+        sampledCalls,
+        probePaths,
+        envOverrides,
+        verdict: status === 'ok'
+          ? okVerdict(sources.length, sampledCalls)
+          : emptyVerdict(probePaths, envOverrides),
+      })
+    } catch (err) {
+      rows.push({
+        provider: provider.name,
+        displayName: provider.displayName,
+        status: 'error',
+        discoveredSources: 0,
+        sampledCalls: 0,
+        probePaths: [],
+        envOverrides: collectEnvOverrides(provider.name),
+        verdict: 'ERROR',
+        error: err instanceof Error ? err.message : String(err),
+      })
     }
   }
-  return undefined
+
+  // Cache-only providers are useful evidence too: an installed source may have
+  // disappeared while durable history remains. Add them only for an all-provider
+  // diagnostic and never duplicate a real provider row.
+  if (providerName === 'all') {
+    const seen = new Set(rows.map(row => row.provider))
+    for (const [name, section] of Object.entries(cache.providers)) {
+      if (seen.has(name)) continue
+      rows.push({
+        provider: name,
+        displayName: name,
+        status: Object.keys(section.files).length > 0 ? 'ok' : 'empty',
+        discoveredSources: 0,
+        sampledCalls: 0,
+        probePaths: [],
+        envOverrides: collectEnvOverrides(name),
+        verdict: Object.keys(section.files).length > 0
+          ? `CACHE ONLY (${Object.keys(section.files).length.toLocaleString('en-US')} retained sources)`
+          : 'CACHE ONLY (empty)',
+      })
+    }
+  }
+
+  rows.sort((a, b) => a.displayName.localeCompare(b.displayName))
+  return { generatedAt: new Date().toISOString(), providers: rows }
 }
 
-// ── Render ────────────────────────────────────────────────────────────────
+function renderPathSummary(paths: DoctorProbePath[]): string {
+  if (paths.length === 0) return '-'
+  return paths.map(p => `${p.exists ? '✓' : '✗'} ${p.path}`).join(', ')
+}
+
+function renderOverrideSummary(overrides: DoctorEnvOverride[]): string {
+  if (overrides.length === 0) return '-'
+  return overrides.map(o => `${o.name}=${o.value}`).join(', ')
+}
+
+export function renderDoctorTable(report: DoctorReport): string {
+  const rows = report.providers.map(r => [
+    r.displayName,
+    r.status.toUpperCase(),
+    r.discoveredSources.toLocaleString('en-US'),
+    r.sampledCalls.toLocaleString('en-US'),
+    r.verdict,
+    renderPathSummary(r.probePaths),
+    renderOverrideSummary(r.envOverrides),
+  ])
+  const headers = ['Provider', 'Status', 'Sources', 'Calls', 'Verdict', 'Paths', 'Overrides']
+  const widths = headers.map((h, i) => Math.max(h.length, ...rows.map(r => r[i]?.length ?? 0)))
+  const line = (cells: string[]) => cells.map((c, i) => c.padEnd(widths[i]!)).join('  ')
+  return [line(headers), line(widths.map(w => '-'.repeat(w))), ...rows.map(line)].join('\n')
+}
 
 export function renderDoctorJson(report: DoctorReport): string {
   return JSON.stringify(report, null, 2)
-}
-
-export function renderDoctorTable(
-  report: DoctorReport,
-  opts: { color?: boolean } = {},
-): string {
-  const c = new Chalk(opts.color === false ? { level: 0 } : {})
-  const out: string[] = []
-
-  const n = report.providers.length
-  out.push(c.bold('Metrora doctor') + c.dim(`   ${n} provider${n === 1 ? '' : 's'}   ${report.generatedAt.slice(0, 19).replace('T', ' ')} UTC`))
-  out.push('')
-
-  const colorVerdict = (r: DoctorProviderReport): string => {
-    if (r.status === 'ok') return c.green(r.verdict)
-    if (r.status === 'network') return c.cyan(r.verdict)
-    if (r.status === 'empty') return c.yellow(r.verdict)
-    return c.red(r.verdict)
-  }
-
-  const rows = report.providers.map(r => [
-    r.displayName,
-    r.status === 'network' ? '-' : String(r.candidatesFound),
-    r.status === 'network' || r.sampled === 0 ? '-' : `${r.parsedOk}/${r.sampled}${r.bounded ? '+' : ''}`,
-    String(r.cachedFiles),
-    colorVerdict(r),
-  ])
-
-  out.push(renderTable(
-    [
-      { header: 'Provider' },
-      { header: 'Sessions', right: true },
-      { header: 'Parsed', right: true },
-      { header: 'Cached', right: true },
-      { header: 'Verdict' },
-    ],
-    rows,
-    { color: opts.color },
-  ))
-
-  // Detail: show the exact probed paths + overrides only where there is
-  // something diagnostic to show (known probe roots, an override, a hard
-  // error, or cached parse failures), so a wrong path is spotted at a glance
-  // without a wall of empty blocks for tools that are simply not installed.
-  const detail = report.providers.filter(
-    r =>
-      r.status === 'error' ||
-      r.status === 'errors' ||
-      r.envOverrides.length > 0 ||
-      r.cachedFailed > 0 ||
-      r.probePaths.some(p => p.label !== 'discovered'),
-  )
-  if (detail.length > 0) {
-    out.push('')
-    out.push(c.bold('Details'))
-    for (const r of detail) {
-      out.push('  ' + c.bold(r.displayName))
-      for (const o of r.envOverrides) {
-        out.push('    ' + c.dim('override ') + `${o.name}=${o.value}`)
-      }
-      for (const p of r.probePaths) {
-        const mark = p.exists ? c.green('exists') : c.red('missing')
-        out.push('    ' + c.dim(`${p.label}: `) + p.path + ' ' + c.dim('(') + mark + c.dim(')'))
-      }
-      if (r.parseVersion) out.push('    ' + c.dim('parser: ') + r.parseVersion)
-      if (r.cachedFailed > 0) out.push('    ' + c.dim('cached parse failures: ') + String(r.cachedFailed))
-      if (r.error) out.push('    ' + c.red('error: ') + r.error)
-    }
-  }
-
-  if (report.claudeRetention) {
-    const r = report.claudeRetention
-    const source = r.configured ? 'cleanupPeriodDays' : 'cleanupPeriodDays not set; Claude Code default'
-    const line = `Claude Code deletes transcripts after ${r.effectiveDays} day${r.effectiveDays === 1 ? '' : 's'} (${source}).`
-    out.push('')
-    if (r.effectiveDays < CLAUDE_RETENTION_WARN_DAYS) {
-      out.push(
-        c.yellow(line) + ' ' +
-        `Daily totals survive in Metrora's cache, but per-session detail older than that is gone for good. ` +
-        `To keep it, set "cleanupPeriodDays": 3650 in ${r.settingsPath}.`,
-      )
-    } else {
-      out.push(c.dim(line + ' Long transcript retention: per-session detail is preserved.'))
-    }
-  }
-
-  out.push('')
-  const broken = report.providers.filter(r => r.status === 'error' || r.status === 'errors')
-  const empty = report.providers.filter(r => r.status === 'empty')
-  const ok = report.providers.filter(r => r.status === 'ok')
-  out.push(
-    c.dim('Bottom line: ') +
-    `${ok.length} OK, ${empty.length} with nothing found, ${broken.length} with errors.`,
-  )
-
-  return out.join('\n') + '\n'
 }

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -1,14 +1,21 @@
 import { existsSync } from 'fs'
-import { dirname } from 'path'
+import { readFile } from 'fs/promises'
+import { dirname, join } from 'path'
 
-import { allProviderNames, getAllProviders, safeDiscoverSessions } from './providers/index.js'
-import { emptyCache, loadCache, PROVIDER_ENV_VARS, type SessionCache } from './session-cache.js'
+import { Chalk } from 'chalk'
+
+import { getClaudeConfigDirs } from './providers/claude.js'
+import { getAllProviders } from './providers/index.js'
 import type { Provider } from './providers/types.js'
+import {
+  PROVIDER_ENV_VARS,
+  PROVIDER_PARSE_VERSIONS,
+  loadCache,
+  type SessionCache,
+} from './session-cache.js'
+import { renderTable } from './text-table.js'
 
-export type DoctorEnvOverride = {
-  name: string
-  value: string
-}
+// ── Types ──────────────────────────────────────────────────────────────
 
 export type DoctorProbePath = {
   path: string
@@ -16,21 +23,58 @@ export type DoctorProbePath = {
   exists: boolean
 }
 
+export type DoctorEnvOverride = {
+  name: string
+  value: string
+}
+
+export type DoctorStatus = 'ok' | 'empty' | 'errors' | 'error' | 'network'
+
 export type DoctorProviderReport = {
   provider: string
   displayName: string
-  status: 'ok' | 'empty' | 'error'
-  discoveredSources: number
-  sampledCalls: number
+  status: DoctorStatus
+  /** Directories/dbs the provider scans, with existence checked (may be empty
+   *  for providers that do not expose probeRoots). */
   probePaths: DoctorProbePath[]
+  /** Env overrides that are actually set for this provider. */
   envOverrides: DoctorEnvOverride[]
+  parseVersion?: string
+  /** Session sources discovered (candidate files/dbs). */
+  candidatesFound: number
+  /** How many discovered sources we attempted to parse (bounded sample). */
+  sampled: number
+  parsedOk: number
+  parseFailed: number
+  /** True when we sampled fewer sources than were discovered. */
+  bounded: boolean
+  /** Files cached for this provider in session-cache.json. */
+  cachedFiles: number
+  /** Cached entries flagged as parse failures. */
+  cachedFailed: number
+  /** One-line human verdict. */
   verdict: string
+  /** Message when the provider itself threw (status 'error'). */
   error?: string
+}
+
+export type ClaudeRetentionNote = {
+  /// Effective transcript retention in days. Claude Code deletes session
+  /// files older than cleanupPeriodDays at startup; 30 is its default when
+  /// the setting is absent.
+  effectiveDays: number
+  /// True when cleanupPeriodDays is explicitly set in settings.json.
+  configured: boolean
+  settingsPath: string
 }
 
 export type DoctorReport = {
   generatedAt: string
   providers: DoctorProviderReport[]
+  /// Present when the Claude provider is in the report and a config dir was
+  /// found. Surfaced because deleted transcripts are unrecoverable: daily
+  /// totals survive in Metrora's cache, but per-session detail does not.
+  claudeRetention?: ClaudeRetentionNote
 }
 
 export type CollectDoctorOptions = {
@@ -56,16 +100,16 @@ const PARSE_CALL_CAP = 500
 const PARSE_SPAWNS = new Set(['antigravity'])
 
 // Declared env inputs that change parsing/accounting but not where discovery
-// looks. They belong in the cache fingerprint, but must never be blamed for a
-// NOTHING FOUND result.
+// looks. They belong in the cache fingerprint, but must never be blamed in a
+// NOTHING FOUND hint.
 const NON_DISCOVERY_ENV_VARS = new Set([
   'METRORA_CACHE_DIR',
   'METRORA_CURSOR_MAX_BUBBLES',
   'KIMI_MODEL_NAME',
 ])
 
-// Windows supplies these to ordinary processes, so they move discovery roots
-// and must be fingerprinted but do not represent deliberate user overrides.
+// Windows supplies these to ordinary processes. They move discovery roots and
+// must be fingerprinted, but do not represent deliberate user overrides.
 const AMBIENT_ENV_VARS = new Set(['APPDATA', 'LOCALAPPDATA'])
 
 // Credential presence is useful diagnostic state; the value is a live secret
@@ -139,137 +183,277 @@ function emptyVerdict(
   // With an override set, a missing probed path is the likely culprit; name it
   // so the row itself points at the misconfiguration (Details lists them all).
   if (hasOverride) {
-    if (missing.length > 0) return `NOTHING FOUND (override ${overrideNames} set; ${missing[0]!.path} does not exist)`
-    return `NOTHING FOUND (override ${overrideNames} set; probed path exists but holds no sessions)`
+    return missing.length > 0
+      ? `NOTHING FOUND (override ${overrideNames} set; ${missing[0]!.path} does not exist)`
+      : `NOTHING FOUND (override ${overrideNames} set; ${present[0]!.path} holds no sessions)`
   }
-  if (present.length > 0) return `NOTHING FOUND (${present[0]!.path} exists but holds no sessions; no history yet)`
-  return `NOTHING FOUND (${missing[0]?.path ?? 'probed path'} does not exist; tool likely not installed)`
+  // No override. If every probed path is missing, the tool is likely not
+  // installed; if some exist, the data dir is there but empty (no history).
+  return present.length === 0
+    ? `NOTHING FOUND (${missing[0]!.path} does not exist; tool likely not installed)`
+    : `NOTHING FOUND (${present[0]!.path} exists but holds no sessions; no history yet)`
 }
 
-function okVerdict(discoveredSources: number, sampledCalls: number): string {
-  if (sampledCalls > 0) return `OK (${pluralSessions(discoveredSources)}, sampled ${sampledCalls.toLocaleString('en-US')} calls)`
-  return `OK (${pluralSessions(discoveredSources)} discovered)`
-}
+async function collectOneProvider(
+  provider: Provider,
+  cache: SessionCache,
+  sampleLimit: number,
+): Promise<DoctorProviderReport> {
+  const base: DoctorProviderReport = {
+    provider: provider.name,
+    displayName: provider.displayName,
+    status: 'ok',
+    probePaths: [],
+    envOverrides: collectEnvOverrides(provider.name),
+    parseVersion: PROVIDER_PARSE_VERSIONS[provider.name],
+    candidatesFound: 0,
+    sampled: 0,
+    parsedOk: 0,
+    parseFailed: 0,
+    bounded: false,
+    cachedFiles: 0,
+    cachedFailed: 0,
+    verdict: '',
+  }
 
-async function sampleProvider(provider: Provider, sources: Awaited<ReturnType<typeof safeDiscoverSessions>>, limit: number): Promise<number> {
-  if (PARSE_SPAWNS.has(provider.name)) return 0
-  let calls = 0
-  const seen = new Set<string>()
-  for (const source of sources.slice(0, limit)) {
-    const parser = provider.createSessionParser(source, seen)
-    for await (const _call of parser.parse()) {
-      calls++
-      if (calls >= PARSE_CALL_CAP) return calls
+  const section = cache.providers[provider.name]
+  if (section) {
+    const files = Object.values(section.files)
+    base.cachedFiles = files.length
+    base.cachedFailed = files.filter(f => f.failed).length
+  }
+
+  // Any single provider throwing (probe, discovery, or a parser) must never
+  // crash doctor or blank the other rows: catch and report it as an ERROR row.
+  try {
+    base.probePaths = await collectProbePaths(provider)
+
+    const sources = await provider.discoverSessions()
+    base.candidatesFound = sources.length
+    if (base.probePaths.length === 0) {
+      base.probePaths = derivePathsFromSources(sources.map(s => s.path))
     }
+
+    // Network providers fetch on parse; doctor runs offline, so we never parse
+    // them. Discovery for the one network provider is offline (it only checks
+    // for a configured API key), so the count above still means something.
+    if (provider.network) {
+      base.status = 'network'
+      base.verdict = base.candidatesFound > 0
+        ? `NETWORK (${base.candidatesFound} source configured; parse skipped offline)`
+        : 'NETWORK (not configured; no API key)'
+      return base
+    }
+
+    if (sources.length > 0 && PARSE_SPAWNS.has(provider.name)) {
+      base.status = 'ok'
+      base.verdict = `OK (${pluralSessions(sources.length)}; parse sample skipped, provider probes live processes)`
+      return base
+    }
+
+    if (sources.length > 0) {
+      const sample = sources.slice(0, sampleLimit)
+      base.bounded = sample.length < sources.length
+      const seenKeys = new Set<string>()
+      for (const source of sample) {
+        base.sampled++
+        try {
+          const parser = provider.createSessionParser(source, seenKeys)
+          let n = 0
+          for await (const _call of parser.parse()) {
+            if (++n >= PARSE_CALL_CAP) break
+          }
+          base.parsedOk++
+        } catch {
+          base.parseFailed++
+        }
+      }
+    }
+
+    if (base.parseFailed > 0) {
+      base.status = 'errors'
+      base.verdict = `ERRORS (${base.parseFailed}/${base.sampled} sampled file${base.sampled === 1 ? '' : 's'} failed to parse)`
+    } else if (base.candidatesFound === 0) {
+      base.status = 'empty'
+      base.verdict = emptyVerdict(base.probePaths, base.envOverrides)
+    } else {
+      base.status = 'ok'
+      base.verdict = `OK (${pluralSessions(base.candidatesFound)})`
+    }
+  } catch (err) {
+    base.status = 'error'
+    base.error = err instanceof Error ? err.message : String(err)
+    base.verdict = `ERROR (${base.error})`
   }
-  return calls
+
+  return base
 }
 
 export async function collectDoctorReport(
-  providerName = 'all',
+  providerFilter?: string,
   opts: CollectDoctorOptions = {},
 ): Promise<DoctorReport> {
-  const providers = opts.providers ?? await getAllProviders()
-  const cache = opts.cache ?? (await loadCache().catch(() => null) ?? emptyCache())
-  const sampleLimit = Math.max(0, opts.sampleLimit ?? DEFAULT_SAMPLE_LIMIT)
-  const selected = providerName === 'all'
-    ? providers
-    : providers.filter(p => p.name === providerName)
+  const all = opts.providers ?? await getAllProviders()
+  const filtered = providerFilter && providerFilter !== 'all'
+    ? all.filter(p => p.name === providerFilter)
+    : all
+  const cache = opts.cache ?? await loadCache()
+  const sampleLimit = opts.sampleLimit ?? DEFAULT_SAMPLE_LIMIT
 
-  if (providerName !== 'all' && !allProviderNames().includes(providerName) && selected.length === 0) {
-    return { generatedAt: new Date().toISOString(), providers: [] }
+  // Doctor promises to be strictly read-only, but sample-parsing drives real
+  // provider parsers, and cursor's writes its results cache to disk before its
+  // first yield. The flag tells cache writers to stand down for this process
+  // while doctor collects; restored afterwards so long-lived embedders (tests,
+  // MCP) keep normal behavior.
+  const prevSuppress = process.env['METRORA_SUPPRESS_CACHE_WRITES']
+  process.env['METRORA_SUPPRESS_CACHE_WRITES'] = '1'
+  try {
+    const providers: DoctorProviderReport[] = []
+    for (const provider of filtered) {
+      providers.push(await collectOneProvider(provider, cache, sampleLimit))
+    }
+    providers.sort((a, b) => (a.displayName < b.displayName ? -1 : a.displayName > b.displayName ? 1 : 0))
+
+    const report: DoctorReport = { generatedAt: new Date().toISOString(), providers }
+    if (providers.some(p => p.provider === 'claude')) {
+      const retention = await collectClaudeRetention()
+      if (retention) report.claudeRetention = retention
+    }
+    return report
+  } finally {
+    if (prevSuppress === undefined) delete process.env['METRORA_SUPPRESS_CACHE_WRITES']
+    else process.env['METRORA_SUPPRESS_CACHE_WRITES'] = prevSuppress
   }
+}
 
-  const rows: DoctorProviderReport[] = []
-  for (const provider of selected) {
+// Claude Code's documented default when cleanupPeriodDays is absent.
+const CLAUDE_DEFAULT_CLEANUP_DAYS = 30
+// Below this, long-horizon views depend entirely on Metrora's daily cache;
+// the doctor line turns into a warning.
+const CLAUDE_RETENTION_WARN_DAYS = 365
+
+async function collectClaudeRetention(): Promise<ClaudeRetentionNote | undefined> {
+  for (const dir of await getClaudeConfigDirs()) {
+    const settingsPath = join(dir, 'settings.json')
+    let raw: string
     try {
-      const sources = await safeDiscoverSessions(provider)
-      let probePaths = await collectProbePaths(provider)
-      if (probePaths.length === 0 && sources.length > 0) probePaths = derivePathsFromSources(sources.map(s => s.path))
-      const envOverrides = collectEnvOverrides(provider.name)
-      const sampledCalls = sampleLimit > 0 && sources.length > 0
-        ? await sampleProvider(provider, sources, sampleLimit)
-        : 0
-      const status: DoctorProviderReport['status'] = sources.length > 0 ? 'ok' : 'empty'
-      rows.push({
-        provider: provider.name,
-        displayName: provider.displayName,
-        status,
-        discoveredSources: sources.length,
-        sampledCalls,
-        probePaths,
-        envOverrides,
-        verdict: status === 'ok'
-          ? okVerdict(sources.length, sampledCalls)
-          : emptyVerdict(probePaths, envOverrides),
-      })
-    } catch (err) {
-      rows.push({
-        provider: provider.name,
-        displayName: provider.displayName,
-        status: 'error',
-        discoveredSources: 0,
-        sampledCalls: 0,
-        probePaths: [],
-        envOverrides: collectEnvOverrides(provider.name),
-        verdict: 'ERROR',
-        error: err instanceof Error ? err.message : String(err),
-      })
+      raw = await readFile(settingsPath, 'utf-8')
+    } catch {
+      continue
+    }
+    try {
+      const parsed: unknown = JSON.parse(raw)
+      const days = (parsed as Record<string, unknown> | null)?.['cleanupPeriodDays']
+      if (typeof days === 'number' && Number.isFinite(days)) {
+        return { effectiveDays: days, configured: true, settingsPath }
+      }
+      return { effectiveDays: CLAUDE_DEFAULT_CLEANUP_DAYS, configured: false, settingsPath }
+    } catch {
+      // Unparseable settings: report the default; Claude Code would apply it too.
+      return { effectiveDays: CLAUDE_DEFAULT_CLEANUP_DAYS, configured: false, settingsPath }
     }
   }
-
-  // Cache-only providers are useful evidence too: an installed source may have
-  // disappeared while durable history remains. Add them only for an all-provider
-  // diagnostic and never duplicate a real provider row.
-  if (providerName === 'all') {
-    const seen = new Set(rows.map(row => row.provider))
-    for (const [name, section] of Object.entries(cache.providers)) {
-      if (seen.has(name)) continue
-      rows.push({
-        provider: name,
-        displayName: name,
-        status: Object.keys(section.files).length > 0 ? 'ok' : 'empty',
-        discoveredSources: 0,
-        sampledCalls: 0,
-        probePaths: [],
-        envOverrides: collectEnvOverrides(name),
-        verdict: Object.keys(section.files).length > 0
-          ? `CACHE ONLY (${Object.keys(section.files).length.toLocaleString('en-US')} retained sources)`
-          : 'CACHE ONLY (empty)',
-      })
-    }
-  }
-
-  rows.sort((a, b) => a.displayName.localeCompare(b.displayName))
-  return { generatedAt: new Date().toISOString(), providers: rows }
+  return undefined
 }
 
-function renderPathSummary(paths: DoctorProbePath[]): string {
-  if (paths.length === 0) return '-'
-  return paths.map(p => `${p.exists ? '✓' : '✗'} ${p.path}`).join(', ')
-}
-
-function renderOverrideSummary(overrides: DoctorEnvOverride[]): string {
-  if (overrides.length === 0) return '-'
-  return overrides.map(o => `${o.name}=${o.value}`).join(', ')
-}
-
-export function renderDoctorTable(report: DoctorReport): string {
-  const rows = report.providers.map(r => [
-    r.displayName,
-    r.status.toUpperCase(),
-    r.discoveredSources.toLocaleString('en-US'),
-    r.sampledCalls.toLocaleString('en-US'),
-    r.verdict,
-    renderPathSummary(r.probePaths),
-    renderOverrideSummary(r.envOverrides),
-  ])
-  const headers = ['Provider', 'Status', 'Sources', 'Calls', 'Verdict', 'Paths', 'Overrides']
-  const widths = headers.map((h, i) => Math.max(h.length, ...rows.map(r => r[i]?.length ?? 0)))
-  const line = (cells: string[]) => cells.map((c, i) => c.padEnd(widths[i]!)).join('  ')
-  return [line(headers), line(widths.map(w => '-'.repeat(w))), ...rows.map(line)].join('\n')
-}
+// ── Render ────────────────────────────────────────────────────────────────
 
 export function renderDoctorJson(report: DoctorReport): string {
   return JSON.stringify(report, null, 2)
+}
+
+export function renderDoctorTable(
+  report: DoctorReport,
+  opts: { color?: boolean } = {},
+): string {
+  const c = new Chalk(opts.color === false ? { level: 0 } : {})
+  const out: string[] = []
+
+  const n = report.providers.length
+  out.push(c.bold('Metrora doctor') + c.dim(`   ${n} provider${n === 1 ? '' : 's'}   ${report.generatedAt.slice(0, 19).replace('T', ' ')} UTC`))
+  out.push('')
+
+  const colorVerdict = (r: DoctorProviderReport): string => {
+    if (r.status === 'ok') return c.green(r.verdict)
+    if (r.status === 'network') return c.cyan(r.verdict)
+    if (r.status === 'empty') return c.yellow(r.verdict)
+    return c.red(r.verdict)
+  }
+
+  const rows = report.providers.map(r => [
+    r.displayName,
+    r.status === 'network' ? '-' : String(r.candidatesFound),
+    r.status === 'network' || r.sampled === 0 ? '-' : `${r.parsedOk}/${r.sampled}${r.bounded ? '+' : ''}`,
+    String(r.cachedFiles),
+    colorVerdict(r),
+  ])
+
+  out.push(renderTable(
+    [
+      { header: 'Provider' },
+      { header: 'Sessions', right: true },
+      { header: 'Parsed', right: true },
+      { header: 'Cached', right: true },
+      { header: 'Verdict' },
+    ],
+    rows,
+    { color: opts.color },
+  ))
+
+  // Detail: show the exact probed paths + overrides only where there is
+  // something diagnostic to show (known probe roots, an override, a hard
+  // error, or cached parse failures), so a wrong path is spotted at a glance
+  // without a wall of empty blocks for tools that are simply not installed.
+  const detail = report.providers.filter(
+    r =>
+      r.status === 'error' ||
+      r.status === 'errors' ||
+      r.envOverrides.length > 0 ||
+      r.cachedFailed > 0 ||
+      r.probePaths.some(p => p.label !== 'discovered'),
+  )
+  if (detail.length > 0) {
+    out.push('')
+    out.push(c.bold('Details'))
+    for (const r of detail) {
+      out.push('  ' + c.bold(r.displayName))
+      for (const o of r.envOverrides) {
+        out.push('    ' + c.dim('override ') + `${o.name}=${o.value}`)
+      }
+      for (const p of r.probePaths) {
+        const mark = p.exists ? c.green('exists') : c.red('missing')
+        out.push('    ' + c.dim(`${p.label}: `) + p.path + ' ' + c.dim('(') + mark + c.dim(')'))
+      }
+      if (r.parseVersion) out.push('    ' + c.dim('parser: ') + r.parseVersion)
+      if (r.cachedFailed > 0) out.push('    ' + c.dim('cached parse failures: ') + String(r.cachedFailed))
+      if (r.error) out.push('    ' + c.red('error: ') + r.error)
+    }
+  }
+
+  if (report.claudeRetention) {
+    const r = report.claudeRetention
+    const source = r.configured ? 'cleanupPeriodDays' : 'cleanupPeriodDays not set; Claude Code default'
+    const line = `Claude Code deletes transcripts after ${r.effectiveDays} day${r.effectiveDays === 1 ? '' : 's'} (${source}).`
+    out.push('')
+    if (r.effectiveDays < CLAUDE_RETENTION_WARN_DAYS) {
+      out.push(
+        c.yellow(line) + ' ' +
+        `Daily totals survive in Metrora's cache, but per-session detail older than that is gone for good. ` +
+        `To keep it, set "cleanupPeriodDays": 3650 in ${r.settingsPath}.`,
+      )
+    } else {
+      out.push(c.dim(line + ' Long transcript retention: per-session detail is preserved.'))
+    }
+  }
+
+  out.push('')
+  const broken = report.providers.filter(r => r.status === 'error' || r.status === 'errors')
+  const empty = report.providers.filter(r => r.status === 'empty')
+  const ok = report.providers.filter(r => r.status === 'ok')
+  out.push(
+    c.dim('Bottom line: ') +
+    `${ok.length} OK, ${empty.length} with nothing found, ${broken.length} with errors.`,
+  )
+
+  return out.join('\n') + '\n'
 }

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1980,17 +1980,13 @@ async function parseSessionFile(
   const dedupedEntries = dedupeStreamingMessageIds(entries)
   let turns = groupIntoTurns(dedupedEntries, seenMsgIds)
   if (dateRange) {
-    // Bucket a turn by the timestamp of its first assistant call (when the cost was
-    // actually incurred). Filtering entries directly produced orphan assistant calls
-    // when a user message sat in one day and the response landed in another -- those
-    // got pushed as turns with empty timestamps, which some code paths counted and
-    // others dropped, producing inconsistent Today totals.
-    turns = turns.filter(turn => {
-      if (turn.assistantCalls.length === 0) return false
-      const firstCallTs = turn.assistantCalls[0]!.timestamp
-      if (!firstCallTs) return false
-      const ts = new Date(firstCallTs)
-      return ts >= dateRange.start && ts <= dateRange.end
+    // Accounting membership is call-level even when turn/day attribution remains
+    // turn-anchored. A turn may span either range boundary; retaining the whole
+    // turn would publish usage outside an exact requested cutoff, while rejecting
+    // it by its first call would lose a later call that enters the range.
+    turns = turns.flatMap(turn => {
+      const sliced = sliceParsedTurnToDateRange(turn, dateRange)
+      return sliced ? [sliced] : []
     })
     if (turns.length === 0) return null
   }
@@ -2342,17 +2338,18 @@ async function scanProjectDirs(
     let carriedPrRefs: string[] | undefined
     let prRefsAtRangeStart: string[] | undefined
     let frozePrRefs = !dateRange
-    let classifiedTurns = reconciledTurns.map(turn => {
+    const classifiedTurns = reconciledTurns.flatMap(turn => {
       if (turn.gitBranch) carriedBranch = turn.gitBranch
       if (dateRange && !frozePrRefs) {
-        const firstTs = turn.calls[0]?.timestamp
-        if (firstTs && new Date(firstTs) >= dateRange.start) {
+        const firstInRange = turn.calls.find(call => callIsInDateRange(call, dateRange))
+        if (firstInRange) {
           prRefsAtRangeStart = carriedPrRefs
           frozePrRefs = true
         }
       }
       if (turn.prRefs?.length) carriedPrRefs = turn.prRefs
-      return cachedTurnToClassified(turn, carriedBranch)
+      const projectedTurn = dateRange ? sliceCachedTurnToDateRange(turn, dateRange) : turn
+      return projectedTurn ? [cachedTurnToClassified(projectedTurn, carriedBranch)] : []
     })
     // Captured from the FULL turn list, before the date slice below can drop the
     // turn a branch was first seen on. Lets the by-branch report keep this
@@ -2364,16 +2361,6 @@ async function scanProjectDirs(
     // right PR even when its launching turn is later sliced out of range. Only for
     // sessions that both spawned subagents and referenced a PR.
     const spawnPrSets = cachedFile.prLinks?.length ? buildSpawnPrSets(reconciledTurns) : {}
-
-    if (dateRange) {
-      classifiedTurns = classifiedTurns.filter(turn => {
-        if (turn.assistantCalls.length === 0) return false
-        const firstCallTs = turn.assistantCalls[0]!.timestamp
-        if (!firstCallTs) return false
-        const ts = new Date(firstCallTs)
-        return ts >= dateRange.start && ts <= dateRange.end
-      })
-    }
 
     // A PR-linked parent that spawned subagents is kept even when its OWN turns all
     // fall out of range, as a 0-cost fold ANCHOR: an in-range child (an async agent
@@ -2865,6 +2852,31 @@ function cachedTurnToClassified(turn: CachedTurn, resolvedBranch?: string): Clas
   return classifyTurn(parsed)
 }
 
+function callIsInDateRange(call: Pick<ParsedApiCall, 'timestamp'>, dateRange: DateRange): boolean {
+  const timestampMs = Date.parse(call.timestamp)
+  if (!Number.isFinite(timestampMs)) return false
+  return timestampMs >= dateRange.start.getTime() && timestampMs <= dateRange.end.getTime()
+}
+
+function sliceParsedTurnToDateRange(turn: ParsedTurn, dateRange: DateRange): ParsedTurn | null {
+  const assistantCalls = turn.assistantCalls.filter(call => callIsInDateRange(call, dateRange))
+  if (assistantCalls.length === 0) return null
+  if (assistantCalls.length === turn.assistantCalls.length) return turn
+  return { ...turn, assistantCalls }
+}
+
+function sliceClassifiedTurnToDateRange(turn: ClassifiedTurn, dateRange: DateRange): ClassifiedTurn | null {
+  const sliced = sliceParsedTurnToDateRange(turn, dateRange)
+  return sliced ? classifyTurn(sliced) : null
+}
+
+function sliceCachedTurnToDateRange(turn: CachedTurn, dateRange: DateRange): CachedTurn | null {
+  const calls = turn.calls.filter(call => callIsInDateRange(call, dateRange))
+  if (calls.length === 0) return null
+  if (calls.length === turn.calls.length) return turn
+  return { ...turn, calls }
+}
+
 // ── Cache-Aware Parsing Helpers ────────────────────────────────────────
 
 // Merge the calls of the last cached turn with the calls parsed from the
@@ -3264,29 +3276,25 @@ async function parseProviderSources(
     if (!cachedFile) continue
 
     for (const turn of cachedFile.turns) {
-      const hasDup = turn.calls.some(c => seenKeys.has(c.deduplicationKey))
+      const projectedTurn = dateRange ? sliceCachedTurnToDateRange(turn, dateRange) : turn
+      if (!projectedTurn) continue
+
+      const hasDup = projectedTurn.calls.some(c => seenKeys.has(c.deduplicationKey))
       if (hasDup) continue
 
-      for (const c of turn.calls) seenKeys.add(c.deduplicationKey)
+      for (const c of projectedTurn.calls) seenKeys.add(c.deduplicationKey)
 
-      if (dateRange) {
-        const callTs = turn.calls[0]?.timestamp
-        if (!callTs) continue
-        const ts = new Date(callTs)
-        if (ts < dateRange.start || ts > dateRange.end) continue
-      }
-
-      const classified = cachedTurnToClassified(turn)
-      const project = turn.calls[0]?.project ?? source.project
+      const classified = cachedTurnToClassified(projectedTurn)
+      const project = projectedTurn.calls[0]?.project ?? source.project
       const key = `${providerName}:${turn.sessionId}:${project}`
 
       const existing = sessionMap.get(key)
       if (existing) {
         existing.turns.push(classified)
-        if (!existing.projectPath && turn.calls[0]?.projectPath) {
-          existing.projectPath = turn.calls[0]!.projectPath
+        if (!existing.projectPath && projectedTurn.calls[0]?.projectPath) {
+          existing.projectPath = projectedTurn.calls[0]!.projectPath
         }
-        if (!existing.workingDirectory && turn.calls[0]?.workingDirectory) existing.workingDirectory = turn.calls[0].workingDirectory
+        if (!existing.workingDirectory && projectedTurn.calls[0]?.workingDirectory) existing.workingDirectory = projectedTurn.calls[0].workingDirectory
         if (cachedFile.prLinks?.length) {
           const links = (existing.prLinks ??= new Set())
           for (const link of cachedFile.prLinks) links.add(link)
@@ -3295,8 +3303,8 @@ async function parseProviderSources(
       } else {
         sessionMap.set(key, {
           project,
-          projectPath: turn.calls[0]?.projectPath,
-          workingDirectory: turn.calls[0]?.workingDirectory,
+          projectPath: projectedTurn.calls[0]?.projectPath,
+          workingDirectory: projectedTurn.calls[0]?.workingDirectory,
           turns: [classified],
           ...(cachedFile.prLinks?.length ? { prLinks: new Set(cachedFile.prLinks) } : {}),
           ...(cachedFile.title ? { title: cachedFile.title } : {}),
@@ -3313,30 +3321,26 @@ async function parseProviderSources(
       if (allDiscoveredFiles.has(cachedPath)) continue  // already counted above
 
       for (const turn of cachedFile.turns) {
-        const hasDup = turn.calls.some(c => seenKeys.has(c.deduplicationKey))
+        const projectedTurn = dateRange ? sliceCachedTurnToDateRange(turn, dateRange) : turn
+        if (!projectedTurn) continue
+
+        const hasDup = projectedTurn.calls.some(c => seenKeys.has(c.deduplicationKey))
         if (hasDup) continue
 
-        for (const c of turn.calls) seenKeys.add(c.deduplicationKey)
+        for (const c of projectedTurn.calls) seenKeys.add(c.deduplicationKey)
 
-        if (dateRange) {
-          const callTs = turn.calls[0]?.timestamp
-          if (!callTs) continue
-          const ts = new Date(callTs)
-          if (ts < dateRange.start || ts > dateRange.end) continue
-        }
-
-        const classified = cachedTurnToClassified(turn)
-        const project = turn.calls[0]?.project ?? providerName
+        const classified = cachedTurnToClassified(projectedTurn)
+        const project = projectedTurn.calls[0]?.project ?? providerName
         const key = `${providerName}:${turn.sessionId}:${project}`
 
         const existingEntry = sessionMap.get(key)
         if (existingEntry) {
           existingEntry.turns.push(classified)
-          if (!existingEntry.projectPath && turn.calls[0]?.projectPath) {
-            existingEntry.projectPath = turn.calls[0]!.projectPath
+          if (!existingEntry.projectPath && projectedTurn.calls[0]?.projectPath) {
+            existingEntry.projectPath = projectedTurn.calls[0]!.projectPath
           }
         } else {
-          sessionMap.set(key, { project, projectPath: turn.calls[0]?.projectPath, workingDirectory: turn.calls[0]?.workingDirectory, turns: [classified] })
+          sessionMap.set(key, { project, projectPath: projectedTurn.calls[0]?.projectPath, workingDirectory: projectedTurn.calls[0]?.workingDirectory, turns: [classified] })
         }
       }
     }
@@ -3449,14 +3453,6 @@ export function filterProjectsByName(
     })
   }
   return result
-}
-
-function turnIsInDateRange(turn: ClassifiedTurn, dateRange: DateRange): boolean {
-  if (turn.assistantCalls.length === 0) return false
-  const firstCallTs = turn.assistantCalls[0]!.timestamp
-  if (!firstCallTs) return false
-  const ts = new Date(firstCallTs)
-  return ts >= dateRange.start && ts <= dateRange.end
 }
 
 function turnDayString(turn: ClassifiedTurn): string | null {
@@ -3796,7 +3792,10 @@ export function filterProjectsByDateRange(projects: ProjectSummary[], dateRange:
     const anchors: SessionSummary[] = [...(project.subagentAnchors ?? [])]
     const survivingIdentities = new Set<string>()
     for (const session of project.sessions) {
-      const turns = session.turns.filter(turn => turnIsInDateRange(turn, dateRange))
+      const turns = session.turns.flatMap(turn => {
+        const sliced = sliceClassifiedTurnToDateRange(turn, dateRange)
+        return sliced ? [sliced] : []
+      })
       if (turns.length === 0) {
         if (isSpawnParent(session)) anchors.push(session)
         continue

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1049,6 +1049,7 @@ export function compactEntry(raw: JournalEntry): JournalEntry {
     usage: compactUsage,
     content: compactContent,
     ...(msg.id ? { id: msg.id } : {}),
+    ...(msg.stop_reason ? { stop_reason: msg.stop_reason } : {}),
   }
 
   return entry
@@ -1417,6 +1418,11 @@ export function parseApiCall(entry: JournalEntry, toolResultMeta?: Map<string, T
     timestamp: entry.timestamp ?? '',
     bashCommands: bashCmds,
     deduplicationKey: msg.id ?? `claude:${entry.timestamp}`,
+    ...(msg.id ? { nativeMessageId: msg.id } : {}),
+    ...(typeof entry['nativeEmissionTimestamp'] === 'string' && entry['nativeEmissionTimestamp']
+      ? { nativeEmissionTimestamp: entry['nativeEmissionTimestamp'] }
+      : { nativeEmissionTimestamp: entry.timestamp ?? '' }),
+    ...(msg.stop_reason ? { nativeSnapshotTerminal: true } : {}),
     cacheCreationOneHourTokens: cacheCreation.oneHourTokens || undefined,
     toolSequence: toolSeq.length > 0 ? toolSeq : undefined,
     ...(spawnIds.length > 0 ? { spawnToolUseIds: spawnIds } : {}),
@@ -1511,12 +1517,126 @@ export function dedupeStreamingMessageIds(entries: JournalEntry[]): JournalEntry
     if (id && lastIdxById.get(id) !== i) continue
     if (id && firstIdxById.get(id) !== i) {
       const firstTs = entries[firstIdxById.get(id)!]!.timestamp
-      result.push({ ...entries[i]!, timestamp: firstTs ?? entries[i]!.timestamp })
+      result.push({
+        ...entries[i]!,
+        timestamp: firstTs ?? entries[i]!.timestamp,
+        nativeEmissionTimestamp: entries[i]!.timestamp ?? firstTs ?? '',
+      })
       continue
     }
     result.push(entries[i]!)
   }
   return result
+}
+
+/**
+ * A Claude JSONL message id is a native accounting identity, not a file-local
+ * key. A parent transcript and a sidechain/mirror can therefore contain two
+ * snapshots of one API response. This comparator deliberately uses only
+ * evidence carried by the native snapshot:
+ *
+ *   1. later native emission timestamp;
+ *   2. a native terminal marker when timestamps tie;
+ *   3. a stable path/ordinal tie-break only when the accounting tuple is
+ *      already identical (or when an ambiguity is explicitly recorded).
+ *
+ * It never takes a maximum per field, adds duplicate snapshots, or lets file
+ * discovery order decide the accounting winner.
+ */
+export type ClaudeNativeCallCandidate = {
+  filePath: string
+  call: CachedCall
+  ordinal: number
+}
+
+export type ClaudeNativeIdentityAmbiguity = {
+  identity: string
+  candidates: ClaudeNativeCallCandidate[]
+}
+
+export type ClaudeNativeReconciliation = {
+  winners: Map<string, ClaudeNativeCallCandidate>
+  ambiguities: ClaudeNativeIdentityAmbiguity[]
+}
+
+export function getClaudeNativeIdentity(call: Pick<CachedCall, 'provider' | 'deduplicationKey' | 'nativeMessageId'>): string | undefined {
+  if (call.provider !== 'claude') return undefined
+  if (call.nativeMessageId) return call.nativeMessageId
+  // Support a one-run projection of a pre-migration cache. Advisor calls use a
+  // derived `:advisor:` key and are deliberately excluded from this fallback.
+  if (call.deduplicationKey.startsWith('claude:') || call.deduplicationKey.includes(':advisor:')) return undefined
+  return call.deduplicationKey || undefined
+}
+
+function nativeAccountingTuple(call: CachedCall): string {
+  return JSON.stringify({
+    model: call.model,
+    modelProvider: call.modelProvider ?? null,
+    inputTokens: call.usage.inputTokens,
+    outputTokens: call.usage.outputTokens,
+    cacheCreationInputTokens: call.usage.cacheCreationInputTokens,
+    cacheReadInputTokens: call.usage.cacheReadInputTokens,
+    cachedInputTokens: call.usage.cachedInputTokens,
+    reasoningTokens: call.usage.reasoningTokens,
+    webSearchRequests: call.usage.webSearchRequests,
+    cacheCreationOneHourTokens: call.usage.cacheCreationOneHourTokens,
+  })
+}
+
+function nativeEmissionMs(call: CachedCall): number | undefined {
+  const raw = call.nativeEmissionTimestamp ?? call.timestamp
+  const ms = Date.parse(raw)
+  return Number.isFinite(ms) ? ms : undefined
+}
+
+function nativeStableKey(candidate: ClaudeNativeCallCandidate): string {
+  const path = candidate.filePath.replace(/\\/g, '/').toLowerCase()
+  return `${path}\u0000${String(candidate.ordinal).padStart(12, '0')}\u0000${nativeAccountingTuple(candidate.call)}`
+}
+
+/** Positive when `a` has stronger native chronology/finality evidence. */
+function compareNativeEvidence(a: ClaudeNativeCallCandidate, b: ClaudeNativeCallCandidate): number {
+  const aMs = nativeEmissionMs(a.call)
+  const bMs = nativeEmissionMs(b.call)
+  if (aMs !== undefined && bMs !== undefined && aMs !== bMs) return aMs > bMs ? 1 : -1
+  if (aMs !== undefined && bMs === undefined) return 1
+  if (aMs === undefined && bMs !== undefined) return -1
+  const aTerminal = a.call.nativeSnapshotTerminal === true
+  const bTerminal = b.call.nativeSnapshotTerminal === true
+  if (aTerminal !== bTerminal) return aTerminal ? 1 : -1
+  return 0
+}
+
+export function reconcileClaudeNativeCalls(
+  files: ReadonlyArray<{ filePath: string; calls: readonly CachedCall[] }>,
+): ClaudeNativeReconciliation {
+  const groups = new Map<string, ClaudeNativeCallCandidate[]>()
+  for (const file of files) {
+    let ordinal = 0
+    for (const call of file.calls) {
+      const identity = getClaudeNativeIdentity(call)
+      if (!identity) continue
+      const group = groups.get(identity) ?? []
+      group.push({ filePath: file.filePath, call, ordinal: ordinal++ })
+      groups.set(identity, group)
+    }
+  }
+
+  const winners = new Map<string, ClaudeNativeCallCandidate>()
+  const ambiguities: ClaudeNativeIdentityAmbiguity[] = []
+  for (const [identity, candidates] of groups) {
+    const ranked = [...candidates].sort((a, b) => {
+      const evidence = compareNativeEvidence(b, a)
+      return evidence !== 0 ? evidence : nativeStableKey(a).localeCompare(nativeStableKey(b))
+    })
+    const winner = ranked[0]
+    if (!winner) continue
+    const equallyAuthoritative = candidates.filter(candidate => compareNativeEvidence(candidate, winner) === 0)
+    const tuples = new Set(equallyAuthoritative.map(candidate => nativeAccountingTuple(candidate.call)))
+    if (tuples.size > 1) ambiguities.push({ identity, candidates: equallyAuthoritative })
+    winners.set(identity, winner)
+  }
+  return { winners, ambiguities }
 }
 
 export function groupIntoTurns(entries: JournalEntry[], seenMsgIds: Set<string>, toolResultMeta?: Map<string, ToolResultMeta>): ParsedTurn[] {
@@ -1933,7 +2053,6 @@ export async function readAgentType(filePath: string): Promise<string | undefine
 
 async function scanProjectDirs(
   dirs: Array<{ path: string; name: string; source?: SessionSourceMetadata }>,
-  seenMsgIds: Set<string>,
   diskCache: SessionCache,
   dateRange?: DateRange,
   // Cold-run robustness: called after every parsed Claude file so a throttled
@@ -1994,15 +2113,6 @@ async function scanProjectDirs(
     unchangedFiles.push({ filePath, dirName, cached })
   }
 
-  // Pre-seed dedup set from cached (unchanged) files
-  for (const { cached } of unchangedFiles) {
-    for (const turn of cached.turns) {
-      for (const call of turn.calls) {
-        seenMsgIds.add(call.deduplicationKey)
-      }
-    }
-  }
-
   const parseProgress = createScanProgress('parsing changed claude sessions', changedFiles.length)
   const progressTotal = changedFiles.length
   let filesDone = 0
@@ -2026,11 +2136,11 @@ async function scanProjectDirs(
         // Straddle guard: a streamed assistant message id that first appeared in
         // the committed prefix can be restated inside the appended region
         // (image-heavy turns stream one id across several records over seconds).
-        // The appended region is grouped before this file's cached keys join
-        // seenMsgIds, so the restated id would count twice; suppressing it
-        // instead would freeze the stale first emission. Neither matches a full
-        // re-parse, so on any id overlap the shortcut is abandoned and the file
-        // re-parses from byte 0 (rare: ~0.3% of real files).
+        // The appended region is grouped with a file-local identity set, then
+        // merged with the cached prefix. A restated id across that boundary
+        // must not freeze the stale first emission, so on any overlap the
+        // shortcut is abandoned and the file re-parses from byte 0 (rare:
+        // ~0.3% of real files).
         const cachedIds = new Set(cached.turns.flatMap(t => t.calls.map(c => c.deduplicationKey)))
         const straddles = newEntries !== null && newEntries.some(e => {
           const id = getMessageId(e)
@@ -2038,7 +2148,7 @@ async function scanProjectDirs(
         })
         if (!straddles) {
           const newTurns = newEntries
-            ? parsedTurnsToCachedTurns(groupIntoTurns(dedupeStreamingMessageIds(newEntries), seenMsgIds, toolResultMeta))
+            ? parsedTurnsToCachedTurns(groupIntoTurns(dedupeStreamingMessageIds(newEntries), new Set<string>(), toolResultMeta))
             : []
 
           const mergedTurns: CachedTurn[] = cached.turns.map(t => ({ ...t, calls: [...t.calls] }))
@@ -2062,11 +2172,6 @@ async function scanProjectDirs(
             }
             for (let i = startIdx; i < newTurns.length; i++) mergedTurns.push(newTurns[i]!)
           }
-
-          // The cached region's dedup keys were not added to seenMsgIds (only
-          // unchanged files pre-seed it), so add them now — a full re-parse would
-          // have, and later files dedup cross-file against them.
-          for (const t of cached.turns) for (const c of t.calls) seenMsgIds.add(c.deduplicationKey)
 
           // First-cwd wins, and the first cwd lives in the cached region whenever
           // one was resolved there; only re-derive if the cached region had none.
@@ -2131,7 +2236,10 @@ async function scanProjectDirs(
       const entries = await parseClaudeEntries(filePath, tracker, undefined, { toolResultMeta, sessionMeta })
       if (!entries) { filesDone++; await parseProgress.tick(filesDone); continue }
 
-      const turns = groupIntoTurns(dedupeStreamingMessageIds(entries), seenMsgIds, toolResultMeta)
+      // Streaming deduplication is deliberately file-local. Native message ids
+      // are reconciled after every file is parsed, so discovery order cannot
+      // decide which cross-file snapshot is accounted.
+      const turns = groupIntoTurns(dedupeStreamingMessageIds(entries), new Set<string>(), toolResultMeta)
       const cwd = extractCanonicalCwd(entries)
       const canonical = (cwd && !isCoworkSession(cwd, filePath)) ? await resolveCanonicalProjectPath(cwd) : undefined
       section.files[filePath] = {
@@ -2190,9 +2298,37 @@ async function scanProjectDirs(
     ...changedFiles.map(f => ({ filePath: f.filePath, dirName: f.info.dirName, source: f.info.source })),
   ]
 
+  // Reconcile the complete cached file set, including unchanged files and any
+  // surviving PR-linked orphan. This is the cross-file authority boundary: a
+  // newly discovered mirror can supersede a partial cached parent without
+  // reparsing the parent, and a warm run is therefore equivalent to cold.
+  const claudeNativeReconciliation = reconcileClaudeNativeCalls(
+    Object.entries(section.files).map(([filePath, cached]) => ({
+      filePath,
+      calls: cached.turns.flatMap(turn => turn.calls),
+    })),
+  )
+  if (claudeNativeReconciliation.ambiguities.length > 0) {
+    process.stderr.write(
+      `metrora: Claude native identity ambiguity for ${claudeNativeReconciliation.ambiguities.length} identity group(s); deterministic single-call projection retained without field-wise merging.\n`,
+    )
+  }
+
   for (const { filePath, dirName, source } of allFiles) {
     const cachedFile = section.files[filePath]
     if (!cachedFile || cachedFile.turns.length === 0) continue
+
+    const reconciledTurns = cachedFile.turns
+      .map(turn => {
+        const calls = turn.calls.filter(call => {
+          const identity = getClaudeNativeIdentity(call)
+          if (!identity) return true
+          return claudeNativeReconciliation.winners.get(identity)?.call === call
+        })
+        return calls.length > 0 ? { ...turn, calls } : null
+      })
+      .filter((turn): turn is CachedTurn => turn !== null)
+    if (reconciledTurns.length === 0) continue
 
     // Carry the git branch forward BEFORE the date filter below: the cache
     // stores a turn's branch only when it changes, so resolving here (over the
@@ -2206,7 +2342,7 @@ async function scanProjectDirs(
     let carriedPrRefs: string[] | undefined
     let prRefsAtRangeStart: string[] | undefined
     let frozePrRefs = !dateRange
-    let classifiedTurns = cachedFile.turns.map(turn => {
+    let classifiedTurns = reconciledTurns.map(turn => {
       if (turn.gitBranch) carriedBranch = turn.gitBranch
       if (dateRange && !frozePrRefs) {
         const firstTs = turn.calls[0]?.timestamp
@@ -2227,7 +2363,7 @@ async function scanProjectDirs(
     // the PR set active at the turn that emitted it. Lets a subagent fold into the
     // right PR even when its launching turn is later sliced out of range. Only for
     // sessions that both spawned subagents and referenced a PR.
-    const spawnPrSets = cachedFile.prLinks?.length ? buildSpawnPrSets(cachedFile.turns) : {}
+    const spawnPrSets = cachedFile.prLinks?.length ? buildSpawnPrSets(reconciledTurns) : {}
 
     if (dateRange) {
       classifiedTurns = classifiedTurns.filter(turn => {
@@ -2517,6 +2653,9 @@ export function apiCallToCachedCall(call: ParsedApiCall): CachedCall {
     skills: call.skills,
     subagentTypes: call.subagentTypes,
     deduplicationKey: call.deduplicationKey,
+    ...(call.nativeMessageId ? { nativeMessageId: call.nativeMessageId } : {}),
+    ...(call.nativeEmissionTimestamp ? { nativeEmissionTimestamp: call.nativeEmissionTimestamp } : {}),
+    ...(call.nativeSnapshotTerminal ? { nativeSnapshotTerminal: true } : {}),
     toolSequence: call.toolSequence,
     ...(call.locAdded ? { locAdded: call.locAdded } : {}),
     ...(call.locRemoved ? { locRemoved: call.locRemoved } : {}),
@@ -2695,6 +2834,9 @@ export function cachedCallToApiCall(call: CachedCall): ParsedApiCall {
     timestamp: call.timestamp,
     bashCommands: call.bashCommands,
     deduplicationKey: call.deduplicationKey,
+    ...(call.nativeMessageId ? { nativeMessageId: call.nativeMessageId } : {}),
+    ...(call.nativeEmissionTimestamp ? { nativeEmissionTimestamp: call.nativeEmissionTimestamp } : {}),
+    ...(call.nativeSnapshotTerminal ? { nativeSnapshotTerminal: true } : {}),
     cacheCreationOneHourTokens: u.cacheCreationOneHourTokens || undefined,
     toolSequence: call.toolSequence,
     activeDurationMs: call.activeDurationMs,
@@ -3749,7 +3891,6 @@ async function runParse(
   options: RunParseOptions = {},
 ): Promise<ProjectSummary[]> {
   const { isCold = false, readOnly = false, cachedOnly = false, refreshLock } = options
-  const seenMsgIds = new Set<string>()
   const seenKeys = new Set<string>()
   const allSources = cachedOnly ? [] : await discoverAllSessions(providerFilter)
 
@@ -3793,7 +3934,7 @@ async function runParse(
   if (includeClaude) {
     if (claudeSources.length > 0) emitScanProgress({ kind: 'provider', provider: 'claude', state: 'start' })
     try {
-      claudeProjects = await scanProjectDirs(claudeDirs, seenMsgIds, diskCache, dateRange, saveProgress, readOnly)
+      claudeProjects = await scanProjectDirs(claudeDirs, diskCache, dateRange, saveProgress, readOnly)
       if (claudeSources.length > 0) emitScanProgress({ kind: 'provider', provider: 'claude', state: 'done', files: claudeSources.length })
     } catch (err) {
       if (!isPermissionError(err)) throw err

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -3113,23 +3113,6 @@ async function parseProviderSources(
     }
   }
 
-  // 90-day age-out for durable providers: remove entries whose newest call is
-  // older than 90 days so the detailed cache remains bounded.
-  if (!readOnly && provider.durableSources) {
-    const cutoffMs = Date.now() - 90 * 24 * 60 * 60 * 1000
-    for (const [cachedPath, cachedFile] of Object.entries(section.files)) {
-      const newestTs = cachedFile.turns
-        .flatMap(t => t.calls)
-        .map(c => new Date(c.timestamp).getTime())
-        .filter(ts => !isNaN(ts))
-        .reduce((max, ts) => Math.max(max, ts), 0)
-      if (newestTs > 0 && newestTs < cutoffMs) {
-        delete section.files[cachedPath]
-        ;(diskCache as { _dirty?: boolean })._dirty = true
-      }
-    }
-  }
-
   // Query-time: derive SessionSummary from all cached turns.
   // Uses seenKeys (shared across providers) for cross-provider dedup.
   const sessionMap = new Map<string, { project: string; projectPath?: string; workingDirectory?: string; turns: ClassifiedTurn[]; prLinks?: Set<string>; title?: string }>()
@@ -3243,6 +3226,28 @@ async function parseProviderSources(
   const projects: ProjectSummary[] = []
   for (const [dirName, { projectPath, sessions }] of projectMap) {
     projects.push(summarizeProject(dirName, projectPath ?? unsanitizePath(dirName), sessions))
+  }
+
+  // Durable source evidence must be materialized into the caller's result
+  // before detailed-cache retention is applied.  The detailed session cache is
+  // intentionally bounded, but a source that is still physically available may
+  // be the only evidence from which the durable daily ledger can be rebuilt.
+  // Evicting it before the query-time projection made cold bootstrap silently
+  // lose old Antigravity responses (and any other durable provider with the same
+  // lifecycle).
+  if (!readOnly && provider.durableSources) {
+    const cutoffMs = Date.now() - 90 * 24 * 60 * 60 * 1000
+    for (const [cachedPath, cachedFile] of Object.entries(section.files)) {
+      const newestTs = cachedFile.turns
+        .flatMap(t => t.calls)
+        .map(c => new Date(c.timestamp).getTime())
+        .filter(ts => !isNaN(ts))
+        .reduce((max, ts) => Math.max(max, ts), 0)
+      if (newestTs > 0 && newestTs < cutoffMs) {
+        delete section.files[cachedPath]
+        ;(diskCache as { _dirty?: boolean })._dirty = true
+      }
+    }
   }
 
   return projects

--- a/src/provider-parse-authorities.ts
+++ b/src/provider-parse-authorities.ts
@@ -1,4 +1,4 @@
-import { createHash } from 'crypto'
+import { createHash } from 'node:crypto'
 
 import { PROVIDER_ENV_VARS, PROVIDER_PARSE_VERSIONS } from './session-cache.js'
 
@@ -9,10 +9,10 @@ export const COPILOT_CLI_RESUME_AUTHORITY = 'resumed-shutdown-delta-v1'
 export const COPILOT_CLI_RESUME_PROVIDER = `copilot-cli-resume-${COPILOT_CLI_RESUME_AUTHORITY}`
 
 /**
- * Provider env reads that materially change discovery or parsing. Metrora
- * inherited a smaller declaration map than its current provider set actually
- * reads, so changing one of these overrides could leave a warm session-cache
- * section attached to the previous source/profile.
+ * Provider env reads that materially change discovery, parsing, or the account
+ * queried by a provider. Metrora inherited a smaller declaration map than its
+ * current provider set actually reads, so changing one of these overrides could
+ * leave a warm session-cache section attached to the previous source/profile.
  *
  * Keep this list Metrora-owned: names intentionally use Metrora's compatibility
  * env contract rather than upstream aliases.
@@ -33,6 +33,7 @@ export const PROVIDER_ENV_FINGERPRINT_ADDITIONS: Readonly<Record<string, readonl
   mux: ['MUX_ROOT', 'METRORA_MUX_DIR'],
   zerostack: ['ZS_DATA_DIR', 'XDG_DATA_HOME'],
   'ibm-bob': ['APPDATA'],
+  'vercel-gateway': ['AI_GATEWAY_API_KEY', 'VERCEL_OIDC_TOKEN'],
 }
 
 /**
@@ -54,17 +55,6 @@ export const COPILOT_DEFERRED_ENV_FINGERPRINTS = [
   'XDG_CONFIG_HOME',
 ] as const
 
-/**
- * Vercel credentials also influence account identity, but are intentionally not
- * declared here yet. `doctor` renders declared overrides, so credential-backed
- * fingerprints must land together with collect-time redaction; adding the names
- * alone would risk leaking a live key in diagnostic output.
- */
-export const VERCEL_DEFERRED_SECRET_FINGERPRINTS = [
-  'AI_GATEWAY_API_KEY',
-  'VERCEL_OIDC_TOKEN',
-] as const
-
 /** Install the static provider env declarations before any cache fingerprint. */
 export function ensureProviderEnvFingerprintAuthorities(): void {
   for (const [provider, additions] of Object.entries(PROVIDER_ENV_FINGERPRINT_ADDITIONS)) {
@@ -79,7 +69,8 @@ export function ensureProviderEnvFingerprintAuthorities(): void {
 
 /**
  * Hash, never serialize, the values behind every declared provider env input.
- * Daily history must move with the same source identity as the session cache.
+ * Daily history must move with the same source/account identity as the session
+ * cache, while credential values themselves must never land in the config key.
  */
 export function getProviderEnvConfigHash(): string {
   ensureProviderEnvFingerprintAuthorities()

--- a/src/provider-parse-authorities.ts
+++ b/src/provider-parse-authorities.ts
@@ -9,10 +9,10 @@ export const COPILOT_CLI_RESUME_AUTHORITY = 'resumed-shutdown-delta-v1'
 export const COPILOT_CLI_RESUME_PROVIDER = `copilot-cli-resume-${COPILOT_CLI_RESUME_AUTHORITY}`
 
 /**
- * Provider env reads that materially change discovery, parsing, or the account
- * queried by a provider. Metrora inherited a smaller declaration map than its
- * current provider set actually reads, so changing one of these overrides could
- * leave a warm session-cache section attached to the previous source/profile.
+ * Provider env reads that materially change discovery or parsing. Metrora
+ * inherited a smaller declaration map than its current provider set actually
+ * reads, so changing one of these overrides could leave a warm session-cache
+ * section attached to the previous source/profile.
  *
  * Keep this list Metrora-owned: names intentionally use Metrora's compatibility
  * env contract rather than upstream aliases.
@@ -33,7 +33,6 @@ export const PROVIDER_ENV_FINGERPRINT_ADDITIONS: Readonly<Record<string, readonl
   mux: ['MUX_ROOT', 'METRORA_MUX_DIR'],
   zerostack: ['ZS_DATA_DIR', 'XDG_DATA_HOME'],
   'ibm-bob': ['APPDATA'],
-  'vercel-gateway': ['AI_GATEWAY_API_KEY', 'VERCEL_OIDC_TOKEN'],
 }
 
 /**
@@ -55,6 +54,17 @@ export const COPILOT_DEFERRED_ENV_FINGERPRINTS = [
   'XDG_CONFIG_HOME',
 ] as const
 
+/**
+ * Vercel credentials also influence account identity, but are intentionally not
+ * declared here yet. `doctor` renders declared overrides, so credential-backed
+ * fingerprints must land together with collect-time redaction; adding the names
+ * alone would risk leaking a live key in diagnostic output.
+ */
+export const VERCEL_DEFERRED_SECRET_FINGERPRINTS = [
+  'AI_GATEWAY_API_KEY',
+  'VERCEL_OIDC_TOKEN',
+] as const
+
 /** Install the static provider env declarations before any cache fingerprint. */
 export function ensureProviderEnvFingerprintAuthorities(): void {
   for (const [provider, additions] of Object.entries(PROVIDER_ENV_FINGERPRINT_ADDITIONS)) {
@@ -69,8 +79,7 @@ export function ensureProviderEnvFingerprintAuthorities(): void {
 
 /**
  * Hash, never serialize, the values behind every declared provider env input.
- * Daily history must move with the same source/account identity as the session
- * cache, while credentials themselves must never land in the cache config key.
+ * Daily history must move with the same source identity as the session cache.
  */
 export function getProviderEnvConfigHash(): string {
   ensureProviderEnvFingerprintAuthorities()

--- a/src/provider-parse-authorities.ts
+++ b/src/provider-parse-authorities.ts
@@ -1,8 +1,86 @@
-import { PROVIDER_PARSE_VERSIONS } from './session-cache.js'
+import { createHash } from 'crypto'
+
+import { PROVIDER_ENV_VARS, PROVIDER_PARSE_VERSIONS } from './session-cache.js'
 
 export const CODEX_LEGACY_SESSION_META_AUTHORITY = 'legacy-session-meta-v1'
 export const COPILOT_CHAT_JOURNAL_AUTHORITY = 'current-chat-journal-v3'
 export const COPILOT_CHAT_JOURNAL_PROVIDER = `copilot-chat-journal-${COPILOT_CHAT_JOURNAL_AUTHORITY}`
+export const COPILOT_CLI_RESUME_AUTHORITY = 'resumed-shutdown-delta-v1'
+export const COPILOT_CLI_RESUME_PROVIDER = `copilot-cli-resume-${COPILOT_CLI_RESUME_AUTHORITY}`
+
+/**
+ * Provider env reads that materially change discovery, parsing, or the account
+ * queried by a provider. Metrora inherited a smaller declaration map than its
+ * current provider set actually reads, so changing one of these overrides could
+ * leave a warm session-cache section attached to the previous source/profile.
+ *
+ * Keep this list Metrora-owned: names intentionally use Metrora's compatibility
+ * env contract rather than upstream aliases.
+ */
+export const PROVIDER_ENV_FINGERPRINT_ADDITIONS: Readonly<Record<string, readonly string[]>> = {
+  claude: ['METRORA_DESKTOP_SESSIONS_DIR', 'APPDATA', 'LOCALAPPDATA'],
+  'cline-cli': ['CLINE_SESSION_DATA_DIR', 'CLINE_DATA_DIR', 'CLINE_DIR'],
+  codebuff: ['CODEBUFF_DATA_DIR'],
+  cursor: ['METRORA_CURSOR_MAX_BUBBLES'],
+  'open-design': ['METRORA_OPEN_DESIGN_DIR', 'APPDATA'],
+  goose: ['GOOSE_PATH_ROOT'],
+  grok: ['GROK_HOME'],
+  crush: ['CRUSH_GLOBAL_DATA', 'LOCALAPPDATA'],
+  'kilo-code': ['XDG_DATA_HOME'],
+  kimi: ['KIMI_SHARE_DIR', 'KIMI_MODEL_NAME'],
+  kiro: ['KIRO_HOME'],
+  'mistral-vibe': ['VIBE_HOME'],
+  mux: ['MUX_ROOT', 'METRORA_MUX_DIR'],
+  zerostack: ['ZS_DATA_DIR', 'XDG_DATA_HOME'],
+  'ibm-bob': ['APPDATA'],
+  'vercel-gateway': ['AI_GATEWAY_API_KEY', 'VERCEL_OIDC_TOKEN'],
+}
+
+/**
+ * Copilot is deliberately excluded from PROVIDER_ENV_VARS for now. Its durable
+ * OTel cache can contain conversations already pruned from a still-existing DB
+ * path. A provider-wide fingerprint change currently drops that present-path
+ * cache entry before reparse, which can destroy history that raw evidence can no
+ * longer recreate. The current-chat journal has its own non-durable namespace,
+ * so its snapshot semantics do not require this unsafe provider-wide bump.
+ */
+export const COPILOT_DEFERRED_ENV_FINGERPRINTS = [
+  'METRORA_COPILOT_SESSION_STATE_DIR',
+  'METRORA_COPILOT_OTEL_DB',
+  'METRORA_COPILOT_JETBRAINS_DIR',
+  'METRORA_COPILOT_WS_STORAGE_DIR',
+  'METRORA_COPILOT_DISABLE_OTEL',
+  'APPDATA',
+  'LOCALAPPDATA',
+  'XDG_CONFIG_HOME',
+] as const
+
+/** Install the static provider env declarations before any cache fingerprint. */
+export function ensureProviderEnvFingerprintAuthorities(): void {
+  for (const [provider, additions] of Object.entries(PROVIDER_ENV_FINGERPRINT_ADDITIONS)) {
+    const current = PROVIDER_ENV_VARS[provider] ?? []
+    const next = [...current]
+    for (const name of additions) {
+      if (!next.includes(name)) next.push(name)
+    }
+    PROVIDER_ENV_VARS[provider] = next
+  }
+}
+
+/**
+ * Hash, never serialize, the values behind every declared provider env input.
+ * Daily history must move with the same source/account identity as the session
+ * cache, while credentials themselves must never land in the cache config key.
+ */
+export function getProviderEnvConfigHash(): string {
+  ensureProviderEnvFingerprintAuthorities()
+  const parts: string[] = []
+  for (const provider of Object.keys(PROVIDER_ENV_VARS).sort()) {
+    const vars = [...(PROVIDER_ENV_VARS[provider] ?? [])].sort()
+    for (const name of vars) parts.push(`${provider}\u0001${name}\u0001${process.env[name] ?? ''}`)
+  }
+  return createHash('sha256').update(parts.join('\u0002')).digest('hex').slice(0, 24)
+}
 
 /**
  * The canonical provider parse-version map is the session-cache authority.

--- a/src/provider-parse-authorities.ts
+++ b/src/provider-parse-authorities.ts
@@ -1,0 +1,21 @@
+import { PROVIDER_PARSE_VERSIONS } from './session-cache.js'
+
+export const CODEX_LEGACY_SESSION_META_AUTHORITY = 'legacy-session-meta-v1'
+export const COPILOT_CHAT_JOURNAL_AUTHORITY = 'current-chat-journal-v3'
+export const COPILOT_CHAT_JOURNAL_PROVIDER = `copilot-chat-journal-${COPILOT_CHAT_JOURNAL_AUTHORITY}`
+
+/**
+ * The canonical provider parse-version map is the session-cache authority.
+ * Install the Codex legacy identity marker before any Codex provider parse or
+ * daily-cache hash calculation so warm caches and daily history advance under
+ * the same authority. Idempotent by construction.
+ */
+export function ensureCodexLegacySessionMetaAuthority(): string {
+  const current = PROVIDER_PARSE_VERSIONS['codex'] ?? ''
+  if (current.includes(CODEX_LEGACY_SESSION_META_AUTHORITY)) return current
+  const effective = current
+    ? `${current}-${CODEX_LEGACY_SESSION_META_AUTHORITY}`
+    : CODEX_LEGACY_SESSION_META_AUTHORITY
+  PROVIDER_PARSE_VERSIONS['codex'] = effective
+  return effective
+}

--- a/src/providers/antigravity.ts
+++ b/src/providers/antigravity.ts
@@ -26,8 +26,8 @@ import {
 export { buildCallsFromGeneratorMetadata, reconcileAntigravityStatusLineCalls } from './antigravity-accounting.js'
 export type { AntigravityCacheEnrichment, GeneratorMetadata } from './antigravity-accounting.js'
 export { antigravityCascadeIdFromPath }
-const CACHE_VERSION = 6
-const PREVIOUS_CACHE_VERSION = 5
+const CACHE_VERSION = 7
+const PREVIOUS_CACHE_VERSIONS = new Set([6, 5])
 
 const RPC_TIMEOUT_MS = 5000
 const MAX_RESPONSE_BYTES = 16 * 1024 * 1024
@@ -260,7 +260,7 @@ async function loadCache(): Promise<AntigravityCache> {
     const raw = await readFile(cachePath, 'utf-8')
     const cache = JSON.parse(raw) as AntigravityCache
     if (
-      (cache.version === CACHE_VERSION || cache.version === PREVIOUS_CACHE_VERSION) &&
+      (cache.version === CACHE_VERSION || PREVIOUS_CACHE_VERSIONS.has(cache.version)) &&
       cache.cascades && typeof cache.cascades === 'object'
     ) {
       memCache = cache.version === CACHE_VERSION
@@ -718,8 +718,10 @@ function buildCallFromSqliteGenMetadataRow(cascadeId: string, row: AntigravityGe
     + protoFieldPositiveInteger(firstProtoField(usageFields, 2))
   const cacheReadTokens = protoFieldPositiveInteger(firstProtoField(usageFields, 5))
   const totalOutputTokens = protoFieldPositiveInteger(firstProtoField(usageFields, 3))
-  let responseTokens = protoFieldPositiveInteger(firstProtoField(usageFields, 9))
-  let thinkingTokens = protoFieldPositiveInteger(firstProtoField(usageFields, 10))
+  // Correlation against same-response RPC metadata establishes #9 as thinking
+  // and #10 as response output. #3 remains the inclusive generated-token total.
+  let thinkingTokens = protoFieldPositiveInteger(firstProtoField(usageFields, 9))
+  let responseTokens = protoFieldPositiveInteger(firstProtoField(usageFields, 10))
 
   if (responseTokens === 0 && thinkingTokens === 0) {
     responseTokens = totalOutputTokens

--- a/src/providers/codex-model-provider.ts
+++ b/src/providers/codex-model-provider.ts
@@ -2,9 +2,21 @@ import { createReadStream } from 'node:fs'
 import { createInterface } from 'node:readline'
 
 import { normalizeExplicitModelProvider } from '../model-provider.js'
+import { PROVIDER_PARSE_VERSIONS } from '../session-cache.js'
 import type { Provider, SessionParser, SessionSource } from './types.js'
 
 const MAX_SESSION_META_LINES = 256
+export const CODEX_LEGACY_SESSION_META_AUTHORITY = 'legacy-session-meta-v1'
+
+export function ensureCodexLegacySessionMetaAuthority(): string {
+  const current = PROVIDER_PARSE_VERSIONS['codex'] ?? ''
+  if (current.includes(CODEX_LEGACY_SESSION_META_AUTHORITY)) return current
+  const effective = current
+    ? `${current}-${CODEX_LEGACY_SESSION_META_AUTHORITY}`
+    : CODEX_LEGACY_SESSION_META_AUTHORITY
+  PROVIDER_PARSE_VERSIONS['codex'] = effective
+  return effective
+}
 
 export class CodexModelProviderContradictionError extends Error {
   constructor() {
@@ -53,12 +65,16 @@ export type CodexModelProviderReader = (sourcePath: string) => Promise<string | 
 
 /**
  * Decorate the canonical Codex provider so fresh parser output carries the
- * source-recorded model/API provider into the ordinary session cache.
+ * source-recorded model/API provider into the ordinary session cache. Installing
+ * the provider also advances the session-cache parser authority for the legacy
+ * session_meta identity admission change, so unchanged warm-cache rollouts are
+ * reparsed before daily history is rehydrated.
  */
 export function withCodexModelProvider(
   provider: Provider,
   readProvider: CodexModelProviderReader = readCodexSessionModelProvider,
 ): Provider {
+  ensureCodexLegacySessionMetaAuthority()
   return {
     ...provider,
     createSessionParser(source: SessionSource, seenKeys, dateRange): SessionParser {

--- a/src/providers/codex-model-provider.ts
+++ b/src/providers/codex-model-provider.ts
@@ -2,21 +2,10 @@ import { createReadStream } from 'node:fs'
 import { createInterface } from 'node:readline'
 
 import { normalizeExplicitModelProvider } from '../model-provider.js'
-import { PROVIDER_PARSE_VERSIONS } from '../session-cache.js'
+import { ensureCodexLegacySessionMetaAuthority } from '../provider-parse-authorities.js'
 import type { Provider, SessionParser, SessionSource } from './types.js'
 
 const MAX_SESSION_META_LINES = 256
-export const CODEX_LEGACY_SESSION_META_AUTHORITY = 'legacy-session-meta-v1'
-
-export function ensureCodexLegacySessionMetaAuthority(): string {
-  const current = PROVIDER_PARSE_VERSIONS['codex'] ?? ''
-  if (current.includes(CODEX_LEGACY_SESSION_META_AUTHORITY)) return current
-  const effective = current
-    ? `${current}-${CODEX_LEGACY_SESSION_META_AUTHORITY}`
-    : CODEX_LEGACY_SESSION_META_AUTHORITY
-  PROVIDER_PARSE_VERSIONS['codex'] = effective
-  return effective
-}
 
 export class CodexModelProviderContradictionError extends Error {
   constructor() {

--- a/src/providers/codex.ts
+++ b/src/providers/codex.ts
@@ -77,6 +77,7 @@ type CodexEntry = {
     cwd?: string
     model_provider?: string
     originator?: string
+    id?: string
     session_id?: string
     forked_from_id?: string
     model?: string
@@ -158,12 +159,17 @@ async function isValidCodexSession(filePath: string): Promise<{ valid: boolean; 
   if (!entry) return { valid: false }
   const payload: unknown = entry.payload
   // Admission is structural and remains confined to Codex-owned roots plus
-  // rollout filename/layout rules. `originator` is untrusted metadata:
-  // third-party app servers may emit valid Codex rollouts without a
-  // Codex-branded value, so branding alone must never decide admission.
+  // rollout filename/layout rules. Legacy Codex session_meta used `payload.id`
+  // before the current `payload.session_id`; both are native session identities.
+  // `originator` is untrusted metadata: third-party app servers may emit valid
+  // Codex rollouts without a Codex-branded value, so branding alone must never
+  // decide admission.
   const valid = entry.type === 'session_meta'
     && isPlainObject(payload)
-    && nonEmptyString(payload['session_id']) !== undefined
+    && (
+      nonEmptyString(payload['session_id']) !== undefined
+      || nonEmptyString(payload['id']) !== undefined
+    )
   return { valid, meta: valid ? entry : undefined }
 }
 
@@ -425,6 +431,7 @@ function parseCodexLine(line: string | Buffer): CodexEntry | null {
       cwd: getRawJsonStringField(pHead, 'cwd'),
       model_provider: getRawJsonStringField(pHead, 'model_provider'),
       originator: getRawJsonStringField(pHead, 'originator'),
+      id: getRawJsonStringField(pHead, 'id'),
       session_id: getRawJsonStringField(pHead, 'session_id'),
       forked_from_id: getRawJsonStringField(pHead, 'forked_from_id'),
       model: getRawJsonStringField(pHead, 'model'),
@@ -623,7 +630,9 @@ function createParser(source: SessionSource, seenKeys: Set<string>): SessionPars
         if (!entry) continue
 
         if (entry.type === 'session_meta') {
-          sessionId = nonEmptyString(entry.payload?.session_id) ?? basename(source.path, '.jsonl')
+          sessionId = nonEmptyString(entry.payload?.session_id)
+            ?? nonEmptyString(entry.payload?.id)
+            ?? basename(source.path, '.jsonl')
           sessionCwd = nonEmptyString(entry.payload?.cwd) ?? sessionCwd
           sessionTimestamp = finiteTimestamp(entry.timestamp) ?? sessionTimestamp
           forkedFromId = nonEmptyString(entry.payload?.forked_from_id) ?? ''

--- a/src/providers/copilot-chat-journal.ts
+++ b/src/providers/copilot-chat-journal.ts
@@ -2,7 +2,6 @@ import { basename } from 'path'
 
 import { readSessionFile } from '../fs-utils.js'
 import { calculateCost } from '../models.js'
-import { PROVIDER_PARSE_VERSIONS } from '../session-cache.js'
 import type { ParsedProviderCall, Provider, SessionParser, SessionSource } from './types.js'
 
 type JournalPathSegment = string | number
@@ -14,15 +13,11 @@ type ChatSessionSource = SessionSource & {
 type JournalRequest = Record<string, unknown>
 
 const FORBIDDEN_PATH_KEYS = new Set(['__proto__', 'prototype', 'constructor'])
-const CHAT_JOURNAL_PARSE_VERSION = 'current-chat-journal-v2'
+export const COPILOT_CHAT_JOURNAL_AUTHORITY = 'current-chat-journal-v3'
+export const COPILOT_CHAT_JOURNAL_PROVIDER = `copilot-chat-journal-${COPILOT_CHAT_JOURNAL_AUTHORITY}`
 
-function registerParseVersion(): void {
-  const current = PROVIDER_PARSE_VERSIONS['copilot'] ?? ''
-  if (!current.split('-').join('-').includes(CHAT_JOURNAL_PARSE_VERSION)) {
-    PROVIDER_PARSE_VERSIONS['copilot'] = current
-      ? `${current}-${CHAT_JOURNAL_PARSE_VERSION}`
-      : CHAT_JOURNAL_PARSE_VERSION
-  }
+function isChatSessionSource(source: SessionSource): source is ChatSessionSource {
+  return (source as ChatSessionSource).sourceType === 'chatsession'
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -336,21 +331,47 @@ function createChatJournalParser(
 }
 
 /**
- * Adds the current VS Code mutation-log accounting contract to the existing
- * multi-source Copilot provider without changing its CLI, transcript, OTel,
- * JetBrains, discovery, or display behavior. Installing the adapter also
- * registers its parser authority so unchanged journals are reparsed once.
+ * Decorates Copilot discovery so current VS Code chat journals are routed into
+ * their own cache namespace. Those journals are authoritative snapshots of the
+ * replayed mutation log, unlike Copilot's durable/prunable sources: when a
+ * present journal changes, its cached calls must be replaced rather than kept
+ * monotonically. The parser override is retained for direct/unit use.
  */
 export function withCopilotChatJournalAccounting(provider: Provider): Provider {
-  registerParseVersion()
   return {
     ...provider,
-    durableFreshWins: true,
+    async discoverSessions(): Promise<SessionSource[]> {
+      const sources = await provider.discoverSessions()
+      return sources.map(source => isChatSessionSource(source)
+        ? { ...source, provider: COPILOT_CHAT_JOURNAL_PROVIDER }
+        : source)
+    },
     createSessionParser(source, seenKeys, dateRange) {
-      if ((source as ChatSessionSource).sourceType === 'chatsession') {
+      if (isChatSessionSource(source)) {
         return createChatJournalParser(source, seenKeys, provider)
       }
       return provider.createSessionParser(source, seenKeys, dateRange)
+    },
+  }
+}
+
+/**
+ * Internal parser authority for the remapped chat-journal sources. It is not
+ * part of provider discovery or the public --provider surface; `copilot`
+ * discovery emits these sources and the parser registry resolves this internal
+ * name. Non-durable semantics make a changed journal replace its prior snapshot.
+ */
+export function createCopilotChatJournalProvider(provider: Provider): Provider {
+  return {
+    ...provider,
+    name: COPILOT_CHAT_JOURNAL_PROVIDER,
+    durableSources: false,
+    durableFreshWins: undefined,
+    async discoverSessions(): Promise<SessionSource[]> {
+      return []
+    },
+    createSessionParser(source, seenKeys): SessionParser {
+      return createChatJournalParser(source, seenKeys, provider)
     },
   }
 }

--- a/src/providers/copilot-chat-journal.ts
+++ b/src/providers/copilot-chat-journal.ts
@@ -2,6 +2,9 @@ import { basename } from 'path'
 
 import { readSessionFile } from '../fs-utils.js'
 import { calculateCost } from '../models.js'
+import {
+  COPILOT_CHAT_JOURNAL_PROVIDER,
+} from '../provider-parse-authorities.js'
 import type { ParsedProviderCall, Provider, SessionParser, SessionSource } from './types.js'
 
 type JournalPathSegment = string | number
@@ -13,8 +16,6 @@ type ChatSessionSource = SessionSource & {
 type JournalRequest = Record<string, unknown>
 
 const FORBIDDEN_PATH_KEYS = new Set(['__proto__', 'prototype', 'constructor'])
-export const COPILOT_CHAT_JOURNAL_AUTHORITY = 'current-chat-journal-v3'
-export const COPILOT_CHAT_JOURNAL_PROVIDER = `copilot-chat-journal-${COPILOT_CHAT_JOURNAL_AUTHORITY}`
 
 function isChatSessionSource(source: SessionSource): source is ChatSessionSource {
   return (source as ChatSessionSource).sourceType === 'chatsession'
@@ -366,7 +367,6 @@ export function createCopilotChatJournalProvider(provider: Provider): Provider {
     ...provider,
     name: COPILOT_CHAT_JOURNAL_PROVIDER,
     durableSources: false,
-    durableFreshWins: undefined,
     async discoverSessions(): Promise<SessionSource[]> {
       return []
     },

--- a/src/providers/copilot-chat-journal.ts
+++ b/src/providers/copilot-chat-journal.ts
@@ -71,12 +71,14 @@ function ensureParent(root: object, path: readonly JournalPathSegment[]): object
   for (let index = 0; index < path.length - 1; index++) {
     const segment = path[index]!
     const nextSegment = path[index + 1]!
-    let child = getValue(current, segment)
-    if (!isContainer(child)) {
-      child = containerFor(nextSegment)
-      setValue(current, segment, child)
+    const child = getValue(current, segment)
+    if (isContainer(child)) {
+      current = child
+      continue
     }
-    current = child
+    const created = containerFor(nextSegment)
+    setValue(current, segment, created)
+    current = created
   }
   return current
 }

--- a/src/providers/copilot-chat-journal.ts
+++ b/src/providers/copilot-chat-journal.ts
@@ -2,6 +2,7 @@ import { basename } from 'path'
 
 import { readSessionFile } from '../fs-utils.js'
 import { calculateCost } from '../models.js'
+import { PROVIDER_PARSE_VERSIONS } from '../session-cache.js'
 import type { ParsedProviderCall, Provider, SessionParser, SessionSource } from './types.js'
 
 type JournalPathSegment = string | number
@@ -13,6 +14,16 @@ type ChatSessionSource = SessionSource & {
 type JournalRequest = Record<string, unknown>
 
 const FORBIDDEN_PATH_KEYS = new Set(['__proto__', 'prototype', 'constructor'])
+const CHAT_JOURNAL_PARSE_VERSION = 'current-chat-journal-v2'
+
+function registerParseVersion(): void {
+  const current = PROVIDER_PARSE_VERSIONS['copilot'] ?? ''
+  if (!current.split('-').join('-').includes(CHAT_JOURNAL_PARSE_VERSION)) {
+    PROVIDER_PARSE_VERSIONS['copilot'] = current
+      ? `${current}-${CHAT_JOURNAL_PARSE_VERSION}`
+      : CHAT_JOURNAL_PARSE_VERSION
+  }
+}
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value)
@@ -327,11 +338,14 @@ function createChatJournalParser(
 /**
  * Adds the current VS Code mutation-log accounting contract to the existing
  * multi-source Copilot provider without changing its CLI, transcript, OTel,
- * JetBrains, discovery, or display behavior.
+ * JetBrains, discovery, or display behavior. Installing the adapter also
+ * registers its parser authority so unchanged journals are reparsed once.
  */
 export function withCopilotChatJournalAccounting(provider: Provider): Provider {
+  registerParseVersion()
   return {
     ...provider,
+    durableFreshWins: true,
     createSessionParser(source, seenKeys, dateRange) {
       if ((source as ChatSessionSource).sourceType === 'chatsession') {
         return createChatJournalParser(source, seenKeys, provider)

--- a/src/providers/copilot-chat-journal.ts
+++ b/src/providers/copilot-chat-journal.ts
@@ -1,0 +1,342 @@
+import { basename } from 'path'
+
+import { readSessionFile } from '../fs-utils.js'
+import { calculateCost } from '../models.js'
+import type { ParsedProviderCall, Provider, SessionParser, SessionSource } from './types.js'
+
+type JournalPathSegment = string | number
+
+type ChatSessionSource = SessionSource & {
+  sourceType?: string
+}
+
+type JournalRequest = Record<string, unknown>
+
+const FORBIDDEN_PATH_KEYS = new Set(['__proto__', 'prototype', 'constructor'])
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function isContainer(value: unknown): value is object {
+  return typeof value === 'object' && value !== null
+}
+
+function createObject(): Record<string, unknown> {
+  return Object.create(null) as Record<string, unknown>
+}
+
+function parsePath(raw: unknown, fallback?: readonly JournalPathSegment[]): JournalPathSegment[] | null {
+  const value = raw === undefined ? fallback : raw
+  if (!Array.isArray(value)) return null
+
+  const path: JournalPathSegment[] = []
+  for (const segment of value) {
+    if (typeof segment === 'number') {
+      if (!Number.isInteger(segment) || segment < 0) return null
+      path.push(segment)
+      continue
+    }
+    if (typeof segment === 'string') {
+      if (FORBIDDEN_PATH_KEYS.has(segment)) return null
+      path.push(segment)
+      continue
+    }
+    return null
+  }
+  return path
+}
+
+function getValue(container: object, segment: JournalPathSegment): unknown {
+  return (container as Record<string, unknown>)[String(segment)]
+}
+
+function setValue(container: object, segment: JournalPathSegment, value: unknown): void {
+  ;(container as Record<string, unknown>)[String(segment)] = value
+}
+
+function containerFor(segment: JournalPathSegment): unknown[] | Record<string, unknown> {
+  return typeof segment === 'number' ? [] : createObject()
+}
+
+function ensureParent(root: object, path: readonly JournalPathSegment[]): object | null {
+  let current: object = root
+  for (let index = 0; index < path.length - 1; index++) {
+    const segment = path[index]!
+    const nextSegment = path[index + 1]!
+    let child = getValue(current, segment)
+    if (!isContainer(child)) {
+      child = containerFor(nextSegment)
+      setValue(current, segment, child)
+    }
+    current = child
+  }
+  return current
+}
+
+function applySet(root: unknown, path: readonly JournalPathSegment[], value: unknown): unknown {
+  if (path.length === 0) return value
+  const working = isContainer(root) ? root : createObject()
+  const parent = ensureParent(working, path)
+  if (!parent) return working
+  setValue(parent, path[path.length - 1]!, value)
+  return working
+}
+
+function applyDelete(root: unknown, path: readonly JournalPathSegment[]): unknown {
+  if (path.length === 0) return undefined
+  const working = isContainer(root) ? root : createObject()
+  const parent = ensureParent(working, path)
+  if (!parent) return working
+  // VS Code's ObjectMutationLog applies Delete as a property assignment to
+  // undefined rather than an array splice. Mirror that replay contract.
+  setValue(parent, path[path.length - 1]!, undefined)
+  return working
+}
+
+function applyPush(
+  root: unknown,
+  path: readonly JournalPathSegment[],
+  values: unknown[] | undefined,
+  startIndex: number | undefined,
+): unknown {
+  const working = isContainer(root) ? root : createObject()
+  if (path.length === 0) {
+    if (!Array.isArray(working)) return working
+    if (startIndex !== undefined) working.length = startIndex
+    if (values?.length) working.push(...values)
+    return working
+  }
+
+  const parent = ensureParent(working, path)
+  if (!parent) return working
+  const key = path[path.length - 1]!
+  const existing = getValue(parent, key)
+  const array = Array.isArray(existing) ? existing : []
+  if (startIndex !== undefined) array.length = startIndex
+  if (values?.length) array.push(...values)
+  setValue(parent, key, array)
+  return working
+}
+
+/**
+ * Replays VS Code's ObjectMutationLog format used by chatSessions JSONL files.
+ * Entry kinds mirror the upstream writer: Initial=0, Set=1, Push/splice=2,
+ * Delete=3. In particular, kind=2's optional `i` truncates the target array
+ * before pushing replacement entries; treating it as append-only preserves
+ * stale request versions and loses the final accounting state.
+ */
+export function replayCopilotChatJournal(content: string): unknown {
+  let root: unknown = createObject()
+
+  for (const line of content.split('\n')) {
+    if (!line.trim()) continue
+    let entry: unknown
+    try {
+      entry = JSON.parse(line) as unknown
+    } catch {
+      continue
+    }
+    if (!isRecord(entry)) continue
+
+    const kind = entry['kind']
+    if (kind === 0) {
+      root = entry['v']
+      continue
+    }
+
+    if (kind === 1) {
+      const path = parsePath(entry['k'])
+      if (path) root = applySet(root, path, entry['v'])
+      continue
+    }
+
+    if (kind === 2) {
+      const path = parsePath(entry['k'], ['requests'])
+      if (!path) continue
+      const rawIndex = entry['i']
+      const startIndex = typeof rawIndex === 'number' && Number.isInteger(rawIndex) && rawIndex >= 0
+        ? rawIndex
+        : undefined
+      const values = Array.isArray(entry['v']) ? entry['v'] : undefined
+      root = applyPush(root, path, values, startIndex)
+      continue
+    }
+
+    if (kind === 3) {
+      const path = parsePath(entry['k'])
+      if (path) root = applyDelete(root, path)
+    }
+  }
+
+  return root
+}
+
+function finiteNonNegative(raw: unknown): number | undefined {
+  return typeof raw === 'number' && Number.isFinite(raw) && raw >= 0
+    ? raw
+    : undefined
+}
+
+function readString(raw: unknown): string {
+  return typeof raw === 'string' ? raw.trim() : ''
+}
+
+function timestampToIso(raw: unknown): string {
+  if (typeof raw === 'number' && Number.isFinite(raw) && raw > 0) {
+    const ms = raw < 1e12 ? raw * 1000 : raw
+    const date = new Date(ms)
+    return Number.isNaN(date.getTime()) ? '' : date.toISOString()
+  }
+  if (typeof raw !== 'string') return ''
+  const trimmed = raw.trim()
+  if (!trimmed) return ''
+  if (/^\d+(?:\.\d+)?$/.test(trimmed)) return timestampToIso(Number(trimmed))
+  const parsed = Date.parse(trimmed)
+  return Number.isNaN(parsed) ? '' : new Date(parsed).toISOString()
+}
+
+function requestMetadata(request: JournalRequest): Record<string, unknown> {
+  const result = request['result']
+  if (!isRecord(result)) return createObject()
+  return isRecord(result['metadata']) ? result['metadata'] : createObject()
+}
+
+function requestModel(request: JournalRequest, metadata: Record<string, unknown>): string {
+  const resolved = readString(metadata['resolvedModel'])
+  if (resolved) return resolved
+  const modelId = readString(request['modelId'])
+  return modelId.replace(/^copilot\//, '') || 'unknown'
+}
+
+function reasoningTokens(metadata: Record<string, unknown>): number {
+  const rounds = metadata['toolCallRounds']
+  if (!Array.isArray(rounds)) return 0
+
+  let total = 0
+  for (const round of rounds) {
+    if (!isRecord(round)) continue
+    const thinking = round['thinking']
+    if (!isRecord(thinking)) continue
+    const tokens = finiteNonNegative(thinking['tokens'])
+    if (tokens !== undefined) total += tokens
+  }
+  return total
+}
+
+function requestTools(metadata: Record<string, unknown>, provider: Provider): string[] {
+  const rounds = metadata['toolCallRounds']
+  if (!Array.isArray(rounds)) return []
+
+  const names = new Set<string>()
+  const add = (raw: unknown): void => {
+    const name = readString(raw)
+    if (name) names.add(provider.toolDisplayName(name))
+  }
+  const inspect = (record: Record<string, unknown>): void => {
+    add(record['toolName'])
+    add(record['name'])
+    add(record['tool'])
+  }
+
+  for (const round of rounds) {
+    if (!isRecord(round)) continue
+    inspect(round)
+    for (const key of ['tools', 'toolCalls', 'toolRequests']) {
+      const values = round[key]
+      if (!Array.isArray(values)) continue
+      for (const value of values) {
+        if (typeof value === 'string') add(value)
+        else if (isRecord(value)) inspect(value)
+      }
+    }
+  }
+  return [...names]
+}
+
+function createChatJournalParser(
+  source: SessionSource,
+  seenKeys: Set<string>,
+  provider: Provider,
+): SessionParser {
+  return {
+    async *parse(): AsyncGenerator<ParsedProviderCall> {
+      const content = await readSessionFile(source.path)
+      if (!content) return
+
+      const replayed = replayCopilotChatJournal(content)
+      if (!isRecord(replayed)) return
+
+      const sessionId = readString(replayed['sessionId']) || basename(source.path, '.jsonl')
+      const sessionCreatedAt = timestampToIso(replayed['creationDate'])
+      const requests = Array.isArray(replayed['requests']) ? replayed['requests'] : []
+
+      for (let index = 0; index < requests.length; index++) {
+        const raw = requests[index]
+        if (!isRecord(raw)) continue
+        const metadata = requestMetadata(raw)
+
+        // VS Code's current persistence schema writes these two usage values on
+        // the request itself. Older journals may only carry the metadata copies.
+        // Presence, including an explicit zero, is authoritative over fallback.
+        const inputTokens = finiteNonNegative(raw['promptTokens'])
+          ?? finiteNonNegative(metadata['promptTokens'])
+          ?? 0
+        const outputTokens = finiteNonNegative(raw['completionTokens'])
+          ?? finiteNonNegative(metadata['outputTokens'])
+          ?? 0
+        const reasoning = reasoningTokens(metadata)
+
+        if (inputTokens === 0 && outputTokens === 0 && reasoning === 0) continue
+
+        const requestId = readString(raw['requestId']) || `request-${index}`
+        const deduplicationKey = `copilot-chatsession:${sessionId}:${requestId}`
+        if (seenKeys.has(deduplicationKey)) continue
+        seenKeys.add(deduplicationKey)
+
+        const model = requestModel(raw, metadata)
+        const timestamp = timestampToIso(raw['timestamp']) || sessionCreatedAt
+        if (!timestamp) continue
+        const costUSD = calculateCost(model, inputTokens, outputTokens + reasoning, 0, 0, 0)
+
+        yield {
+          provider: 'copilot',
+          sessionId,
+          project: source.project,
+          model,
+          inputTokens,
+          outputTokens,
+          cacheCreationInputTokens: 0,
+          cacheReadInputTokens: 0,
+          cachedInputTokens: 0,
+          reasoningTokens: reasoning,
+          webSearchRequests: 0,
+          costUSD,
+          tools: requestTools(metadata, provider),
+          bashCommands: [],
+          timestamp,
+          speed: 'standard',
+          deduplicationKey,
+          userMessage: '',
+        }
+      }
+    },
+  }
+}
+
+/**
+ * Adds the current VS Code mutation-log accounting contract to the existing
+ * multi-source Copilot provider without changing its CLI, transcript, OTel,
+ * JetBrains, discovery, or display behavior.
+ */
+export function withCopilotChatJournalAccounting(provider: Provider): Provider {
+  return {
+    ...provider,
+    createSessionParser(source, seenKeys, dateRange) {
+      if ((source as ChatSessionSource).sourceType === 'chatsession') {
+        return createChatJournalParser(source, seenKeys, provider)
+      }
+      return provider.createSessionParser(source, seenKeys, dateRange)
+    },
+  }
+}

--- a/src/providers/copilot-cli-resume.ts
+++ b/src/providers/copilot-cli-resume.ts
@@ -1,0 +1,206 @@
+import { readFile } from 'fs/promises'
+import { basename, dirname } from 'path'
+
+import { calculateCost } from '../models.js'
+import {
+  COPILOT_CLI_RESUME_PROVIDER,
+} from '../provider-parse-authorities.js'
+import type {
+  ParsedProviderCall,
+  Provider,
+  SessionParser,
+  SessionSource,
+} from './types.js'
+
+type JsonlSource = SessionSource & { sourceType?: string }
+type Usage = {
+  inputTokens: number
+  outputTokens: number
+  cacheReadTokens: number
+  cacheWriteTokens: number
+  reasoningTokens: number
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function numberOrZero(value: unknown): number {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0 ? value : 0
+}
+
+function isCopilotCliJsonl(source: SessionSource): boolean {
+  return (source as JsonlSource).sourceType === 'jsonl'
+}
+
+function timestampToISO(value: unknown): string {
+  if (typeof value === 'string' && value) {
+    const ms = Date.parse(value)
+    return Number.isFinite(ms) ? new Date(ms).toISOString() : ''
+  }
+  if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) return ''
+  const ms = value < 1_000_000_000_000 ? value * 1000 : value
+  const d = new Date(ms)
+  return Number.isNaN(d.getTime()) ? '' : d.toISOString()
+}
+
+function readUsage(raw: unknown): Usage | null {
+  if (!isRecord(raw)) return null
+  return {
+    inputTokens: numberOrZero(raw['inputTokens']),
+    outputTokens: numberOrZero(raw['outputTokens']),
+    cacheReadTokens: numberOrZero(raw['cacheReadTokens']),
+    cacheWriteTokens: numberOrZero(raw['cacheWriteTokens']),
+    reasoningTokens: numberOrZero(raw['reasoningTokens']),
+  }
+}
+
+function counterReset(current: Usage, previous: Usage): boolean {
+  // Copilot's shutdown input total is cache-inclusive and therefore the broadest
+  // monotonic sentinel. A lower value denotes a fresh accounting epoch.
+  return current.inputTokens < previous.inputTokens
+}
+
+function delta(current: Usage, previous: Usage | undefined, key: keyof Usage): number {
+  return Math.max(0, current[key] - (previous?.[key] ?? 0))
+}
+
+/**
+ * Supplemental parser for Copilot CLI resumed sessions.
+ *
+ * The canonical Copilot parser already owns assistant-message output and the
+ * FIRST session.shutdown per model. Newer CLI `--resume` legs append additional
+ * shutdown rows whose model totals are cumulative. The canonical parser's
+ * historical dedup key intentionally collapses those rows, so this namespace
+ * emits ONLY the later-leg deltas. It never duplicates the first shutdown and
+ * never replaces the canonical Copilot source/cache authority.
+ */
+function createResumeParser(source: SessionSource, seenKeys: Set<string>): SessionParser {
+  return {
+    async *parse(): AsyncGenerator<ParsedProviderCall> {
+      let raw: string
+      try {
+        raw = await readFile(source.path, 'utf-8')
+      } catch {
+        return
+      }
+
+      const sessionId = basename(dirname(source.path))
+      const previousByModel = new Map<string, Usage>()
+      const occurrencesByModel = new Map<string, number>()
+      let lastEventTimestamp = ''
+
+      for (const line of raw.split('\n')) {
+        if (!line.trim()) continue
+        let event: Record<string, unknown>
+        try {
+          const parsed = JSON.parse(line) as unknown
+          if (!isRecord(parsed)) continue
+          event = parsed
+        } catch {
+          continue
+        }
+
+        const eventTimestamp = timestampToISO(event['timestamp'])
+        if (eventTimestamp) lastEventTimestamp = eventTimestamp
+        if (event['type'] !== 'session.shutdown') continue
+
+        const data = event['data']
+        if (!isRecord(data) || !isRecord(data['modelMetrics'])) continue
+        const shutdownTimestamp = eventTimestamp
+          || timestampToISO(data['sessionStartTime'])
+          || lastEventTimestamp
+
+        for (const [model, metricsRaw] of Object.entries(data['modelMetrics'])) {
+          if (!model || !isRecord(metricsRaw)) continue
+          const usage = readUsage(metricsRaw['usage'])
+          if (!usage) continue
+
+          const occurrence = (occurrencesByModel.get(model) ?? 0) + 1
+          occurrencesByModel.set(model, occurrence)
+          const rawPrevious = previousByModel.get(model)
+          previousByModel.set(model, usage)
+
+          // The canonical Copilot parser owns occurrence 1. This authority only
+          // recovers later resumed legs that the legacy shared dedup key drops.
+          if (occurrence === 1) continue
+
+          const previous = rawPrevious && !counterReset(usage, rawPrevious)
+            ? rawPrevious
+            : undefined
+          const cacheReadTokens = delta(usage, previous, 'cacheReadTokens')
+          const cacheWriteTokens = delta(usage, previous, 'cacheWriteTokens')
+          const reasoningTokens = delta(usage, previous, 'reasoningTokens')
+          const inputTokens = Math.max(
+            0,
+            delta(usage, previous, 'inputTokens') - cacheReadTokens - cacheWriteTokens,
+          )
+
+          // Output remains owned by assistant.message calls in the canonical
+          // parser. Adding shutdown output here would double-count it.
+          if (inputTokens === 0 && cacheReadTokens === 0 && cacheWriteTokens === 0 && reasoningTokens === 0) {
+            continue
+          }
+
+          const deduplicationKey = `copilot:${sessionId}:shutdown:${model}:resume:${occurrence}`
+          if (seenKeys.has(deduplicationKey)) continue
+          seenKeys.add(deduplicationKey)
+
+          yield {
+            provider: 'copilot',
+            model,
+            inputTokens,
+            outputTokens: 0,
+            cacheCreationInputTokens: cacheWriteTokens,
+            cacheReadInputTokens: cacheReadTokens,
+            cachedInputTokens: 0,
+            reasoningTokens,
+            webSearchRequests: 0,
+            costUSD: calculateCost(model, inputTokens, 0, cacheWriteTokens, cacheReadTokens, 0),
+            costIsEstimated: false,
+            tools: [],
+            bashCommands: [],
+            timestamp: shutdownTimestamp,
+            speed: 'standard',
+            deduplicationKey,
+            userMessage: '',
+            sessionId,
+            project: source.project,
+          }
+        }
+      }
+    },
+  }
+}
+
+/**
+ * Keep canonical Copilot discovery untouched and add a second, internal source
+ * only for CLI JSONL files. The supplemental provider is deliberately absent
+ * from allProviderNames(), while emitted calls remain provider='copilot'.
+ */
+export function withCopilotCliResumeAccounting(base: Provider): Provider {
+  return {
+    ...base,
+    async discoverSessions(): Promise<SessionSource[]> {
+      const sources = await base.discoverSessions()
+      const supplemental = sources
+        .filter(isCopilotCliJsonl)
+        .map(source => ({ ...source, provider: COPILOT_CLI_RESUME_PROVIDER }))
+      return [...sources, ...supplemental]
+    },
+  }
+}
+
+/** Internal durable ledger containing only resumed-shutdown deltas. */
+export function createCopilotCliResumeProvider(base: Provider): Provider {
+  return {
+    name: COPILOT_CLI_RESUME_PROVIDER,
+    displayName: base.displayName,
+    durableSources: true,
+    durableFreshWins: true,
+    modelDisplayName: model => base.modelDisplayName(model),
+    toolDisplayName: tool => base.toolDisplayName(tool),
+    discoverSessions: async () => [],
+    createSessionParser: (source, seenKeys) => createResumeParser(source, seenKeys),
+  }
+}

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -10,6 +10,10 @@ import {
   createCopilotChatJournalProvider,
   withCopilotChatJournalAccounting,
 } from './copilot-chat-journal.js'
+import {
+  createCopilotCliResumeProvider,
+  withCopilotCliResumeAccounting,
+} from './copilot-cli-resume.js'
 import { droid } from './droid.js'
 import { devin } from './devin.js'
 import { gemini } from './gemini.js'
@@ -30,7 +34,14 @@ import { quickdesk } from './quickdesk.js'
 import { rooCode } from './roo-code.js'
 import { zerostack } from './zerostack.js'
 import { grok } from './grok.js'
+import { ensureProviderEnvFingerprintAuthorities } from '../provider-parse-authorities.js'
 import type { Provider, SessionSource } from './types.js'
+
+// Install deterministic source/profile env inputs before parser code computes a
+// session-cache fingerprint. The installer is idempotent and intentionally does
+// not declare Copilot's provider-wide overrides until durable present-path
+// carry-forward can preserve pruned OTel history safely.
+ensureProviderEnvFingerprintAuthorities()
 
 let antigravityProvider: Provider | null = null
 let antigravityLoadAttempted = false
@@ -196,8 +207,12 @@ async function loadZed(): Promise<Provider | null> {
   }
 }
 
-const copilotWithChatJournal = withCopilotChatJournalAccounting(copilot)
-const internalProviders: Provider[] = [createCopilotChatJournalProvider(copilot)]
+const copilotWithCliResume = withCopilotCliResumeAccounting(copilot)
+const copilotWithChatJournal = withCopilotChatJournalAccounting(copilotWithCliResume)
+const internalProviders: Provider[] = [
+  createCopilotChatJournalProvider(copilot),
+  createCopilotCliResumeProvider(copilot),
+]
 const coreProviders: Provider[] = [claude, cline, clineCli, codewhale, codebuff, withCodexModelProvider(codex), copilotWithChatJournal, devin, droid, gemini, hermes, ibmBob, kiloCode, kiro, kimi, kimicode, lingtaiTui, mistralVibe, mux, openclaw, openDesign, pi, omp, qwen, quickdesk, rooCode, zerostack, grok]
 
 // Lazily loaded providers, listed by name so --provider validation works even

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -6,6 +6,7 @@ import { codebuff } from './codebuff.js'
 import { codex } from './codex.js'
 import { withCodexModelProvider } from './codex-model-provider.js'
 import { copilot } from './copilot.js'
+import { withCopilotChatJournalAccounting } from './copilot-chat-journal.js'
 import { droid } from './droid.js'
 import { devin } from './devin.js'
 import { gemini } from './gemini.js'
@@ -192,7 +193,7 @@ async function loadZed(): Promise<Provider | null> {
   }
 }
 
-const coreProviders: Provider[] = [claude, cline, clineCli, codewhale, codebuff, withCodexModelProvider(codex), copilot, devin, droid, gemini, hermes, ibmBob, kiloCode, kiro, kimi, kimicode, lingtaiTui, mistralVibe, mux, openclaw, openDesign, pi, omp, qwen, quickdesk, rooCode, zerostack, grok]
+const coreProviders: Provider[] = [claude, cline, clineCli, codewhale, codebuff, withCodexModelProvider(codex), withCopilotChatJournalAccounting(copilot), devin, droid, gemini, hermes, ibmBob, kiloCode, kiro, kimi, kimicode, lingtaiTui, mistralVibe, mux, openclaw, openDesign, pi, omp, qwen, quickdesk, rooCode, zerostack, grok]
 
 // Lazily loaded providers, listed by name so --provider validation works even
 // when an optional module fails to load. Must stay in sync with getAllProviders.

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -6,7 +6,10 @@ import { codebuff } from './codebuff.js'
 import { codex } from './codex.js'
 import { withCodexModelProvider } from './codex-model-provider.js'
 import { copilot } from './copilot.js'
-import { withCopilotChatJournalAccounting } from './copilot-chat-journal.js'
+import {
+  createCopilotChatJournalProvider,
+  withCopilotChatJournalAccounting,
+} from './copilot-chat-journal.js'
 import { droid } from './droid.js'
 import { devin } from './devin.js'
 import { gemini } from './gemini.js'
@@ -193,15 +196,17 @@ async function loadZed(): Promise<Provider | null> {
   }
 }
 
-const coreProviders: Provider[] = [claude, cline, clineCli, codewhale, codebuff, withCodexModelProvider(codex), withCopilotChatJournalAccounting(copilot), devin, droid, gemini, hermes, ibmBob, kiloCode, kiro, kimi, kimicode, lingtaiTui, mistralVibe, mux, openclaw, openDesign, pi, omp, qwen, quickdesk, rooCode, zerostack, grok]
+const copilotWithChatJournal = withCopilotChatJournalAccounting(copilot)
+const internalProviders: Provider[] = [createCopilotChatJournalProvider(copilot)]
+const coreProviders: Provider[] = [claude, cline, clineCli, codewhale, codebuff, withCodexModelProvider(codex), copilotWithChatJournal, devin, droid, gemini, hermes, ibmBob, kiloCode, kiro, kimi, kimicode, lingtaiTui, mistralVibe, mux, openclaw, openDesign, pi, omp, qwen, quickdesk, rooCode, zerostack, grok]
 
 // Lazily loaded providers, listed by name so --provider validation works even
 // when an optional module fails to load. Must stay in sync with getAllProviders.
 const lazyProviderNames = ['antigravity', 'forge', 'goose', 'cursor', 'opencode', 'cursor-agent', 'crush', 'warp', 'vercel-gateway', 'zcode', 'zed']
 
 // Canonical set of every provider name (core + lazy), used to validate the
-// --provider CLI flag. Computed lazily so importing this module never depends on
-// every provider object being defined at load time (e.g. under test mocks).
+// --provider CLI flag. Internal source-parser namespaces are deliberately
+// excluded: discovery remains exposed as the canonical provider (`copilot`).
 let allProviderNamesCache: string[] | undefined
 export function allProviderNames(): readonly string[] {
   allProviderNamesCache ??= [
@@ -317,4 +322,5 @@ export async function getProvider(name: string): Promise<Provider | undefined> {
     return z ?? undefined
   }
   return coreProviders.find(p => p.name === name)
+    ?? internalProviders.find(p => p.name === name)
 }

--- a/src/providers/vscode-cline-parser.ts
+++ b/src/providers/vscode-cline-parser.ts
@@ -200,7 +200,10 @@ export function createClineParser(source: SessionSource, seenKeys: Set<string>, 
 
         if (tokensIn === 0 && tokensOut === 0 && cacheReads === 0 && cacheWrites === 0 && cost === undefined) continue
 
-        const timestamp = entry.ts ? new Date(entry.ts).toISOString() : ''
+        const rawTimestamp = entry.ts === undefined ? null : new Date(entry.ts)
+        const timestamp = rawTimestamp && !Number.isNaN(rawTimestamp.getTime())
+          ? rawTimestamp.toISOString()
+          : ''
         const costUSD = cost ?? calculateCost(model, tokensIn, tokensOut, cacheWrites, cacheReads, 0)
 
         yield {

--- a/src/session-cache.ts
+++ b/src/session-cache.ts
@@ -251,7 +251,7 @@ export const PROVIDER_PARSE_VERSIONS: Record<string, string> = {
   'roo-code': 'worktree-project-grouping-v1',
   zerostack: 'cumulative-session-v1-provider-provenance-estimated-cost-v2',
   warp: 'worktree-project-grouping-v1-est-cost',
-  antigravity: 'worktree-project-grouping-v6-provider-reasoning-filter-usage-accounting-v2-source-union-v1-durable-v1',
+  antigravity: 'worktree-project-grouping-v6-provider-reasoning-filter-usage-accounting-v2-source-union-v1-durable-v1-output-reasoning-map-v2',
   // OpenCode keeps valid usage in archived root/child sessions. The parser
   // must scan the complete SQLite session tree, not only active sessions.
   opencode: 'sqlite-session-tree-v2-provider-id-v1-free-route-v1-route-cost-v1',
@@ -719,7 +719,7 @@ export function mergeCallByDedupKey(
   }
 }
 
-// ── Temp Cleanup ───────────────────────────────────────────────────────
+// ── Temp Cleanup ────────────────────────────────────────────────────────
 
 export async function cleanupOrphanedTempFiles(): Promise<void> {
   const dir = getCacheDir()

--- a/src/session-cache.ts
+++ b/src/session-cache.ts
@@ -51,6 +51,12 @@ export type CachedCall = {
   projectPath?: string
   workingDirectory?: string
   toolSequence?: ToolCall[][]
+  // Claude native identity reconciliation metadata. `timestamp` remains the
+  // first logical emission timestamp; these fields preserve native identity
+  // and final-emission evidence for cross-file arbitration.
+  nativeMessageId?: string
+  nativeEmissionTimestamp?: string
+  nativeSnapshotTerminal?: boolean
   // Rich-session-capture (capture-only; no report consumes these yet). All
   // optional and omitted at zero/false to keep the per-call cache cost minimal.
   // Lines added/removed by this call's edits, counted from tool-result diffs
@@ -224,7 +230,7 @@ export const PROVIDER_PARSE_VERSIONS: Record<string, string> = {
   // LOC deltas / interruptions / userModified / toolErrors, and session-level
   // title / prLinks / isSidechain. Forces one re-parse so cached sessions gain
   // the new optional fields.
-  claude: 'advisor-usage-v1-skills-rich-capture-v1-cross-provider-pr-v1',
+  claude: 'advisor-usage-v1-skills-rich-capture-v1-cross-provider-pr-v1-native-id-reconciliation-v1',
   cline: 'worktree-project-grouping-v1-vscode-variants-v2-provider-zero-cost',
   codewhale: 'aggregate-session-v2-provider-provenance',
   // Bump when the Codex parser changes attribution so unchanged, already-cached
@@ -399,6 +405,9 @@ function validateCall(c: unknown): c is CachedCall {
     && isOptionalString(o['project'])
     && isOptionalString(o['projectPath'])
     && isOptionalString(o['workingDirectory'])
+    && isOptionalString(o['nativeMessageId'])
+    && isOptionalString(o['nativeEmissionTimestamp'])
+    && isOptionalBool(o['nativeSnapshotTerminal'])
     && (o['toolSequence'] === undefined || (Array.isArray(o['toolSequence']) && (o['toolSequence'] as unknown[]).every(s => isToolCallArray(s))))
     && isOptionalNum(o['locAdded'])
     && isOptionalNum(o['locRemoved'])

--- a/src/types.ts
+++ b/src/types.ts
@@ -133,6 +133,12 @@ export type ParsedApiCall = {
   timestamp: string
   bashCommands: string[]
   deduplicationKey: string
+  /** Claude native message identity, when the source recorded one. */
+  nativeMessageId?: string
+  /** Timestamp of the selected source emission before logical-time rebucketing. */
+  nativeEmissionTimestamp?: string
+  /** Native terminal/final marker (for example Claude `stop_reason`). */
+  nativeSnapshotTerminal?: boolean
   cacheCreationOneHourTokens?: number
   toolSequence?: ToolCall[][]
   /// Claude Code: `tool_use` ids of the `Agent`/`Task` subagent-spawn blocks in

--- a/src/usage-aggregator.ts
+++ b/src/usage-aggregator.ts
@@ -19,7 +19,7 @@ import { aggregateModels } from './models-report.js'
 import { scanUserCorrections, medianTimeToFirstEditMs, aggregateFileChurn, computePricingCoverage } from './workflow-insights.js'
 import { buildPrAttribution, aggregateByBranch } from './sessions-report.js'
 import { scanAndDetect } from './optimize.js'
-import { getDaysInRange, ensureCacheHydrated, loadDailyCache, emptyCache, BACKFILL_DAYS, toDateString, type DailyCache, type DailyEntry } from './daily-cache.js'
+import { getDaysInRange, ensureCacheHydrated, loadDailyCache, emptyCache, BACKFILL_DAYS, DURABLE_HISTORY_AUTHORITY, toDateString, type DailyCache, type DailyEntry } from './daily-cache.js'
 import { getDailyCacheConfigHash } from './daily-cache-config.js'
 export { getDailyCacheConfigHash } from './daily-cache-config.js'
 import { buildGranularHistory } from './granular-history.js'
@@ -96,6 +96,8 @@ async function hydrateCache(): Promise<DailyCache> {
       // Never finalize the daily history off a partial (interrupted) session
       // hydration — that is what froze empty older days into the chart.
       isSessionHydrationComplete,
+      undefined,
+      { durableHistoryAuthority: DURABLE_HISTORY_AUTHORITY },
     )
   } catch (err) {
     // Previously swallowed silently, which turned any backfill failure into an

--- a/tests/daily-cache-tz-provenance.test.ts
+++ b/tests/daily-cache-tz-provenance.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest'
+
+import { mergeTimezoneRebucketedDays } from '../src/daily-cache-tz-reconcile.js'
+import type { DailyEntry, ModelDayStats, ProviderDaySlice } from '../src/daily-cache.js'
+
+const MODEL = 'shared-model'
+
+function model(provider: string, cost: number, input: number): ModelDayStats {
+  return {
+    calls: 1,
+    cost,
+    savingsUSD: 0,
+    inputTokens: input,
+    outputTokens: 0,
+    reasoningTokens: 0,
+    cacheReadTokens: 0,
+    cacheWriteTokens: 0,
+    sourceProviders: [provider],
+  }
+}
+
+function slice(provider: string, cost: number, input: number): ProviderDaySlice {
+  return {
+    calls: 1,
+    cost,
+    savingsUSD: 0,
+    sessions: 1,
+    inputTokens: input,
+    outputTokens: 0,
+    reasoningTokens: 0,
+    cacheReadTokens: 0,
+    cacheWriteTokens: 0,
+    editTurns: 0,
+    oneShotTurns: 0,
+    models: { [MODEL]: model(provider, cost, input) },
+    categories: {},
+  }
+}
+
+function singleProviderDay(date: string, provider: string, providerSlice: ProviderDaySlice): DailyEntry {
+  return {
+    date,
+    cost: providerSlice.cost,
+    savingsUSD: 0,
+    calls: providerSlice.calls,
+    sessions: providerSlice.sessions ?? 0,
+    inputTokens: providerSlice.inputTokens ?? 0,
+    outputTokens: 0,
+    reasoningTokens: 0,
+    cacheReadTokens: 0,
+    cacheWriteTokens: 0,
+    editTurns: 0,
+    oneShotTurns: 0,
+    models: structuredClone(providerSlice.models ?? {}),
+    categories: {},
+    providers: { [provider]: structuredClone(providerSlice) },
+  }
+}
+
+describe('timezone carry model provenance', () => {
+  it('removes a source provider when its whole model contribution rebuckets away', () => {
+    const copilot = slice('copilot', 10, 40)
+    const codex = slice('codex', 20, 60)
+    const baseline: DailyEntry = {
+      date: '2026-08-10',
+      cost: 30,
+      savingsUSD: 0,
+      calls: 2,
+      sessions: 2,
+      inputTokens: 100,
+      outputTokens: 0,
+      reasoningTokens: 0,
+      cacheReadTokens: 0,
+      cacheWriteTokens: 0,
+      editTurns: 0,
+      oneShotTurns: 0,
+      models: {
+        [MODEL]: {
+          calls: 2,
+          cost: 30,
+          savingsUSD: 0,
+          inputTokens: 100,
+          outputTokens: 0,
+          reasoningTokens: 0,
+          cacheReadTokens: 0,
+          cacheWriteTokens: 0,
+          sourceProviders: ['codex', 'copilot'],
+        },
+      },
+      categories: {},
+      providers: {
+        copilot: structuredClone(copilot),
+        codex: structuredClone(codex),
+      },
+      carried: true,
+    }
+
+    const result = mergeTimezoneRebucketedDays(
+      [singleProviderDay('2026-08-11', 'copilot', copilot)],
+      [baseline],
+      [singleProviderDay('2026-08-10', 'copilot', copilot)],
+    )
+
+    const oldDay = result.find(day => day.date === '2026-08-10')!
+    expect(oldDay.models[MODEL]?.sourceProviders).toEqual(['codex'])
+    expect(oldDay.models[MODEL]).toMatchObject({ calls: 1, cost: 20, inputTokens: 60 })
+    expect(oldDay.providers.copilot).toBeUndefined()
+    expect(oldDay.providers.codex?.calls).toBe(1)
+  })
+})

--- a/tests/daily-cache-tz-reconcile.test.ts
+++ b/tests/daily-cache-tz-reconcile.test.ts
@@ -1,0 +1,217 @@
+import { describe, expect, it } from 'vitest'
+
+import { mergeTimezoneRebucketedDays } from '../src/daily-cache-tz-reconcile.js'
+import type {
+  CategoryDayStats,
+  DailyEntry,
+  ModelDayStats,
+  ProjectDayStats,
+  ProviderDaySlice,
+} from '../src/daily-cache.js'
+
+const MODEL = 'model-a'
+const CATEGORY = 'coding'
+const PROJECT = 'metrora'
+
+function model(
+  calls: number,
+  cost: number,
+  inputTokens: number,
+  outputTokens: number,
+  reasoningTokens: number,
+): ModelDayStats {
+  return {
+    calls,
+    cost,
+    savingsUSD: 0,
+    inputTokens,
+    outputTokens,
+    reasoningTokens,
+    cacheReadTokens: 0,
+    cacheWriteTokens: 0,
+    modelProvider: 'openai',
+    sourceProviders: ['copilot'],
+  }
+}
+
+function category(turns: number, cost: number): CategoryDayStats {
+  return { turns, cost, savingsUSD: 0, editTurns: turns, oneShotTurns: turns }
+}
+
+function project(calls: number, cost: number, sessions: number): ProjectDayStats {
+  return { calls, cost, savingsUSD: 0, sessions, path: 'C:/work/metrora' }
+}
+
+function slice(opts: {
+  calls: number
+  cost: number
+  sessions: number
+  inputTokens: number
+  outputTokens: number
+  reasoningTokens: number
+  turns?: number
+}): ProviderDaySlice {
+  const turns = opts.turns ?? opts.calls
+  return {
+    calls: opts.calls,
+    cost: opts.cost,
+    savingsUSD: 0,
+    sessions: opts.sessions,
+    inputTokens: opts.inputTokens,
+    outputTokens: opts.outputTokens,
+    reasoningTokens: opts.reasoningTokens,
+    cacheReadTokens: 0,
+    cacheWriteTokens: 0,
+    editTurns: turns,
+    oneShotTurns: turns,
+    models: { [MODEL]: model(opts.calls, opts.cost, opts.inputTokens, opts.outputTokens, opts.reasoningTokens) },
+    categories: { [CATEGORY]: category(turns, opts.cost) },
+    projects: { [PROJECT]: project(opts.calls, opts.cost, opts.sessions) },
+  }
+}
+
+function day(date: string, providerSlice: ProviderDaySlice): DailyEntry {
+  return {
+    date,
+    cost: providerSlice.cost,
+    savingsUSD: providerSlice.savingsUSD,
+    calls: providerSlice.calls,
+    sessions: providerSlice.sessions ?? 0,
+    inputTokens: providerSlice.inputTokens ?? 0,
+    outputTokens: providerSlice.outputTokens ?? 0,
+    reasoningTokens: providerSlice.reasoningTokens ?? 0,
+    cacheReadTokens: providerSlice.cacheReadTokens ?? 0,
+    cacheWriteTokens: providerSlice.cacheWriteTokens ?? 0,
+    editTurns: providerSlice.editTurns ?? 0,
+    oneShotTurns: providerSlice.oneShotTurns ?? 0,
+    models: structuredClone(providerSlice.models ?? {}),
+    categories: structuredClone(providerSlice.categories ?? {}),
+    projects: structuredClone(providerSlice.projects ?? {}),
+    providers: { copilot: structuredClone(providerSlice) },
+  }
+}
+
+describe('timezone carry reconciliation', () => {
+  it('drops an old-day slice fully explained by the same fresh evidence under the old timezone', () => {
+    const moved = slice({
+      calls: 1,
+      cost: 10,
+      sessions: 1,
+      inputTokens: 100,
+      outputTokens: 20,
+      reasoningTokens: 7,
+    })
+
+    const result = mergeTimezoneRebucketedDays(
+      [day('2026-08-11', moved)],
+      [{ ...day('2026-08-10', moved), carried: true }],
+      [day('2026-08-10', moved)],
+    )
+
+    expect(result.map(entry => entry.date)).toEqual(['2026-08-11'])
+    expect(result[0]?.calls).toBe(1)
+    expect(result[0]?.inputTokens).toBe(100)
+    expect(result[0]?.reasoningTokens).toBe(7)
+  })
+
+  it('keeps only source-gone residual history and preserves Metrora model provenance', () => {
+    const baseline = slice({
+      calls: 2,
+      cost: 30,
+      sessions: 2,
+      inputTokens: 100,
+      outputTokens: 20,
+      reasoningTokens: 10,
+      turns: 2,
+    })
+    const surviving = slice({
+      calls: 1,
+      cost: 10,
+      sessions: 1,
+      inputTokens: 40,
+      outputTokens: 8,
+      reasoningTokens: 4,
+      turns: 1,
+    })
+
+    const result = mergeTimezoneRebucketedDays(
+      [day('2026-08-11', surviving)],
+      [{ ...day('2026-08-10', baseline), carried: true }],
+      [day('2026-08-10', surviving)],
+    )
+
+    expect(result).toHaveLength(2)
+    const residual = result.find(entry => entry.date === '2026-08-10')!
+    const fresh = result.find(entry => entry.date === '2026-08-11')!
+
+    expect(residual.calls).toBe(1)
+    expect(residual.cost).toBe(20)
+    expect(residual.inputTokens).toBe(60)
+    expect(residual.outputTokens).toBe(12)
+    expect(residual.reasoningTokens).toBe(6)
+    expect(residual.providers.copilot?.reasoningTokens).toBe(6)
+    expect(residual.models[MODEL]).toMatchObject({
+      calls: 1,
+      cost: 20,
+      inputTokens: 60,
+      outputTokens: 12,
+      reasoningTokens: 6,
+      modelProvider: 'openai',
+      sourceProviders: ['copilot'],
+    })
+    expect(residual.projects?.[PROJECT]).toMatchObject({ calls: 1, cost: 20, sessions: 1, path: 'C:/work/metrora' })
+
+    expect(residual.calls + fresh.calls).toBe(2)
+    expect(residual.inputTokens + fresh.inputTokens).toBe(100)
+    expect((residual.reasoningTokens ?? 0) + (fresh.reasoningTokens ?? 0)).toBe(10)
+  })
+
+  it('adds distinct residual sessions instead of max-clamping them against a fresh placeholder', () => {
+    const baseline = slice({
+      calls: 1,
+      cost: 10,
+      sessions: 2,
+      inputTokens: 40,
+      outputTokens: 8,
+      reasoningTokens: 4,
+      turns: 1,
+    })
+    const explained = slice({
+      calls: 1,
+      cost: 10,
+      sessions: 1,
+      inputTokens: 40,
+      outputTokens: 8,
+      reasoningTokens: 4,
+      turns: 1,
+    })
+    const placeholder: ProviderDaySlice = {
+      calls: 0,
+      cost: 0,
+      savingsUSD: 0,
+      sessions: 1,
+      inputTokens: 0,
+      outputTokens: 0,
+      reasoningTokens: 0,
+      cacheReadTokens: 0,
+      cacheWriteTokens: 0,
+      editTurns: 0,
+      oneShotTurns: 0,
+      models: {},
+      categories: {},
+      projects: { [PROJECT]: project(0, 0, 1) },
+    }
+
+    const result = mergeTimezoneRebucketedDays(
+      [day('2026-08-10', placeholder)],
+      [{ ...day('2026-08-10', baseline), carried: true }],
+      [day('2026-08-10', explained)],
+    )
+
+    const merged = result[0]!
+    expect(merged.calls).toBe(0)
+    expect(merged.sessions).toBe(2)
+    expect(merged.providers.copilot?.sessions).toBe(2)
+    expect(merged.projects?.[PROJECT]?.sessions).toBe(2)
+  })
+})

--- a/tests/day-aggregator-timezone.test.ts
+++ b/tests/day-aggregator-timezone.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest'
+
+import { dateKeyInTz } from '../src/day-aggregator.js'
+
+describe('dateKeyInTz', () => {
+  it('buckets the same instant on opposite sides of local midnight', () => {
+    const instant = '2026-08-11T00:30:00.000Z'
+    expect(dateKeyInTz(instant, 'Europe/Rome')).toBe('2026-08-11')
+    expect(dateKeyInTz(instant, 'America/New_York')).toBe('2026-08-10')
+  })
+})

--- a/tests/doctor-env-safety.test.ts
+++ b/tests/doctor-env-safety.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { collectDoctorReport, renderDoctorJson, renderDoctorTable } from '../src/doctor.js'
+import { ensureProviderEnvFingerprintAuthorities } from '../src/provider-parse-authorities.js'
+import { emptyCache } from '../src/session-cache.js'
+import type { Provider } from '../src/providers/types.js'
+
+const saved = new Map<string, string | undefined>()
+
+function setEnv(name: string, value: string | undefined): void {
+  if (!saved.has(name)) saved.set(name, process.env[name])
+  if (value === undefined) delete process.env[name]
+  else process.env[name] = value
+}
+
+function fakeProvider(name: string, network = false): Provider {
+  return {
+    name,
+    displayName: name,
+    network,
+    modelDisplayName: model => model,
+    toolDisplayName: tool => tool,
+    discoverSessions: async () => [],
+    createSessionParser: () => ({ async *parse() {} }),
+  }
+}
+
+afterEach(() => {
+  for (const [name, value] of saved) {
+    if (value === undefined) delete process.env[name]
+    else process.env[name] = value
+  }
+  saved.clear()
+})
+
+describe('doctor env authority safety', () => {
+  it('redacts Vercel credential values from the report and both renderers', async () => {
+    ensureProviderEnvFingerprintAuthorities()
+    const secret = 'super-secret-doctor-fixture-value'
+    setEnv('AI_GATEWAY_API_KEY', secret)
+
+    const report = await collectDoctorReport('vercel-gateway', {
+      providers: [fakeProvider('vercel-gateway', true)],
+      cache: emptyCache(),
+    })
+
+    expect(report.providers[0]?.envOverrides).toContainEqual({
+      name: 'AI_GATEWAY_API_KEY',
+      value: '<set>',
+    })
+    expect(JSON.stringify(report)).not.toContain(secret)
+    expect(renderDoctorJson(report)).not.toContain(secret)
+    expect(renderDoctorTable(report, { color: false })).not.toContain(secret)
+  })
+
+  it('fingerprints APPDATA without presenting it as a deliberate override', async () => {
+    ensureProviderEnvFingerprintAuthorities()
+    setEnv('APPDATA', 'C:\\Users\\fixture\\AppData\\Roaming')
+
+    const report = await collectDoctorReport('claude', {
+      providers: [fakeProvider('claude')],
+      cache: emptyCache(),
+    })
+    expect(report.providers[0]?.envOverrides.some(item => item.name === 'APPDATA')).toBe(false)
+  })
+
+  it('does not blame parse-only Cursor settings for empty discovery', async () => {
+    ensureProviderEnvFingerprintAuthorities()
+    setEnv('METRORA_CURSOR_MAX_BUBBLES', '50')
+
+    const report = await collectDoctorReport('cursor', {
+      providers: [fakeProvider('cursor')],
+      cache: emptyCache(),
+    })
+    const row = report.providers[0]!
+    expect(row.envOverrides).toContainEqual({ name: 'METRORA_CURSOR_MAX_BUBBLES', value: '50' })
+    expect(row.verdict).not.toContain('override METRORA_CURSOR_MAX_BUBBLES')
+  })
+})

--- a/tests/parser.test.ts
+++ b/tests/parser.test.ts
@@ -4,7 +4,8 @@
 //   (b) OTel-prune monotonic  — OTel DB rows pruned      → total unchanged
 //   (c) no double-count       — same source parsed twice  → counted once
 //   (d) non-durable evicts    — deleted source for non-durable provider IS removed
-//   (e) 90-day age-out        — orphan ≥ 91d old is pruned; ≤ 89d is retained
+//   (e) bounded durable detail — old physical evidence is projected before
+//       detailed-cache eviction; absent sources do not resurrect it
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { mkdtemp, mkdir, writeFile, rm, unlink } from 'fs/promises'
@@ -357,10 +358,10 @@ describe('(d) non-durable provider evicts deleted sources', () => {
 })
 
 // ═══════════════════════════════════════════════════════════════════════════
-// (e) 90-day age-out: orphan ≥ 91d old is pruned; ≤ 89d is retained
+// (e) bounded durable detail: materialize before eviction
 // ═══════════════════════════════════════════════════════════════════════════
-describe('(e) 90-day age-out for durable providers', () => {
-  it('prunes an orphaned cache entry whose newest call is 91 days old', async () => {
+describe('(e) bounded detailed cache for durable providers', () => {
+  it('projects a physically present 91-day-old source before evicting its detail', async () => {
     const synthFile = join(tmpHome, 'synth-age.txt')
     await writeFile(synthFile, 'placeholder')
 
@@ -380,15 +381,22 @@ describe('(e) 90-day age-out for durable providers', () => {
       userMessage: 'old', sessionId: 'synth-old',
     }]
 
-    // First parse: cached with 91d-old timestamp → immediately pruned by 90-day check
+    // The query result is the materialization boundary: the source is counted
+    // before its detailed session entry is pruned from the bounded cache.
     const proj1 = await parseAllSessions(undefined, 'test-synthetic')
-    expect(totalOutput(proj1)).toBe(0)  // pruned right away
+    expect(totalOutput(proj1)).toBe(8)
 
-    // Confirm: entry is not in the persistent cache after first parse
+    // Confirm: detail is not retained after the first materialization.
+    clearSessionCache()
+    const proj2 = await parseAllSessions(undefined, 'test-synthetic')
+    expect(totalOutput(proj2)).toBe(8)
+
+    // Once the physical source is genuinely absent, bounded detail cannot
+    // recreate it; the durable daily ledger is the history authority then.
     clearSessionCache()
     _synthSources = []  // no longer discovered
-    const proj2 = await parseAllSessions(undefined, 'test-synthetic')
-    expect(totalOutput(proj2)).toBe(0)
+    const proj3 = await parseAllSessions(undefined, 'test-synthetic')
+    expect(totalOutput(proj3)).toBe(0)
   })
 
   it('retains an orphaned cache entry whose newest call is 89 days old', async () => {
@@ -411,7 +419,7 @@ describe('(e) 90-day age-out for durable providers', () => {
       userMessage: 'recent-ish', sessionId: 'synth-recent',
     }]
 
-    // First parse: cached with 89d-old timestamp → NOT pruned (within 90d window)
+    // A recent durable entry remains in the detailed cache.
     const proj1 = await parseAllSessions(undefined, 'test-synthetic')
     expect(totalOutput(proj1)).toBe(7)
 

--- a/tests/provider-env-authorities.test.ts
+++ b/tests/provider-env-authorities.test.ts
@@ -3,7 +3,6 @@ import { afterEach, describe, expect, it } from 'vitest'
 import {
   COPILOT_DEFERRED_ENV_FINGERPRINTS,
   PROVIDER_ENV_FINGERPRINT_ADDITIONS,
-  VERCEL_DEFERRED_SECRET_FINGERPRINTS,
   ensureProviderEnvFingerprintAuthorities,
   getProviderEnvConfigHash,
 } from '../src/provider-parse-authorities.js'
@@ -47,14 +46,6 @@ describe('provider env cache authorities', () => {
     }
   })
 
-  it('does not declare Vercel secrets until doctor redacts declared credential values', () => {
-    ensureProviderEnvFingerprintAuthorities()
-    const declared = PROVIDER_ENV_VARS['vercel-gateway'] ?? []
-    for (const name of VERCEL_DEFERRED_SECRET_FINGERPRINTS) {
-      expect(declared).not.toContain(name)
-    }
-  })
-
   it('changes the daily authority when a declared source/profile override changes without exposing the value', () => {
     setEnv('GROK_HOME', '/tmp/metrora-grok-a')
     const first = getProviderEnvConfigHash()
@@ -66,5 +57,17 @@ describe('provider env cache authorities', () => {
     expect(second).toMatch(/^[0-9a-f]{24}$/)
     expect(first).not.toContain('/tmp/metrora-grok-a')
     expect(second).not.toContain('/tmp/metrora-grok-b')
+  })
+
+  it('fingerprints Vercel account credentials without serializing the secret', () => {
+    const secret = 'metrora-test-secret-never-persist-this-value'
+    setEnv('AI_GATEWAY_API_KEY', secret)
+    const first = getProviderEnvConfigHash()
+    setEnv('AI_GATEWAY_API_KEY', 'different-test-secret')
+    const second = getProviderEnvConfigHash()
+
+    expect(PROVIDER_ENV_VARS['vercel-gateway']).toContain('AI_GATEWAY_API_KEY')
+    expect(first).not.toBe(second)
+    expect(first).not.toContain(secret)
   })
 })

--- a/tests/provider-env-authorities.test.ts
+++ b/tests/provider-env-authorities.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it } from 'vitest'
 import {
   COPILOT_DEFERRED_ENV_FINGERPRINTS,
   PROVIDER_ENV_FINGERPRINT_ADDITIONS,
+  VERCEL_DEFERRED_SECRET_FINGERPRINTS,
   ensureProviderEnvFingerprintAuthorities,
   getProviderEnvConfigHash,
 } from '../src/provider-parse-authorities.js'
@@ -46,6 +47,14 @@ describe('provider env cache authorities', () => {
     }
   })
 
+  it('does not declare Vercel secrets until doctor redacts declared credential values', () => {
+    ensureProviderEnvFingerprintAuthorities()
+    const declared = PROVIDER_ENV_VARS['vercel-gateway'] ?? []
+    for (const name of VERCEL_DEFERRED_SECRET_FINGERPRINTS) {
+      expect(declared).not.toContain(name)
+    }
+  })
+
   it('changes the daily authority when a declared source/profile override changes without exposing the value', () => {
     setEnv('GROK_HOME', '/tmp/metrora-grok-a')
     const first = getProviderEnvConfigHash()
@@ -57,16 +66,5 @@ describe('provider env cache authorities', () => {
     expect(second).toMatch(/^[0-9a-f]{24}$/)
     expect(first).not.toContain('/tmp/metrora-grok-a')
     expect(second).not.toContain('/tmp/metrora-grok-b')
-  })
-
-  it('hashes Vercel credential identity without serializing the credential', () => {
-    const secret = 'metrora-test-secret-never-persist-this-value'
-    setEnv('AI_GATEWAY_API_KEY', secret)
-    const withSecret = getProviderEnvConfigHash()
-    setEnv('AI_GATEWAY_API_KEY', 'different-test-secret')
-    const rotated = getProviderEnvConfigHash()
-
-    expect(withSecret).not.toBe(rotated)
-    expect(withSecret).not.toContain(secret)
   })
 })

--- a/tests/provider-env-authorities.test.ts
+++ b/tests/provider-env-authorities.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, describe, expect, it } from 'vitest'
+
+import {
+  COPILOT_DEFERRED_ENV_FINGERPRINTS,
+  PROVIDER_ENV_FINGERPRINT_ADDITIONS,
+  ensureProviderEnvFingerprintAuthorities,
+  getProviderEnvConfigHash,
+} from '../src/provider-parse-authorities.js'
+import { PROVIDER_ENV_VARS } from '../src/session-cache.js'
+
+const saved = new Map<string, string | undefined>()
+
+function setEnv(name: string, value: string | undefined): void {
+  if (!saved.has(name)) saved.set(name, process.env[name])
+  if (value === undefined) delete process.env[name]
+  else process.env[name] = value
+}
+
+afterEach(() => {
+  for (const [name, value] of saved) {
+    if (value === undefined) delete process.env[name]
+    else process.env[name] = value
+  }
+  saved.clear()
+})
+
+describe('provider env cache authorities', () => {
+  it('installs every reviewed Metrora env declaration idempotently', () => {
+    ensureProviderEnvFingerprintAuthorities()
+    const once = JSON.stringify(PROVIDER_ENV_VARS)
+    ensureProviderEnvFingerprintAuthorities()
+    expect(JSON.stringify(PROVIDER_ENV_VARS)).toBe(once)
+
+    for (const [provider, additions] of Object.entries(PROVIDER_ENV_FINGERPRINT_ADDITIONS)) {
+      for (const name of additions) {
+        expect(PROVIDER_ENV_VARS[provider]).toContain(name)
+      }
+    }
+  })
+
+  it('does not provider-wide fingerprint Copilot until durable present-path history can merge safely', () => {
+    ensureProviderEnvFingerprintAuthorities()
+    const declared = PROVIDER_ENV_VARS['copilot'] ?? []
+    for (const name of COPILOT_DEFERRED_ENV_FINGERPRINTS) {
+      expect(declared).not.toContain(name)
+    }
+  })
+
+  it('changes the daily authority when a declared source/profile override changes without exposing the value', () => {
+    setEnv('GROK_HOME', '/tmp/metrora-grok-a')
+    const first = getProviderEnvConfigHash()
+    setEnv('GROK_HOME', '/tmp/metrora-grok-b')
+    const second = getProviderEnvConfigHash()
+
+    expect(first).not.toBe(second)
+    expect(first).toMatch(/^[0-9a-f]{24}$/)
+    expect(second).toMatch(/^[0-9a-f]{24}$/)
+    expect(first).not.toContain('/tmp/metrora-grok-a')
+    expect(second).not.toContain('/tmp/metrora-grok-b')
+  })
+
+  it('hashes Vercel credential identity without serializing the credential', () => {
+    const secret = 'metrora-test-secret-never-persist-this-value'
+    setEnv('AI_GATEWAY_API_KEY', secret)
+    const withSecret = getProviderEnvConfigHash()
+    setEnv('AI_GATEWAY_API_KEY', 'different-test-secret')
+    const rotated = getProviderEnvConfigHash()
+
+    expect(withSecret).not.toBe(rotated)
+    expect(withSecret).not.toContain(secret)
+  })
+})

--- a/tests/providers/antigravity.test.ts
+++ b/tests/providers/antigravity.test.ts
@@ -980,8 +980,8 @@ describe('antigravity provider helpers', () => {
         provider: 'antigravity',
         model: 'gemini-3.1-pro-high',
         inputTokens: 31281,
-        outputTokens: 659,
-        reasoningTokens: 71,
+        outputTokens: 71,
+        reasoningTokens: 659,
         sessionId: fixture.conversationId,
         project: 'antigravity-cli',
       })
@@ -1074,8 +1074,8 @@ describe('antigravity provider helpers', () => {
       expect(calls).toHaveLength(1)
       expect(calls[0]).toMatchObject({
         inputTokens: 300,
-        outputTokens: 30,
-        reasoningTokens: 20,
+        outputTokens: 20,
+        reasoningTokens: 30,
         cacheReadInputTokens: 700,
         deduplicationKey: 'antigravity:field-session:response-fields',
       })
@@ -1135,8 +1135,8 @@ describe('antigravity provider helpers', () => {
       expect(first).toHaveLength(1)
       expect(first[0]).toMatchObject({ inputTokens: 31281, model: 'gemini-3.1-pro-high' })
       expect(migrated).toMatchObject({
-        version: 6,
-        cascades: { [fixture.conversationId]: { parserVersion: 6 } },
+        version: 7,
+        cascades: { [fixture.conversationId]: { parserVersion: 7 } },
       })
       expect(migrated.cascades.orphanedCascade).toBeUndefined()
 

--- a/tests/providers/codex-legacy-session-meta.test.ts
+++ b/tests/providers/codex-legacy-session-meta.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { mkdir, mkdtemp, rm, writeFile } from 'fs/promises'
+import { join } from 'path'
+import { tmpdir } from 'os'
+
+import { createCodexProvider } from '../../src/providers/codex.js'
+import type { ParsedProviderCall } from '../../src/providers/types.js'
+
+let tmpDir: string
+
+beforeEach(async () => {
+  tmpDir = await mkdtemp(join(tmpdir(), 'codex-legacy-meta-'))
+})
+
+afterEach(async () => {
+  await rm(tmpDir, { recursive: true, force: true })
+})
+
+function cumulativeTokenCount(
+  timestamp: string,
+  total: { input: number; cached: number; output: number; reasoning: number },
+): string {
+  return JSON.stringify({
+    type: 'event_msg',
+    timestamp,
+    payload: {
+      type: 'token_count',
+      info: {
+        model: 'gpt-5.4',
+        total_token_usage: {
+          input_tokens: total.input,
+          cached_input_tokens: total.cached,
+          output_tokens: total.output,
+          reasoning_output_tokens: total.reasoning,
+          total_tokens: total.input + total.output + total.reasoning,
+        },
+      },
+    },
+  })
+}
+
+describe('codex provider - legacy session_meta identity', () => {
+  it('discovers payload.id sessions and preserves cumulative token deltas', async () => {
+    const sessionDir = join(tmpDir, 'sessions', '2026', '02', '23')
+    await mkdir(sessionDir, { recursive: true })
+    await writeFile(
+      join(sessionDir, 'rollout-legacy.jsonl'),
+      [
+        JSON.stringify({
+          type: 'session_meta',
+          timestamp: '2026-02-23T10:00:00Z',
+          payload: {
+            id: 'legacy-session-001',
+            cwd: '/Users/test/legacy-project',
+            originator: 'codex-cli',
+            model: 'gpt-5.4',
+          },
+        }),
+        cumulativeTokenCount('2026-02-23T10:01:00Z', {
+          input: 100,
+          cached: 20,
+          output: 50,
+          reasoning: 10,
+        }),
+        cumulativeTokenCount('2026-02-23T10:02:00Z', {
+          input: 160,
+          cached: 30,
+          output: 80,
+          reasoning: 20,
+        }),
+      ].join('\n') + '\n',
+    )
+
+    const provider = createCodexProvider(tmpDir)
+    const sessions = await provider.discoverSessions()
+
+    expect(sessions).toHaveLength(1)
+    expect(sessions[0]!.project).toBe('Users-test-legacy-project')
+
+    const calls: ParsedProviderCall[] = []
+    const seenKeys = new Set<string>()
+    for await (const call of provider.createSessionParser(sessions[0]!, seenKeys).parse()) {
+      calls.push(call)
+    }
+
+    expect(calls).toHaveLength(2)
+    expect(calls.every(call => call.sessionId === 'legacy-session-001')).toBe(true)
+    expect(calls.reduce((sum, call) => sum + call.inputTokens, 0)).toBe(130)
+    expect(calls.reduce((sum, call) => sum + call.cacheReadInputTokens, 0)).toBe(30)
+    expect(calls.reduce((sum, call) => sum + call.outputTokens, 0)).toBe(80)
+    expect(calls.reduce((sum, call) => sum + call.reasoningTokens, 0)).toBe(20)
+  })
+})

--- a/tests/providers/codex-legacy-session-meta.test.ts
+++ b/tests/providers/codex-legacy-session-meta.test.ts
@@ -3,6 +3,12 @@ import { mkdir, mkdtemp, rm, writeFile } from 'fs/promises'
 import { join } from 'path'
 import { tmpdir } from 'os'
 
+import { getDailyCacheConfigHash } from '../../src/daily-cache-config.js'
+import {
+  CODEX_LEGACY_SESSION_META_AUTHORITY,
+  ensureCodexLegacySessionMetaAuthority,
+} from '../../src/provider-parse-authorities.js'
+import { computeEnvFingerprint, PROVIDER_PARSE_VERSIONS } from '../../src/session-cache.js'
 import { createCodexProvider } from '../../src/providers/codex.js'
 import type { ParsedProviderCall } from '../../src/providers/types.js'
 
@@ -89,5 +95,19 @@ describe('codex provider - legacy session_meta identity', () => {
     expect(calls.reduce((sum, call) => sum + call.cacheReadInputTokens, 0)).toBe(30)
     expect(calls.reduce((sum, call) => sum + call.outputTokens, 0)).toBe(80)
     expect(calls.reduce((sum, call) => sum + call.reasoningTokens, 0)).toBe(20)
+  })
+
+  it('uses the same legacy parser authority for warm session cache and daily history', () => {
+    const effective = ensureCodexLegacySessionMetaAuthority()
+    const fingerprint = computeEnvFingerprint('codex')
+    const repeated = ensureCodexLegacySessionMetaAuthority()
+    const repeatedFingerprint = computeEnvFingerprint('codex')
+    const dailyHash = getDailyCacheConfigHash()
+
+    expect(effective).toContain(CODEX_LEGACY_SESSION_META_AUTHORITY)
+    expect(PROVIDER_PARSE_VERSIONS['codex']).toBe(effective)
+    expect(repeated).toBe(effective)
+    expect(repeatedFingerprint).toBe(fingerprint)
+    expect(dailyHash).toContain(`codexCollector=${effective}`)
   })
 })

--- a/tests/providers/copilot-cli-resume.test.ts
+++ b/tests/providers/copilot-cli-resume.test.ts
@@ -1,0 +1,107 @@
+import { mkdtemp, mkdir, writeFile } from 'fs/promises'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { describe, expect, it } from 'vitest'
+
+import {
+  COPILOT_CLI_RESUME_PROVIDER,
+} from '../../src/provider-parse-authorities.js'
+import {
+  createCopilotCliResumeProvider,
+  withCopilotCliResumeAccounting,
+} from '../../src/providers/copilot-cli-resume.js'
+import { allProviderNames, getProvider } from '../../src/providers/index.js'
+import type { Provider, SessionSource } from '../../src/providers/types.js'
+
+function fakeCopilot(source: SessionSource): Provider {
+  return {
+    name: 'copilot',
+    displayName: 'GitHub Copilot',
+    durableSources: true,
+    modelDisplayName: model => model,
+    toolDisplayName: tool => tool,
+    discoverSessions: async () => [source],
+    createSessionParser: () => ({
+      async *parse() { /* canonical parser is outside this characterization */ },
+    }),
+  }
+}
+
+describe('Copilot CLI resumed shutdown supplemental authority', () => {
+  it('adds an internal source without replacing canonical Copilot discovery', async () => {
+    const source = {
+      path: '/tmp/copilot/session-a/events.jsonl',
+      project: 'demo',
+      provider: 'copilot',
+      sourceType: 'jsonl',
+    } as SessionSource
+    const base = fakeCopilot(source)
+    const wrapped = withCopilotCliResumeAccounting(base)
+
+    const discovered = await wrapped.discoverSessions()
+    expect(discovered).toHaveLength(2)
+    expect(discovered[0]?.provider).toBe('copilot')
+    expect(discovered[1]?.provider).toBe(COPILOT_CLI_RESUME_PROVIDER)
+    expect(discovered[1]?.path).toBe(source.path)
+  })
+
+  it('emits only later shutdown deltas, including a counter-reset leg', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'metrora-copilot-resume-'))
+    const sessionDir = join(root, 'session-a')
+    await mkdir(sessionDir, { recursive: true })
+    const eventsPath = join(sessionDir, 'events.jsonl')
+
+    const rows = [
+      { type: 'session.start', data: { selectedModel: 'gpt-5.3' }, timestamp: '2026-08-10T10:00:00.000Z' },
+      { type: 'session.shutdown', data: { modelMetrics: { 'gpt-5.3': { usage: { inputTokens: 100, outputTokens: 8, cacheReadTokens: 20, cacheWriteTokens: 10, reasoningTokens: 5 } } } }, timestamp: '2026-08-10T10:05:00.000Z' },
+      { type: 'session.shutdown', data: { modelMetrics: { 'gpt-5.3': { usage: { inputTokens: 180, outputTokens: 14, cacheReadTokens: 40, cacheWriteTokens: 15, reasoningTokens: 9 } } } }, timestamp: '2026-08-10T11:05:00.000Z' },
+      // Counter reset: input falls below the prior cumulative total, so this leg
+      // is measured from zero rather than clamped away.
+      { type: 'session.shutdown', data: { modelMetrics: { 'gpt-5.3': { usage: { inputTokens: 10, outputTokens: 2, cacheReadTokens: 0, cacheWriteTokens: 0, reasoningTokens: 1 } } } }, timestamp: '2026-08-10T12:05:00.000Z' },
+    ]
+    await writeFile(eventsPath, rows.map(row => JSON.stringify(row)).join('\n') + '\n')
+
+    const source = {
+      path: eventsPath,
+      project: 'demo',
+      provider: COPILOT_CLI_RESUME_PROVIDER,
+      sourceType: 'jsonl',
+    } as SessionSource
+    const provider = createCopilotCliResumeProvider(fakeCopilot(source))
+    const calls = []
+    for await (const call of provider.createSessionParser(source, new Set()).parse()) calls.push(call)
+
+    expect(calls).toHaveLength(2)
+    expect(calls.map(call => call.deduplicationKey)).toEqual([
+      'copilot:session-a:shutdown:gpt-5.3:resume:2',
+      'copilot:session-a:shutdown:gpt-5.3:resume:3',
+    ])
+
+    expect(calls[0]).toMatchObject({
+      provider: 'copilot',
+      sessionId: 'session-a',
+      inputTokens: 55,
+      outputTokens: 0,
+      cacheReadInputTokens: 20,
+      cacheCreationInputTokens: 5,
+      reasoningTokens: 4,
+    })
+    expect(calls[1]).toMatchObject({
+      provider: 'copilot',
+      sessionId: 'session-a',
+      inputTokens: 10,
+      outputTokens: 0,
+      cacheReadInputTokens: 0,
+      cacheCreationInputTokens: 0,
+      reasoningTokens: 1,
+    })
+  })
+
+  it('keeps the supplemental namespace internal to public provider selection', async () => {
+    expect(allProviderNames()).not.toContain(COPILOT_CLI_RESUME_PROVIDER)
+    const internal = await getProvider(COPILOT_CLI_RESUME_PROVIDER)
+    expect(internal?.name).toBe(COPILOT_CLI_RESUME_PROVIDER)
+    expect(internal?.durableSources).toBe(true)
+    expect(internal?.durableFreshWins).toBe(true)
+  })
+})

--- a/tests/providers/copilot-current-journal.test.ts
+++ b/tests/providers/copilot-current-journal.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { mkdtemp, rm, writeFile } from 'fs/promises'
+import { join } from 'path'
+import { tmpdir } from 'os'
+
+import { createCopilotProvider } from '../../src/providers/copilot.js'
+import {
+  replayCopilotChatJournal,
+  withCopilotChatJournalAccounting,
+} from '../../src/providers/copilot-chat-journal.js'
+import type { ParsedProviderCall, SessionSource } from '../../src/providers/types.js'
+
+const tempDirs: string[] = []
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map(path => rm(path, { recursive: true, force: true })))
+})
+
+async function writeJournal(lines: unknown[]): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), 'metrora-copilot-journal-'))
+  tempDirs.push(dir)
+  const path = join(dir, 'session.jsonl')
+  await writeFile(path, `${lines.map(line => JSON.stringify(line)).join('\n')}\n`, 'utf-8')
+  return path
+}
+
+function request(
+  requestId: string,
+  promptTokens: number,
+  completionTokens: number,
+  reasoningTokens = 0,
+): Record<string, unknown> {
+  return {
+    requestId,
+    timestamp: 1_784_000_000_000,
+    modelId: 'copilot/gpt-5.4',
+    promptTokens,
+    completionTokens,
+    result: {
+      metadata: {
+        resolvedModel: 'gpt-5.4',
+        toolCallRounds: reasoningTokens > 0
+          ? [{ thinking: { tokens: reasoningTokens } }]
+          : [],
+      },
+    },
+  }
+}
+
+describe('Copilot current VS Code chat journal accounting', () => {
+  it('replays kind=2 splice semantics instead of retaining stale request versions', () => {
+    const oldRequest = request('request-1', 100, 10)
+    const freshRequest = request('request-1', 120, 20, 5)
+
+    const replayed = replayCopilotChatJournal([
+      { kind: 0, v: { sessionId: 'session-1', requests: [oldRequest] } },
+      { kind: 2, k: ['requests'], i: 0, v: [freshRequest] },
+    ].map(line => JSON.stringify(line)).join('\n')) as { requests: Array<Record<string, unknown>> }
+
+    expect(replayed.requests).toHaveLength(1)
+    expect(replayed.requests[0]?.['promptTokens']).toBe(120)
+    expect(replayed.requests[0]?.['completionTokens']).toBe(20)
+  })
+
+  it('accounts top-level usage and separately observed reasoning from the final request state', async () => {
+    const path = await writeJournal([
+      {
+        kind: 0,
+        v: {
+          sessionId: 'session-2',
+          creationDate: 1_784_000_000_000,
+          requests: [request('request-2', 100, 10)],
+        },
+      },
+      {
+        kind: 2,
+        k: ['requests'],
+        i: 0,
+        v: [request('request-2', 120, 20, 5)],
+      },
+    ])
+
+    const provider = withCopilotChatJournalAccounting(createCopilotProvider())
+    const source = {
+      path,
+      project: 'fixture',
+      provider: 'copilot',
+      sourceType: 'chatsession',
+    } as SessionSource & { sourceType: 'chatsession' }
+
+    const calls: ParsedProviderCall[] = []
+    for await (const call of provider.createSessionParser(source, new Set()).parse()) {
+      calls.push(call)
+    }
+
+    expect(calls).toHaveLength(1)
+    expect(calls[0]).toMatchObject({
+      deduplicationKey: 'copilot-chatsession:session-2:request-2',
+      model: 'gpt-5.4',
+      inputTokens: 120,
+      outputTokens: 20,
+      reasoningTokens: 5,
+    })
+  })
+
+  it('honors kind=1 updates and kind=3 deletes during reconstruction', () => {
+    const replayed = replayCopilotChatJournal([
+      { kind: 0, v: { requests: [request('request-3', 100, 10)] } },
+      { kind: 1, k: ['requests', 0, 'promptTokens'], v: 140 },
+      { kind: 3, k: ['requests', 0, 'completionTokens'] },
+    ].map(line => JSON.stringify(line)).join('\n')) as { requests: Array<Record<string, unknown>> }
+
+    expect(replayed.requests[0]?.['promptTokens']).toBe(140)
+    expect(replayed.requests[0]?.['completionTokens']).toBeUndefined()
+  })
+})

--- a/tests/providers/copilot-current-journal.test.ts
+++ b/tests/providers/copilot-current-journal.test.ts
@@ -5,10 +5,12 @@ import { tmpdir } from 'os'
 
 import { createCopilotProvider } from '../../src/providers/copilot.js'
 import {
+  COPILOT_CHAT_JOURNAL_PROVIDER,
+  createCopilotChatJournalProvider,
   replayCopilotChatJournal,
   withCopilotChatJournalAccounting,
 } from '../../src/providers/copilot-chat-journal.js'
-import type { ParsedProviderCall, SessionSource } from '../../src/providers/types.js'
+import type { ParsedProviderCall, Provider, SessionSource } from '../../src/providers/types.js'
 
 const tempDirs: string[] = []
 
@@ -62,6 +64,19 @@ describe('Copilot current VS Code chat journal accounting', () => {
     expect(replayed.requests[0]?.['completionTokens']).toBe(20)
   })
 
+  it('removes requests that disappear from the authoritative replayed suffix', () => {
+    const requestA = request('request-a', 100, 10)
+    const requestB = request('request-b', 200, 20)
+
+    const replayed = replayCopilotChatJournal([
+      { kind: 0, v: { sessionId: 'session-truncate', requests: [requestA, requestB] } },
+      { kind: 2, k: ['requests'], i: 1 },
+    ].map(line => JSON.stringify(line)).join('\n')) as { requests: Array<Record<string, unknown>> }
+
+    expect(replayed.requests).toHaveLength(1)
+    expect(replayed.requests[0]?.['requestId']).toBe('request-a')
+  })
+
   it('accounts top-level usage and separately observed reasoning from the final request state', async () => {
     const path = await writeJournal([
       {
@@ -112,5 +127,42 @@ describe('Copilot current VS Code chat journal accounting', () => {
 
     expect(replayed.requests[0]?.['promptTokens']).toBe(140)
     expect(replayed.requests[0]?.['completionTokens']).toBeUndefined()
+  })
+
+  it('routes chat journals to a non-durable internal cache namespace only', async () => {
+    const base = createCopilotProvider()
+    const fake = {
+      ...base,
+      durableSources: true,
+      async discoverSessions(): Promise<SessionSource[]> {
+        return [
+          {
+            path: 'journal.jsonl',
+            project: 'fixture',
+            provider: 'copilot',
+            sourceType: 'chatsession',
+          } as SessionSource & { sourceType: 'chatsession' },
+          {
+            path: 'agent-traces.db',
+            project: 'fixture',
+            provider: 'copilot',
+            sourceType: 'otel',
+          } as SessionSource & { sourceType: 'otel' },
+        ]
+      },
+    } satisfies Provider
+
+    const wrapped = withCopilotChatJournalAccounting(fake)
+    const sources = await wrapped.discoverSessions()
+    const journal = sources.find(source => source.path === 'journal.jsonl')
+    const otel = sources.find(source => source.path === 'agent-traces.db')
+    const internal = createCopilotChatJournalProvider(fake)
+
+    expect(journal?.provider).toBe(COPILOT_CHAT_JOURNAL_PROVIDER)
+    expect(otel?.provider).toBe('copilot')
+    expect(wrapped.durableSources).toBe(true)
+    expect(internal.name).toBe(COPILOT_CHAT_JOURNAL_PROVIDER)
+    expect(internal.durableSources).toBe(false)
+    expect(await internal.discoverSessions()).toEqual([])
   })
 })

--- a/tests/providers/copilot-current-journal.test.ts
+++ b/tests/providers/copilot-current-journal.test.ts
@@ -3,9 +3,9 @@ import { mkdtemp, rm, writeFile } from 'fs/promises'
 import { join } from 'path'
 import { tmpdir } from 'os'
 
+import { COPILOT_CHAT_JOURNAL_PROVIDER } from '../../src/provider-parse-authorities.js'
 import { createCopilotProvider } from '../../src/providers/copilot.js'
 import {
-  COPILOT_CHAT_JOURNAL_PROVIDER,
   createCopilotChatJournalProvider,
   replayCopilotChatJournal,
   withCopilotChatJournalAccounting,

--- a/tests/providers/vscode-cline-malformed-timestamp.test.ts
+++ b/tests/providers/vscode-cline-malformed-timestamp.test.ts
@@ -1,0 +1,40 @@
+import { mkdtemp, mkdir, writeFile } from 'fs/promises'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { describe, expect, it } from 'vitest'
+
+import { createClineParser } from '../../src/providers/vscode-cline-parser.js'
+
+describe('VS Code Cline malformed timestamp isolation', () => {
+  it('keeps valid usage when an api_req_started timestamp is invalid', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'metrora-cline-bad-ts-'))
+    const taskDir = join(root, 'task-a')
+    await mkdir(taskDir, { recursive: true })
+    await writeFile(join(taskDir, 'ui_messages.json'), JSON.stringify([
+      {
+        type: 'say',
+        say: 'api_req_started',
+        ts: Number.MAX_VALUE,
+        text: JSON.stringify({ tokensIn: 12, tokensOut: 3, cacheReads: 2, cacheWrites: 1 }),
+      },
+    ]))
+
+    const parser = createClineParser(
+      { path: taskDir, project: 'Cline', provider: 'cline' },
+      new Set(),
+      'cline',
+      'gpt-5.3',
+    )
+    const calls = []
+    for await (const call of parser.parse()) calls.push(call)
+
+    expect(calls).toHaveLength(1)
+    expect(calls[0]).toMatchObject({
+      inputTokens: 12,
+      outputTokens: 3,
+      cacheReadInputTokens: 2,
+      cacheCreationInputTokens: 1,
+      timestamp: '',
+    })
+  })
+})

--- a/tests/r2-claude-native-identity-reconciliation.test.ts
+++ b/tests/r2-claude-native-identity-reconciliation.test.ts
@@ -1,0 +1,214 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  apiCallToCachedCall,
+  compactEntry,
+  dedupeStreamingMessageIds,
+  getClaudeNativeIdentity,
+  parseApiCall,
+  reconcileClaudeNativeCalls,
+} from '../src/parser.js'
+import { getDailyCacheConfigHash } from '../src/daily-cache-config.js'
+import { computeEnvFingerprint, PROVIDER_PARSE_VERSIONS, type CachedCall } from '../src/session-cache.js'
+import type { JournalEntry } from '../src/types.js'
+
+function makeCall(overrides: Partial<CachedCall> = {}): CachedCall {
+  const timestamp = overrides.timestamp ?? '2026-04-03T13:30:36.680Z'
+  return {
+    provider: 'claude',
+    model: 'claude-sonnet-4-6',
+    usage: {
+      inputTokens: 2506,
+      outputTokens: 6,
+      cacheCreationInputTokens: 11729,
+      cacheReadInputTokens: 38903,
+      cachedInputTokens: 0,
+      reasoningTokens: 0,
+      webSearchRequests: 0,
+      cacheCreationOneHourTokens: 0,
+    },
+    speed: 'standard',
+    timestamp,
+    tools: [],
+    bashCommands: [],
+    skills: [],
+    subagentTypes: [],
+    deduplicationKey: 'native-message-1',
+    nativeMessageId: 'native-message-1',
+    nativeEmissionTimestamp: timestamp,
+    ...overrides,
+  }
+}
+
+function outputOf(files: ReadonlyArray<{ filePath: string; calls: readonly CachedCall[] }>): number {
+  const result = reconcileClaudeNativeCalls(files)
+  return [...result.winners.values()].reduce((sum, candidate) => sum + candidate.call.usage.outputTokens, 0)
+}
+
+function withOutput(call: CachedCall, outputTokens: number): CachedCall {
+  return { ...call, usage: { ...call.usage, outputTokens } }
+}
+
+function assistantEntry(timestamp: string, outputTokens: number, stopReason?: string): JournalEntry {
+  return {
+    type: 'assistant',
+    timestamp,
+    message: {
+      type: 'message',
+      role: 'assistant',
+      model: 'claude-sonnet-4-6',
+      id: 'streamed-message-1',
+      usage: {
+        input_tokens: 100,
+        output_tokens: outputTokens,
+        cache_read_input_tokens: 20,
+        cache_creation_input_tokens: 30,
+      },
+      content: [],
+      ...(stopReason ? { stop_reason: stopReason } : {}),
+    },
+  }
+}
+
+describe('R2 Claude native message identity reconciliation', () => {
+  it('counts an exact duplicate across two files once', () => {
+    const call = makeCall()
+    const result = reconcileClaudeNativeCalls([
+      { filePath: 'parent.jsonl', calls: [call] },
+      { filePath: 'mirror.jsonl', calls: [{ ...call, project: 'same-project' }] },
+    ])
+    expect(result.winners.size).toBe(1)
+    expect(outputOf([
+      { filePath: 'parent.jsonl', calls: [call] },
+      { filePath: 'mirror.jsonl', calls: [{ ...call, project: 'same-project' }] },
+    ])).toBe(6)
+  })
+
+  it('selects a later cumulative snapshot independent of discovery order', () => {
+    const partial = makeCall({ nativeEmissionTimestamp: '2026-04-03T13:30:36.680Z', timestamp: '2026-04-03T13:30:35.212Z' })
+    const final = withOutput(makeCall({ nativeEmissionTimestamp: '2026-04-03T13:30:37.000Z', timestamp: '2026-04-03T13:30:35.212Z', nativeSnapshotTerminal: true }), 376)
+    const first = reconcileClaudeNativeCalls([
+      { filePath: 'a.jsonl', calls: [partial] },
+      { filePath: 'b.jsonl', calls: [final] },
+    ])
+    const reversed = reconcileClaudeNativeCalls([
+      { filePath: 'b.jsonl', calls: [final] },
+      { filePath: 'a.jsonl', calls: [partial] },
+    ])
+    expect(first.winners.get('native-message-1')?.call.usage.outputTokens).toBe(376)
+    expect(reversed.winners.get('native-message-1')?.call.usage.outputTokens).toBe(376)
+    expect(outputOf([
+      { filePath: 'a.jsonl', calls: [partial] },
+      { filePath: 'b.jsonl', calls: [final] },
+    ])).toBe(outputOf([
+      { filePath: 'b.jsonl', calls: [final] },
+      { filePath: 'a.jsonl', calls: [partial] },
+    ]))
+  })
+
+  it('repairs a warm partial cache when the final mirror appears later', () => {
+    const partial = makeCall()
+    const final = withOutput(makeCall({ nativeSnapshotTerminal: true }), 376)
+    expect(outputOf([{ filePath: 'parent.jsonl', calls: [partial] }])).toBe(6)
+    expect(outputOf([
+      { filePath: 'parent.jsonl', calls: [partial] },
+      { filePath: 'mirror.jsonl', calls: [final] },
+    ])).toBe(376)
+  })
+
+  it('uses a terminal native marker when two files share the emission timestamp', () => {
+    const partial = makeCall({ nativeSnapshotTerminal: false })
+    const final = withOutput(makeCall({ nativeSnapshotTerminal: true }), 376)
+    const result = reconcileClaudeNativeCalls([
+      { filePath: 'parent.jsonl', calls: [partial] },
+      { filePath: 'sidechain.jsonl', calls: [final] },
+    ])
+    expect(result.ambiguities).toHaveLength(0)
+    expect(result.winners.get('native-message-1')?.call.nativeSnapshotTerminal).toBe(true)
+    expect(result.winners.get('native-message-1')?.call.usage.outputTokens).toBe(376)
+  })
+
+  it('keeps within-file streaming final payload and first logical timestamp', () => {
+    const entries = dedupeStreamingMessageIds([
+      compactEntry(assistantEntry('2026-04-03T13:30:35.212Z', 5)),
+      compactEntry(assistantEntry('2026-04-03T13:30:36.680Z', 376, 'tool_use')),
+    ])
+    expect(entries).toHaveLength(1)
+    const parsed = parseApiCall(entries[0]!)
+    expect(parsed).not.toBeNull()
+    const call = apiCallToCachedCall(parsed!)
+    expect(call.usage.outputTokens).toBe(376)
+    expect(call.timestamp).toBe('2026-04-03T13:30:35.212Z')
+    expect(call.nativeEmissionTimestamp).toBe('2026-04-03T13:30:36.680Z')
+    expect(call.nativeSnapshotTerminal).toBe(true)
+  })
+
+  it('does not field-wise merge incomparable snapshots and reports ambiguity', () => {
+    const a = withOutput(makeCall({ nativeSnapshotTerminal: false }), 9)
+    const b = withOutput(makeCall({ nativeSnapshotTerminal: false }), 11)
+    const result = reconcileClaudeNativeCalls([
+      { filePath: 'a.jsonl', calls: [a] },
+      { filePath: 'b.jsonl', calls: [b] },
+    ])
+    expect(result.ambiguities).toHaveLength(1)
+    expect(result.winners.size).toBe(1)
+    expect(result.winners.get('native-message-1')?.call.usage.outputTokens).not.toBe(20)
+  })
+
+  it('keeps exact duplicate metadata differences deterministic across restart/order', () => {
+    const a = makeCall({ project: 'project-a', projectPath: '/a' })
+    const b = makeCall({ project: 'project-b', projectPath: '/b' })
+    const first = reconcileClaudeNativeCalls([
+      { filePath: 'z.jsonl', calls: [a] },
+      { filePath: 'a.jsonl', calls: [b] },
+    ])
+    const restarted = reconcileClaudeNativeCalls([
+      { filePath: 'a.jsonl', calls: [b] },
+      { filePath: 'z.jsonl', calls: [a] },
+    ])
+    expect(first.winners.get('native-message-1')?.call.usage).toEqual(restarted.winners.get('native-message-1')?.call.usage)
+    expect(first.winners.get('native-message-1')?.filePath).toBe('a.jsonl')
+    expect(getClaudeNativeIdentity(first.winners.get('native-message-1')!.call)).toBe('native-message-1')
+  })
+
+  it('preserves an unrelated identity while deduplicating the repaired identity', () => {
+    const duplicate = makeCall()
+    const unrelated = makeCall({ nativeMessageId: 'unrelated-message', deduplicationKey: 'unrelated-message', timestamp: '2026-04-03T13:31:00.000Z' })
+    const result = reconcileClaudeNativeCalls([
+      { filePath: 'parent.jsonl', calls: [duplicate, unrelated] },
+      { filePath: 'mirror.jsonl', calls: [{ ...duplicate }] },
+    ])
+    expect(result.winners.size).toBe(2)
+    expect(outputOf([
+      { filePath: 'parent.jsonl', calls: [duplicate, unrelated] },
+      { filePath: 'mirror.jsonl', calls: [{ ...duplicate }] },
+    ])).toBe(12)
+  })
+
+  it('is stable across a restart and never sums the same native identity twice', () => {
+    const call = makeCall()
+    const files = [
+      { filePath: 'parent.jsonl', calls: [call] },
+      { filePath: 'mirror.jsonl', calls: [{ ...call }] },
+    ]
+    expect(outputOf(files)).toBe(6)
+    expect(outputOf(files)).toBe(6)
+  })
+
+  it('bumps both Claude parse and daily authorities for stale-cache self-healing', () => {
+    const version = PROVIDER_PARSE_VERSIONS['claude']!
+    const before = getDailyCacheConfigHash()
+    const envBefore = computeEnvFingerprint('claude')
+    expect(version).toContain('native-id-reconciliation-v1')
+    expect(computeEnvFingerprint('claude')).toBeTypeOf('string')
+    expect(before).toContain(`claudeCollector=${version}`)
+    const original = PROVIDER_PARSE_VERSIONS['claude']
+    PROVIDER_PARSE_VERSIONS['claude'] = `${original}-test-change`
+    try {
+      expect(getDailyCacheConfigHash()).not.toBe(before)
+      expect(computeEnvFingerprint('claude')).not.toBe(envBefore)
+    } finally {
+      PROVIDER_PARSE_VERSIONS['claude'] = original
+    }
+  })
+})

--- a/tests/r2-final-audit-remediation.test.ts
+++ b/tests/r2-final-audit-remediation.test.ts
@@ -1,0 +1,221 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { mkdtemp, rm } from 'fs/promises'
+import { tmpdir } from 'os'
+import { join } from 'path'
+
+import {
+  BACKFILL_DAYS,
+  DAILY_CACHE_RETENTION_DAYS,
+  DURABLE_HISTORY_AUTHORITY,
+  ensureCacheHydrated,
+  type DailyEntry,
+} from '../src/daily-cache.js'
+import { aggregateProjectsIntoDays } from '../src/day-aggregator.js'
+import type { ProjectSummary } from '../src/types.js'
+
+let cacheDir: string
+let previousCacheDir: string | undefined
+let previousTz: string | undefined
+
+const NOW = new Date('2026-08-12T12:00:00.000Z')
+
+function daysAgo(days: number): string {
+  const date = new Date(NOW)
+  date.setUTCDate(date.getUTCDate() - days)
+  return date.toISOString()
+}
+
+function syntheticAntigravityProject(daysAgoCount: number, id: string, tokens: { input: number; output: number; reasoning: number }): ProjectSummary {
+  const timestamp = daysAgo(daysAgoCount)
+  const call = {
+    provider: 'antigravity',
+    model: 'gemini-3.6-flash',
+    modelProvider: 'google',
+    usage: {
+      inputTokens: tokens.input,
+      outputTokens: tokens.output,
+      reasoningTokens: tokens.reasoning,
+      cacheCreationInputTokens: 0,
+      cacheReadInputTokens: 0,
+      cachedInputTokens: 0,
+      webSearchRequests: 0,
+    },
+    costUSD: 1,
+    savingsUSD: 0,
+    tools: [],
+    mcpTools: [],
+    skills: [],
+    subagentTypes: [],
+    hasAgentSpawn: false,
+    hasPlanMode: false,
+    speed: 'standard',
+    timestamp,
+    bashCommands: [],
+    deduplicationKey: `antigravity:${id}`,
+  }
+  const turn = {
+    userMessage: '',
+    assistantCalls: [call],
+    timestamp,
+    sessionId: id,
+    category: 'coding' as const,
+    retries: 0,
+    hasEdits: false,
+  }
+  const session = {
+    sessionId: id,
+    project: 'antigravity-remediation-fixture',
+    firstTimestamp: timestamp,
+    lastTimestamp: timestamp,
+    totalCostUSD: 1,
+    totalSavingsUSD: 0,
+    totalInputTokens: tokens.input,
+    totalOutputTokens: tokens.output,
+    totalReasoningTokens: tokens.reasoning,
+    totalCacheReadTokens: 0,
+    totalCacheWriteTokens: 0,
+    apiCalls: 1,
+    turns: [turn],
+  }
+  return {
+    project: 'antigravity-remediation-fixture',
+    projectPath: 'C:/metrora/r2-fixture',
+    sessions: [session],
+    totalCostUSD: 1,
+    totalSavingsUSD: 0,
+    totalApiCalls: 1,
+    totalProxiedCostUSD: 0,
+  } as unknown as ProjectSummary
+}
+
+function total(dayEntries: DailyEntry[]): { calls: number; input: number; output: number; reasoning: number } {
+  return dayEntries.reduce((sum, day) => ({
+    calls: sum.calls + day.calls,
+    input: sum.input + day.inputTokens,
+    output: sum.output + day.outputTokens,
+    reasoning: sum.reasoning + (day.reasoningTokens ?? 0),
+  }), { calls: 0, input: 0, output: 0, reasoning: 0 })
+}
+
+function parseWithin(projects: ProjectSummary[], ranges: { start: Date; end: Date }[]) {
+  return async (range: { start: Date; end: Date }): Promise<ProjectSummary[]> => {
+    ranges.push(range)
+    return projects.filter(project => project.sessions.some(session => {
+      const timestamp = new Date(session.firstTimestamp)
+      return timestamp >= range.start && timestamp <= range.end
+    }))
+  }
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  vi.setSystemTime(NOW)
+  cacheDir = ''
+  previousCacheDir = process.env['METRORA_CACHE_DIR']
+  previousTz = process.env['TZ']
+  process.env['METRORA_CACHE_DIR'] = ''
+  process.env['TZ'] = 'Europe/Rome'
+})
+
+afterEach(async () => {
+  vi.useRealTimers()
+  if (previousCacheDir === undefined) delete process.env['METRORA_CACHE_DIR']
+  else process.env['METRORA_CACHE_DIR'] = previousCacheDir
+  if (previousTz === undefined) delete process.env['TZ']
+  else process.env['TZ'] = previousTz
+  if (cacheDir) await rm(cacheDir, { recursive: true, force: true })
+})
+
+describe('R2 durable cold-bootstrap remediation', () => {
+  it('reconciles physical durable responses through the full retention horizon once, then stays incremental', async () => {
+    cacheDir = await mkdtemp(join(tmpdir(), 'metrora-r2-remediation-'))
+    process.env['METRORA_CACHE_DIR'] = cacheDir
+
+    const physicalProjects = [
+      syntheticAntigravityProject(91, 'response-91d', { input: 11, output: 7, reasoning: 3 }),
+      syntheticAntigravityProject(366, 'response-366d', { input: 13, output: 8, reasoning: 4 }),
+      syntheticAntigravityProject(3649, 'response-3649d', { input: 17, output: 9, reasoning: 5 }),
+    ]
+    const physical = total(aggregateProjectsIntoDays(physicalProjects))
+    const ranges: { start: Date; end: Date }[] = []
+
+    const cold = await ensureCacheHydrated(
+      parseWithin(physicalProjects, ranges),
+      aggregateProjectsIntoDays,
+      'cfg-A',
+      () => true,
+      undefined,
+      { durableHistoryAuthority: DURABLE_HISTORY_AUTHORITY },
+    )
+
+    expect(ranges).toHaveLength(1)
+    expect(ranges[0]!.start.getTime()).toBeLessThan(NOW.getTime() - (BACKFILL_DAYS + 1) * 24 * 60 * 60 * 1000)
+    expect(ranges[0]!.start.getTime()).toBeGreaterThan(NOW.getTime() - (DAILY_CACHE_RETENTION_DAYS + 2) * 24 * 60 * 60 * 1000)
+    expect(cold.durableHistoryAuthority).toBe(DURABLE_HISTORY_AUTHORITY)
+    expect(total(cold.days)).toEqual(physical)
+    expect(cold.days.map(day => day.date)).toHaveLength(3)
+
+    // A warm run has no gap and must not re-add any response.
+    const warm = await ensureCacheHydrated(
+      parseWithin(physicalProjects, ranges),
+      aggregateProjectsIntoDays,
+      'cfg-A',
+      () => true,
+      undefined,
+      { durableHistoryAuthority: DURABLE_HISTORY_AUTHORITY },
+    )
+    expect(ranges).toHaveLength(1)
+    expect(total(warm.days)).toEqual(physical)
+
+    // A changed accounting authority uses the ordinary 365-day backfill, but
+    // must carry the already-materialized sourceless days without loss.
+    const orphanRanges: { start: Date; end: Date }[] = []
+    const orphaned = await ensureCacheHydrated(
+      async range => { orphanRanges.push(range); return [] },
+      aggregateProjectsIntoDays,
+      'cfg-B',
+      () => true,
+      undefined,
+      { durableHistoryAuthority: DURABLE_HISTORY_AUTHORITY },
+    )
+    expect(orphanRanges).toHaveLength(1)
+    expect(orphanRanges[0]!.start.getTime()).toBeGreaterThan(NOW.getTime() - (BACKFILL_DAYS + 1) * 24 * 60 * 60 * 1000)
+    expect(total(orphaned.days)).toEqual(physical)
+    expect(orphaned.days.every(day => day.carried === true)).toBe(true)
+
+    // If the durable source returns, surviving native evidence may re-derive
+    // its recent slice, while older sourceless slices remain carried exactly
+    // once. No response is added a second time.
+    const returned = await ensureCacheHydrated(
+      parseWithin(physicalProjects, []),
+      aggregateProjectsIntoDays,
+      'cfg-C',
+      () => true,
+      undefined,
+      { durableHistoryAuthority: DURABLE_HISTORY_AUTHORITY },
+    )
+    expect(total(returned.days)).toEqual(physical)
+  })
+
+  it('keeps direct Antigravity response accounting equal to cold durable daily materialization', async () => {
+    cacheDir = await mkdtemp(join(tmpdir(), 'metrora-r2-antigravity-cold-'))
+    process.env['METRORA_CACHE_DIR'] = cacheDir
+
+    const directProjects = [
+      syntheticAntigravityProject(91, 'native-response-1', { input: 100, output: 30, reasoning: 12 }),
+      syntheticAntigravityProject(366, 'native-response-2', { input: 200, output: 40, reasoning: 18 }),
+    ]
+    const direct = total(aggregateProjectsIntoDays(directProjects))
+    const durable = await ensureCacheHydrated(
+      async () => directProjects,
+      aggregateProjectsIntoDays,
+      'cfg-A',
+      () => true,
+      undefined,
+      { durableHistoryAuthority: DURABLE_HISTORY_AUTHORITY },
+    )
+
+    expect(total(durable.days)).toEqual(direct)
+    expect(durable.days.reduce((sum, day) => sum + day.providers.antigravity!.calls, 0)).toBe(2)
+  })
+})

--- a/tests/r2-range-boundary.test.ts
+++ b/tests/r2-range-boundary.test.ts
@@ -1,0 +1,234 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import type { DateRange } from '../src/types.js'
+import type { ParsedProviderCall, SessionSource } from '../src/providers/types.js'
+
+let sources: SessionSource[] = []
+let calls: ParsedProviderCall[] = []
+let onFirstYield: (() => Promise<void>) | undefined
+
+vi.mock('../src/providers/index.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../src/providers/index.js')>()
+  return {
+    ...actual,
+    async discoverAllSessions(filter?: string) {
+      if (filter === 'r2-range') return sources
+      return actual.discoverAllSessions(filter)
+    },
+    async getProvider(name: string) {
+      if (name === 'r2-range') {
+        return {
+          name,
+          displayName: 'R2 Range Fixture',
+          durableSources: false,
+          modelDisplayName: (model: string) => model,
+          toolDisplayName: (tool: string) => tool,
+          async discoverSessions() { return sources },
+          createSessionParser(_source: SessionSource, seenKeys: Set<string>) {
+            return {
+              async *parse() {
+                let first = true
+                for (const call of calls) {
+                  if (first) {
+                    first = false
+                    await onFirstYield?.()
+                  }
+                  if (seenKeys.has(call.deduplicationKey)) continue
+                  seenKeys.add(call.deduplicationKey)
+                  yield call
+                }
+              },
+            }
+          },
+        }
+      }
+      return actual.getProvider(name)
+    },
+  }
+})
+
+const { clearSessionCache, filterProjectsByDateRange, filterProjectsByName, parseAllSessions } = await import('../src/parser.js')
+
+let root = ''
+let sourcePath = ''
+const start = new Date('2026-08-11T12:00:00.000Z')
+const end = new Date('2026-08-11T12:00:02.000Z')
+
+function makeCall(key: string, timestamp: string, overrides: Partial<ParsedProviderCall> = {}): ParsedProviderCall {
+  return {
+    provider: 'r2-range',
+    model: 'model-a',
+    inputTokens: 10,
+    outputTokens: 5,
+    cacheCreationInputTokens: 0,
+    cacheReadInputTokens: 0,
+    cachedInputTokens: 0,
+    reasoningTokens: 0,
+    webSearchRequests: 0,
+    costUSD: 1,
+    tools: [],
+    bashCommands: [],
+    timestamp,
+    speed: 'standard',
+    deduplicationKey: key,
+    turnId: 'turn-1',
+    userMessage: 'work https://github.com/example/repo/pull/7',
+    sessionId: 'session-1',
+    project: 'range-project',
+    projectPath: '/range-project',
+    ...overrides,
+  }
+}
+
+function range(startDate = start, endDate = end): DateRange {
+  return { start: startDate, end: endDate }
+}
+
+function allCalls(projects: Awaited<ReturnType<typeof parseAllSessions>>) {
+  return projects.flatMap(project => project.sessions).flatMap(session => session.turns).flatMap(turn => turn.assistantCalls)
+}
+
+beforeEach(async () => {
+  root = await mkdtemp(join(tmpdir(), 'metrora-r2-range-'))
+  sourcePath = join(root, 'fixture.source')
+  await writeFile(sourcePath, 'fixture-1\n', 'utf8')
+  vi.stubEnv('METRORA_CACHE_DIR', join(root, 'cache'))
+  sources = [{ path: sourcePath, project: 'range-project', provider: 'r2-range' }]
+  calls = []
+  onFirstYield = undefined
+  clearSessionCache()
+})
+
+afterEach(async () => {
+  clearSessionCache()
+  vi.unstubAllEnvs()
+  sources = []
+  calls = []
+  onFirstYield = undefined
+  await rm(root, { recursive: true, force: true })
+})
+
+describe('R2 exact call-range boundaries', () => {
+  it('includes start/end exactly and excludes calls outside both boundaries', async () => {
+    calls = [
+      makeCall('before-start', '2026-08-11T11:59:59.999Z'),
+      makeCall('at-start', '2026-08-11T12:00:00.000Z'),
+      makeCall('at-end', '2026-08-11T12:00:02.000Z'),
+      makeCall('after-end', '2026-08-11T12:00:02.001Z'),
+    ]
+
+    const result = await parseAllSessions(range(), 'r2-range')
+    const selected = allCalls(result)
+    expect(selected.map(call => call.deduplicationKey)).toEqual(['at-start', 'at-end'])
+    expect(selected.reduce((sum, call) => sum + call.usage.inputTokens, 0)).toBe(20)
+    expect(selected.reduce((sum, call) => sum + call.usage.outputTokens, 0)).toBe(10)
+  })
+
+  it('does not lose a later in-range call when the first call is before range.start', async () => {
+    calls = [
+      makeCall('before-start', '2026-08-11T11:59:59.999Z'),
+      makeCall('after-start', '2026-08-11T12:00:00.001Z'),
+    ]
+    const result = await parseAllSessions(range(), 'r2-range')
+    expect(allCalls(result).map(call => call.deduplicationKey)).toEqual(['after-start'])
+  })
+
+  it('rebuilds categories, model, tools, reasoning and cache totals from the sliced calls', async () => {
+    calls = [
+      makeCall('inside', '2026-08-11T12:00:01.000Z', {
+        model: 'model-b', outputTokens: 9, reasoningTokens: 7, cacheReadInputTokens: 11,
+        tools: ['Agent'],
+      }),
+      makeCall('outside', '2026-08-11T12:00:03.000Z', {
+        model: 'model-c', outputTokens: 900, reasoningTokens: 800, cacheReadInputTokens: 700,
+        tools: ['Bash'],
+      }),
+    ]
+    const result = await parseAllSessions(range(), 'r2-range')
+    const project = result[0]!
+    const session = project.sessions[0]!
+    const turn = session.turns[0]!
+    expect(session.apiCalls).toBe(1)
+    expect(session.totalOutputTokens).toBe(9)
+    expect(session.totalReasoningTokens).toBe(7)
+    expect(session.totalCacheReadTokens).toBe(11)
+    expect(session.modelBreakdown['model-b']?.calls).toBe(1)
+    expect(session.modelBreakdown['model-c']).toBeUndefined()
+    expect(turn.assistantCalls[0]?.hasAgentSpawn).toBe(true)
+    expect(turn.prRefs).toEqual(['https://github.com/example/repo/pull/7'])
+    expect(project.totalApiCalls).toBe(1)
+  })
+
+  it('keeps entirely-inside and entirely-outside turns correct', async () => {
+    calls = [
+      makeCall('inside-a', '2026-08-11T12:00:00.100Z', { turnId: 'inside' }),
+      makeCall('inside-b', '2026-08-11T12:00:01.100Z', { turnId: 'inside' }),
+      makeCall('outside-a', '2026-08-11T12:00:03.100Z', { turnId: 'outside' }),
+      makeCall('outside-b', '2026-08-11T12:00:04.100Z', { turnId: 'outside' }),
+    ]
+    const result = await parseAllSessions(range(), 'r2-range')
+    expect(allCalls(result).map(call => call.deduplicationKey)).toEqual(['inside-a', 'inside-b'])
+  })
+
+  it('is deterministic across warm repeats and source appends after the cutoff', async () => {
+    calls = [makeCall('inside', '2026-08-11T12:00:01.000Z')]
+    const first = allCalls(await parseAllSessions(range(), 'r2-range'))
+    clearSessionCache()
+    calls = [...calls, makeCall('appended-after-cutoff', '2026-08-11T12:00:03.000Z')]
+    await writeFile(sourcePath, 'fixture-2\n', 'utf8')
+    const afterAppend = allCalls(await parseAllSessions(range(), 'r2-range'))
+    clearSessionCache()
+    const restart = allCalls(await parseAllSessions(range(), 'r2-range'))
+    expect(afterAppend.map(call => call.deduplicationKey)).toEqual(['inside'])
+    expect(restart.map(call => call.deduplicationKey)).toEqual(first.map(call => call.deduplicationKey))
+  })
+
+  it('isolates a source append that occurs while the range parse is in flight', async () => {
+    calls = [makeCall('inside', '2026-08-11T12:00:01.000Z')]
+    let appended = false
+    onFirstYield = async () => {
+      if (appended) return
+      appended = true
+      calls.push(makeCall('live-after-cutoff', '2026-08-11T12:00:03.000Z'))
+      await writeFile(sourcePath, 'fixture-live-2\n', 'utf8')
+    }
+
+    const inFlight = allCalls(await parseAllSessions(range(), 'r2-range'))
+    expect(inFlight.map(call => call.deduplicationKey)).toEqual(['inside'])
+
+    clearSessionCache()
+    const warm = allCalls(await parseAllSessions(range(), 'r2-range'))
+    expect(warm.map(call => call.deduplicationKey)).toEqual(['inside'])
+
+    clearSessionCache()
+    const allTime = allCalls(await parseAllSessions(undefined, 'r2-range'))
+    expect(allTime.map(call => call.deduplicationKey)).toEqual(['inside', 'live-after-cutoff'])
+  })
+
+  it('clips the already-materialized wide projection without stale turn aggregates', async () => {
+    calls = [
+      makeCall('before', '2026-08-11T11:59:59.000Z'),
+      makeCall('inside', '2026-08-11T12:00:01.000Z'),
+      makeCall('after', '2026-08-11T12:00:03.000Z'),
+    ]
+    const wide = await parseAllSessions(undefined, 'r2-range')
+    const filtered = filterProjectsByDateRange(wide, range())
+    expect(allCalls(filtered).map(call => call.deduplicationKey)).toEqual(['inside'])
+    expect(filtered[0]!.totalApiCalls).toBe(1)
+    expect(filterProjectsByName(filtered, ['range-project'], ['other'])).toHaveLength(1)
+  })
+
+  it('handles a local-midnight crossing by exact call time while retaining the turn context', async () => {
+    const midnightStart = new Date('2026-08-11T00:00:00.000Z')
+    const midnightEnd = new Date('2026-08-11T00:00:01.000Z')
+    calls = [
+      makeCall('previous-day', '2026-08-10T23:59:59.999Z'),
+      makeCall('new-day', '2026-08-11T00:00:00.000Z'),
+    ]
+    const result = await parseAllSessions(range(midnightStart, midnightEnd), 'r2-range')
+    expect(allCalls(result).map(call => call.deduplicationKey)).toEqual(['new-day'])
+  })
+})

--- a/tests/r2-tz-boundary-characterization.test.ts
+++ b/tests/r2-tz-boundary-characterization.test.ts
@@ -1,0 +1,147 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { mkdtemp, rm } from 'fs/promises'
+import { tmpdir } from 'os'
+import { join } from 'path'
+
+import {
+  DAILY_CACHE_VERSION,
+  currentTzKey,
+  ensureCacheHydrated,
+  saveDailyCache,
+  type DailyCache,
+  type DailyEntry,
+  type ProviderDaySlice,
+} from '../src/daily-cache.js'
+
+let cacheDir: string
+let previousCacheDir: string | undefined
+let previousTz: string | undefined
+
+function slice(cost: number, calls = 1): ProviderDaySlice {
+  return {
+    calls,
+    cost,
+    savingsUSD: 0,
+    sessions: calls,
+    inputTokens: calls * 100,
+    outputTokens: calls * 20,
+    reasoningTokens: calls * 7,
+    cacheReadTokens: 0,
+    cacheWriteTokens: 0,
+    editTurns: calls,
+    oneShotTurns: 0,
+    models: {},
+    categories: {},
+    projects: { metrora: { cost, calls, savingsUSD: 0, sessions: calls, path: 'C:/work/metrora' } },
+  }
+}
+
+function day(date: string, provider: string, providerSlice: ProviderDaySlice): DailyEntry {
+  return {
+    date,
+    cost: providerSlice.cost,
+    savingsUSD: providerSlice.savingsUSD,
+    calls: providerSlice.calls,
+    sessions: providerSlice.sessions ?? 0,
+    inputTokens: providerSlice.inputTokens ?? 0,
+    outputTokens: providerSlice.outputTokens ?? 0,
+    reasoningTokens: providerSlice.reasoningTokens ?? 0,
+    cacheReadTokens: providerSlice.cacheReadTokens ?? 0,
+    cacheWriteTokens: providerSlice.cacheWriteTokens ?? 0,
+    editTurns: providerSlice.editTurns ?? 0,
+    oneShotTurns: providerSlice.oneShotTurns ?? 0,
+    models: structuredClone(providerSlice.models ?? {}),
+    categories: structuredClone(providerSlice.categories ?? {}),
+    projects: structuredClone(providerSlice.projects ?? {}),
+    providers: { [provider]: structuredClone(providerSlice) },
+  }
+}
+
+async function seed(days: DailyEntry[], savingsConfigHash: string, tzKey: string): Promise<void> {
+  const cache: DailyCache = {
+    version: DAILY_CACHE_VERSION,
+    savingsConfigHash,
+    tzKey,
+    lastComputedDate: '2026-08-11',
+    days,
+    complete: true,
+  }
+  await saveDailyCache(cache)
+}
+
+beforeEach(async () => {
+  vi.useFakeTimers()
+  vi.setSystemTime(new Date('2026-08-12T12:00:00.000Z'))
+  cacheDir = await mkdtemp(join(tmpdir(), 'metrora-r2-tz-boundary-'))
+  previousCacheDir = process.env['METRORA_CACHE_DIR']
+  previousTz = process.env['TZ']
+  process.env['METRORA_CACHE_DIR'] = cacheDir
+  process.env['TZ'] = 'Europe/Rome'
+})
+
+afterEach(async () => {
+  vi.useRealTimers()
+  if (previousCacheDir === undefined) delete process.env['METRORA_CACHE_DIR']
+  else process.env['METRORA_CACHE_DIR'] = previousCacheDir
+  if (previousTz === undefined) delete process.env['TZ']
+  else process.env['TZ'] = previousTz
+  await rm(cacheDir, { recursive: true, force: true })
+})
+
+describe('R2 timezone boundary characterization', () => {
+  it('has zero accounting delta when the timezone is unchanged', async () => {
+    const baseline = day('2026-08-10', 'codex', slice(5))
+    await seed([baseline], 'cfg-A', currentTzKey())
+    const out = await ensureCacheHydrated(async () => [], () => [], 'cfg-A')
+    expect(out.days).toEqual([baseline])
+  })
+
+  it('refuses to finalize when timezone and accounting config change together', async () => {
+    const baseline = day('2026-08-10', 'codex', slice(5))
+    const freshCurrentTimezone = day('2026-08-11', 'codex', slice(7))
+    const freshOldTimezone = day('2026-08-10', 'codex', slice(7))
+    await seed([baseline], 'cfg-A', 'America/New_York')
+
+    const out = await ensureCacheHydrated(
+      async () => [],
+      () => [freshCurrentTimezone],
+      'cfg-B',
+      () => true,
+      () => [freshOldTimezone],
+    )
+
+    expect(out.days).toEqual([baseline])
+    expect(out.savingsConfigHash).toBe('cfg-A')
+    expect(out.tzKey).toBe('America/New_York')
+  })
+
+  it('does not finalize a timezone migration when the wide snapshot is incomplete', async () => {
+    const baseline = day('2026-08-10', 'codex', slice(5))
+    const freshCurrentTimezone = day('2026-08-11', 'codex', slice(7))
+    await seed([baseline], 'cfg-A', 'America/New_York')
+    let completeChecks = 0
+
+    const out = await ensureCacheHydrated(
+      async () => [],
+      () => [freshCurrentTimezone],
+      'cfg-A',
+      () => ++completeChecks === 1,
+      () => [],
+    )
+
+    expect(completeChecks).toBe(2)
+    expect(out.complete).toBe(false)
+    expect(out.lastComputedDate).toBe('2026-08-10')
+    expect(out.days.find(entry => entry.date === '2026-08-10')?.cost).toBe(5)
+  })
+
+  it('does not drop an old-TZ finalized day that shares the new local today label', async () => {
+    const oldYesterday = day('2026-08-12', 'codex', slice(5))
+    await seed([oldYesterday], 'cfg-A', 'America/New_York')
+
+    const out = await ensureCacheHydrated(async () => [], () => [], 'cfg-A')
+
+    expect(out.days).toHaveLength(1)
+    expect(out.days[0]).toMatchObject({ date: '2026-08-12', cost: 5, carried: true })
+  })
+})

--- a/tests/r2-tz-boundary-characterization.test.ts
+++ b/tests/r2-tz-boundary-characterization.test.ts
@@ -5,6 +5,7 @@ import { join } from 'path'
 
 import {
   DAILY_CACHE_VERSION,
+  DURABLE_HISTORY_AUTHORITY,
   currentTzKey,
   ensureCacheHydrated,
   saveDailyCache,
@@ -96,23 +97,51 @@ describe('R2 timezone boundary characterization', () => {
     expect(out.days).toEqual([baseline])
   })
 
-  it('refuses to finalize when timezone and accounting config change together', async () => {
+  it('serializes simultaneous timezone and accounting changes and converges in three runs', async () => {
     const baseline = day('2026-08-10', 'codex', slice(5))
     const freshCurrentTimezone = day('2026-08-11', 'codex', slice(7))
     const freshOldTimezone = day('2026-08-10', 'codex', slice(7))
     await seed([baseline], 'cfg-A', 'America/New_York')
 
-    const out = await ensureCacheHydrated(
+    const first = await ensureCacheHydrated(
       async () => [],
       () => [freshCurrentTimezone],
       'cfg-B',
       () => true,
       () => [freshOldTimezone],
+      { durableHistoryAuthority: DURABLE_HISTORY_AUTHORITY },
     )
 
-    expect(out.days).toEqual([baseline])
-    expect(out.savingsConfigHash).toBe('cfg-A')
-    expect(out.tzKey).toBe('America/New_York')
+    // Phase 1 changes accounting only; the old timezone remains the explicit
+    // bucket authority and no old-money/new-money subtraction is attempted.
+    expect(first.savingsConfigHash).toBe('cfg-B')
+    expect(first.tzKey).toBe('America/New_York')
+    expect(first.days.find(entry => entry.date === '2026-08-10')?.cost).toBe(7)
+
+    // A restart between phases is represented by the persisted B/A state.
+    const second = await ensureCacheHydrated(
+      async () => [],
+      () => [freshCurrentTimezone],
+      'cfg-B',
+      () => true,
+      () => [freshOldTimezone],
+      { durableHistoryAuthority: DURABLE_HISTORY_AUTHORITY },
+    )
+    expect(second.savingsConfigHash).toBe('cfg-B')
+    expect(second.tzKey).toBe(currentTzKey())
+    expect(second.days).toEqual([freshCurrentTimezone])
+
+    const third = await ensureCacheHydrated(
+      async () => [],
+      () => [freshCurrentTimezone],
+      'cfg-B',
+      () => true,
+      () => [freshOldTimezone],
+      { durableHistoryAuthority: DURABLE_HISTORY_AUTHORITY },
+    )
+    expect(third).toEqual(second)
+    expect(third.days.reduce((sum, entry) => sum + entry.calls, 0)).toBe(1)
+    expect(third.complete).toBe(true)
   })
 
   it('does not finalize a timezone migration when the wide snapshot is incomplete', async () => {

--- a/tests/session-cache-v5-adoption.test.ts
+++ b/tests/session-cache-v5-adoption.test.ts
@@ -185,12 +185,12 @@ describe('v5 -> v6 cache adoption of expired PR sessions', () => {
   })
 })
 
-function expiredPrEntry(cwd: string, name: string, prUrl: string): Record<string, unknown> {
+function expiredPrEntry(cwd: string, name: string, prUrl: string, deduplicationKey = 'kk'): Record<string, unknown> {
   return {
     fingerprint: { dev: 1, ino: 2, mtimeMs: 3, sizeBytes: 4 },
     mcpInventory: [], canonicalCwd: cwd, canonicalProjectName: name,
     prLinks: [prUrl],
-    turns: [{ timestamp: '2026-07-20T10:00:00.000Z', sessionId: 'gone', userMessage: 'shipped', calls: [cachedCall('kk', 40)] }],
+    turns: [{ timestamp: '2026-07-20T10:00:00.000Z', sessionId: 'gone', userMessage: 'shipped', calls: [cachedCall(deduplicationKey, 40)] }],
   }
 }
 
@@ -221,11 +221,11 @@ describe('newest-prior cache adoption (v6 then v5)', () => {
     const v5Path = join(configDir, 'projects', 'in5', 'in5.jsonl')
     await writeFile(join(cacheDir, 'session-cache.v6.json'), JSON.stringify({
       version: 6, complete: true,
-      providers: { claude: { envFingerprint: 'v6', files: { [v6Path]: expiredPrEntry('/in6', 'in6', 'https://github.com/o/r/pull/60') } } },
+      providers: { claude: { envFingerprint: 'v6', files: { [v6Path]: expiredPrEntry('/in6', 'in6', 'https://github.com/o/r/pull/60', 'kk-v6') } } },
     }))
     await writeFile(join(cacheDir, 'session-cache.v5.json'), JSON.stringify({
       version: 5, complete: true,
-      providers: { claude: { envFingerprint: 'v5', files: { [v5Path]: expiredPrEntry('/in5', 'in5', 'https://github.com/o/r/pull/50') } } },
+      providers: { claude: { envFingerprint: 'v5', files: { [v5Path]: expiredPrEntry('/in5', 'in5', 'https://github.com/o/r/pull/50', 'kk-v5') } } },
     }))
 
     const range = { start: new Date('2026-07-20T00:00:00Z'), end: new Date('2026-07-20T23:59:59Z') }
@@ -233,6 +233,46 @@ describe('newest-prior cache adoption (v6 then v5)', () => {
     // A sparse newer file must NOT mask older-only orphans: BOTH survive.
     expect(urls).toContain('https://github.com/o/r/pull/60') // from v6
     expect(urls).toContain('https://github.com/o/r/pull/50') // from v5, not masked
+  })
+
+  it('deduplicates the same legacy native identity across different source paths', async () => {
+    await loadPricing()
+    const v6Path = join(configDir, 'projects', 'same-native-v6', 'same-native-v6.jsonl')
+    const v5Path = join(configDir, 'projects', 'same-native-v5', 'same-native-v5.jsonl')
+    const sharedNativeKey = 'legacy-native-message'
+    await writeFile(join(cacheDir, 'session-cache.v6.json'), JSON.stringify({
+      version: 6, complete: true,
+      providers: { claude: { envFingerprint: 'v6', files: { [v6Path]: expiredPrEntry('/same-native-v6', 'same-native-v6', 'https://github.com/o/r/pull/60', sharedNativeKey) } } },
+    }))
+    await writeFile(join(cacheDir, 'session-cache.v5.json'), JSON.stringify({
+      version: 5, complete: true,
+      providers: { claude: { envFingerprint: 'v5', files: { [v5Path]: expiredPrEntry('/same-native-v5', 'same-native-v5', 'https://github.com/o/r/pull/50', sharedNativeKey) } } },
+    }))
+
+    const range = { start: new Date('2026-07-20T00:00:00Z'), end: new Date('2026-07-20T23:59:59Z') }
+    const urls = aggregateByPr(await parseAllSessions(range, 'claude')).map(r => r.url)
+    expect(urls).toHaveLength(1)
+    expect(['https://github.com/o/r/pull/60', 'https://github.com/o/r/pull/50']).toContain(urls[0])
+  })
+
+  it('keeps separate synthetic legacy orphans when their key is not authoritative', async () => {
+    await loadPricing()
+    const v6Path = join(configDir, 'projects', 'synthetic-v6', 'synthetic-v6.jsonl')
+    const v5Path = join(configDir, 'projects', 'synthetic-v5', 'synthetic-v5.jsonl')
+    const syntheticKey = 'claude:2026-07-20T10:00:00.000Z'
+    await writeFile(join(cacheDir, 'session-cache.v6.json'), JSON.stringify({
+      version: 6, complete: true,
+      providers: { claude: { envFingerprint: 'v6', files: { [v6Path]: expiredPrEntry('/synthetic-v6', 'synthetic-v6', 'https://github.com/o/r/pull/60', syntheticKey) } } },
+    }))
+    await writeFile(join(cacheDir, 'session-cache.v5.json'), JSON.stringify({
+      version: 5, complete: true,
+      providers: { claude: { envFingerprint: 'v5', files: { [v5Path]: expiredPrEntry('/synthetic-v5', 'synthetic-v5', 'https://github.com/o/r/pull/50', syntheticKey) } } },
+    }))
+
+    const range = { start: new Date('2026-07-20T00:00:00Z'), end: new Date('2026-07-20T23:59:59Z') }
+    const urls = aggregateByPr(await parseAllSessions(range, 'claude')).map(r => r.url)
+    expect(urls).toContain('https://github.com/o/r/pull/60')
+    expect(urls).toContain('https://github.com/o/r/pull/50')
   })
 
   it('a newer version wins per source path when both hold the same path', async () => {


### PR DESCRIPTION
## Summary

Reconcile source-backed usage accounting with durable history across the current collector set while preserving historical data that can no longer be re-derived from local sources.

This change set:

- recovers legacy and cumulative Codex accounting without double-counting native identities;
- reconstructs current VS Code Copilot chat journals using their mutation-log semantics and preserves resumed CLI shutdown deltas;
- corrects Antigravity output/reasoning accounting and materializes durable usage before bounded detail eviction;
- reconciles Claude native message identities across transcript/mirror files deterministically;
- makes exact date ranges call-authoritative instead of turn-authoritative;
- makes timezone/accounting migrations converge without dropping sourceless historical slices;
- expands cache/environment authority so source/profile changes invalidate the appropriate projections without serializing credentials;
- preserves project/filter and unattributed-history semantics across durable projections;
- hardens malformed timestamp and cache migration edge cases.

Pricing/catalog changes are intentionally out of scope.

## Validation

Validated on the exact head of this PR:

- `npx tsc --noEmit` — PASS
- complete test suite — 2,849 passed, 5 skipped
- focused R2 matrix — PASS
- source/native accounting reconciliation — PASS
- cold/warm/restart and stale-cache migration — PASS
- exact range boundary and live-append cutoff checks — PASS
- durable history / source disappearance-return checks — PASS
- timezone/accounting finite-convergence checks — PASS
- provider/model/daily/project/filter conservation — PASS

The final test-only cache-adoption fixture closure changes no production files relative to the previously validated production tree.

## Scope boundary

No pricing catalog changes, release changes, Store packaging changes, dependency changes, CI workflow changes, or UI changes are included.

Head expected for review: `a89a3fd009cc1f504f7ed08372298617815b502d`.