### PR TITLE
chore(release): advance source candidate to 1.0.0-rc.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,16 @@
 
 This file records Metrora-originated public changes. Required third-party notices and licence texts are maintained separately in [`THIRD_PARTY_NOTICES.md`](THIRD_PARTY_NOTICES.md) and [`LICENSES/`](LICENSES/).
 
-## Unreleased — current source line `1.0.0-rc.9`
+## Unreleased — current source line `1.0.0-rc.10`
 
-RC9 is the current source/pre-submission candidate. It is not yet a Microsoft Store submission, certification or publication.
+RC10 is the current source/pre-submission candidate. It advances RC9 after source-completeness and durable-history reconciliation materially changed user-visible accounting. It is not yet a Microsoft Store submission, certification or publication.
+
+### Source completeness and durable history
+
+- Reconciled exact native-source accounting with durable historical totals so source expiration or cache eviction does not silently lose previously observed usage.
+- Corrected provider identity, request-boundary and timezone reconciliation where those boundaries could change calls or token totals.
+- Preserved estimated or otherwise non-native rows as explicit non-exact accounting rather than blending them into native-source evidence.
+- Kept project, model, daily and filtered views conserved against their applicable durable accounting authority.
 
 ### Accounting reconciliation
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -8,8 +8,8 @@ Metrora does not yet have an official stable desktop release. This document defi
 - Domain: **metrora.eu**
 - Repository: `maikolsiragusaa/metrora`
 - Canonical command: `metrora`
-- Current source candidate: `1.0.0-rc.9`
-- Current desktop build version: `1.0.0.9`
+- Current source candidate: `1.0.0-rc.10`
+- Current desktop build version: `1.0.0.10`
 - Latest published GitHub technical preview: `1.0.0-rc.7`
 
 The published command is `metrora`. Historical protocol and signed-data
@@ -20,7 +20,7 @@ The root npm package is private and must not be published from this repository.
 
 ## Current engineering authority
 
-`1.0.0-rc.9` is the current **source/pre-submission candidate line**. It advances RC8 because accounting presentation and the packaged Store CLI runtime changed materially after physical pre-submission review. Its metadata does not by itself make any artifact accepted, signed, submitted or published.
+`1.0.0-rc.10` is the current **source/pre-submission candidate line**. It advances RC9 because audited source-completeness and durable-history reconciliation materially changed user-visible accounting after the RC9 candidate was established. RC9 had already introduced the explicit durable-vs-surviving-detail accounting boundary and the sealed packaged Store CLI runtime. RC10 metadata does not by itself make any artifact accepted, signed, submitted or published.
 
 `1.0.0-rc.7` remains the latest published GitHub Windows technical preview. That channel is unsigned, manually updated and not Microsoft Store certified. Its source, release assets, manifests and checksums remain immutable historical publication evidence.
 
@@ -32,8 +32,8 @@ Exact source commits and artifact digests belong in the applicable workflow/rele
 
 Metrora deliberately separates three version forms:
 
-- product/source SemVer: `1.0.0-rc.9`;
-- desktop build version: `1.0.0.9`;
+- product/source SemVer: `1.0.0-rc.10`;
+- desktop build version: `1.0.0.10`;
 - Microsoft Store AppX package identity version for the `1.0.0` line: `1.0.0.0`.
 
 The Store's four-component package identity is a platform contract and must not be confused with the desktop build counter or the SemVer pre-release label. See [`docs/VERSIONING.md`](docs/VERSIONING.md).

--- a/app/DISTRIBUTION.md
+++ b/app/DISTRIBUTION.md
@@ -7,8 +7,8 @@ This document defines the desktop packaging boundary. Platform-specific release 
 - Product: `Metrora`
 - Desktop app ID: `eu.metrora.desktop`
 - Website: `https://metrora.eu`
-- Current source/desktop candidate: `1.0.0-rc.9`
-- Current desktop build version: `1.0.0.9`
+- Current source/desktop candidate: `1.0.0-rc.10`
+- Current desktop build version: `1.0.0.10`
 - Latest published GitHub technical preview: `1.0.0-rc.7`
 - Current non-publishing Store AppX identity version: `1.0.0.0`
 

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "metrora-desktop",
-  "version": "1.0.0-rc.9",
+  "version": "1.0.0-rc.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "metrora-desktop",
-      "version": "1.0.0-rc.9",
+      "version": "1.0.0-rc.10",
       "dependencies": {
         "@gsap/react": "^2.1.2",
         "gsap": "^3.15.0",

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "metrora-desktop",
   "private": true,
-  "version": "1.0.0-rc.9",
+  "version": "1.0.0-rc.10",
   "description": "Metrora Desktop — local-first AI usage intelligence",
   "main": "dist/electron/bootstrap.js",
   "scripts": {
@@ -141,7 +141,7 @@
       "maintainer": "Vensent (https://metrora.eu)",
       "executableName": "metrora"
     },
-    "buildVersion": "1.0.0.9"
+    "buildVersion": "1.0.0.10"
   },
   "homepage": "https://metrora.eu",
   "publisher": "Vensent",

--- a/docs/VERSIONING.md
+++ b/docs/VERSIONING.md
@@ -4,8 +4,8 @@ Metrora uses semantic versioning for public product identity and separate numeri
 
 ## Current line
 
-- Current source candidate: `1.0.0-rc.9`
-- Desktop build version: `1.0.0.9`
+- Current source candidate: `1.0.0-rc.10`
+- Desktop build version: `1.0.0.10`
 - Latest published GitHub technical preview: `1.0.0-rc.7`
 - First intended stable release: `1.0.0`
 
@@ -35,8 +35,8 @@ The final component is `0` for the Store package contract. The SemVer pre-releas
 
 For the current `1.0.0` pre-submission line:
 
-- source/product candidate: `1.0.0-rc.9`;
-- desktop build version: `1.0.0.9`;
+- source/product candidate: `1.0.0-rc.10`;
+- desktop build version: `1.0.0.10`;
 - local/non-publishing Store AppX identity version: `1.0.0.0`.
 
 A locally validated `1.0.0.0` AppX does not mean that version has been submitted, certified or published. Once a package version is actually submitted to Microsoft, later Store updates must advance according to the Store's package-version rules rather than reusing an already submitted identity.

--- a/docs/WINDOWS_DISTRIBUTION.md
+++ b/docs/WINDOWS_DISTRIBUTION.md
@@ -6,7 +6,7 @@ Metrora does not yet have an official stable Windows release.
 
 The latest public Windows technical preview is the **unsigned** GitHub pre-release `v1.0.0-rc.7`. It remains bound to its accepted source, manifests, checksums and publication evidence. It is not a signed stable package, a Microsoft Store package or an automatic update channel.
 
-The active source/pre-submission line is `1.0.0-rc.9`, with desktop build version `1.0.0.9`. RC9 advances RC8 after pre-submission review found two material issues: model-accounting surfaces needed an explicit durable-vs-surviving-detail boundary, and the Store AppX needed a sealed CLI runtime rather than a loose scoped npm dependency tree.
+The active source/pre-submission line is `1.0.0-rc.10`, with desktop build version `1.0.0.10`. RC10 advances RC9 because audited source-completeness and durable-history reconciliation materially changed user-visible accounting after the RC9 candidate was established. RC9 had already introduced the explicit durable-vs-surviving-detail accounting boundary and sealed Store CLI runtime.
 
 Metrora has an assigned Microsoft Store identity and a reviewed non-publishing AppX workflow/local-test path. No Store submission, certification or publication is claimed until Microsoft actually accepts that channel.
 
@@ -24,8 +24,8 @@ Protected credentials and verification material remain outside untrusted public 
 
 Windows uses multiple version authorities deliberately:
 
-- product/source candidate: `1.0.0-rc.9`;
-- desktop build version: `1.0.0.9`;
+- product/source candidate: `1.0.0-rc.10`;
+- desktop build version: `1.0.0.10`;
 - current non-publishing Microsoft Store AppX identity version: `1.0.0.0`.
 
 The Store AppX four-part identity is not the desktop build counter. See [Versioning authority](VERSIONING.md).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "metrora",
-  "version": "1.0.0-rc.9",
+  "version": "1.0.0-rc.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "metrora",
-      "version": "1.0.0-rc.9",
+      "version": "1.0.0-rc.10",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metrora",
-  "version": "1.0.0-rc.9",
+  "version": "1.0.0-rc.10",
   "private": true,
   "description": "Metrora — local-first AI usage intelligence for tools, models, projects and sessions",
   "type": "module",

--- a/scripts/Test-Metrora-Windows-Store-Local-Test-Runtime.ps1
+++ b/scripts/Test-Metrora-Windows-Store-Local-Test-Runtime.ps1
@@ -73,7 +73,7 @@ try {
   $artifactManifest = [pscustomobject]@{
     schemaVersion = 1
     sourceCommit = ('a' * 40)
-    artifactName = 'Metrora-1.0.0-rc.9-Windows-Store-x64.appx'
+    artifactName = 'Metrora-1.0.0-rc.10-Windows-Store-x64.appx'
     sha256 = ('b' * 64)
     packageVersion = '1.0.0.0'
     architecture = 'x64'

--- a/scripts/windows-store-identity.node-test.mjs
+++ b/scripts/windows-store-identity.node-test.mjs
@@ -69,11 +69,11 @@ assert.equal(
 )
 
 assert.equal(desktopPackage.version, rootPackage.version, 'desktop and root product SemVer must match')
-assert.equal(rootPackage.version, '1.0.0-rc.9', 'the current source candidate must remain 1.0.0-rc.9')
+assert.equal(rootPackage.version, '1.0.0-rc.10', 'the current source candidate must remain 1.0.0-rc.10')
 assert.equal(
   desktopPackage.build?.buildVersion,
-  '1.0.0.9',
-  'the current desktop build version authority must remain 1.0.0.9',
+  '1.0.0.10',
+  'the current desktop build version authority must remain 1.0.0.10',
 )
 
 const productCore = rootPackage.version.replace(/-rc\.\d+$/, '')


### PR DESCRIPTION
## Summary

Advance the active Metrora source/pre-submission candidate from `1.0.0-rc.9` to `1.0.0-rc.10` after the audited source-completeness and durable-history reconciliation landed on `main`.

This PR:
- advances product/source SemVer to `1.0.0-rc.10`;
- maps the desktop build version to `1.0.0.10`;
- keeps the non-publishing Microsoft Store AppX identity version at `1.0.0.0`;
- updates the active release/version/distribution authorities and changelog;
- updates current Store identity/runtime fixtures to the RC10 candidate;
- preserves historical release and compatibility evidence unchanged.

## Boundary

This is release metadata, authority and current-fixture alignment only. It does not change accounting implementation, pricing, Store identity, signing, submission or publication behavior.

No Microsoft Store submission, certification or publication is claimed by this PR. The exact RC10 Windows/Store artifacts must still be produced from the accepted source commit and pass the applicable candidate and local physical acceptance path before any submission decision.