### PR TITLE
fix: harden post-store pricing authority

### DIFF
--- a/src/models.ts
+++ b/src/models.ts
@@ -1,19 +1,17 @@
-import { readFile, writeFile, mkdir } from 'fs/promises'
-import { join } from 'path'
 import { getMetroraCacheDir } from './product-paths.js'
 import snapshotData from './data/litellm-snapshot.json'
 import fallbackData from './data/pricing-fallback.json'
-import { fetchWithTimeout } from './fetch-utils.js'
 import { REVIEWED_MODEL_DISPLAY_NAMES } from './model-display-labels.js'
+import { loadRemotePricing } from './pricing/litellm-pricing.js'
+import {
+  buildCosts,
+  safePerTokenRate,
+  tupleToCosts,
+  type ModelCosts,
+  type SnapshotEntry,
+} from './pricing/model-costs.js'
 
-export type ModelCosts = {
-  inputCostPerToken: number
-  outputCostPerToken: number
-  cacheWriteCostPerToken: number
-  cacheReadCostPerToken: number
-  webSearchCostPerRequest: number
-  fastMultiplier: number
-}
+export type { ModelCosts } from './pricing/model-costs.js'
 
 type PriceOverrideRates = {
   input: number
@@ -22,20 +20,6 @@ type PriceOverrideRates = {
   cacheCreation?: number
 }
 
-type JsonObject = Record<string, unknown>
-
-function isJsonObject(value: unknown): value is JsonObject {
-  return typeof value === 'object' && value !== null && !Array.isArray(value)
-}
-
-// [input, output, cacheWrite, cacheRead, fastMultiplier]. The trailing fast
-// multiplier is carried straight from LiteLLM's provider_specific_entry.fast so
-// new models pick it up automatically — no hand-maintained per-model table.
-type SnapshotEntry = [number, number, number | null, number | null, (number | null)?]
-
-const LITELLM_URL = 'https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json'
-const CACHE_TTL_MS = 24 * 60 * 60 * 1000
-const WEB_SEARCH_COST = 0.01
 export const PRICING_LOOKUP_VERSION = 'context-capacity-tags-v1'; const ONE_HOUR_CACHE_WRITE_MULTIPLIER_FROM_FIVE_MINUTE_RATE = 1.6
 
 // Explicit USD/token prices that must override LiteLLM/cache data. Cursor
@@ -49,32 +33,6 @@ const BUILTIN_PRICE_OVERRIDES: Record<string, SnapshotEntry> = {
   'composer-2': [0.5e-6, 2.5e-6, 0.5e-6, 0.2e-6],
   'composer-1.5': [3.5e-6, 17.5e-6, 3.5e-6, 0.35e-6],
   'composer-1': [1.25e-6, 10e-6, 1.25e-6, 0.125e-6],
-}
-
-// Assemble a ModelCosts, applying the cache-cost heuristics (write = 1.25x
-// input, read = 0.1x input) when a source omits them. Shared by the bundled
-// tuple path (tupleToCosts) and the live LiteLLM path (parseLiteLLMEntry) so the
-// multipliers live in exactly one place.
-function buildCosts(
-  input: number,
-  output: number,
-  cacheWrite: number | null | undefined,
-  cacheRead: number | null | undefined,
-  fast: number | null | undefined,
-): ModelCosts {
-  return {
-    inputCostPerToken: input,
-    outputCostPerToken: output,
-    cacheWriteCostPerToken: cacheWrite ?? input * 1.25,
-    cacheReadCostPerToken: cacheRead ?? input * 0.1,
-    webSearchCostPerRequest: WEB_SEARCH_COST,
-    fastMultiplier: fast ?? 1,
-  }
-}
-
-function tupleToCosts(raw: SnapshotEntry): ModelCosts {
-  const [input, output, cacheWrite, cacheRead, fast] = raw
-  return buildCosts(input, output, cacheWrite, cacheRead, fast)
 }
 
 function applyBuiltinPriceOverrides(pricing: Map<string, ModelCosts>): Map<string, ModelCosts> {
@@ -142,87 +100,6 @@ function getLowercasePricingIndex(): Map<string, ModelCosts> {
   return lowercasePricingIndex
 }
 
-const getCacheDir = (): string => getMetroraCacheDir()
-
-const getCachePath = (): string => join(getCacheDir(), 'litellm-pricing.json')
-
-/// Clamp a per-token rate to a sane non-negative value. Defense in depth
-/// against a tampered LiteLLM JSON shipping a negative `input_cost_per_token`,
-/// which would otherwise produce negative costs that subtract from totals.
-/// We use Number.isFinite to also reject NaN/Infinity, and cap at $1/token
-/// (well above the most expensive frontier model) so a stray decimal-place
-/// shift in the upstream JSON can't wildly inflate spend numbers either.
-function safePerTokenRate(n: unknown): number | null {
-  if (typeof n !== 'number' || !Number.isFinite(n) || n < 0) return null
-  if (n > 1) return 1
-  return n
-}
-
-function safeFastMultiplier(n: unknown): number | undefined {
-  return typeof n === 'number' && Number.isFinite(n) && n > 0 ? n : undefined
-}
-
-function parseLiteLLMEntry(entry: unknown): ModelCosts | null {
-  if (!isJsonObject(entry)) return null
-
-  const inputCost = safePerTokenRate(entry['input_cost_per_token'])
-  const outputCost = safePerTokenRate(entry['output_cost_per_token'])
-  if (inputCost === null || outputCost === null) return null
-
-  const providerSpecificEntry = isJsonObject(entry['provider_specific_entry'])
-    ? entry['provider_specific_entry']
-    : undefined
-  return buildCosts(
-    inputCost,
-    outputCost,
-    safePerTokenRate(entry['cache_creation_input_token_cost']),
-    safePerTokenRate(entry['cache_read_input_token_cost']),
-    safeFastMultiplier(providerSpecificEntry?.['fast']),
-  )
-}
-
-async function fetchAndCachePricing(): Promise<Map<string, ModelCosts>> {
-  // Bounded: runs on every CLI invocation (the menubar shells out and blocks on
-  // it). Without a timeout a half-open network after wake-from-sleep makes
-  // fetch() hang forever, wedging the menubar's loading spinner. On timeout the
-  // caller's catch falls back to the bundled price snapshot.
-  const response = await fetchWithTimeout(LITELLM_URL)
-  if (!response.ok) throw new Error(`HTTP ${response.status}`)
-  const payload = await response.json() as unknown
-  const data = isJsonObject(payload) ? payload : {}
-  const pricing = new Map<string, ModelCosts>()
-
-  for (const [name, entry] of Object.entries(data)) {
-    const costs = parseLiteLLMEntry(entry)
-    if (!costs) continue
-    pricing.set(name, costs)
-    // Also index by stripped name so lookups work without provider prefix:
-    // 'anthropic/claude-opus-4-6' is also queryable as 'claude-opus-4-6'.
-    // First write wins so direct-provider entries take precedence over re-hosters.
-    const stripped = name.replace(/^[^/]+\//, '')
-    if (stripped !== name && !pricing.has(stripped)) pricing.set(stripped, costs)
-  }
-
-  await mkdir(getCacheDir(), { recursive: true })
-  await writeFile(getCachePath(), JSON.stringify({
-    timestamp: Date.now(),
-    data: Object.fromEntries(pricing),
-  }))
-
-  return pricing
-}
-
-async function loadCachedPricing(): Promise<Map<string, ModelCosts> | null> {
-  try {
-    const raw = await readFile(getCachePath(), 'utf-8')
-    const cached = JSON.parse(raw) as { timestamp: number; data: Record<string, ModelCosts> }
-    if (Date.now() - cached.timestamp > CACHE_TTL_MS) return null
-    return new Map(Object.entries(cached.data))
-  } catch {
-    return null
-  }
-}
-
 function mergeSnapshotFallbacks(pricing: Map<string, ModelCosts>): Map<string, ModelCosts> {
   for (const [name, costs] of loadSnapshot()) {
     if (!pricing.has(name)) pricing.set(name, costs)
@@ -231,20 +108,11 @@ function mergeSnapshotFallbacks(pricing: Map<string, ModelCosts>): Map<string, M
 }
 
 export async function loadPricing(): Promise<void> {
-  const cached = await loadCachedPricing()
-  if (cached) {
-    pricingCache = mergeSnapshotFallbacks(cached)
+  const remotePricing = await loadRemotePricing(getMetroraCacheDir())
+  if (remotePricing) {
+    pricingCache = mergeSnapshotFallbacks(remotePricing)
     sortedPricingKeys = null
     lowercasePricingIndex = null
-    return
-  }
-
-  try {
-    pricingCache = mergeSnapshotFallbacks(await fetchAndCachePricing())
-    sortedPricingKeys = null
-    lowercasePricingIndex = null
-  } catch {
-    // snapshot already loaded at init; nothing more to do
   }
 }
 

--- a/src/models.ts
+++ b/src/models.ts
@@ -22,12 +22,10 @@ type PriceOverrideRates = {
   cacheCreation?: number
 }
 
-type LiteLLMEntry = {
-  input_cost_per_token?: number
-  output_cost_per_token?: number
-  cache_creation_input_token_cost?: number
-  cache_read_input_token_cost?: number
-  provider_specific_entry?: { fast?: number }
+type JsonObject = Record<string, unknown>
+
+function isJsonObject(value: unknown): value is JsonObject {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
 }
 
 // [input, output, cacheWrite, cacheRead, fastMultiplier]. The trailing fast
@@ -154,22 +152,32 @@ const getCachePath = (): string => join(getCacheDir(), 'litellm-pricing.json')
 /// We use Number.isFinite to also reject NaN/Infinity, and cap at $1/token
 /// (well above the most expensive frontier model) so a stray decimal-place
 /// shift in the upstream JSON can't wildly inflate spend numbers either.
-function safePerTokenRate(n: number | undefined): number | null {
-  if (n === undefined || !Number.isFinite(n) || n < 0) return null
+function safePerTokenRate(n: unknown): number | null {
+  if (typeof n !== 'number' || !Number.isFinite(n) || n < 0) return null
   if (n > 1) return 1
   return n
 }
 
-function parseLiteLLMEntry(entry: LiteLLMEntry): ModelCosts | null {
-  const inputCost = safePerTokenRate(entry.input_cost_per_token)
-  const outputCost = safePerTokenRate(entry.output_cost_per_token)
+function safeFastMultiplier(n: unknown): number | undefined {
+  return typeof n === 'number' && Number.isFinite(n) && n > 0 ? n : undefined
+}
+
+function parseLiteLLMEntry(entry: unknown): ModelCosts | null {
+  if (!isJsonObject(entry)) return null
+
+  const inputCost = safePerTokenRate(entry['input_cost_per_token'])
+  const outputCost = safePerTokenRate(entry['output_cost_per_token'])
   if (inputCost === null || outputCost === null) return null
+
+  const providerSpecificEntry = isJsonObject(entry['provider_specific_entry'])
+    ? entry['provider_specific_entry']
+    : undefined
   return buildCosts(
     inputCost,
     outputCost,
-    safePerTokenRate(entry.cache_creation_input_token_cost),
-    safePerTokenRate(entry.cache_read_input_token_cost),
-    entry.provider_specific_entry?.fast,
+    safePerTokenRate(entry['cache_creation_input_token_cost']),
+    safePerTokenRate(entry['cache_read_input_token_cost']),
+    safeFastMultiplier(providerSpecificEntry?.['fast']),
   )
 }
 
@@ -180,7 +188,8 @@ async function fetchAndCachePricing(): Promise<Map<string, ModelCosts>> {
   // caller's catch falls back to the bundled price snapshot.
   const response = await fetchWithTimeout(LITELLM_URL)
   if (!response.ok) throw new Error(`HTTP ${response.status}`)
-  const data = await response.json() as Record<string, LiteLLMEntry>
+  const payload = await response.json() as unknown
+  const data = isJsonObject(payload) ? payload : {}
   const pricing = new Map<string, ModelCosts>()
 
   for (const [name, entry] of Object.entries(data)) {

--- a/src/pricing/litellm-pricing.ts
+++ b/src/pricing/litellm-pricing.ts
@@ -1,0 +1,90 @@
+import { readFile, writeFile, mkdir } from 'fs/promises'
+import { join } from 'path'
+
+import { fetchWithTimeout } from '../fetch-utils.js'
+import { buildCosts, safePerTokenRate, type ModelCosts } from './model-costs.js'
+
+const LITELLM_URL = 'https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json'
+const CACHE_TTL_MS = 24 * 60 * 60 * 1000
+const CACHE_FILE = 'litellm-pricing.json'
+
+type JsonObject = Record<string, unknown>
+
+function isJsonObject(value: unknown): value is JsonObject {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function safeFastMultiplier(n: unknown): number | undefined {
+  return typeof n === 'number' && Number.isFinite(n) && n > 0 ? n : undefined
+}
+
+function parseLiteLLMEntry(entry: unknown): ModelCosts | null {
+  if (!isJsonObject(entry)) return null
+
+  const inputCost = safePerTokenRate(entry['input_cost_per_token'])
+  const outputCost = safePerTokenRate(entry['output_cost_per_token'])
+  if (inputCost === null || outputCost === null) return null
+
+  const providerSpecificEntry = isJsonObject(entry['provider_specific_entry'])
+    ? entry['provider_specific_entry']
+    : undefined
+  return buildCosts(
+    inputCost,
+    outputCost,
+    safePerTokenRate(entry['cache_creation_input_token_cost']),
+    safePerTokenRate(entry['cache_read_input_token_cost']),
+    safeFastMultiplier(providerSpecificEntry?.['fast']),
+  )
+}
+
+async function fetchAndCachePricing(cacheDir: string, cachePath: string): Promise<Map<string, ModelCosts>> {
+  // Bounded: the menubar shells out and blocks on this path. A half-open
+  // network after wake-from-sleep must not wedge its loading spinner.
+  const response = await fetchWithTimeout(LITELLM_URL)
+  if (!response.ok) throw new Error(`HTTP ${response.status}`)
+  const payload = await response.json() as unknown
+  const data = isJsonObject(payload) ? payload : {}
+  const pricing = new Map<string, ModelCosts>()
+
+  for (const [name, entry] of Object.entries(data)) {
+    const costs = parseLiteLLMEntry(entry)
+    if (!costs) continue
+    pricing.set(name, costs)
+    // Also index by stripped name so lookups work without provider prefix.
+    // First write wins so direct-provider entries take precedence.
+    const stripped = name.replace(/^[^/]+\//, '')
+    if (stripped !== name && !pricing.has(stripped)) pricing.set(stripped, costs)
+  }
+
+  await mkdir(cacheDir, { recursive: true })
+  await writeFile(cachePath, JSON.stringify({
+    timestamp: Date.now(),
+    data: Object.fromEntries(pricing),
+  }))
+
+  return pricing
+}
+
+async function loadCachedPricing(cachePath: string): Promise<Map<string, ModelCosts> | null> {
+  try {
+    const raw = await readFile(cachePath, 'utf-8')
+    const cached = JSON.parse(raw) as { timestamp: number; data: Record<string, ModelCosts> }
+    if (Date.now() - cached.timestamp > CACHE_TTL_MS) return null
+    return new Map(Object.entries(cached.data))
+  } catch {
+    return null
+  }
+}
+
+/** Load the remote/cache layer without owning Metrora's active pricing table. */
+export async function loadRemotePricing(cacheDir: string): Promise<Map<string, ModelCosts> | null> {
+  const cachePath = join(cacheDir, CACHE_FILE)
+  const cached = await loadCachedPricing(cachePath)
+  if (cached) return cached
+
+  try {
+    return await fetchAndCachePricing(cacheDir, cachePath)
+  } catch {
+    return null
+  }
+}

--- a/src/pricing/model-costs.ts
+++ b/src/pricing/model-costs.ts
@@ -1,0 +1,50 @@
+export type ModelCosts = {
+  inputCostPerToken: number
+  outputCostPerToken: number
+  cacheWriteCostPerToken: number
+  cacheReadCostPerToken: number
+  webSearchCostPerRequest: number
+  fastMultiplier: number
+}
+
+// [input, output, cacheWrite, cacheRead, fastMultiplier]. The trailing fast
+// multiplier is carried straight from LiteLLM's provider_specific_entry.fast
+// so new models pick it up without a hand-maintained per-model table.
+export type SnapshotEntry = [number, number, number | null, number | null, (number | null)?]
+
+const WEB_SEARCH_COST = 0.01
+
+/// Clamp a per-token rate to a sane non-negative value. Defense in depth
+/// against a tampered pricing source shipping a negative rate, NaN or Infinity.
+/// The $1/token ceiling prevents a stray decimal-place shift from wildly
+/// inflating spend numbers.
+export function safePerTokenRate(n: unknown): number | null {
+  if (typeof n !== 'number' || !Number.isFinite(n) || n < 0) return null
+  if (n > 1) return 1
+  return n
+}
+
+// Assemble a ModelCosts, applying the cache-cost heuristics (write = 1.25x
+// input, read = 0.1x input) when a source omits them. Shared by bundled,
+// override and live LiteLLM pricing paths.
+export function buildCosts(
+  input: number,
+  output: number,
+  cacheWrite: number | null | undefined,
+  cacheRead: number | null | undefined,
+  fast: number | null | undefined,
+): ModelCosts {
+  return {
+    inputCostPerToken: input,
+    outputCostPerToken: output,
+    cacheWriteCostPerToken: cacheWrite ?? input * 1.25,
+    cacheReadCostPerToken: cacheRead ?? input * 0.1,
+    webSearchCostPerRequest: WEB_SEARCH_COST,
+    fastMultiplier: fast ?? 1,
+  }
+}
+
+export function tupleToCosts(raw: SnapshotEntry): ModelCosts {
+  const [input, output, cacheWrite, cacheRead, fast] = raw
+  return buildCosts(input, output, cacheWrite, cacheRead, fast)
+}

--- a/tests/litellm-refresh-malformed-entry.test.ts
+++ b/tests/litellm-refresh-malformed-entry.test.ts
@@ -1,0 +1,57 @@
+import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { getModelCosts, loadPricing } from '../src/models.js'
+
+describe('LiteLLM refresh entry validation', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('skips null, primitive, array, and malformed entries while retaining later valid entries', async () => {
+    const cacheDir = await mkdtemp(join(tmpdir(), 'metrora-litellm-malformed-'))
+    const previousCacheDir = process.env['METRORA_CACHE_DIR']
+
+    try {
+      process.env['METRORA_CACHE_DIR'] = cacheDir
+      const dataset = {
+        'invalid-null-entry': null,
+        'invalid-array-entry': [],
+        'invalid-string-entry': 'not an object',
+        'invalid-number-entry': 42,
+        'invalid-partial-entry': { input_cost_per_token: 1e-6 },
+        'valid-after-malformed-entries': {
+          input_cost_per_token: 1e-6,
+          output_cost_per_token: 2e-6,
+        },
+      }
+
+      vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify(dataset), { status: 200 })))
+
+      await loadPricing()
+
+      expect(getModelCosts('valid-after-malformed-entries')).toMatchObject({
+        inputCostPerToken: 1e-6,
+        outputCostPerToken: 2e-6,
+      })
+      expect(getModelCosts('invalid-null-entry')).toBeNull()
+      expect(getModelCosts('invalid-array-entry')).toBeNull()
+      expect(getModelCosts('invalid-string-entry')).toBeNull()
+      expect(getModelCosts('invalid-number-entry')).toBeNull()
+      expect(getModelCosts('invalid-partial-entry')).toBeNull()
+
+      const cache = JSON.parse(await readFile(join(cacheDir, 'litellm-pricing.json'), 'utf8')) as {
+        data: Record<string, unknown>
+      }
+      expect(cache.data['valid-after-malformed-entries']).toBeDefined()
+      expect(cache.data['invalid-null-entry']).toBeUndefined()
+    } finally {
+      if (previousCacheDir === undefined) delete process.env['METRORA_CACHE_DIR']
+      else process.env['METRORA_CACHE_DIR'] = previousCacheDir
+      await rm(cacheDir, { recursive: true, force: true })
+    }
+  })
+})

--- a/tests/pricing-authority-reconciliation.test.ts
+++ b/tests/pricing-authority-reconciliation.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, describe, expect, it } from 'vitest'
+
+import {
+  getModelCosts,
+  setModelAliases,
+} from '../src/models.js'
+import { assignRuntimeCostV1 } from '../src/pricing/runtime-cost-assignment.js'
+
+const originalMode = process.env['METRORA_HISTORICAL_PRICING']
+
+afterEach(() => {
+  setModelAliases({})
+  if (originalMode === undefined) delete process.env['METRORA_HISTORICAL_PRICING']
+  else process.env['METRORA_HISTORICAL_PRICING'] = originalMode
+})
+
+function assignment(timestamp: string, overrides: Record<string, unknown> = {}) {
+  return assignRuntimeCostV1({
+    provider: 'codex',
+    model: 'openai/gpt-5.6-luna',
+    modelProvider: 'openai',
+    timestamp,
+    speed: 'standard',
+    usage: {
+      inputTokens: 1_000_000,
+      outputTokens: 100_000,
+      cacheCreationInputTokens: 100_000,
+      cacheReadInputTokens: 2_000_000,
+      reasoningTokens: 25_000,
+      webSearchRequests: 0,
+    },
+    legacyCostUSD: 1.6,
+    ...overrides,
+  })
+}
+
+describe('pricing authority reconciliation fixtures', () => {
+  it('changes only the price authority at an effective boundary for identical usage', () => {
+    process.env['METRORA_HISTORICAL_PRICING'] = 'historical'
+    const before = assignment('2026-07-30T20:08:00Z')
+    const atBoundary = assignment('2026-07-30T20:08:01Z')
+
+    expect(before.storedAssignment.kind).toBe('token-price')
+    expect(atBoundary.storedAssignment.kind).toBe('token-price')
+    expect(before.storedAssignment.priceRecordId).toContain('litellm-a874de6')
+    expect(atBoundary.storedAssignment.priceRecordId).toContain('litellm-f1b781d')
+    expect(before.storedCostUSD).toBeGreaterThan(atBoundary.storedCostUSD ?? 0)
+    expect(before.storedCostUSD).toBeCloseTo((atBoundary.storedCostUSD ?? 0) * 5, 12)
+    expect(atBoundary.storedLegacyCostUSD).toBeCloseTo(1.6, 12)
+  })
+
+  it('keeps a current fallback-only model out of historical authority', () => {
+    const currentFallback = getModelCosts('qwen3.7-max')
+    expect(currentFallback).not.toBeNull()
+    expect(currentFallback!.inputCostPerToken).toBeGreaterThan(0)
+
+    const historical = assignment('2026-08-07T12:00:00Z', {
+      model: 'qwen3.7-max',
+      modelProvider: 'openrouter',
+      legacyCostUSD: 0.25,
+    })
+    expect(historical.storedCostUSD).toBe(0.25)
+    expect(historical.storedAssignment.kind).toBe('legacy-frozen')
+  })
+
+  it('keeps aliases internal and does not collapse provider-specific authority', () => {
+    setModelAliases({ 'local-luna-alias': 'gpt-5.6-luna' })
+    const aliased = getModelCosts('local-luna-alias')
+    const direct = getModelCosts('gpt-5.6-luna')
+
+    expect(aliased).toEqual(direct)
+    const routed = assignment('2026-07-31T00:00:00Z')
+    expect(routed.storedAssignment.kind).toBe('token-price')
+    expect(routed.storedAssignment.priceRecordId).toContain('openai:')
+  })
+
+  it('does not treat a batch suffix as historical evidence for a separate tier', () => {
+    const batch = getModelCosts('gpt-4.1:batch')
+    // No date-effective batch record is inferred from a model suffix.
+    expect(batch).toBeNull()
+  })
+})


### PR DESCRIPTION
## Scope

Post-RC10 pricing robustness and authority reconciliation. The RC10 Microsoft Store submission artifact is not rebuilt or changed by this branch.

### 1. LiteLLM robustness

- Characterized the actual remote LiteLLM refresh path against null, array, string, number, partially malformed and valid object entries.
- Confirmed and fixed the malformed-entry dereference path: invalid records are skipped, valid later records continue, and global fallback behavior remains unchanged.
- Kept typed object/finite-rate guards; no indiscriminate any, secret/content logging or global error swallowing.

### 2. Pricing-data reconciliation

- Reconstructed Metrora's bundled/current, remote LiteLLM, cache, alias/normalization, historical catalog, effective-interval and runtime assignment layers.
- Extracted the independent pricing/LiteLLM authority into src/pricing/model-costs.ts and src/pricing/litellm-pricing.ts; src/models.ts is reduced from 973 baseline lines to 849.
- No wholesale upstream fallback replacement, unverified effective date, retroactive historical interval or unrelated model-price change.
- No cache-authority version bump: the historical authority and materialized assignments are unchanged.

### 3. Historical pricing behavior

Regression fixtures cover old/new historical rates, exact boundaries, unknown and fallback-only models, aliases, provider-specific identities and batch variants. Historical assignments remain date-effective and refreshes do not reprice settled history.

### 4. Evidence

- 10 focused test files: 198 passed.
- npx tsc --noEmit: passed.
- npm run build:cli: passed.
- Source-size architecture ratchet against origin/main: passed.
- git diff --check: passed.
- No new CI gate, package, Store identity, release or main merge is included.