### PR TITLE
fix: bound malformed sharing request URLs

### DIFF
--- a/src/sharing/share-server-url-boundary.test.ts
+++ b/src/sharing/share-server-url-boundary.test.ts
@@ -1,0 +1,110 @@
+import { connect } from 'node:tls'
+
+import { describe, expect, it } from 'vitest'
+
+import { generateIdentity } from './identity.js'
+import { PeerStore } from './pairing.js'
+import { companionPairRequest } from './client.js'
+import { parseShareRequestUrl, ShareServer } from './share-server.js'
+
+function rawTlsRequest(
+  port: number,
+  identity: Awaited<ReturnType<typeof generateIdentity>>,
+  target: string,
+): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const socket = connect({
+      host: '127.0.0.1',
+      port,
+      key: identity.key,
+      cert: identity.cert,
+      rejectUnauthorized: false,
+    })
+    let response = ''
+    socket.setEncoding('utf8')
+    socket.setTimeout(1_500, () => socket.destroy(new Error('sharing request timed out')))
+    socket.on('secureConnect', () => {
+      socket.write(`GET ${target} HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n`)
+    })
+    socket.on('data', chunk => { response += chunk })
+    socket.on('end', () => resolve(response))
+    socket.on('error', reject)
+  })
+}
+
+describe('sharing request URL error boundary', () => {
+  it('classifies the request-target matrix without changing valid URL semantics', () => {
+    expect(parseShareRequestUrl('/api/peer/hello').pathname).toBe('/api/peer/hello')
+    expect(parseShareRequestUrl(`https://localhost/api/peer/hello?value=${'a'.repeat(8_000)}`).pathname)
+      .toBe('/api/peer/hello')
+
+    for (const target of [
+      'ftp://example.test/api/peer/hello',
+      'https://%zz/api/peer/hello',
+      'http://[',
+      '',
+      '   ',
+    ]) {
+      expect(() => parseShareRequestUrl(target)).toThrow('invalid sharing request URL')
+    }
+  })
+
+  it('returns a deterministic client error for a malformed absolute request target', async () => {
+    const serverIdentity = await generateIdentity('Metrora desktop')
+    const clientIdentity = await generateIdentity('Metrora companion')
+    const server = new ShareServer({
+      identity: serverIdentity,
+      peers: new PeerStore(),
+      getUsage: async () => ({}),
+    })
+    const port = await server.listen(0, '127.0.0.1')
+
+    try {
+      const response = await rawTlsRequest(port, clientIdentity, 'http://[')
+      expect(response).toContain('HTTP/1.1 400')
+      expect(response).toContain('{"error":"invalid sharing request URL"}')
+      expect(response).not.toContain('Invalid URL')
+    } finally {
+      await server.close()
+    }
+  })
+
+  it('returns the same deterministic client error for an unsupported protocol', async () => {
+    const serverIdentity = await generateIdentity('Metrora desktop')
+    const clientIdentity = await generateIdentity('Metrora companion')
+    const server = new ShareServer({
+      identity: serverIdentity,
+      peers: new PeerStore(),
+      getUsage: async () => ({}),
+    })
+    const port = await server.listen(0, '127.0.0.1')
+
+    try {
+      const response = await rawTlsRequest(port, clientIdentity, 'ftp://example.test/api/peer/hello')
+      expect(response).toContain('HTTP/1.1 400')
+      expect(response).toContain('{"error":"invalid sharing request URL"}')
+    } finally {
+      await server.close()
+    }
+  })
+
+  it('preserves the existing route-failure boundary after valid URL parsing', async () => {
+    const serverIdentity = await generateIdentity('Metrora desktop')
+    const clientIdentity = await generateIdentity('Metrora companion')
+    const server = new ShareServer({
+      identity: serverIdentity,
+      peers: new PeerStore(),
+      getUsage: async () => ({}),
+      approve: async () => { throw new Error('simulated request failure') },
+    })
+    const port = await server.listen(0, '127.0.0.1')
+
+    try {
+      const response = await companionPairRequest({ identity: clientIdentity, host: '127.0.0.1', port }, 'Companion')
+      expect(response.status).toBe(500)
+      expect(response.json).toEqual({ error: 'simulated request failure' })
+    } finally {
+      await server.close()
+    }
+  })
+})

--- a/src/sharing/share-server.ts
+++ b/src/sharing/share-server.ts
@@ -28,6 +28,26 @@ export type ShareServerOptions = {
 
 export const SHARE_API_VERSION = 1 as const
 
+const SHARE_REQUEST_BASE_URL = 'https://localhost'
+const INVALID_SHARE_REQUEST_URL = 'invalid sharing request URL'
+
+class ShareRequestUrlError extends Error {}
+
+/** Parse only HTTPS/origin-form request targets without reflecting private input. */
+export function parseShareRequestUrl(value: string | undefined): URL {
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    throw new ShareRequestUrlError(INVALID_SHARE_REQUEST_URL)
+  }
+  let parsed: URL
+  try {
+    parsed = new URL(value, SHARE_REQUEST_BASE_URL)
+  } catch {
+    throw new ShareRequestUrlError(INVALID_SHARE_REQUEST_URL)
+  }
+  if (parsed.protocol !== 'https:') throw new ShareRequestUrlError(INVALID_SHARE_REQUEST_URL)
+  return parsed
+}
+
 /**
  * Keep the inherited unversioned routes working while making `/api/v1` the
  * stable first-party surface for Metrora companions and integrations.
@@ -125,19 +145,25 @@ export class ShareServer {
   }
 
   private async handle(req: IncomingMessage, res: ServerResponse): Promise<void> {
-    const url = new URL(req.url ?? '/', 'https://localhost')
     const json = (code: number, body: unknown): void => {
       res.writeHead(code, { 'content-type': 'application/json' })
       res.end(JSON.stringify(body))
     }
     try {
+      const url = parseShareRequestUrl(req.url)
       await this.route(url, req, res, json)
     } catch (err) {
       // Never leave a request hanging (a hung peer makes the caller time out
       // and drop this device); always answer, even on an internal error.
       if (!res.headersSent) {
-        const message = err instanceof Error ? err.message : String(err)
-        json(err instanceof UsageQueryError ? 400 : 500, { error: message })
+        if (err instanceof ShareRequestUrlError) {
+          json(400, { error: INVALID_SHARE_REQUEST_URL })
+        } else if (err instanceof UsageQueryError) {
+          json(400, { error: err.message })
+        } else {
+          const message = err instanceof Error ? err.message : String(err)
+          json(500, { error: message })
+        }
       }
     }
   }


### PR DESCRIPTION
## What changed

- Parse sharing request targets inside the existing per-request error boundary.
- Reject empty, whitespace-only, malformed, and non-HTTPS absolute request targets with a deterministic `400` JSON error.
- Keep valid origin-form and HTTPS request semantics unchanged.
- Add TLS-level regression coverage plus a parser matrix for malformed hostnames, malformed IPv6, unsupported protocols, long valid URLs, and post-parse request failures.

## Root cause

`ShareServer.handle()` constructed `new URL(req.url, ...)` before entering its `try` block. A malformed absolute request target such as `http://[` rejected the async handler, produced an unhandled `TypeError: Invalid URL`, and left the peer socket waiting until timeout.

## Impact

Malformed sharing requests now receive `{ "error": "invalid sharing request URL" }` with status 400. Raw parser details, request input, credentials, and stack traces are not reflected. Existing routing, timeout, cancellation, pairing, persistence rollback, and valid URL behavior remain intact.

## Validation

- Characterization reproduced socket timeout plus unhandled `ERR_INVALID_URL` before the fix.
- `npx vitest run tests/sharing src/sharing` — 48 passed.
- `npx tsc --noEmit` — passed.
- `npm run build:cli` — passed.
- Source-size ratchet against `origin/main` — passed.
- `git diff --check` — passed.