### PR TITLE
fix: time-bound working-directory PR attribution

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -58,6 +58,7 @@ import { callIsInDateRange, sliceCachedTurnToDateRange, sliceClassifiedTurnToDat
 import { claudeSlugFallbackPath, normalizeProjectPathKey, projectNameFromPath, unsanitizePath } from './project-path-utils.js'
 import { flushCopilotChatJournalInvalidations, queueCopilotChatJournalSource, recordCopilotChatJournalSourceChange, recordCopilotChatJournalSourceFailure } from './copilot-chat-journal-reconciliation.js'
 import { reconcileMissingProviderSources, shouldReconcileMissingProviderSources } from './parser-source-reconciliation.js'
+import { buildCwdEvidenceIndex, timeBoundCwdRefs } from './pr-attribution-time-bound.js'
 
 
 
@@ -3492,11 +3493,6 @@ function summaryProvider(session: SessionSummary): string {
   return session.turns.flatMap(t => t.assistantCalls)[0]?.provider ?? 'unknown'
 }
 
-function normalizedWorkingDirectory(path: string | undefined): string | null {
-  if (!path?.trim()) return null
-  return path.trim().replace(/\\/g, '/').replace(/\/+$/, '').toLowerCase()
-}
-
 function normalizedPrompt(text: string): string {
   return text.replace(/\s+/g, ' ').trim()
 }
@@ -3516,11 +3512,12 @@ function assignCorrelatedPrs(
 }
 
 /**
- * Correlate saved sessions across AI providers without timestamp guessing.
+ * Correlate saved sessions across AI providers without an invented TTL.
  *
  * Evidence, strongest first:
  *  1. exact launch-prompt text embedded in a PR-linked session's shell command;
- *  2. exact provider-recorded cwd shared with one unambiguous PR.
+ *  2. exact provider-recorded cwd inside one locally observed PR-evidence
+ *     envelope.
  *
  * Timestamps only narrow prompt comparisons for performance; they can never
  * create attribution. Conflicting PR evidence is deliberately left unassigned.
@@ -3595,24 +3592,14 @@ export function correlateCrossProviderPrSessions(projects: ProjectSummary[]): vo
     }
   }
 
-  // Prompt-linked sessions become valid cwd anchors too. Attribute only when an
-  // exact cwd maps to one PR set; a main checkout used for multiple PRs remains
-  // intentionally ambiguous.
-  const refsByCwd = new Map<string, Map<string, string[]>>()
-  for (const [session, evidenceRefs] of evidence) {
-    const cwd = normalizedWorkingDirectory(session.workingDirectory)
-    if (!cwd || evidenceRefs.length !== 1) continue
-    const refs = evidenceRefs.slice().sort()
-    const sets = refsByCwd.get(cwd) ?? new Map<string, string[]>()
-    sets.set(refs.join('\0'), refs)
-    refsByCwd.set(cwd, sets)
-  }
+  // Prompt-linked sessions become valid cwd anchors too. The fallback is
+  // reconstructed from observed timestamps on every parse; it is not durable
+  // PR truth and cannot extend a checkout association beyond local evidence.
+  const cwdEvidence = buildCwdEvidenceIndex(evidence)
   for (const session of sessions) {
     if (session.prLinks?.length || session.parentSessionId) continue
-    const cwd = normalizedWorkingDirectory(session.workingDirectory)
-    if (!cwd) continue
-    const sets = refsByCwd.get(cwd)
-    if (sets?.size === 1) assignCorrelatedPrs(session, [...sets.values()][0]!, 'working-directory')
+    const refs = timeBoundCwdRefs(session, cwdEvidence)
+    if (refs) assignCorrelatedPrs(session, refs, 'working-directory')
   }
 }
 

--- a/src/pr-attribution-time-bound.ts
+++ b/src/pr-attribution-time-bound.ts
@@ -1,0 +1,79 @@
+import type { SessionSummary } from './types.js'
+
+type EvidenceEnvelope = {
+  refs: string[]
+  minMs: number
+  maxMs: number
+}
+
+export type CwdEvidenceIndex = Map<string, Map<string, EvidenceEnvelope>>
+
+export function normalizedWorkingDirectory(path: string | undefined): string | null {
+  if (!path?.trim()) return null
+  return path.trim().replace(/\\/g, '/').replace(/\/+$/, '').toLowerCase()
+}
+
+function turnTimestampMs(turn: SessionSummary['turns'][number]): number {
+  return Date.parse(turn.assistantCalls[0]?.timestamp || turn.timestamp)
+}
+
+function evidenceTimestamps(session: SessionSummary, refs: readonly string[]): number[] {
+  if (refs.length !== 1) return []
+
+  // Launcher and native sidechain linkage already proved the PR association,
+  // but do not carry an exact transcript turn ref on the linked session.
+  if (session.prAttributionSource === 'launcher-prompt' || !session.prLinks?.length) {
+    const atMs = Date.parse(session.firstTimestamp)
+    return Number.isFinite(atMs) ? [atMs] : []
+  }
+
+  const key = refs[0]!
+  const observed: number[] = []
+  for (const turn of session.turns) {
+    if (turn.prRefs?.length !== 1 || turn.prRefs[0] !== key) continue
+    const atMs = turnTimestampMs(turn)
+    if (Number.isFinite(atMs)) observed.push(atMs)
+  }
+  return observed
+}
+
+export function buildCwdEvidenceIndex(
+  evidence: Iterable<readonly [SessionSummary, readonly string[]]>,
+): CwdEvidenceIndex {
+  const byCwd: CwdEvidenceIndex = new Map()
+  for (const [session, refsInput] of evidence) {
+    const cwd = normalizedWorkingDirectory(session.workingDirectory)
+    const refs = [...new Set(refsInput)].sort()
+    if (!cwd || refs.length !== 1) continue
+    const timestamps = evidenceTimestamps(session, refs)
+    if (timestamps.length === 0) continue
+    const key = refs.join('\0')
+    const envelopes = byCwd.get(cwd) ?? new Map<string, EvidenceEnvelope>()
+    const existing = envelopes.get(key)
+    const minMs = Math.min(...timestamps)
+    const maxMs = Math.max(...timestamps)
+    if (existing) {
+      existing.minMs = Math.min(existing.minMs, minMs)
+      existing.maxMs = Math.max(existing.maxMs, maxMs)
+    } else {
+      envelopes.set(key, { refs, minMs, maxMs })
+    }
+    byCwd.set(cwd, envelopes)
+  }
+  return byCwd
+}
+
+export function timeBoundCwdRefs(
+  session: SessionSummary,
+  evidence: CwdEvidenceIndex,
+): string[] | null {
+  const cwd = normalizedWorkingDirectory(session.workingDirectory)
+  if (!cwd) return null
+  const firstMs = Date.parse(session.firstTimestamp)
+  const lastMs = Date.parse(session.lastTimestamp)
+  if (!Number.isFinite(firstMs) || !Number.isFinite(lastMs) || lastMs < firstMs) return null
+
+  const matches = [...(evidence.get(cwd)?.values() ?? [])]
+    .filter(envelope => firstMs >= envelope.minMs && lastMs <= envelope.maxMs)
+  return matches.length === 1 ? matches[0]!.refs : null
+}

--- a/tests/cross-provider-pr-correlation.test.ts
+++ b/tests/cross-provider-pr-correlation.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { correlateCrossProviderPrSessions, extractPrUrlsFromText } from '../src/parser.js'
+import { correlateCrossProviderPrSessions, extractPrUrlsFromText, filterProjectsByDateRange } from '../src/parser.js'
 import type { ClassifiedTurn, ParsedApiCall, ProjectSummary, SessionSummary } from '../src/types.js'
 
 const A = 'https://github.com/maikolsiragusaa/metrora/pull/790'
@@ -25,10 +25,11 @@ function turn(provider: string, timestamp: string, userMessage: string, refs?: s
   }
 }
 
-function session(opts: { id: string; provider: string; timestamp: string; message: string; refs?: string[]; cwd?: string; command?: string; parentId?: string; agentId?: string }): SessionSummary {
+function session(opts: { id: string; provider: string; timestamp: string; lastTimestamp?: string; message: string; refs?: string[]; cwd?: string; command?: string; parentId?: string; agentId?: string; gitBranch?: string }): SessionSummary {
   const turns = [turn(opts.provider, opts.timestamp, opts.message, opts.refs, opts.command)]
+  if (opts.gitBranch) turns[0]!.gitBranch = opts.gitBranch
   return {
-    sessionId: opts.id, project: 'metrora', firstTimestamp: opts.timestamp, lastTimestamp: opts.timestamp,
+    sessionId: opts.id, project: 'metrora', firstTimestamp: opts.timestamp, lastTimestamp: opts.lastTimestamp ?? opts.timestamp,
     totalCostUSD: 1, totalSavingsUSD: 0, totalInputTokens: 1, totalOutputTokens: 1,
     totalReasoningTokens: 0, totalCacheReadTokens: 0, totalCacheWriteTokens: 0, apiCalls: 1, turns,
     modelBreakdown: {}, toolBreakdown: {}, mcpBreakdown: {}, bashBreakdown: {}, categoryBreakdown: {}, skillBreakdown: {}, subagentBreakdown: {},
@@ -51,6 +52,11 @@ describe('provider-neutral PR references', () => {
 
 describe('cross-provider PR correlation', () => {
   const prompt = 'Adversarial review of the cross-provider pull-request attribution implementation with concrete failure scenarios.'
+  const cwd = '/repo/.claude/worktrees/agent-123'
+
+  function evidence(id: string, refs: string[], timestamp: string, provider = 'claude'): SessionSummary {
+    return session({ id, provider, timestamp, message: 'exact evidence', refs, cwd })
+  }
 
   it('links an externally launched saved session by exact prompt evidence', () => {
     const parent = session({ id: 'claude', provider: 'claude', timestamp: '2026-07-21T00:00:00Z', message: 'launch review', refs: [B], command: `codex exec '${prompt}'` })
@@ -68,6 +74,15 @@ describe('cross-provider PR correlation', () => {
     expect(unrelated.prLinks).toBeUndefined()
   })
 
+  it('bounds exact launcher-prompt evidence to plus or minus fifteen minutes', () => {
+    const parent = session({ id: 'claude', provider: 'claude', timestamp: '2026-07-21T00:00:00Z', message: 'launch review', refs: [B], command: `codex exec '${prompt}'` })
+    const before = session({ id: 'before', provider: 'codex', timestamp: '2026-07-20T23:44:59Z', message: prompt })
+    const after = session({ id: 'after', provider: 'gemini', timestamp: '2026-07-21T00:15:01Z', message: prompt })
+    correlateCrossProviderPrSessions([project([parent, before, after])])
+    expect(before.prLinks).toBeUndefined()
+    expect(after.prLinks).toBeUndefined()
+  })
+
   it('does not treat a session-level PR union as active before its first turn ref', () => {
     const parent = session({ id: 'claude', provider: 'claude', timestamp: '2026-07-21T00:00:00Z', message: 'launch', refs: [A, B], command: `codex exec '${prompt}'` })
     delete parent.turns[0]!.prRefs
@@ -77,10 +92,10 @@ describe('cross-provider PR correlation', () => {
   })
 
   it('links an exact shared cwd only when it resolves to one PR set', () => {
-    const cwd = '/repo/.claude/worktrees/agent-123'
-    const parent = session({ id: 'claude', provider: 'claude', timestamp: '2026-07-21T00:00:00Z', message: 'work', refs: [B], cwd })
+    const start = evidence('start', [B], '2026-07-21T00:00:00Z')
+    const end = evidence('end', [B], '2026-07-21T02:00:00Z')
     const child = session({ id: 'gemini', provider: 'gemini', timestamp: '2026-07-21T01:00:00Z', message: 'short', cwd })
-    correlateCrossProviderPrSessions([project([parent, child])])
+    correlateCrossProviderPrSessions([project([start, child, end])])
     expect(child.prLinks).toEqual([B])
     expect(child.prAttributionSource).toBe('working-directory')
   })
@@ -104,5 +119,132 @@ describe('cross-provider PR correlation', () => {
     expect(child.prLinks).toBeUndefined()
     expect(codex.prLinks).toEqual([B])
     expect(codex.prAttributionSource).toBe('launcher-prompt')
+  })
+
+  it('preserves exact evidence even when cwd evidence is ambiguous', () => {
+    const a0 = evidence('a0', [A], '2026-07-21T00:00:00Z')
+    const a2 = evidence('a2', [A], '2026-07-21T02:00:00Z')
+    const b0 = evidence('b0', [B], '2026-07-21T00:00:00Z')
+    const b2 = evidence('b2', [B], '2026-07-21T02:00:00Z')
+    const exact = session({ id: 'exact', provider: 'codex', timestamp: '2026-07-21T01:00:00Z', message: 'exact', refs: [A], cwd })
+    correlateCrossProviderPrSessions([project([a0, a2, b0, b2, exact])])
+    expect(exact.prLinks).toEqual([A])
+    expect(exact.prAttributionSource).toBe('transcript')
+  })
+
+  it('lets launcher evidence beat conflicting cwd evidence', () => {
+    const launch = session({ id: 'launch', provider: 'claude', timestamp: '2026-07-21T01:00:00Z', message: 'launch', refs: [B], command: `codex exec '${prompt}'` })
+    const a0 = evidence('a0', [A], '2026-07-21T00:00:00Z')
+    const a2 = evidence('a2', [A], '2026-07-21T02:00:00Z')
+    const child = session({ id: 'child', provider: 'codex', timestamp: '2026-07-21T01:00:05Z', message: prompt, cwd })
+    correlateCrossProviderPrSessions([project([a0, launch, child, a2])])
+    expect(child.prLinks).toEqual([B])
+    expect(child.prAttributionSource).toBe('launcher-prompt')
+  })
+
+  it('does not carry January Claude evidence into an August Codex session', () => {
+    const claude = evidence('claude-january', [A], '2026-01-10T12:00:00Z')
+    const codex = session({ id: 'codex-august', provider: 'codex', timestamp: '2026-08-10T12:00:00Z', message: 'short', cwd })
+    correlateCrossProviderPrSessions([project([claude, codex])])
+    expect(codex.prLinks).toBeUndefined()
+  })
+
+  it.each([
+    ['branch reused', '2026-08-10T12:00:00Z', 'feature/reused'],
+    ['checkout idle for days', '2026-01-20T12:00:00Z', undefined],
+    ['detached HEAD', '2026-01-20T12:00:00Z', 'HEAD'],
+  ])('fails closed for %s outside the observed envelope', (_label, timestamp, gitBranch) => {
+    const old = evidence('old', [A], '2026-01-10T12:00:00Z')
+    const candidate = session({ id: 'candidate', provider: 'codex', timestamp, message: 'short', cwd, ...(gitBranch ? { gitBranch } : {}) })
+    correlateCrossProviderPrSessions([project([old, candidate])])
+    expect(candidate.prLinks).toBeUndefined()
+  })
+
+  it('attributes the later PR after the same cwd moves to another PR', () => {
+    const a0 = evidence('a0', [A], '2026-01-10T10:00:00Z')
+    const a1 = evidence('a1', [A], '2026-01-10T11:00:00Z')
+    const b0 = evidence('b0', [B], '2026-02-10T10:00:00Z')
+    const b1 = evidence('b1', [B], '2026-02-10T11:00:00Z')
+    const candidate = session({ id: 'candidate', provider: 'codex', timestamp: '2026-02-10T10:30:00Z', message: 'short', cwd })
+    correlateCrossProviderPrSessions([project([a0, a1, b0, candidate, b1])])
+    expect(candidate.prLinks).toEqual([B])
+  })
+
+  it.each([
+    ['before first evidence', '2026-01-10T09:59:59Z'],
+    ['after last evidence', '2026-01-10T11:00:01Z'],
+  ])('does not attribute a session %s', (_label, timestamp) => {
+    const start = evidence('start', [A], '2026-01-10T10:00:00Z')
+    const end = evidence('end', [A], '2026-01-10T11:00:00Z')
+    const candidate = session({ id: 'candidate', provider: 'codex', timestamp, message: 'short', cwd })
+    correlateCrossProviderPrSessions([project([start, candidate, end])])
+    expect(candidate.prLinks).toBeUndefined()
+  })
+
+  it.each([
+    ['invalid', 'not-a-time', 'not-a-time'],
+    ['missing', '', ''],
+    ['inverted', '2026-01-10T10:30:00Z', '2026-01-10T10:29:59Z'],
+  ])('fails closed for %s candidate timestamps', (_label, timestamp, lastTimestamp) => {
+    const start = evidence('start', [A], '2026-01-10T10:00:00Z')
+    const end = evidence('end', [A], '2026-01-10T11:00:00Z')
+    const candidate = session({ id: 'candidate', provider: 'codex', timestamp, lastTimestamp, message: 'short', cwd })
+    correlateCrossProviderPrSessions([project([start, candidate, end])])
+    expect(candidate.prLinks).toBeUndefined()
+  })
+
+  it('fails closed when two PR evidence envelopes overlap', () => {
+    const a0 = evidence('a0', [A], '2026-01-10T10:00:00Z')
+    const a2 = evidence('a2', [A], '2026-01-10T12:00:00Z')
+    const b0 = evidence('b0', [B], '2026-01-10T11:00:00Z')
+    const b2 = evidence('b2', [B], '2026-01-10T13:00:00Z')
+    const candidate = session({ id: 'candidate', provider: 'codex', timestamp: '2026-01-10T11:30:00Z', message: 'short', cwd })
+    correlateCrossProviderPrSessions([project([a0, b0, candidate, a2, b2])])
+    expect(candidate.prLinks).toBeUndefined()
+  })
+
+  it('is stable for warm reuse and a cold reconstructed graph', () => {
+    const make = () => {
+      const candidate = session({ id: 'candidate', provider: 'codex', timestamp: '2026-01-10T10:30:00Z', message: 'short', cwd })
+      return { candidate, projects: [project([evidence('start', [A], '2026-01-10T10:00:00Z'), candidate, evidence('end', [A], '2026-01-10T11:00:00Z')])] }
+    }
+    const warm = make()
+    correlateCrossProviderPrSessions(warm.projects)
+    correlateCrossProviderPrSessions(warm.projects)
+    const cold = make()
+    correlateCrossProviderPrSessions(cold.projects)
+    expect(warm.candidate.prLinks).toEqual([A])
+    expect(cold.candidate.prLinks).toEqual([A])
+  })
+
+  it('rebuilds cwd attribution from new evidence instead of persisting derived truth', () => {
+    const initialCandidate = session({ id: 'candidate', provider: 'codex', timestamp: '2026-01-10T10:30:00Z', message: 'short', cwd })
+    correlateCrossProviderPrSessions([project([
+      evidence('a-start', [A], '2026-01-10T10:00:00Z'), initialCandidate,
+      evidence('a-end', [A], '2026-01-10T11:00:00Z'),
+    ])])
+    expect(initialCandidate.prLinks).toEqual([A])
+
+    // A cold/cache-invalidated parse reconstructs sessions from persisted source
+    // evidence. New overlapping evidence must make the cwd fallback ambiguous.
+    const rebuiltCandidate = session({ id: 'candidate', provider: 'codex', timestamp: '2026-01-10T10:30:00Z', message: 'short', cwd })
+    correlateCrossProviderPrSessions([project([
+      evidence('a-start', [A], '2026-01-10T10:00:00Z'),
+      evidence('b-start', [B], '2026-01-10T10:00:00Z'),
+      rebuiltCandidate,
+      evidence('a-end', [A], '2026-01-10T11:00:00Z'),
+      evidence('b-end', [B], '2026-01-10T11:00:00Z'),
+    ])])
+    expect(rebuiltCandidate.prLinks).toBeUndefined()
+  })
+
+  it('does not retain out-of-range evidence after date slicing', () => {
+    const old = evidence('old', [A], '2026-01-10T10:00:00Z')
+    const candidate = session({ id: 'candidate', provider: 'codex', timestamp: '2026-08-10T10:00:00Z', message: 'short', cwd })
+    const sliced = filterProjectsByDateRange([project([old, candidate])], {
+      start: new Date('2026-08-01T00:00:00Z'), end: new Date('2026-08-31T23:59:59Z'),
+    })
+    correlateCrossProviderPrSessions(sliced)
+    expect(sliced[0]!.sessions[0]!.prLinks).toBeUndefined()
   })
 })


### PR DESCRIPTION
## Summary

- preserve exact/native/turn PR evidence and the existing ±15 minute launcher-prompt authority
- constrain working-directory fallback to locally observed timestamp envelopes for a single PR
- fail closed for missing/invalid time, stale checkout evidence, and overlapping PR envelopes
- keep derived cwd attribution reconstructible rather than durable cache truth

## Root cause

A working directory mapped to one PR set indefinitely, so an exact PR reference from January could attribute an unrelated session in the same checkout in August.

## Validation

- 24 focused cross-provider characterization/regression tests
- 9 parser, PR reporting, subagent, cache, range and durable suites / 141 tests
- `npx tsc --noEmit`
- `npm run build:cli`
- source-size ratchet against `origin/main`
- `git diff --check`