### PR TITLE
fix: reconcile durable Copilot journal mutations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 This file records Metrora-originated public changes. Required third-party notices and licence texts are maintained separately in [`THIRD_PARTY_NOTICES.md`](THIRD_PARTY_NOTICES.md) and [`LICENSES/`](LICENSES/).
 
-## Unreleased — current source line `1.0.0-rc.10`
+## `1.0.0-rc.10` — frozen Microsoft Store submission
 
-RC10 is the current source/pre-submission candidate. It advances RC9 after source-completeness and durable-history reconciliation materially changed user-visible accounting. It is not yet a Microsoft Store submission, certification or publication.
+RC10 is the exact source line used for the Microsoft Store submission. The submission remains frozen and under Microsoft review; submission is not certification and certification is not publication. Post-RC10 development is separate and must not be represented as part of the submitted package.
 
 ### Source completeness and durable history
 
@@ -34,6 +34,14 @@ RC10 is the current source/pre-submission candidate. It advances RC9 after sourc
 - Retained Windows PowerShell 5.1-compatible physical-test platform detection.
 - Retained persisted Workspace endpoint software reconciliation to the current packaged Metrora/collector version without replacing endpoint identity, membership or evidence history.
 - Retained Store-facing product identity cleanup, canonical Metrora local paths, sync credential adoption and public-identity regression checks introduced on the RC8 source line.
+
+## Unreleased — post-RC10 development
+
+### Copilot durable-history reconciliation
+
+- Reconcile only the affected source/day slices when a mutable current Copilot journal changes after daily history was materialized, so removed requests do not remain as daily-history ghosts.
+- Treat an explicit Copilot storage-root switch as an identity boundary when the account/profile identity cannot be established safely: current output follows the new root, while prior durable evidence remains separate rather than being merged or discarded.
+- Preserve other providers, sourceless validated durable history, provenance and historical pricing authority during the bounded reconciliation.
 
 ## `1.0.0-rc.7` — published unsigned Windows technical preview
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 This file records Metrora-originated public changes. Required third-party notices and licence texts are maintained separately in [`THIRD_PARTY_NOTICES.md`](THIRD_PARTY_NOTICES.md) and [`LICENSES/`](LICENSES/).
 
-## `1.0.0-rc.10` — frozen Microsoft Store submission
+## `1.0.0-rc.10` — Microsoft Store submission source line
 
-RC10 is the exact source line used for the Microsoft Store submission. The submission remains frozen and under Microsoft review; submission is not certification and certification is not publication. Post-RC10 development is separate and must not be represented as part of the submitted package.
+RC10 is the exact source line associated with the Microsoft Store submission. Submission, certification and publication are separate gates. Post-RC10 development is separate from the submitted package.
 
 ### Source completeness and durable history
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -96,7 +96,7 @@ The Store candidate must be built from the exact reviewed source commit using th
 7. the sanitized local acceptance report must pass;
 8. submission requires an explicit stop/go after those checks.
 
-A passing local test is not Microsoft certification and does not authorize a publication claim. The RC10 submission does not authorize changing the submitted package, modifying Partner Center metadata, executing a publication action or representing post-RC10 code as submitted code. A future Store update requires a new reviewed candidate and its own acceptance/submission decision.
+A passing local test is not Microsoft certification and does not authorize a publication claim. The RC10 submission does not authorize changing the submitted package, changing submission metadata, executing a publication action or representing post-RC10 code as submitted code. A future Store update requires a new reviewed candidate and its own acceptance/submission decision.
 
 ## Versioning and notes
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -20,11 +20,11 @@ The root npm package is private and must not be published from this repository.
 
 ## Current engineering authority
 
-`1.0.0-rc.10` is the frozen **Microsoft Store submission source line**. It advances RC9 because audited source-completeness and durable-history reconciliation materially changed user-visible accounting after the RC9 candidate was established. RC9 had already introduced the explicit durable-vs-surviving-detail accounting boundary and the sealed packaged Store CLI runtime. The submitted RC10 package is separate from post-RC10 development. Submission is not certification and certification is not publication.
+`1.0.0-rc.10` is the **Microsoft Store submission source line**. It advances RC9 because audited source-completeness and durable-history reconciliation materially changed user-visible accounting after the RC9 candidate was established. RC9 had already introduced the explicit durable-vs-surviving-detail accounting boundary and the sealed packaged Store CLI runtime. Post-RC10 development is separate from the submitted package. Submission, certification and publication are distinct gates.
 
 `1.0.0-rc.7` remains the latest published GitHub Windows technical preview. That channel is unsigned, manually updated and not Microsoft Store certified. Its source, release assets, manifests and checksums remain immutable historical publication evidence.
 
-The Microsoft Store path is separate. Metrora has an assigned Store identity and a non-publishing AppX build/local-acceptance workflow. The RC10 package passed the recorded local and physical acceptance and was submitted to Microsoft; it remains frozen while certification is pending. No Store certification, publication or availability claim is made until the relevant state is independently known.
+The Microsoft Store path is separate. Metrora has an assigned Store identity and a non-publishing AppX build/local-acceptance workflow. The RC10 candidate passed its local and physical acceptance boundary and is the source line associated with the submission. This guidance makes no certification, publication or Store-availability claim.
 
 Exact source commits and artifact digests belong in the applicable workflow/release acceptance evidence rather than being copied into general release guidance.
 
@@ -83,9 +83,9 @@ The public acceptance contract is [`docs/WINDOWS_GITHUB_PRE_RELEASE_ACCEPTANCE_V
 
 An unsigned GitHub pre-release must state that its portable/installer assets are unsigned, may trigger SmartScreen, require manual updates and are not Microsoft Store certified. It must not be presented as stable merely because GitHub represents it as a release object.
 
-## Microsoft Store submission and publication
+## Microsoft Store candidate boundary
 
-The Store candidate must be built from the exact reviewed source commit using the non-publishing Store workflow. The RC10 submission followed these boundaries and remains frozen:
+The Store candidate must be built from the exact reviewed source commit using the non-publishing Store workflow. A submitted artifact remains bound to that source line:
 
 1. the exact AppX artifact and workflow manifest must verify;
 2. Store identity, publisher, architecture, capabilities and package version must match reviewed configuration;
@@ -96,7 +96,7 @@ The Store candidate must be built from the exact reviewed source commit using th
 7. the sanitized local acceptance report must pass;
 8. submission requires an explicit stop/go after those checks.
 
-A passing local test is not Microsoft certification and does not authorize a publication claim. The RC10 submission does not authorize changing the submitted package, changing submission metadata, executing a publication action or representing post-RC10 code as submitted code. A future Store update requires a new reviewed candidate and its own acceptance/submission decision.
+A passing local test is not Microsoft certification and does not authorize publication or Store-availability claims. A future Store update requires a new reviewed candidate and its own acceptance/submission decision.
 
 ## Versioning and notes
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -20,11 +20,11 @@ The root npm package is private and must not be published from this repository.
 
 ## Current engineering authority
 
-`1.0.0-rc.10` is the current **source/pre-submission candidate line**. It advances RC9 because audited source-completeness and durable-history reconciliation materially changed user-visible accounting after the RC9 candidate was established. RC9 had already introduced the explicit durable-vs-surviving-detail accounting boundary and the sealed packaged Store CLI runtime. RC10 metadata does not by itself make any artifact accepted, signed, submitted or published.
+`1.0.0-rc.10` is the frozen **Microsoft Store submission source line**. It advances RC9 because audited source-completeness and durable-history reconciliation materially changed user-visible accounting after the RC9 candidate was established. RC9 had already introduced the explicit durable-vs-surviving-detail accounting boundary and the sealed packaged Store CLI runtime. The submitted RC10 package is separate from post-RC10 development. Submission is not certification and certification is not publication.
 
 `1.0.0-rc.7` remains the latest published GitHub Windows technical preview. That channel is unsigned, manually updated and not Microsoft Store certified. Its source, release assets, manifests and checksums remain immutable historical publication evidence.
 
-The Microsoft Store path is separate. Metrora has an assigned Store identity and a non-publishing AppX build/local-acceptance workflow, but no Store certification or publication is claimed until Microsoft has accepted the corresponding submission.
+The Microsoft Store path is separate. Metrora has an assigned Store identity and a non-publishing AppX build/local-acceptance workflow. The RC10 package passed the recorded local and physical acceptance and was submitted to Microsoft; it remains frozen while certification is pending. No Store certification, publication or availability claim is made until the relevant state is independently known.
 
 Exact source commits and artifact digests belong in the applicable workflow/release acceptance evidence rather than being copied into general release guidance.
 
@@ -83,9 +83,9 @@ The public acceptance contract is [`docs/WINDOWS_GITHUB_PRE_RELEASE_ACCEPTANCE_V
 
 An unsigned GitHub pre-release must state that its portable/installer assets are unsigned, may trigger SmartScreen, require manual updates and are not Microsoft Store certified. It must not be presented as stable merely because GitHub represents it as a release object.
 
-## Microsoft Store pre-submission
+## Microsoft Store submission and publication
 
-The Store candidate must be built from the exact reviewed source commit using the non-publishing Store workflow. Before Partner Center submission:
+The Store candidate must be built from the exact reviewed source commit using the non-publishing Store workflow. The RC10 submission followed these boundaries and remains frozen:
 
 1. the exact AppX artifact and workflow manifest must verify;
 2. Store identity, publisher, architecture, capabilities and package version must match reviewed configuration;
@@ -96,7 +96,7 @@ The Store candidate must be built from the exact reviewed source commit using th
 7. the sanitized local acceptance report must pass;
 8. submission requires an explicit stop/go after those checks.
 
-A passing local test is not Microsoft certification and does not authorize a publication claim.
+A passing local test is not Microsoft certification and does not authorize a publication claim. The RC10 submission does not authorize changing the submitted package, modifying Partner Center metadata, pressing `Publish now` or representing post-RC10 code as submitted code. A future Store update requires a new reviewed candidate and its own acceptance/submission decision.
 
 ## Versioning and notes
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -96,7 +96,7 @@ The Store candidate must be built from the exact reviewed source commit using th
 7. the sanitized local acceptance report must pass;
 8. submission requires an explicit stop/go after those checks.
 
-A passing local test is not Microsoft certification and does not authorize a publication claim. The RC10 submission does not authorize changing the submitted package, modifying Partner Center metadata, pressing `Publish now` or representing post-RC10 code as submitted code. A future Store update requires a new reviewed candidate and its own acceptance/submission decision.
+A passing local test is not Microsoft certification and does not authorize a publication claim. The RC10 submission does not authorize changing the submitted package, modifying Partner Center metadata, executing a publication action or representing post-RC10 code as submitted code. A future Store update requires a new reviewed candidate and its own acceptance/submission decision.
 
 ## Versioning and notes
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -35,7 +35,7 @@ Security reports are welcome for:
 
 The latest public Windows technical preview is the **unsigned** GitHub pre-release `v1.0.0-rc.7`. Its release assets are bound to the published release evidence and checksums; it is not a signed stable channel, a Microsoft Store package, or an automatic update channel.
 
-Metrora also has an assigned Microsoft Store package identity and a reviewed non-publishing AppX build/local-acceptance path. That work is **pre-submission**: no Microsoft Store certification or publication is claimed by this repository until Microsoft has actually accepted and published the corresponding submission.
+Metrora also has an assigned Microsoft Store package identity and a reviewed non-publishing AppX build/local-acceptance path. The RC10 package passed the recorded acceptance and was submitted; it remains frozen under Microsoft review. Submission is not certification, and no Microsoft Store publication or availability is claimed yet.
 
 Stable signing, Store publication, and any future update-channel claims must remain explicit and channel-specific. Upstream Metrora artifacts are not Metrora releases.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -35,7 +35,7 @@ Security reports are welcome for:
 
 The latest public Windows technical preview is the **unsigned** GitHub pre-release `v1.0.0-rc.7`. Its release assets are bound to the published release evidence and checksums; it is not a signed stable channel, a Microsoft Store package, or an automatic update channel.
 
-Metrora also has an assigned Microsoft Store package identity and a reviewed non-publishing AppX build/local-acceptance path. The RC10 package passed the recorded acceptance and was submitted; it remains frozen under Microsoft review. Submission is not certification, and no Microsoft Store publication or availability is claimed yet.
+Metrora also has an assigned Microsoft Store package identity and a reviewed non-publishing AppX build/local-acceptance path. RC10 is the source line associated with the Store submission. Submission is not certification or publication, and this repository makes no Store-availability claim.
 
 Stable signing, Store publication, and any future update-channel claims must remain explicit and channel-specific. Upstream Metrora artifacts are not Metrora releases.
 

--- a/app/DISTRIBUTION.md
+++ b/app/DISTRIBUTION.md
@@ -10,7 +10,7 @@ This document defines the desktop packaging boundary. Platform-specific release 
 - Current source/desktop candidate: `1.0.0-rc.10`
 - Current desktop build version: `1.0.0.10`
 - Latest published GitHub technical preview: `1.0.0-rc.7`
-- Current non-publishing Store AppX identity version: `1.0.0.0`
+- Current Store AppX identity version: `1.0.0.0` (frozen in the RC10 submission)
 
 Inherited names may remain only where required for compatibility or upstream provenance. They are not Metrora distribution names.
 

--- a/app/DISTRIBUTION.md
+++ b/app/DISTRIBUTION.md
@@ -10,7 +10,7 @@ This document defines the desktop packaging boundary. Platform-specific release 
 - Current source/desktop candidate: `1.0.0-rc.10`
 - Current desktop build version: `1.0.0.10`
 - Latest published GitHub technical preview: `1.0.0-rc.7`
-- Current Store AppX identity version: `1.0.0.0` (frozen in the RC10 submission)
+- Current non-publishing Store AppX identity version: `1.0.0.0`
 
 Inherited names may remain only where required for compatibility or upstream provenance. They are not Metrora distribution names.
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -2,7 +2,7 @@
 
 Metrora does not yet have an official stable desktop distribution. You can evaluate it from source, or use the published **unsigned Windows x64 technical preview `v1.0.0-rc.7`** from GitHub Releases. RC7 is not signed, Microsoft Store certified, automatically updated or the stable `1.0.0` release.
 
-The repository's active source line may be newer than the latest published technical preview. Source builds must therefore be identified by their exact commit/version rather than treated as RC7 release assets or as part of the frozen RC10 Store submission.
+The repository's active source line may be newer than the latest published technical preview. Source builds must therefore be identified by their exact commit/version rather than treated as RC7 release assets or Store packages.
 
 ## Requirements
 
@@ -142,7 +142,7 @@ npm --prefix app run typecheck
 npm --prefix app run build
 ```
 
-Development builds are not official signed releases. Windows is the first official desktop distribution target. Metrora has an assigned Microsoft Store identity and a non-publishing AppX local-acceptance path. The RC10 package was submitted and remains frozen under Microsoft review; submission is not certification and no Store publication or availability is claimed yet.
+Development builds are not official signed releases. Windows is the first official desktop distribution target. Metrora has an assigned Microsoft Store identity and a non-publishing AppX local-acceptance path. Source builds are not Store submissions; submission, certification and publication are separate gates.
 
 See [Windows distribution](WINDOWS_DISTRIBUTION.md), [Versioning authority](VERSIONING.md) and [`RELEASING.md`](../RELEASING.md).
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -2,7 +2,7 @@
 
 Metrora does not yet have an official stable desktop distribution. You can evaluate it from source, or use the published **unsigned Windows x64 technical preview `v1.0.0-rc.7`** from GitHub Releases. RC7 is not signed, Microsoft Store certified, automatically updated or the stable `1.0.0` release.
 
-The repository's active source/pre-submission line may be newer than the latest published technical preview. Source builds must therefore be identified by their exact commit/version rather than treated as RC7 release assets.
+The repository's active source line may be newer than the latest published technical preview. Source builds must therefore be identified by their exact commit/version rather than treated as RC7 release assets or as part of the frozen RC10 Store submission.
 
 ## Requirements
 
@@ -142,7 +142,7 @@ npm --prefix app run typecheck
 npm --prefix app run build
 ```
 
-Development builds are not official signed releases. Windows is the first official desktop distribution target. Metrora has an assigned Microsoft Store identity and a non-publishing AppX pre-submission path, but no Store certification/publication is claimed until Microsoft accepts a submission.
+Development builds are not official signed releases. Windows is the first official desktop distribution target. Metrora has an assigned Microsoft Store identity and a non-publishing AppX local-acceptance path. The RC10 package was submitted and remains frozen under Microsoft review; submission is not certification and no Store publication or availability is claimed yet.
 
 See [Windows distribution](WINDOWS_DISTRIBUTION.md), [Versioning authority](VERSIONING.md) and [`RELEASING.md`](../RELEASING.md).
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -37,7 +37,7 @@ Component references in this section explain bounded implementation responsibili
 
 - [Windows distribution](WINDOWS_DISTRIBUTION.md) — canonical current Windows package, identity and publication boundary.
 - [Windows Store package identity v1](WINDOWS_STORE_IDENTITY_V1.md) — assigned package identity and separate AppX/MSIX build boundary.
-- [Windows Store local package test](WINDOWS_STORE_LOCAL_TEST_GUIDED.md) — bounded pre-submission installation and cleanup path.
+- [Windows Store local package test](WINDOWS_STORE_LOCAL_TEST_GUIDED.md) — bounded local installation and cleanup path used for Store candidates.
 - [Windows release candidate v1](WINDOWS_RELEASE_CANDIDATE_V1.md) — unsigned candidate manifest and independent verification contract.
 - [Windows format derivation v1](WINDOWS_FORMAT_DERIVATION_V1.md) — one-payload portable and installer derivation.
 - [Windows clean install v1](WINDOWS_CLEAN_INSTALL_V1.md) — isolated NSIS installation and state-preservation contract.

--- a/docs/VERSIONING.md
+++ b/docs/VERSIONING.md
@@ -33,13 +33,13 @@ The Microsoft Store AppX/MSIX manifest has a separate four-component package ide
 
 The final component is `0` for the Store package contract. The SemVer pre-release suffix (`-rc.N`) is **not** encoded into the AppX identity version, and the desktop build counter (`MAJOR.MINOR.PATCH.N`) must not be presented as the Store package version.
 
-For the current `1.0.0` pre-submission line:
+For the current `1.0.0` Store-submission line:
 
 - source/product candidate: `1.0.0-rc.10`;
 - desktop build version: `1.0.0.10`;
-- local/non-publishing Store AppX identity version: `1.0.0.0`.
+- frozen submitted Store AppX identity version: `1.0.0.0`.
 
-A locally validated `1.0.0.0` AppX does not mean that version has been submitted, certified or published. Once a package version is actually submitted to Microsoft, later Store updates must advance according to the Store's package-version rules rather than reusing an already submitted identity.
+A locally validated `1.0.0.0` AppX does not by itself mean that version is certified or published. The RC10 package using this identity was submitted and remains frozen. Later Store updates must advance according to the Store's package-version rules rather than reusing an already submitted identity.
 
 ## Ordering
 

--- a/docs/VERSIONING.md
+++ b/docs/VERSIONING.md
@@ -33,13 +33,13 @@ The Microsoft Store AppX/MSIX manifest has a separate four-component package ide
 
 The final component is `0` for the Store package contract. The SemVer pre-release suffix (`-rc.N`) is **not** encoded into the AppX identity version, and the desktop build counter (`MAJOR.MINOR.PATCH.N`) must not be presented as the Store package version.
 
-For the current `1.0.0` Store-submission line:
+For the current `1.0.0` Store-associated source line:
 
 - source/product candidate: `1.0.0-rc.10`;
 - desktop build version: `1.0.0.10`;
-- frozen submitted Store AppX identity version: `1.0.0.0`.
+- non-publishing Store AppX identity version: `1.0.0.0`.
 
-A locally validated `1.0.0.0` AppX does not by itself mean that version is certified or published. The RC10 package using this identity was submitted and remains frozen. Later Store updates must advance according to the Store's package-version rules rather than reusing an already submitted identity.
+A locally validated `1.0.0.0` AppX does not by itself mean that version was submitted, certified or published. Submission, certification and publication are separate gates. Later Store updates must advance according to the Store's package-version rules rather than reusing an already submitted identity.
 
 ## Ordering
 

--- a/docs/WINDOWS_DISTRIBUTION.md
+++ b/docs/WINDOWS_DISTRIBUTION.md
@@ -6,9 +6,9 @@ Metrora does not yet have an official stable Windows release.
 
 The latest public Windows technical preview is the **unsigned** GitHub pre-release `v1.0.0-rc.7`. It remains bound to its accepted source, manifests, checksums and publication evidence. It is not a signed stable package, a Microsoft Store package or an automatic update channel.
 
-The active source/pre-submission line is `1.0.0-rc.10`, with desktop build version `1.0.0.10`. RC10 advances RC9 because audited source-completeness and durable-history reconciliation materially changed user-visible accounting after the RC9 candidate was established. RC9 had already introduced the explicit durable-vs-surviving-detail accounting boundary and sealed Store CLI runtime.
+The active submitted source line is `1.0.0-rc.10`, with desktop build version `1.0.0.10`. RC10 advances RC9 because audited source-completeness and durable-history reconciliation materially changed user-visible accounting after the RC9 candidate was established. RC9 had already introduced the explicit durable-vs-surviving-detail accounting boundary and sealed Store CLI runtime.
 
-Metrora has an assigned Microsoft Store identity and a reviewed non-publishing AppX workflow/local-test path. No Store submission, certification or publication is claimed until Microsoft actually accepts that channel.
+Metrora has an assigned Microsoft Store identity and a reviewed non-publishing AppX workflow/local-test path. The RC10 package passed the recorded local and physical acceptance and was submitted to Microsoft. The submission is frozen; post-RC10 changes are separate. Submission is not certification, and no certification, publication or Store availability claim is made yet.
 
 Historical 0.9.19 acceptance material remains immutable engineering evidence for its own source line only.
 
@@ -49,11 +49,11 @@ An unsigned GitHub pre-release follows the separate source, candidate, physical 
 
 The existing RC7 release remains immutable. Later Store-readiness changes do not retroactively modify or re-label those artifacts.
 
-## Microsoft Store pre-submission
+## Microsoft Store submission and publication
 
 The Store workflow builds an unsigned AppX candidate and inspects its identity, architecture, capabilities and payload boundary without publishing it. The packaged CLI production closure is sealed inside `cli.asar`; only a tiny stable launcher remains loose. The workflow must execute that packaged CLI from the extracted AppX payload using packaged `Metrora.exe`, and a loose CLI `node_modules` tree is not an accepted Store runtime boundary. A separate copy may be signed with a temporary local certificate only for physical acceptance.
 
-Before Partner Center submission, the exact source-bound candidate must pass the bounded local Store test and cleanup. A local PASS is pre-submission evidence only; it is not Microsoft certification.
+The RC10 submission was made only after the exact source-bound candidate passed the bounded local Store test and cleanup. A local PASS is evidence for submission; it is not Microsoft certification. The submitted package remains frozen and is not changed by post-RC10 development.
 
 ## Accounting presentation boundary
 

--- a/docs/WINDOWS_DISTRIBUTION.md
+++ b/docs/WINDOWS_DISTRIBUTION.md
@@ -6,9 +6,9 @@ Metrora does not yet have an official stable Windows release.
 
 The latest public Windows technical preview is the **unsigned** GitHub pre-release `v1.0.0-rc.7`. It remains bound to its accepted source, manifests, checksums and publication evidence. It is not a signed stable package, a Microsoft Store package or an automatic update channel.
 
-The active submitted source line is `1.0.0-rc.10`, with desktop build version `1.0.0.10`. RC10 advances RC9 because audited source-completeness and durable-history reconciliation materially changed user-visible accounting after the RC9 candidate was established. RC9 had already introduced the explicit durable-vs-surviving-detail accounting boundary and sealed Store CLI runtime.
+The active source line associated with the Store submission is `1.0.0-rc.10`, with desktop build version `1.0.0.10`. RC10 advances RC9 because audited source-completeness and durable-history reconciliation materially changed user-visible accounting after the RC9 candidate was established. RC9 had already introduced the explicit durable-vs-surviving-detail accounting boundary and sealed Store CLI runtime.
 
-Metrora has an assigned Microsoft Store identity and a reviewed non-publishing AppX workflow/local-test path. The RC10 package passed the recorded local and physical acceptance and was submitted to Microsoft. The submission is frozen; post-RC10 changes are separate. Submission is not certification, and no certification, publication or Store availability claim is made yet.
+Metrora has an assigned Microsoft Store identity and a reviewed non-publishing AppX workflow/local-test path. Post-RC10 development is separate from the source line associated with the submission. Submission, certification, publication and Store availability are distinct gates; this document makes no certification or publication claim.
 
 Historical 0.9.19 acceptance material remains immutable engineering evidence for its own source line only.
 
@@ -49,11 +49,11 @@ An unsigned GitHub pre-release follows the separate source, candidate, physical 
 
 The existing RC7 release remains immutable. Later Store-readiness changes do not retroactively modify or re-label those artifacts.
 
-## Microsoft Store submission and publication
+## Microsoft Store candidate boundary
 
 The Store workflow builds an unsigned AppX candidate and inspects its identity, architecture, capabilities and payload boundary without publishing it. The packaged CLI production closure is sealed inside `cli.asar`; only a tiny stable launcher remains loose. The workflow must execute that packaged CLI from the extracted AppX payload using packaged `Metrora.exe`, and a loose CLI `node_modules` tree is not an accepted Store runtime boundary. A separate copy may be signed with a temporary local certificate only for physical acceptance.
 
-The RC10 submission was made only after the exact source-bound candidate passed the bounded local Store test and cleanup. A local PASS is evidence for submission; it is not Microsoft certification. The submitted package remains frozen and is not changed by post-RC10 development.
+The source line associated with the Store submission passed the exact source-bound local Store test and cleanup. A local PASS is evidence for candidate acceptance; it is not Microsoft certification and does not establish publication or availability. Later source work remains separate from that submitted artifact.
 
 ## Accounting presentation boundary
 

--- a/docs/WINDOWS_STORE_IDENTITY_V1.md
+++ b/docs/WINDOWS_STORE_IDENTITY_V1.md
@@ -1,6 +1,6 @@
 # Windows Store package identity v1
 
-**Status:** identity assigned / packaging and local-test path implemented / not submitted
+**Status:** identity assigned / RC10 package locally and physically accepted / RC10 submission frozen / publication pending
 
 ## Purpose
 
@@ -8,7 +8,7 @@ Define the separate Windows Store packaging boundary for Metrora.
 
 The exact manifest values are maintained in the reviewed desktop build configuration. They must match Partner Center byte-for-byte and must not be duplicated across public documentation.
 
-This document does not authorize submission, certification, publication, stable `1.0.0`, or any change to the already published GitHub `1.0.0-rc.7` artifacts.
+This document does not authorize a different submission, certification or publication, or any change to the already published GitHub `1.0.0-rc.7` artifacts. The RC10 package was submitted after acceptance and remains frozen; post-RC10 development is separate.
 
 ## Build boundary
 
@@ -34,10 +34,10 @@ The guided local path is documented in [`WINDOWS_STORE_LOCAL_TEST_GUIDED.md`](WI
 
 It signs only a temporary copy. The public test certificate is trusted at machine level while its private key remains in the current-user personal store; both are removed with the installed package after validation. The unsigned candidate intended for Partner Center is not modified.
 
-A local PASS is not Store certification and does not authorize submission.
+A local PASS is not Store certification and does not authorize publication.
 
 ## Current limitations
 
-The Store target is packaging-ready only. It is not submitted, certified, signed by Microsoft, published, or an automatic update for existing installations.
+The RC10 Store target is submitted and frozen. It is not certified, signed by Microsoft, published, or an automatic update for existing installations.
 
-Store-specific acceptance and separate publication authorization remain required.
+Certification and separate manual publication authorization remain distinct requirements. No post-RC10 code is part of the submitted package.

--- a/docs/WINDOWS_STORE_IDENTITY_V1.md
+++ b/docs/WINDOWS_STORE_IDENTITY_V1.md
@@ -1,14 +1,14 @@
 # Windows Store package identity v1
 
-**Status:** identity assigned / RC10 package locally and physically accepted / RC10 submission frozen / publication pending
+**Status:** identity assigned / separate Store candidate boundary
 
 ## Purpose
 
 Define the separate Windows Store packaging boundary for Metrora.
 
-The exact manifest values are maintained in the reviewed desktop build configuration. They must match Partner Center byte-for-byte and must not be duplicated across public documentation.
+The exact manifest values are maintained in the reviewed desktop build configuration. They must match the Store authority byte-for-byte and must not be duplicated across public documentation.
 
-This document does not authorize a different submission, certification or publication, or any change to the already published GitHub `1.0.0-rc.7` artifacts. The RC10 package was submitted after acceptance and remains frozen; post-RC10 development is separate.
+RC10 is the source line associated with the Store submission. This document does not claim certification, publication or availability, and post-RC10 development is separate from that submitted artifact. It also does not authorize a different submission or any change to the already published GitHub `1.0.0-rc.7` artifacts.
 
 ## Build boundary
 
@@ -32,12 +32,12 @@ Neither channel inherits the signature, certification or publication status of t
 
 The guided local path is documented in [`WINDOWS_STORE_LOCAL_TEST_GUIDED.md`](WINDOWS_STORE_LOCAL_TEST_GUIDED.md).
 
-It signs only a temporary copy. The public test certificate is trusted at machine level while its private key remains in the current-user personal store; both are removed with the installed package after validation. The unsigned candidate intended for Partner Center is not modified.
+It signs only a temporary copy. The public test certificate is trusted at machine level while its private key remains in the current-user personal store; both are removed with the installed package after validation. The unsigned candidate intended for Store submission is not modified.
 
-A local PASS is not Store certification and does not authorize publication.
+A local PASS is not Store certification and does not authorize publication or availability claims.
 
 ## Current limitations
 
-The RC10 Store target is submitted and frozen. It is not certified, signed by Microsoft, published, or an automatic update for existing installations.
+The Store target has a separate package identity and local-acceptance path. It is not a signed Microsoft channel, an automatic update for existing installations, or a publication claim.
 
-Certification and separate manual publication authorization remain distinct requirements. No post-RC10 code is part of the submitted package.
+The RC10 source line is associated with the Store submission; certification and publication remain distinct gates. No post-RC10 code is part of that submitted artifact.

--- a/docs/WINDOWS_STORE_LOCAL_TEST_GUIDED.md
+++ b/docs/WINDOWS_STORE_LOCAL_TEST_GUIDED.md
@@ -1,6 +1,6 @@
 # Windows Store local package test
 
-This guide documents the physical-Windows test used before a Store submission. It remains a procedure for future candidates and does not authorize changing the frozen RC10 submission or publishing it.
+This guide documents the physical-Windows test used for Store candidates. It is a procedure for candidate acceptance and does not authorize changing a submitted artifact or making certification, publication or availability claims.
 
 It does not imitate Microsoft certification. The submission candidate remains unsigned and unchanged. A separate copy is signed with a temporary test certificate only so Windows can install it locally.
 
@@ -109,4 +109,4 @@ A passing local report is one submission input only. It does not authorize:
 - replacement of the existing portable or NSIS channels;
 - claims about Store-managed update behavior.
 
-RC10 is already submitted and remains frozen. Certification and any later publication remain separate decisions; this guide does not authorize a publication action or a Store-availability claim.
+Submission, certification, publication and availability remain separate gates; this guide does not authorize a publication action or a Store-availability claim.

--- a/docs/WINDOWS_STORE_LOCAL_TEST_GUIDED.md
+++ b/docs/WINDOWS_STORE_LOCAL_TEST_GUIDED.md
@@ -1,6 +1,6 @@
 # Windows Store local package test
 
-This guide validates the current AppX candidate on physical Windows before any Partner Center submission.
+This guide documents the physical-Windows test used before a Store submission. It remains a procedure for future candidates and does not authorize changing the frozen RC10 submission or publishing it.
 
 It does not imitate Microsoft certification. The submission candidate remains unsigned and unchanged. A separate copy is signed with a temporary test certificate only so Windows can install it locally.
 
@@ -100,7 +100,7 @@ When cleanup is incomplete, the local context is deliberately preserved. Do not 
 
 ## Boundaries
 
-A passing local report is one pre-submission input only. It does not authorize:
+A passing local report is one submission input only. It does not authorize:
 
 - uploading or submitting a package;
 - Microsoft Store certification or publication claims;
@@ -109,4 +109,4 @@ A passing local report is one pre-submission input only. It does not authorize:
 - replacement of the existing portable or NSIS channels;
 - claims about Store-managed update behavior.
 
-Store submission and any later publication remain separate decisions.
+RC10 is already submitted and remains frozen. Certification and any later publication remain separate decisions; this guide does not authorize a `Publish now` action or a Store-availability claim.

--- a/docs/WINDOWS_STORE_LOCAL_TEST_GUIDED.md
+++ b/docs/WINDOWS_STORE_LOCAL_TEST_GUIDED.md
@@ -109,4 +109,4 @@ A passing local report is one submission input only. It does not authorize:
 - replacement of the existing portable or NSIS channels;
 - claims about Store-managed update behavior.
 
-RC10 is already submitted and remains frozen. Certification and any later publication remain separate decisions; this guide does not authorize a `Publish now` action or a Store-availability claim.
+RC10 is already submitted and remains frozen. Certification and any later publication remain separate decisions; this guide does not authorize a publication action or a Store-availability claim.

--- a/scripts/check-version-consistency.mjs
+++ b/scripts/check-version-consistency.mjs
@@ -33,7 +33,7 @@ requireText('docs/VERSIONING.md', `- Current source candidate: \`${version}\``, 
 requireText('docs/VERSIONING.md', `- Desktop build version: \`${expectedBuildVersion}\``, 'desktop build version')
 requireText(
   'docs/WINDOWS_DISTRIBUTION.md',
-  `The active source/pre-submission line is \`${version}\`, with desktop build version \`${expectedBuildVersion}\`.`,
+  `The active submitted source line is \`${version}\`, with desktop build version \`${expectedBuildVersion}\`.`,
   'Windows distribution version',
 )
 

--- a/scripts/check-version-consistency.mjs
+++ b/scripts/check-version-consistency.mjs
@@ -33,7 +33,7 @@ requireText('docs/VERSIONING.md', `- Current source candidate: \`${version}\``, 
 requireText('docs/VERSIONING.md', `- Desktop build version: \`${expectedBuildVersion}\``, 'desktop build version')
 requireText(
   'docs/WINDOWS_DISTRIBUTION.md',
-  `The active submitted source line is \`${version}\`, with desktop build version \`${expectedBuildVersion}\`.`,
+  `The active source line associated with the Store submission is \`${version}\`, with desktop build version \`${expectedBuildVersion}\`.`,
   'Windows distribution version',
 )
 

--- a/src/copilot-chat-journal-hydration.ts
+++ b/src/copilot-chat-journal-hydration.ts
@@ -1,0 +1,111 @@
+import { resolve } from 'node:path'
+
+import type { DateRange, ProjectSummary } from './types.js'
+import { parseAllSessions, clearSessionCache } from './parser.js'
+import { COPILOT_CHAT_JOURNAL_PROVIDER } from './provider-parse-authorities.js'
+import { loadCache as loadSessionCache } from './session-cache.js'
+import { DURABLE_HISTORY_AUTHORITY, emptyCache, ensureCacheHydrated, type DailyCache, type DailyEntry } from './daily-cache.js'
+import {
+  beginCopilotChatJournalIdentityBoundary,
+  clearCopilotChatJournalInvalidations,
+  endCopilotChatJournalIdentityBoundary,
+  getCopilotChatJournalFingerprints,
+  readCopilotChatJournalInvalidatedDays,
+} from './copilot-chat-journal-reconciliation.js'
+
+async function copilotChatJournalChanged(): Promise<boolean> {
+  const current = await getCopilotChatJournalFingerprints()
+  const sessionCache = await loadSessionCache()
+  const cached = sessionCache.providers[COPILOT_CHAT_JOURNAL_PROVIDER]?.files ?? {}
+  if (current.length !== Object.keys(cached).length) return current.length > 0 || Object.keys(cached).length > 0
+
+  const byPath = new Map(current.map(fingerprint => [fingerprint.path, fingerprint]))
+  for (const [path, file] of Object.entries(cached)) {
+    const fingerprint = byPath.get(path)
+    if (!fingerprint) return true
+    if (
+      file.fingerprint.dev !== fingerprint.dev
+      || file.fingerprint.ino !== fingerprint.ino
+      || file.fingerprint.mtimeMs !== fingerprint.mtimeMs
+      || file.fingerprint.sizeBytes !== fingerprint.sizeBytes
+    ) return true
+  }
+  return false
+}
+
+async function copilotChatJournalRootChanged(): Promise<boolean> {
+  const configuredRoot = process.env['METRORA_COPILOT_WS_STORAGE_DIR']
+  if (!configuredRoot) return false
+  const sessionCache = await loadSessionCache()
+  const files = sessionCache.providers[COPILOT_CHAT_JOURNAL_PROVIDER]?.files ?? {}
+  if (Object.keys(files).length === 0) return false
+  const canonical = (value: string): string => {
+    const slashes = value.replaceAll('\\', '/')
+    const compared = process.platform === 'win32' ? slashes.toLowerCase() : slashes
+    return compared.replace(/\/+$/, '')
+  }
+  const normalizedRoot = canonical(resolve(configuredRoot))
+  const normalizedPrefix = `${normalizedRoot}/`
+  return Object.keys(files).some(path => {
+    const normalizedPath = canonical(resolve(path))
+    return normalizedPath !== normalizedRoot && !normalizedPath.startsWith(normalizedPrefix)
+  })
+}
+
+/** Prepare only the journal reconciliation work required by this hydration. */
+export async function prepareCopilotChatJournalReconciliation(): Promise<string[]> {
+  if (await copilotChatJournalRootChanged()) {
+    // A root/profile/account switch is identity-ambiguous. Reparse the new
+    // root for current output, but keep the old daily ledger separate.
+    await clearCopilotChatJournalInvalidations()
+    clearSessionCache()
+    beginCopilotChatJournalIdentityBoundary()
+    try {
+      await parseAllSessions(undefined, 'all')
+    } finally {
+      endCopilotChatJournalIdentityBoundary()
+    }
+    await clearCopilotChatJournalInvalidations()
+    return []
+  }
+
+  let days = await readCopilotChatJournalInvalidatedDays()
+  if (await copilotChatJournalChanged()) {
+    clearSessionCache()
+    await parseAllSessions(undefined, 'all')
+    days = await readCopilotChatJournalInvalidatedDays()
+  }
+  return days
+}
+
+export async function hydrateCopilotDailyCache(
+  parseSessions: (range: DateRange) => Promise<ProjectSummary[]>,
+  aggregateDays: (projects: ProjectSummary[]) => DailyEntry[],
+  savingsConfigHash: string,
+  sessionComplete: () => boolean,
+): Promise<DailyCache> {
+  try {
+    const copilotJournalDays = await prepareCopilotChatJournalReconciliation()
+    const cache = await ensureCacheHydrated(
+      parseSessions,
+      aggregateDays,
+      savingsConfigHash,
+      sessionComplete,
+      undefined,
+      {
+        durableHistoryAuthority: DURABLE_HISTORY_AUTHORITY,
+        ...(copilotJournalDays.length > 0 ? { reconcileProviderDays: { copilot: copilotJournalDays } } : {}),
+      },
+    )
+    if (copilotJournalDays.length > 0 && cache.complete === true) {
+      await clearCopilotChatJournalInvalidations()
+    }
+    return cache
+  } catch (err) {
+    process.stderr.write(
+      `metrora: daily history backfill failed; the trend chart may be incomplete. ` +
+      `${err instanceof Error ? err.message : String(err)}\n`
+    )
+    return emptyCache()
+  }
+}

--- a/src/copilot-chat-journal-reconciliation.ts
+++ b/src/copilot-chat-journal-reconciliation.ts
@@ -1,0 +1,113 @@
+import { createHash, randomBytes } from 'node:crypto'
+import { existsSync } from 'node:fs'
+import { mkdir, readFile, rename, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+
+import { getMetroraCacheDir } from './product-paths.js'
+
+const MANIFEST_VERSION = 1
+const MANIFEST_FILE = 'copilot-chat-journal-invalidations.v1.json'
+const DATE_KEY_RE = /^\d{4}-\d{2}-\d{2}$/
+
+type Manifest = {
+  version: number
+  sources: Record<string, string[]>
+}
+
+const pending = new Map<string, Set<string>>()
+let suppressPendingInvalidation = false
+
+function manifestPath(): string {
+  return join(getMetroraCacheDir(), MANIFEST_FILE)
+}
+
+function sourceIdentity(sourcePath: string): string {
+  // The path is an internal identity only. Persist its digest so the manifest
+  // never becomes a source-path inventory or a privacy-bearing log.
+  return createHash('sha256').update(sourcePath).digest('hex').slice(0, 24)
+}
+
+function validDays(raw: unknown): string[] {
+  if (!Array.isArray(raw)) return []
+  return [...new Set(raw.filter((value): value is string => typeof value === 'string' && DATE_KEY_RE.test(value)))].sort()
+}
+
+function mergeSourceDays(target: Map<string, Set<string>>, source: string, days: Iterable<string>): void {
+  const existing = target.get(source) ?? new Set<string>()
+  for (const day of days) {
+    if (DATE_KEY_RE.test(day)) existing.add(day)
+  }
+  if (existing.size > 0) target.set(source, existing)
+}
+
+export function recordCopilotChatJournalInvalidation(sourcePath: string, days: Iterable<string>): void {
+  if (suppressPendingInvalidation) return
+  mergeSourceDays(pending, sourceIdentity(sourcePath), days)
+}
+
+/** Used only for an identity-ambiguous source-root switch. */
+export function beginCopilotChatJournalIdentityBoundary(): void {
+  suppressPendingInvalidation = true
+}
+
+export function endCopilotChatJournalIdentityBoundary(): void {
+  suppressPendingInvalidation = false
+}
+
+function parseManifest(raw: unknown): Map<string, Set<string>> {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return new Map()
+  const record = raw as Record<string, unknown>
+  if (record['version'] !== MANIFEST_VERSION || !record['sources'] || typeof record['sources'] !== 'object' || Array.isArray(record['sources'])) {
+    return new Map()
+  }
+  const result = new Map<string, Set<string>>()
+  for (const [source, rawDays] of Object.entries(record['sources'] as Record<string, unknown>)) {
+    const days = validDays(rawDays)
+    if (days.length > 0) result.set(source, new Set(days))
+  }
+  return result
+}
+
+async function readManifest(): Promise<Map<string, Set<string>>> {
+  try {
+    return parseManifest(JSON.parse(await readFile(manifestPath(), 'utf-8')) as unknown)
+  } catch {
+    return new Map()
+  }
+}
+
+async function writeManifest(values: Map<string, Set<string>>): Promise<void> {
+  const path = manifestPath()
+  await mkdir(getMetroraCacheDir(), { recursive: true })
+  const sources: Record<string, string[]> = {}
+  for (const [source, days] of [...values.entries()].sort(([a], [b]) => a.localeCompare(b))) {
+    const valid = [...days].filter(day => DATE_KEY_RE.test(day)).sort()
+    if (valid.length > 0) sources[source] = valid
+  }
+  const temp = `${path}.${randomBytes(6).toString('hex')}.tmp`
+  await writeFile(temp, JSON.stringify({ version: MANIFEST_VERSION, sources } satisfies Manifest), { encoding: 'utf-8', mode: 0o600 })
+  await rename(temp, path)
+}
+
+/** Publish parser-observed invalidations without exposing source content. */
+export async function flushCopilotChatJournalInvalidations(): Promise<void> {
+  if (pending.size === 0) return
+  const updates = new Map([...pending.entries()].map(([source, days]) => [source, new Set(days)] as const))
+  const merged = await readManifest()
+  for (const [source, days] of updates) mergeSourceDays(merged, source, days)
+  await writeManifest(merged)
+  for (const source of updates.keys()) pending.delete(source)
+}
+
+/** Return all affected days, preserving source identity only inside the file. */
+export async function readCopilotChatJournalInvalidatedDays(): Promise<string[]> {
+  const manifest = await readManifest()
+  return [...new Set([...manifest.values()].flatMap(days => [...days]))].sort()
+}
+
+export async function clearCopilotChatJournalInvalidations(): Promise<void> {
+  // Keep an empty, versioned marker rather than removing an arbitrary file;
+  // this is safe across concurrent readers and makes the authority explicit.
+  if (!existsSync(getMetroraCacheDir())) return
+  await writeManifest(new Map())
+}

--- a/src/copilot-chat-journal-reconciliation.ts
+++ b/src/copilot-chat-journal-reconciliation.ts
@@ -1,9 +1,13 @@
 import { createHash, randomBytes } from 'node:crypto'
 import { existsSync } from 'node:fs'
-import { mkdir, readFile, rename, writeFile } from 'node:fs/promises'
+import { mkdir, readFile, rename, stat, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 
 import { getMetroraCacheDir } from './product-paths.js'
+import { copilot } from './providers/copilot.js'
+import type { SessionSource } from './providers/types.js'
+import type { FileFingerprint } from './session-cache.js'
+import { COPILOT_CHAT_JOURNAL_PROVIDER } from './provider-parse-authorities.js'
 
 const MANIFEST_VERSION = 1
 const MANIFEST_FILE = 'copilot-chat-journal-invalidations.v1.json'
@@ -15,7 +19,16 @@ type Manifest = {
 }
 
 const pending = new Map<string, Set<string>>()
+const previousTurns = new Map<string, JournalTurn[]>()
 let suppressPendingInvalidation = false
+
+export type CopilotChatJournalFingerprint = {
+  path: string
+  dev: number
+  ino: number
+  mtimeMs: number
+  sizeBytes: number
+}
 
 function manifestPath(): string {
   return join(getMetroraCacheDir(), MANIFEST_FILE)
@@ -43,6 +56,85 @@ function mergeSourceDays(target: Map<string, Set<string>>, source: string, days:
 export function recordCopilotChatJournalInvalidation(sourcePath: string, days: Iterable<string>): void {
   if (suppressPendingInvalidation) return
   mergeSourceDays(pending, sourceIdentity(sourcePath), days)
+}
+
+function isChatSessionSource(source: SessionSource): source is SessionSource & { sourceType: 'chatsession' } {
+  return (source as SessionSource & { sourceType?: unknown }).sourceType === 'chatsession'
+}
+
+/** Read only source identity/stat metadata; never return journal content. */
+export async function getCopilotChatJournalFingerprints(): Promise<CopilotChatJournalFingerprint[]> {
+  const sources = await copilot.discoverSessions().catch(() => [])
+  const fingerprints: CopilotChatJournalFingerprint[] = []
+  for (const source of sources) {
+    if (!isChatSessionSource(source)) continue
+    const current = await stat(source.path).catch(() => null)
+    if (!current?.isFile()) continue
+    fingerprints.push({
+      path: source.path,
+      dev: Number(current.dev),
+      ino: Number(current.ino),
+      mtimeMs: current.mtimeMs,
+      sizeBytes: current.size,
+    })
+  }
+  return fingerprints.sort((left, right) => left.path.localeCompare(right.path))
+}
+
+type JournalTurn = { timestamp: string }
+
+type QueuedSource = {
+  source: SessionSource
+  fp: Pick<FileFingerprint, 'dev' | 'ino' | 'mtimeMs' | 'sizeBytes'>
+}
+
+export function queueCopilotChatJournalSource(
+  providerName: string,
+  source: SessionSource,
+  fp: QueuedSource['fp'],
+  turns: Iterable<JournalTurn>,
+): QueuedSource {
+  if (providerName === COPILOT_CHAT_JOURNAL_PROVIDER) {
+    previousTurns.set(source.path, [...turns].map(turn => ({ timestamp: turn.timestamp })))
+  }
+  return { source, fp }
+}
+
+function turnDayKey(timestamp: string): string {
+  const date = new Date(timestamp)
+  if (Number.isNaN(date.getTime())) return ''
+  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`
+}
+
+function turnDays(turns: Iterable<JournalTurn>): string[] {
+  return [...turns].map(turn => turnDayKey(turn.timestamp)).filter(Boolean)
+}
+
+/** Parser-facing adapter keeps the provider-specific invalidation policy here. */
+export function recordCopilotChatJournalSourceChange(
+  providerName: string,
+  sourcePath: string,
+  currentTurns: Iterable<JournalTurn>,
+): void {
+  if (providerName !== COPILOT_CHAT_JOURNAL_PROVIDER) return
+  const oldTurns = previousTurns.get(sourcePath) ?? []
+  recordCopilotChatJournalInvalidation(sourcePath, [...turnDays(oldTurns), ...turnDays(currentTurns)])
+}
+
+export function recordCopilotChatJournalSourceFailure(
+  providerName: string,
+  sourcePath: string,
+): void {
+  recordCopilotChatJournalSourceChange(providerName, sourcePath, [])
+}
+
+export function recordCopilotChatJournalSourceEviction(
+  providerName: string,
+  sourcePath: string,
+  turns: Iterable<JournalTurn>,
+): void {
+  if (providerName !== COPILOT_CHAT_JOURNAL_PROVIDER) return
+  recordCopilotChatJournalInvalidation(sourcePath, turnDays(turns))
 }
 
 /** Used only for an identity-ambiguous source-root switch. */
@@ -91,12 +183,16 @@ async function writeManifest(values: Map<string, Set<string>>): Promise<void> {
 
 /** Publish parser-observed invalidations without exposing source content. */
 export async function flushCopilotChatJournalInvalidations(): Promise<void> {
-  if (pending.size === 0) return
+  if (pending.size === 0) {
+    previousTurns.clear()
+    return
+  }
   const updates = new Map([...pending.entries()].map(([source, days]) => [source, new Set(days)] as const))
   const merged = await readManifest()
   for (const [source, days] of updates) mergeSourceDays(merged, source, days)
   await writeManifest(merged)
   for (const source of updates.keys()) pending.delete(source)
+  previousTurns.clear()
 }
 
 /** Return all affected days, preserving source identity only inside the file. */

--- a/src/daily-cache-core.ts
+++ b/src/daily-cache-core.ts
@@ -102,6 +102,26 @@ export function emptyCache(savingsConfigHash = ''): DailyCache {
   return { version: DAILY_CACHE_VERSION, savingsConfigHash, tzKey: currentTzKey(), lastComputedDate: null, days: [], complete: false }
 }
 
+/** Empty primary row used to tombstone a provider slice on a re-derived day. */
+export function emptyDailyEntry(date: string): DailyEntry {
+  return {
+    date,
+    cost: 0,
+    savingsUSD: 0,
+    calls: 0,
+    sessions: 0,
+    inputTokens: 0,
+    outputTokens: 0,
+    cacheReadTokens: 0,
+    cacheWriteTokens: 0,
+    editTurns: 0,
+    oneShotTurns: 0,
+    models: {},
+    categories: {},
+    providers: {},
+  }
+}
+
 export function isMigratableCache(parsed: unknown): parsed is {
   version: number
   lastComputedDate: string | null
@@ -516,7 +536,12 @@ function setOwn<T>(target: Record<string, T>, key: string, value: T): void {
 /// A primary slice blocks a secondary one only when it carries DATA; a
 /// zero-data placeholder (sessions only) is merged into, not treated as a
 /// re-derivation of the provider's day.
-export function mergeDayEntries(primary: DailyEntry[], secondary: DailyEntry[], markSecondaryCarried: boolean): DailyEntry[] {
+export function mergeDayEntries(
+  primary: DailyEntry[],
+  secondary: DailyEntry[],
+  markSecondaryCarried: boolean,
+  blockedSecondaryProviderDays: ReadonlySet<string> = new Set(),
+): DailyEntry[] {
   const byDate = new Map<string, DailyEntry>()
   for (const day of primary) byDate.set(day.date, structuredClone(day))
   for (const day of secondary) {
@@ -529,6 +554,7 @@ export function mergeDayEntries(primary: DailyEntry[], secondary: DailyEntry[], 
     }
     if (isOpaqueDay(existing)) continue
     for (const [provider, slice] of Object.entries(day.providers)) {
+      if (blockedSecondaryProviderDays.has(`${provider}\u0000${day.date}`)) continue
       // Sessions-only slices (a session whose calls all landed on another
       // day) still carry a real session count — worth preserving.
       if (!hasSliceData(slice) && !(slice.sessions ?? 0)) continue
@@ -569,6 +595,8 @@ export type CacheHydrationOptions = {
   /// a new authority scans the full durable daily-retention horizon; subsequent
   /// runs return to BACKFILL_DAYS.
   durableHistoryAuthority?: string
+  /** Replace only these provider slices on the listed dates. */
+  reconcileProviderDays?: Readonly<Record<string, readonly string[]>>
 }
 
 export function toDateString(date: Date): string {

--- a/src/daily-cache-core.ts
+++ b/src/daily-cache-core.ts
@@ -4,8 +4,9 @@ import { mkdir, open, readdir, readFile, rename, stat, unlink } from 'fs/promise
 import { join } from 'path'
 import type { DateRange, ProjectSummary } from './types.js'
 import { getMetroraCacheDir } from './product-paths.js'
-import { emptyModelStats, mergeModelStats, sanitizeModels } from './daily-cache-model-detail.js'
+import { sanitizeModels } from './daily-cache-model-detail.js'
 import type { CategoryDayStats, DailyCache, DailyEntry, ModelDayStats, ProjectDayStats, ProviderDaySlice } from './daily-cache-types.js'
+import { mergeDayEntries, setOwn } from './daily-cache-merge.js'
 // v18: Copilot accounting changed; v17 history is adopted untrusted, re-derived where sources survive, and carried otherwise.
 // Bumped to 16: historical per-call cost assignments. Surviving source days
 // re-derive under immutable date-effective settlements; sourceless provider
@@ -78,6 +79,8 @@ const DAILY_CACHE_FILENAME = `daily-cache.v${DAILY_CACHE_VERSION}.json`
 
 
 export type { CategoryDayStats, DailyCache, DailyEntry, ModelDayStats, ProjectDayStats, ProviderDaySlice } from './daily-cache-types.js'
+export { emptyDailyEntry } from './daily-cache-reconciliation.js'
+export { mergeDayEntries } from './daily-cache-merge.js'
 
 function getCacheDir(): string {
   return getMetroraCacheDir()
@@ -100,26 +103,6 @@ export function dailyCachePath(): string {
 
 export function emptyCache(savingsConfigHash = ''): DailyCache {
   return { version: DAILY_CACHE_VERSION, savingsConfigHash, tzKey: currentTzKey(), lastComputedDate: null, days: [], complete: false }
-}
-
-/** Empty primary row used to tombstone a provider slice on a re-derived day. */
-export function emptyDailyEntry(date: string): DailyEntry {
-  return {
-    date,
-    cost: 0,
-    savingsUSD: 0,
-    calls: 0,
-    sessions: 0,
-    inputTokens: 0,
-    outputTokens: 0,
-    cacheReadTokens: 0,
-    cacheWriteTokens: 0,
-    editTurns: 0,
-    oneShotTurns: 0,
-    models: {},
-    categories: {},
-    providers: {},
-  }
 }
 
 export function isMigratableCache(parsed: unknown): parsed is {
@@ -426,145 +409,6 @@ export function applyRetention(days: DailyEntry[], newestDate: string): DailyEnt
   cutoffDate.setUTCDate(cutoffDate.getUTCDate() - DAILY_CACHE_RETENTION_DAYS)
   const cutoff = toDateString(cutoffDate)
   return days.filter(d => d.date >= cutoff)
-}
-
-function hasSliceData(slice: ProviderDaySlice): boolean {
-  return slice.cost > 0 || slice.calls > 0 || (slice.savingsUSD ?? 0) > 0
-}
-
-/// A day from a pre-v5-era cache: day-level totals exist but the providers map
-/// is empty, so nothing can be attributed per provider. Such a day merges
-/// all-or-nothing — filling slices into it would double-count whatever share
-/// of its totals the incoming provider already contributed.
-function isOpaqueDay(day: DailyEntry): boolean {
-  return (day.cost > 0 || day.calls > 0) && Object.keys(day.providers).length === 0
-}
-
-/// Fold one provider's day slice into a day: the providers map, the day-level
-/// totals, and (when the slice carries them — v14+ slices do) the model and
-/// category breakdowns. Skinny slices from pre-v14 caches restore only
-/// cost/calls/savings; the day's other totals simply don't grow. A zero-data
-/// placeholder already present for the provider (a session that started this
-/// day but whose turns all landed on another) only contributes its session
-/// count, deduplicated by max — the same real session may be counted on both
-/// sides.
-function addSliceIntoDay(day: DailyEntry, provider: string, slice: ProviderDaySlice): void {
-  // Reads keyed by names from foreign caches use hasOwn throughout: a plain
-  // lookup of "__proto__" returns the prototype object, and accumulating into
-  // it pollutes every object in the process.
-  const placeholder = Object.hasOwn(day.providers, provider) ? day.providers[provider] : undefined
-  const placeholderSessions = placeholder?.sessions ?? 0
-  const merged = structuredClone(slice)
-  if (placeholderSessions > (merged.sessions ?? 0)) merged.sessions = placeholderSessions
-  setOwn(day.providers, provider, merged)
-  day.cost += slice.cost
-  day.calls += slice.calls
-  day.savingsUSD += slice.savingsUSD ?? 0
-  day.sessions += Math.max(0, (slice.sessions ?? 0) - placeholderSessions)
-  day.inputTokens += slice.inputTokens ?? 0
-  day.outputTokens += slice.outputTokens ?? 0
-  if (slice.reasoningTokens !== undefined) day.reasoningTokens = (day.reasoningTokens ?? 0) + slice.reasoningTokens
-  day.cacheReadTokens += slice.cacheReadTokens ?? 0
-  day.cacheWriteTokens += slice.cacheWriteTokens ?? 0
-  day.editTurns += slice.editTurns ?? 0
-  day.oneShotTurns += slice.oneShotTurns ?? 0
-  for (const [name, m] of Object.entries(slice.models ?? {})) {
-    const acc = Object.hasOwn(day.models, name) ? day.models[name]! : emptyModelStats()
-    mergeModelStats(acc, m)
-    setOwn(day.models, name, acc)
-  }
-  for (const [cat, c] of Object.entries(slice.categories ?? {})) {
-    const acc = Object.hasOwn(day.categories, cat) ? day.categories[cat]! : { turns: 0, cost: 0, savingsUSD: 0, editTurns: 0, oneShotTurns: 0 }
-    acc.turns += c.turns
-    acc.cost += c.cost
-    acc.savingsUSD += c.savingsUSD ?? 0
-    acc.editTurns += c.editTurns
-    acc.oneShotTurns += c.oneShotTurns
-    setOwn(day.categories, cat, acc)
-  }
-  const placeholderProjects = placeholder?.projects ?? {}
-  for (const [name, p] of Object.entries(slice.projects ?? {})) {
-    if (!p || typeof p !== 'object' || Array.isArray(p)) continue
-    const dayProjects = (day.projects ??= {})
-    const acc = Object.hasOwn(dayProjects, name) ? dayProjects[name]! : { cost: 0, calls: 0, savingsUSD: 0, sessions: 0 }
-    acc.cost += num(p.cost)
-    acc.calls += num(p.calls)
-    acc.savingsUSD += num(p.savingsUSD)
-    if (!acc.path && typeof p.path === 'string') acc.path = p.path
-    // Same session dedup as the slice-level sessions above: a placeholder's
-    // project sessions were already counted into the day when the fresh day
-    // was built, so only the excess is added.
-    const placeholderProjectSessions = Object.hasOwn(placeholderProjects, name) ? num(placeholderProjects[name]?.sessions) : 0
-    acc.sessions += Math.max(0, num(p.sessions) - placeholderProjectSessions)
-    setOwn(dayProjects, name, acc)
-  }
-  // Placeholder-only projects (session counted fresh, calls landed elsewhere)
-  // survive on the merged slice rather than being dropped by the clone above.
-  const mergedProjects = merged.projects
-  if (mergedProjects) {
-    for (const [name, p] of Object.entries(placeholderProjects)) {
-      if (!p || typeof p !== 'object') continue
-      if (Object.hasOwn(mergedProjects, name)) {
-        if (num(p.sessions) > num(mergedProjects[name]!.sessions)) mergedProjects[name]!.sessions = num(p.sessions)
-      } else {
-        setOwn(mergedProjects, name, { cost: 0, calls: 0, savingsUSD: 0, sessions: num(p.sessions) })
-      }
-    }
-  } else if (placeholder?.projects) {
-    merged.projects = structuredClone(placeholder.projects)
-  }
-}
-
-/// Assign via defineProperty so filesystem-derived keys like "__proto__" become
-/// ordinary own properties instead of mutating the prototype link.
-function setOwn<T>(target: Record<string, T>, key: string, value: T): void {
-  Object.defineProperty(target, key, { value, enumerable: true, writable: true, configurable: true })
-}
-
-/// Merge two day lists per (date, provider): `primary` wins wherever both have
-/// data; `secondary` only fills dates primary lacks entirely and provider
-/// slices primary lacks on shared dates. Nothing in secondary can overwrite or
-/// double into primary. With markSecondaryCarried, every day that received a
-/// secondary contribution is flagged `carried`.
-///
-/// Days that cannot be attributed per provider merge all-or-nothing:
-///  - an OPAQUE primary day (pre-v5-era: totals but empty providers map) is
-///    never slice-filled — its totals may already contain the incoming
-///    provider's share, so adding would double-count;
-///  - an opaque secondary day on a date primary already has contributes
-///    nothing — its day-level totals cannot be attributed without slices.
-/// A primary slice blocks a secondary one only when it carries DATA; a
-/// zero-data placeholder (sessions only) is merged into, not treated as a
-/// re-derivation of the provider's day.
-export function mergeDayEntries(
-  primary: DailyEntry[],
-  secondary: DailyEntry[],
-  markSecondaryCarried: boolean,
-  blockedSecondaryProviderDays: ReadonlySet<string> = new Set(),
-): DailyEntry[] {
-  const byDate = new Map<string, DailyEntry>()
-  for (const day of primary) byDate.set(day.date, structuredClone(day))
-  for (const day of secondary) {
-    const existing = byDate.get(day.date)
-    if (!existing) {
-      const copy = structuredClone(day)
-      if (markSecondaryCarried) copy.carried = true
-      byDate.set(day.date, copy)
-      continue
-    }
-    if (isOpaqueDay(existing)) continue
-    for (const [provider, slice] of Object.entries(day.providers)) {
-      if (blockedSecondaryProviderDays.has(`${provider}\u0000${day.date}`)) continue
-      // Sessions-only slices (a session whose calls all landed on another
-      // day) still carry a real session count — worth preserving.
-      if (!hasSliceData(slice) && !(slice.sessions ?? 0)) continue
-      const existingSlice = Object.hasOwn(existing.providers, provider) ? existing.providers[provider] : undefined
-      if (existingSlice && hasSliceData(existingSlice)) continue
-      addSliceIntoDay(existing, provider, slice)
-      if (markSecondaryCarried) existing.carried = true
-    }
-  }
-  return [...byDate.values()].sort((a, b) => a.date.localeCompare(b.date))
 }
 
 export function getDaysInRange(cache: DailyCache, start: string, end: string): DailyEntry[] {

--- a/src/daily-cache-merge.ts
+++ b/src/daily-cache-merge.ts
@@ -1,0 +1,121 @@
+import { emptyModelStats, mergeModelStats } from './daily-cache-model-detail.js'
+import type { DailyEntry, ProviderDaySlice } from './daily-cache-types.js'
+
+function num(v: unknown): number {
+  return typeof v === 'number' && Number.isFinite(v) ? v : 0
+}
+
+function hasSliceData(slice: ProviderDaySlice): boolean {
+  return slice.cost > 0 || slice.calls > 0 || (slice.savingsUSD ?? 0) > 0
+}
+
+/** A legacy day whose totals cannot be attributed to individual providers. */
+function isOpaqueDay(day: DailyEntry): boolean {
+  return (day.cost > 0 || day.calls > 0) && Object.keys(day.providers).length === 0
+}
+
+/// Fold one provider's day slice into a day: the providers map, the day-level
+/// totals, and (when the slice carries them) the model and category breakdowns.
+function addSliceIntoDay(day: DailyEntry, provider: string, slice: ProviderDaySlice): void {
+  // Reads keyed by names from foreign caches use hasOwn throughout: a plain
+  // lookup of "__proto__" returns the prototype object, and accumulating into
+  // it pollutes every object in the process.
+  const placeholder = Object.hasOwn(day.providers, provider) ? day.providers[provider] : undefined
+  const placeholderSessions = placeholder?.sessions ?? 0
+  const merged = structuredClone(slice)
+  if (placeholderSessions > (merged.sessions ?? 0)) merged.sessions = placeholderSessions
+  setOwn(day.providers, provider, merged)
+  day.cost += slice.cost
+  day.calls += slice.calls
+  day.savingsUSD += slice.savingsUSD ?? 0
+  day.sessions += Math.max(0, (slice.sessions ?? 0) - placeholderSessions)
+  day.inputTokens += slice.inputTokens ?? 0
+  day.outputTokens += slice.outputTokens ?? 0
+  if (slice.reasoningTokens !== undefined) day.reasoningTokens = (day.reasoningTokens ?? 0) + slice.reasoningTokens
+  day.cacheReadTokens += slice.cacheReadTokens ?? 0
+  day.cacheWriteTokens += slice.cacheWriteTokens ?? 0
+  day.editTurns += slice.editTurns ?? 0
+  day.oneShotTurns += slice.oneShotTurns ?? 0
+  for (const [name, m] of Object.entries(slice.models ?? {})) {
+    const acc = Object.hasOwn(day.models, name) ? day.models[name]! : emptyModelStats()
+    mergeModelStats(acc, m)
+    setOwn(day.models, name, acc)
+  }
+  for (const [cat, c] of Object.entries(slice.categories ?? {})) {
+    const acc = Object.hasOwn(day.categories, cat) ? day.categories[cat]! : { turns: 0, cost: 0, savingsUSD: 0, editTurns: 0, oneShotTurns: 0 }
+    acc.turns += c.turns
+    acc.cost += c.cost
+    acc.savingsUSD += c.savingsUSD ?? 0
+    acc.editTurns += c.editTurns
+    acc.oneShotTurns += c.oneShotTurns
+    setOwn(day.categories, cat, acc)
+  }
+  const placeholderProjects = placeholder?.projects ?? {}
+  for (const [name, p] of Object.entries(slice.projects ?? {})) {
+    if (!p || typeof p !== 'object' || Array.isArray(p)) continue
+    const dayProjects = (day.projects ??= {})
+    const acc = Object.hasOwn(dayProjects, name) ? dayProjects[name]! : { cost: 0, calls: 0, savingsUSD: 0, sessions: 0 }
+    acc.cost += num(p.cost)
+    acc.calls += num(p.calls)
+    acc.savingsUSD += num(p.savingsUSD)
+    if (!acc.path && typeof p.path === 'string') acc.path = p.path
+    const placeholderProjectSessions = Object.hasOwn(placeholderProjects, name) ? num(placeholderProjects[name]?.sessions) : 0
+    acc.sessions += Math.max(0, num(p.sessions) - placeholderProjectSessions)
+    setOwn(dayProjects, name, acc)
+  }
+  // Placeholder-only projects survive on the merged slice rather than being
+  // dropped by the clone above.
+  const mergedProjects = merged.projects
+  if (mergedProjects) {
+    for (const [name, p] of Object.entries(placeholderProjects)) {
+      if (!p || typeof p !== 'object') continue
+      if (Object.hasOwn(mergedProjects, name)) {
+        if (num(p.sessions) > num(mergedProjects[name]!.sessions)) mergedProjects[name]!.sessions = num(p.sessions)
+      } else {
+        setOwn(mergedProjects, name, { cost: 0, calls: 0, savingsUSD: 0, sessions: num(p.sessions) })
+      }
+    }
+  } else if (placeholder?.projects) {
+    merged.projects = structuredClone(placeholder.projects)
+  }
+}
+
+/// Assign via defineProperty so filesystem-derived keys like "__proto__" become
+/// ordinary own properties instead of mutating the prototype link.
+export function setOwn<T>(target: Record<string, T>, key: string, value: T): void {
+  Object.defineProperty(target, key, { value, enumerable: true, writable: true, configurable: true })
+}
+
+/// Merge two day lists per (date, provider): `primary` wins wherever both have
+/// data; `secondary` only fills dates primary lacks entirely and provider slices
+/// primary lacks on shared dates. With markSecondaryCarried, every day that
+/// received a secondary contribution is flagged `carried`.
+export function mergeDayEntries(
+  primary: DailyEntry[],
+  secondary: DailyEntry[],
+  markSecondaryCarried: boolean,
+  blockedSecondaryProviderDays: ReadonlySet<string> = new Set(),
+): DailyEntry[] {
+  const byDate = new Map<string, DailyEntry>()
+  for (const day of primary) byDate.set(day.date, structuredClone(day))
+  for (const day of secondary) {
+    const existing = byDate.get(day.date)
+    if (!existing) {
+      const copy = structuredClone(day)
+      if (markSecondaryCarried) copy.carried = true
+      byDate.set(day.date, copy)
+      continue
+    }
+    if (isOpaqueDay(existing)) continue
+    for (const [provider, slice] of Object.entries(day.providers)) {
+      if (blockedSecondaryProviderDays.has(`${provider}\u0000${day.date}`)) continue
+      // Sessions-only slices still carry a real session count and are worth preserving.
+      if (!hasSliceData(slice) && !(slice.sessions ?? 0)) continue
+      const existingSlice = Object.hasOwn(existing.providers, provider) ? existing.providers[provider] : undefined
+      if (existingSlice && hasSliceData(existingSlice)) continue
+      addSliceIntoDay(existing, provider, slice)
+      if (markSecondaryCarried) existing.carried = true
+    }
+  }
+  return [...byDate.values()].sort((a, b) => a.date.localeCompare(b.date))
+}

--- a/src/daily-cache-reconciliation.ts
+++ b/src/daily-cache-reconciliation.ts
@@ -1,0 +1,21 @@
+import type { DailyEntry } from './daily-cache-types.js'
+
+/** Empty primary row used to tombstone one provider slice during reconciliation. */
+export function emptyDailyEntry(date: string): DailyEntry {
+  return {
+    date,
+    cost: 0,
+    savingsUSD: 0,
+    calls: 0,
+    sessions: 0,
+    inputTokens: 0,
+    outputTokens: 0,
+    cacheReadTokens: 0,
+    cacheWriteTokens: 0,
+    editTurns: 0,
+    oneShotTurns: 0,
+    models: {},
+    categories: {},
+    providers: {},
+  }
+}

--- a/src/daily-cache.ts
+++ b/src/daily-cache.ts
@@ -113,6 +113,76 @@ function applyRetention(days: core.DailyEntry[], newestDate: string): core.Daily
   return days.filter(day => day.date >= cutoff)
 }
 
+function dateFromKey(key: string): Date | null {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(key)
+  if (!match) return null
+  const date = new Date(Number(match[1]), Number(match[2]) - 1, Number(match[3]))
+  return Number.isNaN(date.getTime()) ? null : date
+}
+
+function hasDailyData(day: core.DailyEntry): boolean {
+  return day.calls > 0 || day.cost !== 0 || day.savingsUSD !== 0 || day.sessions > 0
+    || day.inputTokens > 0 || day.outputTokens > 0 || day.cacheReadTokens > 0 || day.cacheWriteTokens > 0
+    || Object.keys(day.providers).length > 0
+}
+
+async function reconcileProviderDays(
+  cache: DailyCache,
+  parseSessions: (range: DateRange) => Promise<ProjectSummary[]>,
+  aggregateDays: (projects: ProjectSummary[]) => core.DailyEntry[],
+  sessionComplete: () => boolean,
+  requested: Readonly<Record<string, readonly string[]>> | undefined,
+  yesterdayEnd: Date,
+  yesterdayStr: string,
+): Promise<DailyCache> {
+  if (!requested) return cache
+
+  const requestedDays = new Map<string, Set<string>>()
+  for (const [provider, days] of Object.entries(requested)) {
+    for (const day of days) {
+      const parsed = dateFromKey(day)
+      if (!parsed || parsed.getTime() > yesterdayEnd.getTime()) continue
+      const existing = requestedDays.get(provider) ?? new Set<string>()
+      existing.add(day)
+      requestedDays.set(provider, existing)
+    }
+  }
+  if (requestedDays.size === 0) return cache
+
+  const affectedDays = [...new Set([...requestedDays.values()].flatMap(days => [...days]))].sort()
+  const first = dateFromKey(affectedDays[0]!)
+  const last = dateFromKey(affectedDays[affectedDays.length - 1]!)
+  if (!first || !last) return cache
+
+  const fresh = aggregateDays(await parseSessions({
+    start: first,
+    end: new Date(last.getTime() + 24 * 60 * 60 * 1000 - 1),
+  }))
+  if (!sessionComplete()) return cache
+
+  // An empty primary day is intentional: it prevents NEVER-LOSE carry-forward
+  // from resurrecting a deleted journal slice when the new snapshot has no
+  // calls on that date.
+  const primaryDates = new Set(fresh.map(day => day.date))
+  const primary = [...fresh]
+  for (const day of affectedDays) {
+    if (!primaryDates.has(day)) primary.push(core.emptyDailyEntry(day))
+  }
+
+  const blocked = new Set<string>()
+  for (const [provider, days] of requestedDays) {
+    for (const day of days) blocked.add(`${provider}\u0000${day}`)
+  }
+  const merged = core.mergeDayEntries(primary, cache.days, true, blocked)
+    .filter(hasDailyData)
+
+  return withTrust({
+    ...cache,
+    lastComputedDate: cache.lastComputedDate ?? yesterdayStr,
+    days: applyRetention(merged, yesterdayStr),
+  }, cache.watermarkTrusted === true)
+}
+
 async function parseIsAuthoritative(
   sessionComplete: () => boolean,
   allowDegradedSourceReconciliation = false,
@@ -153,6 +223,16 @@ export async function ensureCacheHydrated(
     const durableHistoryAuthority = options.durableHistoryAuthority
     const historyAuthorityChanged = durableHistoryAuthority !== undefined
       && cache.durableHistoryAuthority !== durableHistoryAuthority
+
+    cache = await reconcileProviderDays(
+      cache,
+      parseSessions,
+      aggregateDays,
+      sessionComplete,
+      options.reconcileProviderDays,
+      yesterdayEnd,
+      yesterdayStr,
+    )
 
     // Serialize simultaneous invalidations. First re-derive the accounting
     // authority while retaining the old timezone, then persist that intermediate

--- a/src/parser-source-reconciliation.ts
+++ b/src/parser-source-reconciliation.ts
@@ -1,0 +1,22 @@
+import type { ProviderSection, SessionCache } from './session-cache.js'
+import { recordCopilotChatJournalSourceEviction } from './copilot-chat-journal-reconciliation.js'
+import { COPILOT_CHAT_JOURNAL_PROVIDER } from './provider-parse-authorities.js'
+
+export function shouldReconcileMissingProviderSources(providerName: string, sourceCount: number): boolean {
+  return sourceCount > 0 || providerName === COPILOT_CHAT_JOURNAL_PROVIDER
+}
+
+/** Remove source files that disappeared from discovery and notify source-specific authorities. */
+export function reconcileMissingProviderSources(
+  providerName: string,
+  section: ProviderSection,
+  discoveredPaths: ReadonlySet<string>,
+  diskCache: SessionCache,
+): void {
+  for (const cachedPath of Object.keys(section.files)) {
+    if (discoveredPaths.has(cachedPath)) continue
+    recordCopilotChatJournalSourceEviction(providerName, cachedPath, section.files[cachedPath]!.turns)
+    delete section.files[cachedPath]
+    ;(diskCache as SessionCache & { _dirty?: boolean })._dirty = true
+  }
+}

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -56,11 +56,8 @@ import { isSnapshotReadMode } from './read-lifecycle.js'
 import { getClaudeNativeIdentity, reconcileClaudeNativeCalls } from './claude-native-reconciliation.js'
 import { callIsInDateRange, sliceCachedTurnToDateRange, sliceClassifiedTurnToDateRange, sliceParsedTurnToDateRange } from './date-range-projection.js'
 import { claudeSlugFallbackPath, normalizeProjectPathKey, projectNameFromPath, unsanitizePath } from './project-path-utils.js'
-import {
-  flushCopilotChatJournalInvalidations,
-  recordCopilotChatJournalInvalidation,
-} from './copilot-chat-journal-reconciliation.js'
-import { COPILOT_CHAT_JOURNAL_PROVIDER } from './provider-parse-authorities.js'
+import { flushCopilotChatJournalInvalidations, queueCopilotChatJournalSource, recordCopilotChatJournalSourceChange, recordCopilotChatJournalSourceFailure } from './copilot-chat-journal-reconciliation.js'
+import { reconcileMissingProviderSources, shouldReconcileMissingProviderSources } from './parser-source-reconciliation.js'
 
 
 
@@ -2968,13 +2965,8 @@ async function parseProviderSources(
   const allDiscoveredFiles = new Set<string>()
   const servedSources = [...sources]
 
-  type SourceInfo = {
-    source: SessionSource
-    fp: NonNullable<Awaited<ReturnType<typeof fingerprintFile>>>
-    previousTurns: CachedTurn[]
-  }
   const unchangedSources: Array<{ source: SessionSource; cached: CachedFile }> = []
-  const changedSources: SourceInfo[] = []
+  const changedSources: Array<{ source: SessionSource; fp: NonNullable<Awaited<ReturnType<typeof fingerprintFile>>> }> = []
 
   for (const source of sources) {
     allDiscoveredFiles.add(source.path)
@@ -2984,7 +2976,7 @@ async function parseProviderSources(
     // fingerprint or incrementally cache, so re-fetch every run with a synthetic
     // fingerprint (mtime=now so the date-range filter below never excludes it).
     if (provider.network && !readOnly) {
-      changedSources.push({ source, fp: { dev: 0, ino: 0, mtimeMs: Date.now(), sizeBytes: 0 }, previousTurns: [] })
+      changedSources.push({ source, fp: { dev: 0, ino: 0, mtimeMs: Date.now(), sizeBytes: 0 } })
       continue
     }
 
@@ -2999,7 +2991,7 @@ async function parseProviderSources(
     if (cached && (readOnly || (action.action === 'unchanged' && (cached.failed || !cachedFileNeedsProviderReparse(providerName, source.path, cached))))) {
       unchangedSources.push({ source, cached })
     } else if (!readOnly) {
-      changedSources.push({ source, fp, previousTurns: cached?.turns ?? [] })
+      changedSources.push(queueCopilotChatJournalSource(providerName, source, fp, cached?.turns ?? []))
     }
   }
 
@@ -3035,7 +3027,7 @@ async function parseProviderSources(
   // being wiped on every iteration.
   const clearedPaths = new Set<string>()
   try {
-    for (const { source, fp, previousTurns } of changedSources) {
+    for (const { source, fp } of changedSources) {
       if (dateRange) {
         if (fp.mtimeMs < dateRange.start.getTime()) continue
       }
@@ -3087,12 +3079,7 @@ async function parseProviderSources(
             section.files[source.path] = { fingerprint: fp, mcpInventory: [], turns }
           }
         }
-        if (providerName === COPILOT_CHAT_JOURNAL_PROVIDER) {
-          recordCopilotChatJournalInvalidation(source.path, [
-            ...previousTurns.map(turn => turnDayKey(turn.timestamp)),
-            ...turns.map(turn => turnDayKey(turn.timestamp)),
-          ])
-        }
+        recordCopilotChatJournalSourceChange(providerName, source.path, turns)
         didParse = true
         ;(diskCache as { _dirty?: boolean })._dirty = true
       } catch (err) {
@@ -3107,9 +3094,7 @@ async function parseProviderSources(
         // on every refresh; it re-parses only if it changes. Empty turns => no
         // usage contributed.
         section.files[source.path] = { fingerprint: fp, mcpInventory: [], turns: [], failed: true }
-        if (providerName === COPILOT_CHAT_JOURNAL_PROVIDER) {
-          recordCopilotChatJournalInvalidation(source.path, previousTurns.map(turn => turnDayKey(turn.timestamp)))
-        }
+        recordCopilotChatJournalSourceFailure(providerName, source.path)
         ;(diskCache as { _dirty?: boolean })._dirty = true
         warnProviderParseFailure(providerName, source.path, err)
         continue
@@ -3130,16 +3115,8 @@ async function parseProviderSources(
     ;(diskCache as { _dirty?: boolean })._dirty = true
   }
 
-  if (!readOnly && !provider.durableSources && (sources.length > 0 || providerName === COPILOT_CHAT_JOURNAL_PROVIDER)) {
-    for (const cachedPath of Object.keys(section.files)) {
-      if (!allDiscoveredFiles.has(cachedPath)) {
-        if (providerName === COPILOT_CHAT_JOURNAL_PROVIDER) {
-          recordCopilotChatJournalInvalidation(cachedPath, section.files[cachedPath]!.turns.map(turn => turnDayKey(turn.timestamp)))
-        }
-        delete section.files[cachedPath]
-        ;(diskCache as { _dirty?: boolean })._dirty = true
-      }
-    }
+  if (!readOnly && !provider.durableSources && shouldReconcileMissingProviderSources(providerName, sources.length)) {
+    reconcileMissingProviderSources(providerName, section, allDiscoveredFiles, diskCache)
   }
 
   // Query-time: derive SessionSummary from all cached turns.
@@ -3272,12 +3249,6 @@ async function parseProviderSources(
   }
 
   return projects
-}
-
-function turnDayKey(timestamp: string): string {
-  const date = new Date(timestamp)
-  if (Number.isNaN(date.getTime())) return ''
-  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`
 }
 
 const CACHE_TTL_MS = 180_000

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -56,6 +56,11 @@ import { isSnapshotReadMode } from './read-lifecycle.js'
 import { getClaudeNativeIdentity, reconcileClaudeNativeCalls } from './claude-native-reconciliation.js'
 import { callIsInDateRange, sliceCachedTurnToDateRange, sliceClassifiedTurnToDateRange, sliceParsedTurnToDateRange } from './date-range-projection.js'
 import { claudeSlugFallbackPath, normalizeProjectPathKey, projectNameFromPath, unsanitizePath } from './project-path-utils.js'
+import {
+  flushCopilotChatJournalInvalidations,
+  recordCopilotChatJournalInvalidation,
+} from './copilot-chat-journal-reconciliation.js'
+import { COPILOT_CHAT_JOURNAL_PROVIDER } from './provider-parse-authorities.js'
 
 
 
@@ -2963,7 +2968,11 @@ async function parseProviderSources(
   const allDiscoveredFiles = new Set<string>()
   const servedSources = [...sources]
 
-  type SourceInfo = { source: SessionSource; fp: NonNullable<Awaited<ReturnType<typeof fingerprintFile>>> }
+  type SourceInfo = {
+    source: SessionSource
+    fp: NonNullable<Awaited<ReturnType<typeof fingerprintFile>>>
+    previousTurns: CachedTurn[]
+  }
   const unchangedSources: Array<{ source: SessionSource; cached: CachedFile }> = []
   const changedSources: SourceInfo[] = []
 
@@ -2975,7 +2984,7 @@ async function parseProviderSources(
     // fingerprint or incrementally cache, so re-fetch every run with a synthetic
     // fingerprint (mtime=now so the date-range filter below never excludes it).
     if (provider.network && !readOnly) {
-      changedSources.push({ source, fp: { dev: 0, ino: 0, mtimeMs: Date.now(), sizeBytes: 0 } })
+      changedSources.push({ source, fp: { dev: 0, ino: 0, mtimeMs: Date.now(), sizeBytes: 0 }, previousTurns: [] })
       continue
     }
 
@@ -2990,7 +2999,7 @@ async function parseProviderSources(
     if (cached && (readOnly || (action.action === 'unchanged' && (cached.failed || !cachedFileNeedsProviderReparse(providerName, source.path, cached))))) {
       unchangedSources.push({ source, cached })
     } else if (!readOnly) {
-      changedSources.push({ source, fp })
+      changedSources.push({ source, fp, previousTurns: cached?.turns ?? [] })
     }
   }
 
@@ -3026,7 +3035,7 @@ async function parseProviderSources(
   // being wiped on every iteration.
   const clearedPaths = new Set<string>()
   try {
-    for (const { source, fp } of changedSources) {
+    for (const { source, fp, previousTurns } of changedSources) {
       if (dateRange) {
         if (fp.mtimeMs < dateRange.start.getTime()) continue
       }
@@ -3078,6 +3087,12 @@ async function parseProviderSources(
             section.files[source.path] = { fingerprint: fp, mcpInventory: [], turns }
           }
         }
+        if (providerName === COPILOT_CHAT_JOURNAL_PROVIDER) {
+          recordCopilotChatJournalInvalidation(source.path, [
+            ...previousTurns.map(turn => turnDayKey(turn.timestamp)),
+            ...turns.map(turn => turnDayKey(turn.timestamp)),
+          ])
+        }
         didParse = true
         ;(diskCache as { _dirty?: boolean })._dirty = true
       } catch (err) {
@@ -3092,6 +3107,9 @@ async function parseProviderSources(
         // on every refresh; it re-parses only if it changes. Empty turns => no
         // usage contributed.
         section.files[source.path] = { fingerprint: fp, mcpInventory: [], turns: [], failed: true }
+        if (providerName === COPILOT_CHAT_JOURNAL_PROVIDER) {
+          recordCopilotChatJournalInvalidation(source.path, previousTurns.map(turn => turnDayKey(turn.timestamp)))
+        }
         ;(diskCache as { _dirty?: boolean })._dirty = true
         warnProviderParseFailure(providerName, source.path, err)
         continue
@@ -3112,9 +3130,12 @@ async function parseProviderSources(
     ;(diskCache as { _dirty?: boolean })._dirty = true
   }
 
-  if (!readOnly && sources.length > 0 && !provider.durableSources) {
+  if (!readOnly && !provider.durableSources && (sources.length > 0 || providerName === COPILOT_CHAT_JOURNAL_PROVIDER)) {
     for (const cachedPath of Object.keys(section.files)) {
       if (!allDiscoveredFiles.has(cachedPath)) {
+        if (providerName === COPILOT_CHAT_JOURNAL_PROVIDER) {
+          recordCopilotChatJournalInvalidation(cachedPath, section.files[cachedPath]!.turns.map(turn => turnDayKey(turn.timestamp)))
+        }
         delete section.files[cachedPath]
         ;(diskCache as { _dirty?: boolean })._dirty = true
       }
@@ -3251,6 +3272,12 @@ async function parseProviderSources(
   }
 
   return projects
+}
+
+function turnDayKey(timestamp: string): string {
+  const date = new Date(timestamp)
+  if (Number.isNaN(date.getTime())) return ''
+  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`
 }
 
 const CACHE_TTL_MS = 180_000
@@ -3833,6 +3860,8 @@ async function runParse(
     const projects = await parseProviderSources(providerName, [], seenKeys, diskCache, dateRange, readOnly)
     otherProjects.push(...projects)
   }
+
+  if (!readOnly) await flushCopilotChatJournalInvalidations()
 
   // Every published v8 call carries an explicit valuation basis. This also
   // settles carried v7 PR/durable orphans that can no longer be re-parsed.

--- a/src/providers/copilot.ts
+++ b/src/providers/copilot.ts
@@ -1809,14 +1809,6 @@ interface ChatSessionSource extends SessionSource {
   sourceType: 'chatsession'
 }
 
-export type CopilotChatJournalFingerprint = {
-  path: string
-  dev: number
-  ino: number
-  mtimeMs: number
-  sizeBytes: number
-}
-
 interface JetBrainsSessionSource extends SessionSource {
   sourceType: 'jetbrains'
   // Fallback conversation id for turns whose own GUID can't be recovered (the
@@ -2405,26 +2397,3 @@ export function createCopilotProvider(
 
 // Default export for the provider registry
 export const copilot = createCopilotProvider()
-
-/**
- * Cheap source-authority probe used by daily hydration. It reads only source
- * identity/stat metadata; journal content is parsed by the normal provider
- * lifecycle and is never returned or logged here.
- */
-export async function getCopilotChatJournalFingerprints(): Promise<CopilotChatJournalFingerprint[]> {
-  const sources = await copilot.discoverSessions().catch(() => [])
-  const fingerprints: CopilotChatJournalFingerprint[] = []
-  for (const source of sources) {
-    if (!isChatSessionSource(source)) continue
-    const current = await stat(source.path).catch(() => null)
-    if (!current?.isFile()) continue
-    fingerprints.push({
-      path: source.path,
-      dev: Number(current.dev),
-      ino: Number(current.ino),
-      mtimeMs: current.mtimeMs,
-      sizeBytes: current.size,
-    })
-  }
-  return fingerprints.sort((left, right) => left.path.localeCompare(right.path))
-}

--- a/src/providers/copilot.ts
+++ b/src/providers/copilot.ts
@@ -1809,6 +1809,14 @@ interface ChatSessionSource extends SessionSource {
   sourceType: 'chatsession'
 }
 
+export type CopilotChatJournalFingerprint = {
+  path: string
+  dev: number
+  ino: number
+  mtimeMs: number
+  sizeBytes: number
+}
+
 interface JetBrainsSessionSource extends SessionSource {
   sourceType: 'jetbrains'
   // Fallback conversation id for turns whose own GUID can't be recovered (the
@@ -2397,3 +2405,26 @@ export function createCopilotProvider(
 
 // Default export for the provider registry
 export const copilot = createCopilotProvider()
+
+/**
+ * Cheap source-authority probe used by daily hydration. It reads only source
+ * identity/stat metadata; journal content is parsed by the normal provider
+ * lifecycle and is never returned or logged here.
+ */
+export async function getCopilotChatJournalFingerprints(): Promise<CopilotChatJournalFingerprint[]> {
+  const sources = await copilot.discoverSessions().catch(() => [])
+  const fingerprints: CopilotChatJournalFingerprint[] = []
+  for (const source of sources) {
+    if (!isChatSessionSource(source)) continue
+    const current = await stat(source.path).catch(() => null)
+    if (!current?.isFile()) continue
+    fingerprints.push({
+      path: source.path,
+      dev: Number(current.dev),
+      ino: Number(current.ino),
+      mtimeMs: current.mtimeMs,
+      sizeBytes: current.size,
+    })
+  }
+  return fingerprints.sort((left, right) => left.path.localeCompare(right.path))
+}

--- a/src/usage-aggregator.ts
+++ b/src/usage-aggregator.ts
@@ -1,10 +1,12 @@
 import { homedir } from 'node:os'
+import { resolve } from 'node:path'
 import { CATEGORY_LABELS, type ProjectSummary, type TaskCategory, type DateRange } from './types.js'
 import { type PeriodData, type ProviderCost, type BreakdownArrays, type MenubarPayload, type ClaudeConfigSelector, buildMenubarPayload } from './menubar-json.js'
-import { parseAllSessions, filterProjectsByName, filterProjectsByDays, filterProjectsByClaudeConfigSource, isSessionHydrationComplete } from './parser.js'
+import { parseAllSessions, clearSessionCache, filterProjectsByName, filterProjectsByDays, filterProjectsByClaudeConfigSource, isSessionHydrationComplete } from './parser.js'
 import { findUnpricedModels, getShortModelName, isExpectedFreeModel } from './models.js'
 import { getAllProviders, safeDiscoverSessions } from './providers/index.js'
 import { claude, getClaudeConfigDirs, getDesktopSessionsDirs } from './providers/claude.js'
+import { getCopilotChatJournalFingerprints } from './providers/copilot.js'
 import { stat } from 'node:fs/promises'
 import { aggregateProjectsIntoDays, buildPeriodDataFromDays } from './day-aggregator.js'
 import {
@@ -24,6 +26,14 @@ import { getDailyCacheConfigHash } from './daily-cache-config.js'
 export { getDailyCacheConfigHash } from './daily-cache-config.js'
 import { buildGranularHistory } from './granular-history.js'
 import { isSnapshotReadMode, withReadFreshness } from './read-lifecycle.js'
+import { COPILOT_CHAT_JOURNAL_PROVIDER } from './provider-parse-authorities.js'
+import { loadCache as loadSessionCache } from './session-cache.js'
+import {
+  beginCopilotChatJournalIdentityBoundary,
+  clearCopilotChatJournalInvalidations,
+  endCopilotChatJournalIdentityBoundary,
+  readCopilotChatJournalInvalidatedDays,
+} from './copilot-chat-journal-reconciliation.js'
 // Row caps for the by-PR / by-branch payload aggregations, ranked by cost.
 const TOP_BRANCHES = 15
 export function buildPeriodData(label: string, projects: ProjectSummary[]): PeriodData {
@@ -87,16 +97,94 @@ export function buildPeriodData(label: string, projects: ProjectSummary[]): Peri
   }
 }
 
+async function copilotChatJournalChanged(): Promise<boolean> {
+  const current = await getCopilotChatJournalFingerprints()
+  const sessionCache = await loadSessionCache()
+  const section = sessionCache.providers[COPILOT_CHAT_JOURNAL_PROVIDER]
+  const cached = section?.files ?? {}
+  if (current.length !== Object.keys(cached).length) return current.length > 0 || Object.keys(cached).length > 0
+
+  const byPath = new Map(current.map(fingerprint => [fingerprint.path, fingerprint]))
+  for (const [path, file] of Object.entries(cached)) {
+    const fingerprint = byPath.get(path)
+    if (!fingerprint) return true
+    if (
+      file.fingerprint.dev !== fingerprint.dev
+      || file.fingerprint.ino !== fingerprint.ino
+      || file.fingerprint.mtimeMs !== fingerprint.mtimeMs
+      || file.fingerprint.sizeBytes !== fingerprint.sizeBytes
+    ) return true
+  }
+  return false
+}
+
+async function copilotChatJournalRootChanged(): Promise<boolean> {
+  const configuredRoot = process.env['METRORA_COPILOT_WS_STORAGE_DIR']
+  if (!configuredRoot) return false
+  const sessionCache = await loadSessionCache()
+  const files = sessionCache.providers[COPILOT_CHAT_JOURNAL_PROVIDER]?.files ?? {}
+  if (Object.keys(files).length === 0) return false
+  const canonical = (value: string): string => {
+    const slashes = value.replaceAll('\\', '/')
+    const compared = process.platform === 'win32' ? slashes.toLowerCase() : slashes
+    return compared.replace(/\/+$/, '')
+  }
+  const normalizedRoot = canonical(resolve(configuredRoot))
+  const normalizedPrefix = `${normalizedRoot}/`
+  return Object.keys(files).some(path => {
+    const normalizedPath = canonical(resolve(path))
+    return normalizedPath !== normalizedRoot && !normalizedPath.startsWith(normalizedPrefix)
+  })
+}
+
+async function prepareCopilotChatJournalReconciliation(): Promise<string[]> {
+  if (await copilotChatJournalRootChanged()) {
+    // A root/profile/account switch is not evidence that the old and new
+    // journals are the same identity. Reparse the new root for current output,
+    // but leave the prior daily ledger untouched until an identity contract is
+    // available. This is deliberately fail-closed, not an implicit union/drop.
+    await clearCopilotChatJournalInvalidations()
+    clearSessionCache()
+    beginCopilotChatJournalIdentityBoundary()
+    try {
+      await parseAllSessions(undefined, 'all')
+    } finally {
+      endCopilotChatJournalIdentityBoundary()
+    }
+    await clearCopilotChatJournalInvalidations()
+    return []
+  }
+  let days = await readCopilotChatJournalInvalidatedDays()
+  if (await copilotChatJournalChanged()) {
+    // The parser's normal refresh path records old/new day keys and publishes
+    // them to the bounded invalidation manifest. Clear only the in-process
+    // result memo so a changed journal cannot be served for 180 seconds.
+    clearSessionCache()
+    await parseAllSessions(undefined, 'all')
+    days = await readCopilotChatJournalInvalidatedDays()
+  }
+  return days
+}
+
 async function hydrateCache(): Promise<DailyCache> {
   try {
-    return await ensureCacheHydrated(
+    const copilotJournalDays = await prepareCopilotChatJournalReconciliation()
+    const cache = await ensureCacheHydrated(
       (range) => parseAllSessions(range, 'all'),
       aggregateProjectsIntoDays,
       getDailyCacheConfigHash(),
       // Never finalize daily history from a partial hydration; that previously froze empty older days.
       isSessionHydrationComplete,
-      undefined, { durableHistoryAuthority: DURABLE_HISTORY_AUTHORITY },
+      undefined,
+      {
+        durableHistoryAuthority: DURABLE_HISTORY_AUTHORITY,
+        ...(copilotJournalDays.length > 0 ? { reconcileProviderDays: { copilot: copilotJournalDays } } : {}),
+      },
     )
+    if (copilotJournalDays.length > 0 && cache.complete === true) {
+      await clearCopilotChatJournalInvalidations()
+    }
+    return cache
   } catch (err) {
     // Previously swallowed silently, which turned any backfill failure into an
     // empty trend/history with no signal (issue #441). Per-file parse errors no

--- a/src/usage-aggregator.ts
+++ b/src/usage-aggregator.ts
@@ -1,12 +1,10 @@
 import { homedir } from 'node:os'
-import { resolve } from 'node:path'
 import { CATEGORY_LABELS, type ProjectSummary, type TaskCategory, type DateRange } from './types.js'
 import { type PeriodData, type ProviderCost, type BreakdownArrays, type MenubarPayload, type ClaudeConfigSelector, buildMenubarPayload } from './menubar-json.js'
-import { parseAllSessions, clearSessionCache, filterProjectsByName, filterProjectsByDays, filterProjectsByClaudeConfigSource, isSessionHydrationComplete } from './parser.js'
+import { parseAllSessions, filterProjectsByName, filterProjectsByDays, filterProjectsByClaudeConfigSource, isSessionHydrationComplete } from './parser.js'
 import { findUnpricedModels, getShortModelName, isExpectedFreeModel } from './models.js'
 import { getAllProviders, safeDiscoverSessions } from './providers/index.js'
 import { claude, getClaudeConfigDirs, getDesktopSessionsDirs } from './providers/claude.js'
-import { getCopilotChatJournalFingerprints } from './providers/copilot.js'
 import { stat } from 'node:fs/promises'
 import { aggregateProjectsIntoDays, buildPeriodDataFromDays } from './day-aggregator.js'
 import {
@@ -21,19 +19,12 @@ import { aggregateModels } from './models-report.js'
 import { scanUserCorrections, medianTimeToFirstEditMs, aggregateFileChurn, computePricingCoverage } from './workflow-insights.js'
 import { buildPrAttribution, aggregateByBranch } from './sessions-report.js'
 import { scanAndDetect } from './optimize.js'
-import { getDaysInRange, ensureCacheHydrated, loadDailyCache, emptyCache, BACKFILL_DAYS, DURABLE_HISTORY_AUTHORITY, toDateString, type DailyCache, type DailyEntry } from './daily-cache.js'
+import { getDaysInRange, loadDailyCache, emptyCache, BACKFILL_DAYS, toDateString, type DailyCache, type DailyEntry } from './daily-cache.js'
 import { getDailyCacheConfigHash } from './daily-cache-config.js'
 export { getDailyCacheConfigHash } from './daily-cache-config.js'
 import { buildGranularHistory } from './granular-history.js'
 import { isSnapshotReadMode, withReadFreshness } from './read-lifecycle.js'
-import { COPILOT_CHAT_JOURNAL_PROVIDER } from './provider-parse-authorities.js'
-import { loadCache as loadSessionCache } from './session-cache.js'
-import {
-  beginCopilotChatJournalIdentityBoundary,
-  clearCopilotChatJournalInvalidations,
-  endCopilotChatJournalIdentityBoundary,
-  readCopilotChatJournalInvalidatedDays,
-} from './copilot-chat-journal-reconciliation.js'
+import { hydrateCopilotDailyCache } from './copilot-chat-journal-hydration.js'
 // Row caps for the by-PR / by-branch payload aggregations, ranked by cost.
 const TOP_BRANCHES = 15
 export function buildPeriodData(label: string, projects: ProjectSummary[]): PeriodData {
@@ -97,105 +88,13 @@ export function buildPeriodData(label: string, projects: ProjectSummary[]): Peri
   }
 }
 
-async function copilotChatJournalChanged(): Promise<boolean> {
-  const current = await getCopilotChatJournalFingerprints()
-  const sessionCache = await loadSessionCache()
-  const section = sessionCache.providers[COPILOT_CHAT_JOURNAL_PROVIDER]
-  const cached = section?.files ?? {}
-  if (current.length !== Object.keys(cached).length) return current.length > 0 || Object.keys(cached).length > 0
-
-  const byPath = new Map(current.map(fingerprint => [fingerprint.path, fingerprint]))
-  for (const [path, file] of Object.entries(cached)) {
-    const fingerprint = byPath.get(path)
-    if (!fingerprint) return true
-    if (
-      file.fingerprint.dev !== fingerprint.dev
-      || file.fingerprint.ino !== fingerprint.ino
-      || file.fingerprint.mtimeMs !== fingerprint.mtimeMs
-      || file.fingerprint.sizeBytes !== fingerprint.sizeBytes
-    ) return true
-  }
-  return false
-}
-
-async function copilotChatJournalRootChanged(): Promise<boolean> {
-  const configuredRoot = process.env['METRORA_COPILOT_WS_STORAGE_DIR']
-  if (!configuredRoot) return false
-  const sessionCache = await loadSessionCache()
-  const files = sessionCache.providers[COPILOT_CHAT_JOURNAL_PROVIDER]?.files ?? {}
-  if (Object.keys(files).length === 0) return false
-  const canonical = (value: string): string => {
-    const slashes = value.replaceAll('\\', '/')
-    const compared = process.platform === 'win32' ? slashes.toLowerCase() : slashes
-    return compared.replace(/\/+$/, '')
-  }
-  const normalizedRoot = canonical(resolve(configuredRoot))
-  const normalizedPrefix = `${normalizedRoot}/`
-  return Object.keys(files).some(path => {
-    const normalizedPath = canonical(resolve(path))
-    return normalizedPath !== normalizedRoot && !normalizedPath.startsWith(normalizedPrefix)
-  })
-}
-
-async function prepareCopilotChatJournalReconciliation(): Promise<string[]> {
-  if (await copilotChatJournalRootChanged()) {
-    // A root/profile/account switch is not evidence that the old and new
-    // journals are the same identity. Reparse the new root for current output,
-    // but leave the prior daily ledger untouched until an identity contract is
-    // available. This is deliberately fail-closed, not an implicit union/drop.
-    await clearCopilotChatJournalInvalidations()
-    clearSessionCache()
-    beginCopilotChatJournalIdentityBoundary()
-    try {
-      await parseAllSessions(undefined, 'all')
-    } finally {
-      endCopilotChatJournalIdentityBoundary()
-    }
-    await clearCopilotChatJournalInvalidations()
-    return []
-  }
-  let days = await readCopilotChatJournalInvalidatedDays()
-  if (await copilotChatJournalChanged()) {
-    // The parser's normal refresh path records old/new day keys and publishes
-    // them to the bounded invalidation manifest. Clear only the in-process
-    // result memo so a changed journal cannot be served for 180 seconds.
-    clearSessionCache()
-    await parseAllSessions(undefined, 'all')
-    days = await readCopilotChatJournalInvalidatedDays()
-  }
-  return days
-}
-
 async function hydrateCache(): Promise<DailyCache> {
-  try {
-    const copilotJournalDays = await prepareCopilotChatJournalReconciliation()
-    const cache = await ensureCacheHydrated(
-      (range) => parseAllSessions(range, 'all'),
-      aggregateProjectsIntoDays,
-      getDailyCacheConfigHash(),
-      // Never finalize daily history from a partial hydration; that previously froze empty older days.
-      isSessionHydrationComplete,
-      undefined,
-      {
-        durableHistoryAuthority: DURABLE_HISTORY_AUTHORITY,
-        ...(copilotJournalDays.length > 0 ? { reconcileProviderDays: { copilot: copilotJournalDays } } : {}),
-      },
-    )
-    if (copilotJournalDays.length > 0 && cache.complete === true) {
-      await clearCopilotChatJournalInvalidations()
-    }
-    return cache
-  } catch (err) {
-    // Previously swallowed silently, which turned any backfill failure into an
-    // empty trend/history with no signal (issue #441). Per-file parse errors no
-    // longer reach here (they're isolated in parseProviderSources), so anything
-    // that does is exceptional and worth surfacing.
-    process.stderr.write(
-      `metrora: daily history backfill failed; the trend chart may be incomplete. ` +
-      `${err instanceof Error ? err.message : String(err)}\n`
-    )
-    return emptyCache()
-  }
+  return hydrateCopilotDailyCache(
+    (range) => parseAllSessions(range, 'all'),
+    aggregateProjectsIntoDays,
+    getDailyCacheConfigHash(),
+    isSessionHydrationComplete,
+  )
 }
 export type PeriodInfo = { range: DateRange; label: string }
 export type AggregateOpts = {

--- a/tests/copilot-late-journal-daily-reconciliation.test.ts
+++ b/tests/copilot-late-journal-daily-reconciliation.test.ts
@@ -1,0 +1,185 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { mkdir, mkdtemp, rm, stat, utimes, writeFile } from 'fs/promises'
+import { join } from 'path'
+import { tmpdir } from 'os'
+
+import {
+  buildDurablePeriod,
+  getDailyCacheConfigHash,
+} from '../src/usage-aggregator.js'
+import { clearSessionCache } from '../src/parser.js'
+import { emptyCache, ensureCacheHydrated, saveDailyCache, type DailyEntry } from '../src/daily-cache.js'
+
+let homeDir: string
+let cacheDir: string
+let workspaceStorageDir: string
+let alternateWorkspaceStorageDir: string | undefined
+
+const historicalTimestamp = 1_784_000_000_000
+
+function request(requestId: string, inputTokens: number, outputTokens: number, model = 'gpt-5.4'): Record<string, unknown> {
+  return {
+    requestId,
+    timestamp: historicalTimestamp,
+    modelId: `copilot/${model}`,
+    promptTokens: inputTokens,
+    completionTokens: outputTokens,
+    result: { metadata: { resolvedModel: model } },
+  }
+}
+
+function journal(requests: Array<Record<string, unknown>>, sessionId = 'late-journal-session'): string {
+  return `${JSON.stringify({
+    kind: 0,
+    v: {
+      sessionId,
+      creationDate: historicalTimestamp,
+      requests,
+    },
+  })}\n`
+}
+
+function dayBounds(timestamp: number): { start: Date; end: Date } {
+  const date = new Date(timestamp)
+  const start = new Date(date.getFullYear(), date.getMonth(), date.getDate())
+  return { start, end: new Date(start.getTime() + 24 * 60 * 60 * 1000) }
+}
+
+describe('Copilot late current-journal daily reconciliation', () => {
+  beforeEach(async () => {
+    homeDir = await mkdtemp(join(tmpdir(), 'metrora-copilot-late-home-'))
+    cacheDir = await mkdtemp(join(tmpdir(), 'metrora-copilot-late-cache-'))
+    workspaceStorageDir = await mkdtemp(join(tmpdir(), 'metrora-copilot-late-ws-'))
+
+    await mkdir(join(workspaceStorageDir, 'workspace-hash', 'chatSessions'), { recursive: true })
+
+    process.env['HOME'] = homeDir
+    process.env['METRORA_CACHE_DIR'] = cacheDir
+    process.env['METRORA_COPILOT_DISABLE_OTEL'] = '1'
+    process.env['METRORA_COPILOT_SESSION_STATE_DIR'] = join(homeDir, 'no-session-state')
+    process.env['METRORA_COPILOT_GLOBAL_STORAGE_DIR'] = join(homeDir, 'no-global-storage')
+    process.env['METRORA_COPILOT_JETBRAINS_DIR'] = join(homeDir, 'no-jetbrains')
+    process.env['METRORA_COPILOT_WS_STORAGE_DIR'] = workspaceStorageDir
+  })
+
+  afterEach(async () => {
+    clearSessionCache()
+    await rm(homeDir, { recursive: true, force: true })
+    await rm(cacheDir, { recursive: true, force: true })
+    await rm(workspaceStorageDir, { recursive: true, force: true })
+    if (alternateWorkspaceStorageDir) await rm(alternateWorkspaceStorageDir, { recursive: true, force: true })
+    alternateWorkspaceStorageDir = undefined
+  })
+
+  it('reconciles daily history after a late mutation of the same journal path', async () => {
+    const journalPath = join(workspaceStorageDir, 'workspace-hash', 'chatSessions', 'late.jsonl')
+    const requestA = request('request-a', 100, 10)
+    const requestB = request('request-b', 200, 20)
+    await writeFile(journalPath, journal([requestA, requestB]), 'utf-8')
+
+    const bounds = dayBounds(historicalTimestamp)
+    const range = { start: bounds.start, end: bounds.end }
+    const first = await buildDurablePeriod({ range, label: 'historical' })
+    const firstDay = first.cache.days.find(day => day.date === first.cache.days[0]?.date)
+    expect(firstDay?.providers.copilot?.calls).toBe(2)
+
+    const before = await stat(journalPath)
+    await writeFile(journalPath, journal([requestA]), 'utf-8')
+    await utimes(journalPath, new Date(), new Date(Date.now() + 2_000))
+    const after = await stat(journalPath)
+    expect(after.mtimeMs).not.toBe(before.mtimeMs)
+
+    // A new lifecycle sees the changed source and the session snapshot converges.
+    clearSessionCache()
+    const second = await buildDurablePeriod({ range, label: 'historical' })
+    const secondDay = second.cache.days.find(day => day.date === firstDay?.date)
+
+    expect(second.liveProjects.flatMap(project => project.sessions).flatMap(session => session.turns).flatMap(turn => turn.assistantCalls)).toHaveLength(1)
+    expect(secondDay?.providers.copilot?.calls).toBe(1)
+    expect(second.data.calls).toBe(1)
+  })
+
+  it('preserves unrelated sourceless durable provider slices on the affected day', async () => {
+    const date = '2026-07-14'
+    const baseline: DailyEntry = {
+      date,
+      cost: 0.004,
+      savingsUSD: 0,
+      calls: 5,
+      sessions: 2,
+      inputTokens: 300,
+      outputTokens: 50,
+      cacheReadTokens: 0,
+      cacheWriteTokens: 0,
+      editTurns: 0,
+      oneShotTurns: 0,
+      models: {},
+      categories: {},
+      providers: {
+        copilot: { calls: 2, cost: 0.002, savingsUSD: 0, sessions: 1 },
+        otel: { calls: 3, cost: 0.002, savingsUSD: 0, sessions: 1 },
+      },
+    }
+    const fresh: DailyEntry = {
+      ...baseline,
+      cost: 0.001,
+      calls: 1,
+      sessions: 1,
+      inputTokens: 100,
+      outputTokens: 10,
+      providers: {
+        copilot: { calls: 1, cost: 0.001, savingsUSD: 0, sessions: 1 },
+      },
+    }
+    const seeded = emptyCache('cfg')
+    const yesterday = new Date(Date.now() - 24 * 60 * 60 * 1000)
+    seeded.lastComputedDate = `${yesterday.getFullYear()}-${String(yesterday.getMonth() + 1).padStart(2, '0')}-${String(yesterday.getDate()).padStart(2, '0')}`
+    seeded.complete = true
+    seeded.watermarkTrusted = true
+    seeded.days = [baseline]
+    await saveDailyCache(seeded)
+
+    const reconciled = await ensureCacheHydrated(
+      async () => [],
+      () => [fresh],
+      'cfg',
+      () => true,
+      undefined,
+      { reconcileProviderDays: { copilot: [date] } },
+    )
+    const day = reconciled.days.find(entry => entry.date === date)
+
+    expect(day?.providers.copilot?.calls).toBe(1)
+    expect(day?.providers.otel?.calls).toBe(3)
+    expect(day?.calls).toBe(4)
+    expect(day?.cost).toBeCloseTo(0.003)
+  })
+
+  it('characterizes an explicit workspace-root switch as a separate source identity', async () => {
+    const rootAPath = join(workspaceStorageDir, 'workspace-a', 'chatSessions', 'a.jsonl')
+    await mkdir(join(workspaceStorageDir, 'workspace-a', 'chatSessions'), { recursive: true })
+    await writeFile(rootAPath, journal([request('request-a', 100, 10)], 'root-a-session'), 'utf-8')
+
+    const bounds = dayBounds(historicalTimestamp)
+    const range = { start: bounds.start, end: bounds.end }
+    await buildDurablePeriod({ range, label: 'historical' })
+    const sourceHash = getDailyCacheConfigHash()
+
+    alternateWorkspaceStorageDir = await mkdtemp(join(tmpdir(), 'metrora-copilot-switch-ws-'))
+    const rootBDir = join(alternateWorkspaceStorageDir, 'workspace-b', 'chatSessions')
+    await mkdir(rootBDir, { recursive: true })
+    await writeFile(join(rootBDir, 'b.jsonl'), journal([request('request-b', 100, 20, 'gpt-4.1')], 'root-b-session'), 'utf-8')
+    process.env['METRORA_COPILOT_WS_STORAGE_DIR'] = alternateWorkspaceStorageDir
+    expect(getDailyCacheConfigHash()).toBe(sourceHash)
+
+    clearSessionCache()
+    const switched = await buildDurablePeriod({ range, label: 'historical' })
+    const liveCalls = switched.liveProjects.flatMap(project => project.sessions).flatMap(session => session.turns).flatMap(turn => turn.assistantCalls)
+    const day = switched.cache.days.find(entry => entry.date === switched.cache.days[0]?.date)
+
+    expect(liveCalls).toHaveLength(1)
+    expect(liveCalls[0]?.model).toBe('gpt-4.1')
+    expect(day?.models['gpt-5.4']?.calls).toBe(1)
+    expect(day?.models['gpt-4.1']).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Scope

Bounded post-R2 durable reconciliation for mutable VS Code Copilot chat journals. The RC10 Microsoft Store submission artifact is not rebuilt or changed by this branch.

### 1. Late-journal daily reconciliation

- Keeps source/path/native identity to affected-day invalidation bounded and content-free.
- A+B → finalized daily history → the same journal becomes A now converges to A across session, provider/model totals, daily history and cost without manual cache deletion.
- Preserves other providers, sourceless validated durable history, OTel retention, provenance, reasoning and historical pricing authority.

### 2. Environment/root switches

- Isolated source-root characterization verifies current output follows the new root without unioning identities.
- Explicit root switches remain an identity boundary when available evidence cannot distinguish moved same-account storage from a different profile/account or mirror.
- The implementation fails closed: prior durable evidence remains separate rather than being merged into the new identity or discarded.

### 3. Architecture boundary remediation

Responsibilities were decomposed without changing the ratchet:

- src/daily-cache-core.ts: 702 baseline → 573 lines; merge/tombstone responsibilities moved to src/daily-cache-merge.ts and src/daily-cache-reconciliation.ts.
- src/parser.ts: 3903 baseline → 3902 lines; Copilot journal hooks and missing-source reconciliation extracted.
- src/providers/copilot.ts: 2400 baseline → 2399 lines; stat-only journal fingerprint probe extracted.
- src/usage-aggregator.ts: 764 baseline → 750 lines; Copilot journal authority/hydration extracted to src/copilot-chat-journal-hydration.ts.

### 4. Public documentation

- Removed temporary review/pending/manual-publication status language and reduced duplicated Store wording.
- Public contract now states only that RC10 is the source line associated with the Store submission, submission/certification/publication are distinct, post-RC10 development is separate, and no certification/publication/availability claim is made here.
- Copilot durable-history behavior remains documented in the changelog as a public behavior change.

### 5. Evidence

- 9 focused test files: 96 passed.
- npx tsc --noEmit: passed.
- npm run build:cli: passed.
- Source-size architecture ratchet against origin/main: passed.
- npm run version:check: passed.
- npm run identity:public:check: passed.
- git diff --check: passed.
- No new CI gate, provider-wide reset, full-history wipe, Store action, release or main merge is included.