### PR TITLE
perf: validate session cache cost assignments once

### DIFF
--- a/src/pricing/cost-assignment.test.ts
+++ b/src/pricing/cost-assignment.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest'
+import { z } from 'zod'
 
 import {
   CostAssignmentV1Schema,
@@ -8,6 +9,29 @@ import {
   settledCostMicrosV1,
   settledCostUsdV1,
 } from './cost-assignment.js'
+
+const oldNonNegativeSafeMicrosSchema = z.number().int().nonnegative().max(Number.MAX_SAFE_INTEGER)
+const oldIdentifierSchema = z.string().trim().min(1).max(240)
+const oldOriginSchema = z.enum(['reviewed-book', 'local-observation'])
+const oldRateSchema = z.discriminatedUnion('kind', [
+  z.strictObject({ kind: z.literal('base') }),
+  z.strictObject({ kind: z.literal('prompt-input-tokens-above'), tokens: z.number().int().positive().max(Number.MAX_SAFE_INTEGER) }),
+])
+const oldSequentialSchema = z.union([
+  z.strictObject({ version: z.literal(1), kind: z.literal('metered'), amountMicrosUsd: oldNonNegativeSafeMicrosSchema, source: z.enum(['provider', 'client', 'billing-export']) }),
+  z.strictObject({ version: z.literal(1), kind: z.literal('token-price'), amountMicrosUsd: oldNonNegativeSafeMicrosSchema, priceRecordId: oldIdentifierSchema, priceOrigin: oldOriginSchema, rateSelection: oldRateSchema }),
+  z.strictObject({ version: z.literal(1), kind: z.literal('explicit-zero'), amountMicrosUsd: z.literal(0), reason: z.enum(['free-route', 'free-model', 'local-inference', 'manual-reviewed']), priceRecordId: oldIdentifierSchema.optional(), priceOrigin: oldOriginSchema.optional() }),
+  z.strictObject({ version: z.literal(1), kind: z.literal('legacy-frozen'), amountMicrosUsd: oldNonNegativeSafeMicrosSchema, reason: z.enum(['inherited-token-pricing', 'collector-estimate', 'unknown']) }),
+  z.strictObject({ version: z.literal(1), kind: z.literal('unavailable'), reason: z.enum(['no-price-record', 'missing-required-rate', 'conflicting-evidence']) }),
+]).superRefine((assignment, context) => {
+  if (assignment.kind === 'explicit-zero'
+    && ((assignment.priceRecordId === undefined) !== (assignment.priceOrigin === undefined))) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: 'explicit-zero priceRecordId and priceOrigin must be present together',
+    })
+  }
+})
 
 describe('cost assignment v1', () => {
   it('stores metered cost as safe integer micro-USD', () => {
@@ -107,5 +131,42 @@ describe('cost assignment v1', () => {
       amountMicrosUsd: Number.MAX_SAFE_INTEGER + 1,
       source: 'provider',
     })).toThrow()
+  })
+
+  it('matches the old sequential validator across a generated compatibility corpus', () => {
+    const valid = [
+      { version: 1, kind: 'metered', amountMicrosUsd: 0, source: 'provider' },
+      { version: 1, kind: 'metered', amountMicrosUsd: Number.MAX_SAFE_INTEGER, source: 'billing-export' },
+      { version: 1, kind: 'token-price', amountMicrosUsd: 1, priceRecordId: '  record  ', priceOrigin: 'reviewed-book', rateSelection: { kind: 'base' } },
+      { version: 1, kind: 'token-price', amountMicrosUsd: 2, priceRecordId: 'observed', priceOrigin: 'local-observation', rateSelection: { kind: 'prompt-input-tokens-above', tokens: Number.MAX_SAFE_INTEGER } },
+      { version: 1, kind: 'explicit-zero', amountMicrosUsd: 0, reason: 'free-route' },
+      { version: 1, kind: 'explicit-zero', amountMicrosUsd: 0, reason: 'manual-reviewed', priceRecordId: 'zero', priceOrigin: 'reviewed-book' },
+      { version: 1, kind: 'legacy-frozen', amountMicrosUsd: 0, reason: 'collector-estimate' },
+      { version: 1, kind: 'unavailable', reason: 'conflicting-evidence' },
+    ]
+    const mutationValues: unknown[] = [undefined, null, false, '', 'wrong', -1, 0.5, Number.NaN, Number.POSITIVE_INFINITY, Number.MAX_SAFE_INTEGER + 1, [], {}]
+    const corpus: unknown[] = [null, 1, 'assignment', [], {}, ...valid]
+    for (const assignment of valid) {
+      for (const key of Object.keys(assignment)) {
+        const missing = { ...assignment } as Record<string, unknown>
+        delete missing[key]
+        corpus.push(missing)
+        for (const value of mutationValues) corpus.push({ ...assignment, [key]: value })
+      }
+      corpus.push({ ...assignment, unknownKey: true })
+    }
+    corpus.push(
+      { version: 1, kind: 'future-kind', amountMicrosUsd: 0 },
+      { version: 2, kind: 'metered', amountMicrosUsd: 0, source: 'provider' },
+      { version: 1, kind: 'explicit-zero', amountMicrosUsd: 0, reason: 'free-route', priceRecordId: 'partial' },
+    )
+
+    expect(corpus.length).toBeGreaterThan(500)
+    for (const candidate of corpus) {
+      const oldResult = oldSequentialSchema.safeParse(candidate)
+      const newResult = CostAssignmentV1Schema.safeParse(candidate)
+      expect(newResult.success, JSON.stringify(candidate)).toBe(oldResult.success)
+      if (oldResult.success && newResult.success) expect(newResult.data).toEqual(oldResult.data)
+    }
   })
 })

--- a/src/pricing/cost-assignment.ts
+++ b/src/pricing/cost-assignment.ts
@@ -62,7 +62,7 @@ const UnavailableCostAssignmentV1Schema = z.strictObject({
   ]),
 })
 
-const CostAssignmentUnionV1Schema = z.union([
+const CostAssignmentUnionV1Schema = z.discriminatedUnion('kind', [
   MeteredCostAssignmentV1Schema,
   TokenPriceCostAssignmentV1Schema,
   ExplicitZeroCostAssignmentV1Schema,
@@ -110,6 +110,14 @@ export function costAssignmentMatchesUsdV1(
   costUSD: number,
 ): boolean {
   const assignment = CostAssignmentV1Schema.parse(assignmentValue)
+  return validatedCostAssignmentMatchesUsdV1(assignment, costUSD)
+}
+
+/** Compare a cost only after the assignment has already passed V1 validation. */
+export function validatedCostAssignmentMatchesUsdV1(
+  assignment: CostAssignmentV1,
+  costUSD: number,
+): boolean {
   const micros = settledCostMicrosV1(assignment)
   if (micros === undefined) return false
   return micros === costUsdToMicrosV1(costUSD)
@@ -120,7 +128,7 @@ export function assertCostAssignmentMatchesUsdV1(
   costUSD: number,
 ): CostAssignmentV1 {
   const assignment = CostAssignmentV1Schema.parse(assignmentValue)
-  if (!costAssignmentMatchesUsdV1(assignment, costUSD)) {
+  if (!validatedCostAssignmentMatchesUsdV1(assignment, costUSD)) {
     throw new Error('cost assignment does not match the call cost at micro-USD precision')
   }
   return assignment

--- a/src/session-cache-validation.ts
+++ b/src/session-cache-validation.ts
@@ -1,0 +1,172 @@
+import { CostAssignmentV1Schema, validatedCostAssignmentMatchesUsdV1 } from './pricing/cost-assignment.js'
+import type {
+  CachedCall,
+  CachedFile,
+  CachedTurn,
+  CachedUsage,
+  FileFingerprint,
+  ProviderSection,
+  SessionCache,
+} from './session-cache.js'
+
+function isNum(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value)
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every(element => typeof element === 'string')
+}
+
+function isOptionalString(value: unknown): boolean {
+  return value === undefined || typeof value === 'string'
+}
+
+function isOptionalNum(value: unknown): boolean {
+  return value === undefined || isNum(value)
+}
+
+function isOptionalBool(value: unknown): boolean {
+  return value === undefined || typeof value === 'boolean'
+}
+
+// A plain object whose every value is a string. Used for the sidechain
+// `agentSpawnLinks` map (agentId -> spawn tool_use id).
+function isOptionalStringRecord(value: unknown): boolean {
+  if (value === undefined) return true
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false
+  return Object.values(value as Record<string, unknown>).every(element => typeof element === 'string')
+}
+
+function isToolCall(value: unknown): boolean {
+  if (!value || typeof value !== 'object') return false
+  const toolCall = value as Record<string, unknown>
+  return typeof toolCall['tool'] === 'string'
+    && isOptionalString(toolCall['file'])
+    && isOptionalString(toolCall['command'])
+}
+
+function isToolCallArray(value: unknown): boolean {
+  return Array.isArray(value) && value.every(isToolCall)
+}
+
+function validateFingerprint(value: unknown): value is FileFingerprint {
+  if (!value || typeof value !== 'object') return false
+  const fingerprint = value as Record<string, unknown>
+  const wal = fingerprint['sqliteWal']
+  return isNum(fingerprint['dev']) && isNum(fingerprint['ino'])
+    && isNum(fingerprint['mtimeMs']) && isNum(fingerprint['sizeBytes'])
+    && (wal === undefined || (
+      !!wal && typeof wal === 'object'
+      && isNum((wal as Record<string, unknown>)['mtimeMs'])
+      && isNum((wal as Record<string, unknown>)['sizeBytes'])
+    ))
+}
+
+function validateUsage(value: unknown): value is CachedUsage {
+  if (!value || typeof value !== 'object') return false
+  const usage = value as Record<string, unknown>
+  return isNum(usage['inputTokens']) && isNum(usage['outputTokens'])
+    && isNum(usage['cacheCreationInputTokens']) && isNum(usage['cacheReadInputTokens'])
+    && isNum(usage['cachedInputTokens']) && isNum(usage['reasoningTokens'])
+    && isNum(usage['webSearchRequests']) && isNum(usage['cacheCreationOneHourTokens'])
+}
+
+function validateCachedCostAssignment(assignmentValue: unknown, costValue: unknown): boolean {
+  if (assignmentValue === undefined) return true
+  const parsed = CostAssignmentV1Schema.safeParse(assignmentValue)
+  if (!parsed.success) return false
+  if (parsed.data.kind === 'unavailable') return costValue === undefined
+  if (typeof costValue !== 'number' || !Number.isFinite(costValue) || costValue < 0) return false
+  try {
+    return validatedCostAssignmentMatchesUsdV1(parsed.data, costValue)
+  } catch {
+    return false
+  }
+}
+
+function validateCall(value: unknown): value is CachedCall {
+  if (!value || typeof value !== 'object') return false
+  const call = value as Record<string, unknown>
+  return typeof call['provider'] === 'string'
+    && typeof call['model'] === 'string'
+    && typeof call['deduplicationKey'] === 'string'
+    && typeof call['timestamp'] === 'string'
+    && (call['speed'] === 'standard' || call['speed'] === 'fast')
+    && isOptionalNum(call['costUSD'])
+    && isOptionalNum(call['legacyCostUSD'])
+    && validateCachedCostAssignment(call['costAssignment'], call['costUSD'])
+    && isOptionalBool(call['isEstimated'])
+    && isOptionalNum(call['activeDurationMs'])
+    && isOptionalNum(call['activeGeneratedTokens'])
+    && isOptionalNum(call['toolWaitMs'])
+    && isStringArray(call['tools'])
+    && isStringArray(call['bashCommands'])
+    && isStringArray(call['skills'])
+    && (call['subagentTypes'] === undefined || isStringArray(call['subagentTypes']))
+    && isOptionalString(call['project'])
+    && isOptionalString(call['projectPath'])
+    && isOptionalString(call['workingDirectory'])
+    && isOptionalString(call['nativeMessageId'])
+    && isOptionalString(call['nativeEmissionTimestamp'])
+    && isOptionalBool(call['nativeSnapshotTerminal'])
+    && (call['toolSequence'] === undefined || (
+      Array.isArray(call['toolSequence']) && call['toolSequence'].every(isToolCallArray)
+    ))
+    && isOptionalNum(call['locAdded'])
+    && isOptionalNum(call['locRemoved'])
+    && isOptionalBool(call['interrupted'])
+    && isOptionalBool(call['userModified'])
+    && isOptionalNum(call['toolErrors'])
+    && isOptionalNum(call['editFailed'])
+    && validateUsage(call['usage'])
+}
+
+function validateTurn(value: unknown): value is CachedTurn {
+  if (!value || typeof value !== 'object') return false
+  const turn = value as Record<string, unknown>
+  return typeof turn['timestamp'] === 'string'
+    && typeof turn['sessionId'] === 'string'
+    && typeof turn['userMessage'] === 'string'
+    && isOptionalString(turn['gitBranch'])
+    && (turn['prRefs'] === undefined || isStringArray(turn['prRefs']))
+    && (turn['spawnToolUseIds'] === undefined || isStringArray(turn['spawnToolUseIds']))
+    && Array.isArray(turn['calls'])
+    && turn['calls'].every(validateCall)
+}
+
+export function validateCachedFile(value: unknown): value is CachedFile {
+  if (!value || typeof value !== 'object') return false
+  const file = value as Record<string, unknown>
+  return validateFingerprint(file['fingerprint'])
+    && isOptionalNum(file['lastCompleteLineOffset'])
+    && isOptionalString(file['canonicalCwd'])
+    && isOptionalString(file['workingDirectory'])
+    && isOptionalString(file['canonicalProjectName'])
+    && isStringArray(file['mcpInventory'])
+    && isOptionalString(file['title'])
+    && (file['prLinks'] === undefined || isStringArray(file['prLinks']))
+    && isOptionalBool(file['isSidechain'])
+    && isOptionalString(file['agentType'])
+    && isOptionalBool(file['failed'])
+    && isOptionalString(file['parentSessionId'])
+    && isOptionalStringRecord(file['agentSpawnLinks'])
+    && (file['ambiguousSpawnAgentIds'] === undefined || isStringArray(file['ambiguousSpawnAgentIds']))
+    && Array.isArray(file['turns'])
+    && file['turns'].every(validateTurn)
+}
+
+function validateProviderSection(value: unknown): value is ProviderSection {
+  if (!value || typeof value !== 'object') return false
+  const section = value as Record<string, unknown>
+  if (typeof section['envFingerprint'] !== 'string') return false
+  if (!section['files'] || typeof section['files'] !== 'object' || Array.isArray(section['files'])) return false
+  return Object.values(section['files'] as Record<string, unknown>).every(validateCachedFile)
+}
+
+export function validateSessionCache(raw: unknown, expectedVersion: number): raw is SessionCache {
+  if (!raw || typeof raw !== 'object') return false
+  const cache = raw as Record<string, unknown>
+  if (cache['version'] !== expectedVersion) return false
+  if (!cache['providers'] || typeof cache['providers'] !== 'object' || Array.isArray(cache['providers'])) return false
+  return Object.values(cache['providers'] as Record<string, unknown>).every(validateProviderSection)
+}

--- a/src/session-cache.ts
+++ b/src/session-cache.ts
@@ -4,9 +4,10 @@ import { createHash, randomBytes } from 'crypto'
 import { join } from 'path'
 import type { ReasoningLevel, ReasoningLevelSource } from './reasoning-level.js'
 import type { ToolCall } from './types.js'
-import { CostAssignmentV1Schema, costAssignmentMatchesUsdV1, type CostAssignmentV1 } from './pricing/cost-assignment.js'
+import type { CostAssignmentV1 } from './pricing/cost-assignment.js'
 import { fingerprintSourceFile, type SQLiteWalFingerprint } from './sqlite-source-fingerprint.js'
 import { getMetroraCacheDir } from './product-paths.js'
+import { validateCachedFile, validateSessionCache } from './session-cache-validation.js'
 // ── Types ──────────────────────────────────────────────────────────────
 
 export type CachedUsage = {
@@ -297,167 +298,11 @@ export function isCacheComplete(cache: SessionCache): boolean {
   return cache.complete === true
 }
 
-function isNum(v: unknown): v is number {
-  return typeof v === 'number' && Number.isFinite(v)
-}
-
-function isStringArray(v: unknown): v is string[] {
-  return Array.isArray(v) && v.every(e => typeof e === 'string')
-}
-
-function isOptionalString(v: unknown): boolean {
-  return v === undefined || typeof v === 'string'
-}
-
-function isOptionalNum(v: unknown): boolean {
-  return v === undefined || isNum(v)
-}
-
-function isOptionalBool(v: unknown): boolean {
-  return v === undefined || typeof v === 'boolean'
-}
-
-function isOptionalCostAssignment(v: unknown): v is CostAssignmentV1 | undefined {
-  return v === undefined || CostAssignmentV1Schema.safeParse(v).success
-}
-
-// A plain object whose every value is a string (or undefined). Used for the
-// sidechain `agentSpawnLinks` map (agentId -> spawn tool_use id).
-function isOptionalStringRecord(v: unknown): boolean {
-  if (v === undefined) return true
-  if (!v || typeof v !== 'object' || Array.isArray(v)) return false
-  return Object.values(v as Record<string, unknown>).every(e => typeof e === 'string')
-}
-
-function isToolCall(v: unknown): boolean {
-  if (!v || typeof v !== 'object') return false
-  const o = v as Record<string, unknown>
-  return typeof o['tool'] === 'string'
-    && isOptionalString(o['file'])
-    && isOptionalString(o['command'])
-}
-
-function isToolCallArray(v: unknown): boolean {
-  return Array.isArray(v) && (v as unknown[]).every(isToolCall)
-}
-
-function validateFingerprint(fp: unknown): fp is FileFingerprint {
-  if (!fp || typeof fp !== 'object') return false
-  const f = fp as Record<string, unknown>
-  const wal = f['sqliteWal']
-  return isNum(f['dev']) && isNum(f['ino']) && isNum(f['mtimeMs']) && isNum(f['sizeBytes'])
-    && (wal === undefined || (
-      !!wal && typeof wal === 'object'
-      && isNum((wal as Record<string, unknown>)['mtimeMs'])
-      && isNum((wal as Record<string, unknown>)['sizeBytes'])
-    ))
-}
-
-function validateUsage(u: unknown): u is CachedUsage {
-  if (!u || typeof u !== 'object') return false
-  const o = u as Record<string, unknown>
-  return isNum(o['inputTokens']) && isNum(o['outputTokens'])
-    && isNum(o['cacheCreationInputTokens']) && isNum(o['cacheReadInputTokens'])
-    && isNum(o['cachedInputTokens']) && isNum(o['reasoningTokens'])
-    && isNum(o['webSearchRequests']) && isNum(o['cacheCreationOneHourTokens'])
-}
-
-function validateCachedCostAssignment(assignmentValue: unknown, costValue: unknown): boolean {
-  if (assignmentValue === undefined) return true
-  const parsed = CostAssignmentV1Schema.safeParse(assignmentValue)
-  if (!parsed.success) return false
-  if (parsed.data.kind === 'unavailable') return costValue === undefined
-  if (typeof costValue !== 'number' || !Number.isFinite(costValue) || costValue < 0) return false
-  try {
-    return costAssignmentMatchesUsdV1(parsed.data, costValue)
-  } catch {
-    return false
-  }
-}
-
-function validateCall(c: unknown): c is CachedCall {
-  if (!c || typeof c !== 'object') return false
-  const o = c as Record<string, unknown>
-  return typeof o['provider'] === 'string'
-    && typeof o['model'] === 'string'
-    && typeof o['deduplicationKey'] === 'string'
-    && typeof o['timestamp'] === 'string'
-    && (o['speed'] === 'standard' || o['speed'] === 'fast')
-    && isOptionalNum(o['costUSD'])
-    && isOptionalNum(o['legacyCostUSD'])
-    && isOptionalCostAssignment(o['costAssignment'])
-    && validateCachedCostAssignment(o['costAssignment'], o['costUSD'])
-    && isOptionalBool(o['isEstimated'])
-    && isOptionalNum(o['activeDurationMs'])
-    && isOptionalNum(o['activeGeneratedTokens'])
-    && isOptionalNum(o['toolWaitMs'])
-    && isStringArray(o['tools'])
-    && isStringArray(o['bashCommands'])
-    && isStringArray(o['skills'])
-    && (o['subagentTypes'] === undefined || isStringArray(o['subagentTypes']))
-    && isOptionalString(o['project'])
-    && isOptionalString(o['projectPath'])
-    && isOptionalString(o['workingDirectory'])
-    && isOptionalString(o['nativeMessageId']) && isOptionalString(o['nativeEmissionTimestamp']) && isOptionalBool(o['nativeSnapshotTerminal'])
-    && (o['toolSequence'] === undefined || (Array.isArray(o['toolSequence']) && (o['toolSequence'] as unknown[]).every(s => isToolCallArray(s))))
-    && isOptionalNum(o['locAdded'])
-    && isOptionalNum(o['locRemoved'])
-    && isOptionalBool(o['interrupted'])
-    && isOptionalBool(o['userModified'])
-    && isOptionalNum(o['toolErrors'])
-    && isOptionalNum(o['editFailed'])
-    && validateUsage(o['usage'])
-}
-
-function validateTurn(t: unknown): t is CachedTurn {
-  if (!t || typeof t !== 'object') return false
-  const o = t as Record<string, unknown>
-  return typeof o['timestamp'] === 'string'
-    && typeof o['sessionId'] === 'string'
-    && typeof o['userMessage'] === 'string'
-    && isOptionalString(o['gitBranch'])
-    && (o['prRefs'] === undefined || isStringArray(o['prRefs']))
-    && (o['spawnToolUseIds'] === undefined || isStringArray(o['spawnToolUseIds']))
-    && Array.isArray(o['calls'])
-    && (o['calls'] as unknown[]).every(validateCall)
-}
-
-export function validateCachedFile(f: unknown): f is CachedFile {
-  if (!f || typeof f !== 'object') return false
-  const o = f as Record<string, unknown>
-  return validateFingerprint(o['fingerprint'])
-    && isOptionalNum(o['lastCompleteLineOffset'])
-    && isOptionalString(o['canonicalCwd'])
-    && isOptionalString(o['workingDirectory'])
-    && isOptionalString(o['canonicalProjectName'])
-    && isStringArray(o['mcpInventory'])
-    && isOptionalString(o['title'])
-    && (o['prLinks'] === undefined || isStringArray(o['prLinks']))
-    && isOptionalBool(o['isSidechain'])
-    && isOptionalString(o['agentType'])
-    && isOptionalBool(o['failed'])
-    && isOptionalString(o['parentSessionId'])
-    && isOptionalStringRecord(o['agentSpawnLinks'])
-    && (o['ambiguousSpawnAgentIds'] === undefined || isStringArray(o['ambiguousSpawnAgentIds']))
-    && Array.isArray(o['turns'])
-    && (o['turns'] as unknown[]).every(validateTurn)
-}
-
-function validateProviderSection(s: unknown): s is ProviderSection {
-  if (!s || typeof s !== 'object') return false
-  const o = s as Record<string, unknown>
-  if (typeof o['envFingerprint'] !== 'string') return false
-  if (!o['files'] || typeof o['files'] !== 'object' || Array.isArray(o['files'])) return false
-  return Object.values(o['files'] as Record<string, unknown>).every(validateCachedFile)
-}
-
 export function isValidCache(raw: unknown): raw is SessionCache {
-  if (!raw || typeof raw !== 'object') return false
-  const o = raw as Record<string, unknown>
-  if (o['version'] !== CACHE_VERSION) return false
-  if (!o['providers'] || typeof o['providers'] !== 'object' || Array.isArray(o['providers'])) return false
-  return Object.values(o['providers'] as Record<string, unknown>).every(validateProviderSection)
+  return validateSessionCache(raw, CACHE_VERSION)
 }
+
+export { validateCachedFile }
 
 // Every prior versioned cache file that can still exist on disk from a shipped or
 // dev build, NEWEST first. On a bump we adopt the newest one present: its

--- a/tests/session-cache-cost-assignment-validation.test.ts
+++ b/tests/session-cache-cost-assignment-validation.test.ts
@@ -1,0 +1,288 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+
+import { CostAssignmentV1Schema } from '../src/pricing/cost-assignment.js'
+import {
+  CACHE_VERSION,
+  emptyCache,
+  isValidCache,
+  loadCache,
+  sessionCachePath,
+  type CachedCall,
+  type SessionCache,
+} from '../src/session-cache.js'
+
+const originalCacheDir = process.env.METRORA_CACHE_DIR
+let cacheDir = ''
+
+function usage() {
+  return {
+    inputTokens: 1,
+    outputTokens: 2,
+    cacheCreationInputTokens: 3,
+    cacheReadInputTokens: 4,
+    cachedInputTokens: 5,
+    reasoningTokens: 6,
+    webSearchRequests: 7,
+    cacheCreationOneHourTokens: 8,
+  }
+}
+
+function call(overrides: Partial<CachedCall> & Record<string, unknown> = {}): CachedCall {
+  return {
+    provider: 'openai',
+    model: 'gpt-test',
+    modelProvider: 'azure',
+    usage: usage(),
+    speed: 'standard',
+    timestamp: '2026-08-12T12:00:00.000Z',
+    tools: [],
+    bashCommands: [],
+    skills: [],
+    subagentTypes: [],
+    deduplicationKey: 'call-1',
+    ...overrides,
+  } as CachedCall
+}
+
+function cacheWithCalls(calls: unknown[]): unknown {
+  return {
+    version: CACHE_VERSION,
+    complete: true,
+    providers: {
+      codex: {
+        envFingerprint: 'env',
+        files: {
+          'C:/fixture/session.jsonl': {
+            fingerprint: { dev: 1, ino: 2, mtimeMs: 3, sizeBytes: 4 },
+            mcpInventory: [],
+            turns: [{ timestamp: '2026-08-12T12:00:00.000Z', sessionId: 's', userMessage: 'u', calls }],
+          },
+        },
+      },
+    },
+  }
+}
+
+async function writeActiveRaw(raw: string): Promise<void> {
+  await mkdir(cacheDir, { recursive: true })
+  await writeFile(sessionCachePath(), raw)
+}
+
+beforeEach(async () => {
+  cacheDir = await mkdtemp(join(tmpdir(), 'metrora-cost-cache-validation-'))
+  process.env.METRORA_CACHE_DIR = cacheDir
+})
+
+afterEach(async () => {
+  vi.restoreAllMocks()
+  if (originalCacheDir === undefined) delete process.env.METRORA_CACHE_DIR
+  else process.env.METRORA_CACHE_DIR = originalCacheDir
+  await rm(cacheDir, { recursive: true, force: true })
+})
+
+describe('persisted cost assignment validation', () => {
+  const validCases: Array<{ name: string; assignment: CachedCall['costAssignment']; costUSD?: number; estimated?: boolean }> = [
+    {
+      name: 'provider-metered zero',
+      assignment: { version: 1, kind: 'metered', amountMicrosUsd: 0, source: 'provider' },
+      costUSD: 0,
+    },
+    {
+      name: 'client-metered',
+      assignment: { version: 1, kind: 'metered', amountMicrosUsd: 250_000, source: 'client' },
+      costUSD: 0.25,
+    },
+    {
+      name: 'billing-export boundary',
+      assignment: { version: 1, kind: 'metered', amountMicrosUsd: Number.MAX_SAFE_INTEGER - 1, source: 'billing-export' },
+      costUSD: (Number.MAX_SAFE_INTEGER - 1) / 1_000_000,
+    },
+    {
+      name: 'historical base token price',
+      assignment: {
+        version: 1,
+        kind: 'token-price',
+        amountMicrosUsd: 420_000,
+        priceRecordId: 'openai:gpt-test:2026-08-01',
+        priceOrigin: 'reviewed-book',
+        rateSelection: { kind: 'base' },
+      },
+      costUSD: 0.42,
+    },
+    {
+      name: 'historical long-context token price',
+      assignment: {
+        version: 1,
+        kind: 'token-price',
+        amountMicrosUsd: 1,
+        priceRecordId: 'local-observation:test',
+        priceOrigin: 'local-observation',
+        rateSelection: { kind: 'prompt-input-tokens-above', tokens: Number.MAX_SAFE_INTEGER },
+      },
+      costUSD: 0.000001,
+      estimated: true,
+    },
+    {
+      name: 'explicit zero with reviewed metadata',
+      assignment: {
+        version: 1,
+        kind: 'explicit-zero',
+        amountMicrosUsd: 0,
+        reason: 'free-route',
+        priceRecordId: 'free-route-record',
+        priceOrigin: 'reviewed-book',
+      },
+      costUSD: 0,
+    },
+    {
+      name: 'explicit zero local inference',
+      assignment: { version: 1, kind: 'explicit-zero', amountMicrosUsd: 0, reason: 'local-inference' },
+      costUSD: 0,
+      estimated: true,
+    },
+    {
+      name: 'legacy inherited pricing',
+      assignment: { version: 1, kind: 'legacy-frozen', amountMicrosUsd: 987_654, reason: 'inherited-token-pricing' },
+      costUSD: 0.987654,
+    },
+    {
+      name: 'legacy collector estimate fallback',
+      assignment: { version: 1, kind: 'legacy-frozen', amountMicrosUsd: 10, reason: 'collector-estimate' },
+      costUSD: 0.00001,
+      estimated: true,
+    },
+    {
+      name: 'unavailable pricing',
+      assignment: { version: 1, kind: 'unavailable', reason: 'missing-required-rate' },
+    },
+  ]
+
+  it.each(validCases)('accepts $name', ({ assignment, costUSD, estimated }) => {
+    expect(isValidCache(cacheWithCalls([call({ costAssignment: assignment, costUSD, isEstimated: estimated })]))).toBe(true)
+  })
+
+  it('accepts a cache mixing every assignment kind without changing call metadata', () => {
+    const calls = validCases.map((fixture, index) => call({
+      costAssignment: fixture.assignment,
+      costUSD: fixture.costUSD,
+      isEstimated: fixture.estimated,
+      deduplicationKey: `mixed-${index}`,
+      provider: index % 2 === 0 ? 'openai' : 'anthropic',
+      model: `model-${index}`,
+      modelProvider: index % 2 === 0 ? 'azure' : 'bedrock',
+    }))
+    expect(isValidCache(cacheWithCalls(calls))).toBe(true)
+  })
+
+  it.each([
+    ['unknown kind', { version: 1, kind: 'future-kind', amountMicrosUsd: 0 }],
+    ['missing kind', { version: 1, amountMicrosUsd: 0 }],
+    ['null', null],
+    ['primitive', 7],
+    ['array', []],
+    ['missing required field', { version: 1, kind: 'metered', amountMicrosUsd: 1 }],
+    ['wrong field type', { version: 1, kind: 'metered', amountMicrosUsd: '1', source: 'provider' }],
+    ['unknown field', { version: 1, kind: 'metered', amountMicrosUsd: 1, source: 'provider', extra: true }],
+    ['negative micros', { version: 1, kind: 'legacy-frozen', amountMicrosUsd: -1, reason: 'unknown' }],
+    ['unsafe micros', { version: 1, kind: 'metered', amountMicrosUsd: Number.MAX_SAFE_INTEGER + 1, source: 'provider' }],
+    ['NaN micros', { version: 1, kind: 'metered', amountMicrosUsd: Number.NaN, source: 'provider' }],
+    ['infinite micros', { version: 1, kind: 'metered', amountMicrosUsd: Number.POSITIVE_INFINITY, source: 'provider' }],
+    ['fractional micros', { version: 1, kind: 'metered', amountMicrosUsd: 0.5, source: 'provider' }],
+    ['partial explicit-zero identity', { version: 1, kind: 'explicit-zero', amountMicrosUsd: 0, reason: 'free-model', priceRecordId: 'only-id' }],
+    ['nonzero explicit-zero', { version: 1, kind: 'explicit-zero', amountMicrosUsd: 1, reason: 'free-model' }],
+    ['invalid rate boundary', { version: 1, kind: 'token-price', amountMicrosUsd: 0, priceRecordId: 'r', priceOrigin: 'reviewed-book', rateSelection: { kind: 'prompt-input-tokens-above', tokens: 0 } }],
+  ])('rejects %s', (_name, assignment) => {
+    expect(isValidCache(cacheWithCalls([call({ costAssignment: assignment as CachedCall['costAssignment'], costUSD: 0.000001 })]))).toBe(false)
+  })
+
+  it.each([
+    ['inconsistent micros', 0.25, { version: 1, kind: 'metered', amountMicrosUsd: 250_001, source: 'provider' }],
+    ['negative stored USD', -1, { version: 1, kind: 'metered', amountMicrosUsd: 0, source: 'provider' }],
+    ['NaN stored USD', Number.NaN, { version: 1, kind: 'metered', amountMicrosUsd: 0, source: 'provider' }],
+    ['infinite stored USD', Number.POSITIVE_INFINITY, { version: 1, kind: 'metered', amountMicrosUsd: 0, source: 'provider' }],
+    ['unavailable with stored USD', 0, { version: 1, kind: 'unavailable', reason: 'no-price-record' }],
+  ])('rejects %s', (_name, costUSD, assignment) => {
+    expect(isValidCache(cacheWithCalls([call({ costAssignment: assignment as CachedCall['costAssignment'], costUSD })]))).toBe(false)
+  })
+
+  it('parses each persisted assignment exactly once', () => {
+    const assignments = Array.from({ length: 250 }, (_, index) => call({
+      deduplicationKey: `single-pass-${index}`,
+      costUSD: index / 1_000_000,
+      costAssignment: { version: 1, kind: 'metered', amountMicrosUsd: index, source: 'provider' },
+    }))
+    const safeParse = vi.spyOn(CostAssignmentV1Schema, 'safeParse')
+    expect(isValidCache(cacheWithCalls(assignments))).toBe(true)
+    expect(safeParse).toHaveBeenCalledTimes(assignments.length)
+  })
+
+  it('fails closed for one malformed assignment among valid calls', async () => {
+    const raw = cacheWithCalls([
+      call({ costUSD: 0.25, costAssignment: { version: 1, kind: 'metered', amountMicrosUsd: 250_000, source: 'provider' } }),
+      call({ deduplicationKey: 'bad', costUSD: 0.25, costAssignment: { version: 1, kind: 'metered', amountMicrosUsd: 250_001, source: 'provider' } }),
+    ])
+    await writeActiveRaw(JSON.stringify(raw))
+    expect(await loadCache()).toEqual(emptyCache())
+  })
+
+  it('keeps legacy unversioned cache adoption valid', async () => {
+    const legacy = cacheWithCalls([call({
+      costUSD: 0.42,
+      costAssignment: {
+        version: 1,
+        kind: 'token-price',
+        amountMicrosUsd: 420_000,
+        priceRecordId: 'legacy-valid',
+        priceOrigin: 'reviewed-book',
+        rateSelection: { kind: 'base' },
+      },
+    })]) as SessionCache
+    await writeFile(join(cacheDir, 'session-cache.json'), JSON.stringify(legacy))
+    expect(await loadCache()).toEqual(legacy)
+    expect(JSON.parse(await readFile(sessionCachePath(), 'utf8'))).toEqual(legacy)
+  })
+})
+
+describe('adversarial cache input', () => {
+  it.each([
+    ['truncated JSON', '{"version":8,"providers":'],
+    ['valid JSON with structural truncation', JSON.stringify({ version: CACHE_VERSION, providers: { codex: { envFingerprint: 'x' } } })],
+    ['old schema version', JSON.stringify({ version: CACHE_VERSION - 1, providers: {} })],
+    ['future assignment kind', JSON.stringify(cacheWithCalls([call({ costUSD: 0, costAssignment: { version: 1, kind: 'future', amountMicrosUsd: 0 } as never })]))],
+  ])('fails closed for %s', async (_name, raw) => {
+    await writeActiveRaw(raw)
+    expect(await loadCache()).toEqual(emptyCache())
+  })
+
+  it('uses JSON last-key semantics but still validates the surviving assignment', async () => {
+    const prefix = `{"version":${CACHE_VERSION},"providers":{"codex":{"envFingerprint":"x","files":{"f":{"fingerprint":{"dev":1,"ino":2,"mtimeMs":3,"sizeBytes":4},"mcpInventory":[],"turns":[{"timestamp":"t","sessionId":"s","userMessage":"u","calls":[{`
+    const suffix = `"provider":"p","model":"m","usage":{"inputTokens":0,"outputTokens":0,"cacheCreationInputTokens":0,"cacheReadInputTokens":0,"cachedInputTokens":0,"reasoningTokens":0,"webSearchRequests":0,"cacheCreationOneHourTokens":0},"speed":"standard","timestamp":"t","tools":[],"bashCommands":[],"skills":[],"deduplicationKey":"k","costUSD":1,"costUSD":0.25,"costAssignment":{"version":1,"kind":"metered","amountMicrosUsd":250000,"source":"provider"}}]}]}}}}}`
+    await writeActiveRaw(prefix + suffix)
+    expect((await loadCache()).providers).not.toEqual({})
+  })
+
+  it('accepts bounded large strings and a large mixed valid call array', () => {
+    const assignments: CachedCall['costAssignment'][] = [
+      { version: 1, kind: 'metered', amountMicrosUsd: 1, source: 'provider' },
+      { version: 1, kind: 'token-price', amountMicrosUsd: 1, priceRecordId: 'r', priceOrigin: 'reviewed-book', rateSelection: { kind: 'base' } },
+      { version: 1, kind: 'explicit-zero', amountMicrosUsd: 0, reason: 'free-route' },
+      { version: 1, kind: 'legacy-frozen', amountMicrosUsd: 1, reason: 'collector-estimate' },
+      { version: 1, kind: 'unavailable', reason: 'no-price-record' },
+    ]
+    const calls = Array.from({ length: 5_000 }, (_, index) => {
+      const assignment = assignments[index % assignments.length]!
+      return call({
+        deduplicationKey: `large-${index}`,
+        costAssignment: assignment,
+        costUSD: assignment.kind === 'unavailable' ? undefined : assignment.amountMicrosUsd / 1_000_000,
+      })
+    })
+    const cache = cacheWithCalls(calls) as SessionCache
+    const file = cache.providers['codex']!.files['C:/fixture/session.jsonl']!
+    file.turns[0]!.userMessage = 'x'.repeat(512 * 1024)
+    expect(isValidCache(cache)).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary
- validate each persisted cost assignment exactly once on the normal session-cache path
- discriminate CostAssignmentV1 directly by `kind` and reuse the parsed value for micro-USD consistency
- extract structural cache validation from the already-large session-cache module
- preserve cache version 8, historical assignment semantics, pricing authority, and fail-closed whole-cache rejection

## Correctness
- differential accept/reject and parsed-value equivalence against the previous sequential union on 500+ generated/mutated inputs
- corruption matrix covers every real assignment kind, missing/unknown kinds, malformed values, numeric boundaries, legacy/historical assignments, mixed caches, truncation, duplicate keys, old/future versions, and large valid fixtures
- a schema parse-count assertion proves one safeParse per persisted assignment

## Performance (100,244,054-byte real cache; 71,254 assignments)
- structural validation median: 2,307.9 ms → 239.0 ms (9.65×)
- loadCache median: 3,165.9 ms → 999.3 ms (3.17×)
- warm one-shot menubar CLI median: ~4,570 ms baseline → 2,583.1 ms (1.77×)
- desktop warm miss median: 2,589.9 ms; immediate 5 s TTL hit: 0.70 ms

## Validation
- 197 relevant tests passed in final run
- `npx tsc --noEmit`
- `npm run build:cli`
- source-size ratchet against `origin/main`
- `git diff --check`

Draft only. Do not merge.