### PR TITLE
feat: add bounded provider source diagnostics

### DIFF
--- a/src/doctor-source-diagnostics.ts
+++ b/src/doctor-source-diagnostics.ts
@@ -1,4 +1,4 @@
-import { existsSync } from 'node:fs'
+import { statSync } from 'node:fs'
 import { lstat, open, readdir, readFile } from 'node:fs/promises'
 import { homedir } from 'node:os'
 import { join } from 'node:path'
@@ -164,7 +164,11 @@ export function inspectReadonlySqlite(
   requiredTables: readonly string[],
   classifyRows?: (db: SqliteDatabase) => StateReason,
 ): DoctorPathProbe {
-  if (!existsSync(path)) return { state: 'MISSING', reason: 'source is absent' }
+  try {
+    statSync(path)
+  } catch (error) {
+    return classifyDoctorError(error)
+  }
   try {
     const db = openDatabase(path)
     try {

--- a/src/doctor-source-diagnostics.ts
+++ b/src/doctor-source-diagnostics.ts
@@ -1,0 +1,385 @@
+import { existsSync } from 'node:fs'
+import { lstat, open, readdir, readFile } from 'node:fs/promises'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+
+import { isSqliteBusyError, openDatabase, type SqliteDatabase } from './sqlite.js'
+import type { ProbeRoot } from './providers/types.js'
+
+export const DOCTOR_SOURCE_STATES = [
+  'PRESENT',
+  'PRESENT_EMPTY',
+  'MISSING',
+  'INACCESSIBLE',
+  'MALFORMED',
+  'UNSUPPORTED_VARIANT',
+  'UNKNOWN',
+] as const
+
+export type DoctorSourceState = (typeof DOCTOR_SOURCE_STATES)[number]
+
+export type DoctorSourceDiagnostic = {
+  family: string
+  state: DoctorSourceState
+  root: string
+  reason: string
+  override?: string
+}
+
+export type DoctorPathProbe = {
+  state: DoctorSourceState
+  reason: string
+  entries?: string[]
+}
+
+type StateReason = Pick<DoctorPathProbe, 'state' | 'reason'>
+
+const MAX_DIRECTORY_ENTRIES = 128
+const MAX_NESTED_ENTRIES = 32
+
+function reasonForCode(code: string | undefined): StateReason | undefined {
+  if (code === 'ENOENT' || code === 'ENOTDIR') return { state: 'MISSING', reason: 'source is absent' }
+  if (code === 'EACCES' || code === 'EPERM') return { state: 'INACCESSIBLE', reason: 'permission denied' }
+  return undefined
+}
+
+export function classifyDoctorError(error: unknown): StateReason {
+  if (isSqliteBusyError(error)) return { state: 'UNKNOWN', reason: 'SQLite is busy or locked' }
+  const value = error as { code?: unknown; message?: unknown; name?: unknown } | null
+  const code = typeof value?.code === 'string' ? value.code : undefined
+  const byCode = reasonForCode(code)
+  if (byCode) return byCode
+  const message = typeof value?.message === 'string' ? value.message : ''
+  if (value?.name === 'SyntaxError' || /not a database|malformed|corrupt|invalid json|unexpected end/i.test(message)) {
+    return { state: 'MALFORMED', reason: 'recognized source is corrupted' }
+  }
+  return { state: 'UNKNOWN', reason: 'source could not be classified safely' }
+}
+
+function rootReplacements(): Array<[string, string]> {
+  const roots: Array<[string, string]> = []
+  const home = homedir()
+  const envRoots: Array<[string, string]> = [
+    ['APPDATA', '%APPDATA%'],
+    ['LOCALAPPDATA', '%LOCALAPPDATA%'],
+    ['XDG_CONFIG_HOME', '%XDG_CONFIG_HOME%'],
+    ['XDG_DATA_HOME', '%XDG_DATA_HOME%'],
+    ['HOME', '~'],
+    ['USERPROFILE', '~'],
+  ]
+  for (const [name, replacement] of envRoots) {
+    const value = process.env[name]
+    if (value) roots.push([value, replacement])
+  }
+  roots.push([join(home, 'AppData', 'Roaming'), '%APPDATA%'])
+  roots.push([join(home, 'AppData', 'Local'), '%LOCALAPPDATA%'])
+  roots.push([home, '~'])
+  return roots.sort((a, b) => b[0].length - a[0].length)
+}
+
+export function redactPath(value: string): string {
+  const normalized = value.replace(/\\/g, '/')
+  const lower = normalized.toLowerCase()
+  for (const [rawRoot, replacement] of rootReplacements()) {
+    const root = rawRoot.replace(/\\/g, '/').replace(/\/$/, '')
+    const rootLower = root.toLowerCase()
+    if (lower === rootLower) return replacement
+    if (lower.startsWith(rootLower + '/')) return replacement + normalized.slice(root.length)
+  }
+  if (/^(?:[a-z]:\/|\/|\\\\)/i.test(normalized)) return '<redacted-path>'
+  return normalized
+}
+
+export function redactText(value: string): string {
+  return value
+    .replace(/[A-Za-z]:[\\/][^"'\n]+/g, '<redacted-path>')
+    .replace(/\\\\[^"'\n]+/g, '<redacted-path>')
+    .replace(/(^|[\s("'])\/[^"'\n]*/g, '$1<redacted-path>')
+}
+
+export async function inspectPath(path: string): Promise<DoctorPathProbe> {
+  try {
+    const info = await lstat(path)
+    if (info.isDirectory()) {
+      const entries = await readdir(path)
+      return entries.length === 0
+        ? { state: 'PRESENT_EMPTY', reason: 'directory is readable but has no entries', entries }
+        : { state: 'PRESENT', reason: 'directory is readable', entries: entries.slice(0, MAX_DIRECTORY_ENTRIES) }
+    }
+    if (info.isFile()) {
+      const handle = await open(path, 'r')
+      await handle.close()
+      return { state: 'PRESENT', reason: 'source is readable' }
+    }
+    return { state: 'UNSUPPORTED_VARIANT', reason: 'source is neither a regular file nor directory' }
+  } catch (error) {
+    return classifyDoctorError(error)
+  }
+}
+
+async function readDirectory(path: string): Promise<DoctorPathProbe> {
+  try {
+    const info = await lstat(path)
+    if (!info.isDirectory()) return { state: 'UNSUPPORTED_VARIANT', reason: 'expected a directory' }
+    const entries = await readdir(path)
+    return entries.length === 0
+      ? { state: 'PRESENT_EMPTY', reason: 'directory is readable but has no supported sources', entries }
+      : { state: 'PRESENT', reason: 'directory is readable', entries: entries.slice(0, MAX_DIRECTORY_ENTRIES) }
+  } catch (error) {
+    return classifyDoctorError(error)
+  }
+}
+
+async function inspectJsonLines(path: string): Promise<StateReason> {
+  try {
+    const raw = await readFile(path, 'utf8')
+    const line = raw.split(/\r?\n/).find(item => item.trim())
+    if (!line) return { state: 'PRESENT_EMPTY', reason: 'source is readable but empty' }
+    const parsed: unknown = JSON.parse(line)
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+      ? { state: 'PRESENT', reason: 'recognized JSON source is readable' }
+      : { state: 'UNSUPPORTED_VARIANT', reason: 'JSON source shape is not supported' }
+  } catch (error) {
+    return classifyDoctorError(error)
+  }
+}
+
+async function inspectJsonDocument(path: string, requiredArray?: string): Promise<StateReason> {
+  try {
+    const parsed: unknown = JSON.parse(await readFile(path, 'utf8'))
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      return { state: 'UNSUPPORTED_VARIANT', reason: 'JSON document shape is not supported' }
+    }
+    if (requiredArray && !Array.isArray((parsed as Record<string, unknown>)[requiredArray])) {
+      return { state: 'UNSUPPORTED_VARIANT', reason: 'recognized JSON document has an unsupported version' }
+    }
+    return { state: 'PRESENT', reason: 'recognized JSON source is readable' }
+  } catch (error) {
+    return classifyDoctorError(error)
+  }
+}
+
+export function inspectReadonlySqlite(
+  path: string,
+  requiredTables: readonly string[],
+  classifyRows?: (db: SqliteDatabase) => StateReason,
+): DoctorPathProbe {
+  if (!existsSync(path)) return { state: 'MISSING', reason: 'source is absent' }
+  try {
+    const db = openDatabase(path)
+    try {
+      const tables = new Set(db.query<{ name: string }>(
+        "SELECT name FROM sqlite_master WHERE type = 'table'",
+      ).map(row => row.name))
+      const missing = requiredTables.find(table => !tables.has(table))
+      if (missing) return { state: 'UNSUPPORTED_VARIANT', reason: 'SQLite schema is not supported' }
+      return classifyRows?.(db) ?? { state: 'PRESENT', reason: 'recognized SQLite source is readable' }
+    } finally {
+      db.close()
+    }
+  } catch (error) {
+    return classifyDoctorError(error)
+  }
+}
+
+function diagnostic(family: string, root: string, probe: StateReason, override?: string): DoctorSourceDiagnostic {
+  return { family, root: redactPath(root), state: probe.state, reason: probe.reason, ...(override ? { override } : {}) }
+}
+
+function overrideNameFor(providerName: string, family: string): string | undefined {
+  if (providerName === 'kiro' && (family === 'cli' || family === 'kiro-v2') && process.env['KIRO_HOME']) return 'KIRO_HOME'
+  if (providerName !== 'copilot') return undefined
+  if (family === 'otel-agent-traces') {
+    if (process.env['METRORA_COPILOT_OTEL_DB']) return 'METRORA_COPILOT_OTEL_DB'
+    if (process.env['METRORA_COPILOT_DISABLE_OTEL'] === '1') return 'METRORA_COPILOT_DISABLE_OTEL'
+  }
+  if (family === 'cli-session-state' && process.env['METRORA_COPILOT_SESSION_STATE_DIR']) return 'METRORA_COPILOT_SESSION_STATE_DIR'
+  if (family === 'vscode-workspace-storage' && process.env['METRORA_COPILOT_WS_STORAGE_DIR']) return 'METRORA_COPILOT_WS_STORAGE_DIR'
+  if (family === 'empty-window-global-storage' && process.env['METRORA_COPILOT_GLOBAL_STORAGE_DIR']) return 'METRORA_COPILOT_GLOBAL_STORAGE_DIR'
+  if (family === 'jetbrains' && process.env['METRORA_COPILOT_JETBRAINS_DIR']) return 'METRORA_COPILOT_JETBRAINS_DIR'
+  return undefined
+}
+
+function cursorSqlite(path: string): DoctorSourceDiagnostic {
+  const probe = inspectReadonlySqlite(path, ['cursorDiskKV'], db => {
+    const rows = db.query<{ count: number }>(
+      "SELECT COUNT(*) AS count FROM cursorDiskKV WHERE key LIKE 'bubbleId:%' OR key LIKE 'agentKv:%'",
+    )
+    return Number(rows[0]?.count ?? 0) > 0
+      ? { state: 'PRESENT', reason: 'recognized Cursor state with supported records' }
+      : { state: 'PRESENT_EMPTY', reason: 'recognized Cursor state has no supported records' }
+  })
+  return diagnostic('global-state', path, probe)
+}
+
+async function cursorWorkspace(path: string): Promise<DoctorSourceDiagnostic> {
+  const directory = await readDirectory(path)
+  if (!directory.entries || directory.state !== 'PRESENT') return diagnostic('workspace-storage', path, directory)
+  let recognized = false
+  for (const entry of directory.entries.slice(0, MAX_NESTED_ENTRIES)) {
+    const entryPath = join(path, entry)
+    const info = await inspectPath(entryPath)
+    if (info.state !== 'PRESENT') continue
+    const workspaceJson = join(entryPath, 'workspace.json')
+    const workspace = await inspectPath(workspaceJson)
+    if (workspace.state === 'PRESENT') {
+      const parsed = await inspectJsonDocument(workspaceJson)
+      if (parsed.state === 'MALFORMED') return diagnostic('workspace-storage', path, parsed)
+      if (parsed.state === 'PRESENT') recognized = true
+    }
+    const workspaceDb = join(entryPath, 'state.vscdb')
+    const db = await inspectPath(workspaceDb)
+    if (db.state === 'PRESENT') {
+      const schema = inspectReadonlySqlite(workspaceDb, ['ItemTable'])
+      if (schema.state === 'MALFORMED' || schema.state === 'UNKNOWN') return diagnostic('workspace-storage', path, schema)
+      if (schema.state === 'PRESENT') recognized = true
+    }
+  }
+  return diagnostic('workspace-storage', path, recognized
+    ? { state: 'PRESENT', reason: 'recognized Cursor workspace storage is readable' }
+    : { state: 'PRESENT_EMPTY', reason: 'workspace storage has no supported sessions' })
+}
+
+function kiroDirectory(path: string, family: string): Promise<DoctorSourceDiagnostic> {
+  return readDirectory(path).then(async directory => {
+    if (!directory.entries || directory.state !== 'PRESENT') return diagnostic(family, path, directory)
+    if (family === 'cli') {
+      const files = directory.entries.filter(entry => entry.endsWith('.jsonl'))
+      if (files.length === 0) return diagnostic(family, path, { state: 'PRESENT_EMPTY', reason: 'directory has no supported sessions' })
+      for (const file of files.slice(0, MAX_NESTED_ENTRIES)) {
+        const probe = await inspectJsonLines(join(path, file))
+        if (probe.state === 'MALFORMED' || probe.state === 'UNKNOWN') return diagnostic(family, path, probe)
+      }
+      return diagnostic(family, path, { state: 'PRESENT', reason: 'recognized Kiro CLI sessions are readable' }, overrideNameFor('kiro', family))
+    }
+    if (family === 'kiro-v2') {
+      let supported = false
+      for (const hash of directory.entries.slice(0, MAX_NESTED_ENTRIES)) {
+        const hashPath = join(path, hash)
+        const hashProbe = await inspectPath(hashPath)
+        if (hashProbe.state !== 'PRESENT' || !hashProbe.entries) continue
+        for (const session of hashProbe.entries.filter(entry => entry.startsWith('sess_')).slice(0, MAX_NESTED_ENTRIES)) {
+          const sessionPath = join(hashPath, session)
+          const messagePath = join(sessionPath, 'messages.jsonl')
+          const messageProbe = await inspectPath(messagePath)
+          if (messageProbe.state !== 'PRESENT') continue
+          const meta = await inspectJsonDocument(join(sessionPath, 'session.json'), 'workspacePaths')
+          if (meta.state === 'MALFORMED' || meta.state === 'UNKNOWN') return diagnostic(family, path, meta, overrideNameFor('kiro', family))
+          if (meta.state === 'PRESENT' || meta.state === 'MISSING') supported = true
+        }
+      }
+      return diagnostic(family, path, supported
+        ? { state: 'PRESENT', reason: 'recognized Kiro v2 sessions are readable' }
+        : { state: 'PRESENT_EMPTY', reason: 'Kiro v2 root has no supported sessions' }, overrideNameFor('kiro', family))
+    }
+    const supported = family === 'legacy-ide' || family === 'legacy-ide-server'
+      ? directory.entries.some(entry => entry === 'workspace-sessions' || /^[a-f0-9]{32}$/i.test(entry))
+      : directory.entries.some(entry => entry.length > 0)
+    return diagnostic(family, path, supported
+      ? { state: 'PRESENT', reason: 'recognized Kiro IDE storage is readable' }
+      : { state: 'PRESENT_EMPTY', reason: 'Kiro storage has no supported sessions' })
+  })
+}
+
+async function copilotJsonDirectory(path: string, family: string, nested: boolean): Promise<DoctorSourceDiagnostic> {
+  const directory = await readDirectory(path)
+  if (!directory.entries || directory.state !== 'PRESENT') return diagnostic(family, path, directory)
+  const files: string[] = []
+  for (const entry of directory.entries.slice(0, MAX_NESTED_ENTRIES)) {
+    const entryPath = join(path, entry)
+    const info = await inspectPath(entryPath)
+    if (info.state !== 'PRESENT') continue
+    if (!nested && entry.endsWith('.jsonl')) files.push(entryPath)
+    if (nested && info.entries) {
+      for (const hash of info.entries.slice(0, MAX_NESTED_ENTRIES)) {
+        const hashPath = join(entryPath, hash)
+        const hashInfo = await inspectPath(hashPath)
+        if (hashInfo.state !== 'PRESENT') continue
+        const candidates = [join(hashPath, 'chatSessions'), join(hashPath, 'GitHub.copilot-chat', 'transcripts')]
+        for (const candidate of candidates) {
+          const candidateInfo = await inspectPath(candidate)
+          if (candidateInfo.state !== 'PRESENT' || !candidateInfo.entries) continue
+          for (const file of candidateInfo.entries.filter(item => item.endsWith('.jsonl')).slice(0, MAX_NESTED_ENTRIES)) files.push(join(candidate, file))
+        }
+      }
+    }
+  }
+  if (files.length === 0) return diagnostic(family, path, { state: 'PRESENT_EMPTY', reason: 'directory has no supported sessions' })
+  for (const file of files.slice(0, MAX_NESTED_ENTRIES)) {
+    const probe = await inspectJsonLines(file)
+    if (probe.state === 'MALFORMED' || probe.state === 'UNKNOWN') return diagnostic(family, path, probe)
+  }
+  return diagnostic(family, path, { state: 'PRESENT', reason: 'recognized Copilot JSON sources are readable' })
+}
+
+async function copilotJetBrains(path: string): Promise<DoctorSourceDiagnostic> {
+  const root = await readDirectory(path)
+  if (!root.entries || root.state !== 'PRESENT') return diagnostic('jetbrains', path, root)
+  let found = false
+  for (const ide of root.entries.slice(0, MAX_NESTED_ENTRIES)) {
+    const ideInfo = await inspectPath(join(path, ide))
+    if (ideInfo.state !== 'PRESENT' || !ideInfo.entries) continue
+    for (const kind of ideInfo.entries.slice(0, MAX_NESTED_ENTRIES)) {
+      const kindInfo = await inspectPath(join(path, ide, kind))
+      if (kindInfo.state !== 'PRESENT' || !kindInfo.entries) continue
+      for (const store of kindInfo.entries.slice(0, MAX_NESTED_ENTRIES)) {
+        const storeInfo = await inspectPath(join(path, ide, kind, store))
+        if (storeInfo.state !== 'PRESENT' || !storeInfo.entries) continue
+        const db = storeInfo.entries.find(entry => entry.endsWith('-nitrite.db') || entry.endsWith('.db'))
+        if (!db) continue
+        const dbInfo = await inspectPath(join(path, ide, kind, store, db))
+        if (dbInfo.state !== 'PRESENT') continue
+        found = true
+      }
+    }
+  }
+  return diagnostic('jetbrains', path, found
+    ? { state: 'PRESENT', reason: 'recognized JetBrains Copilot stores are readable' }
+    : { state: 'PRESENT_EMPTY', reason: 'JetBrains root has no supported stores' })
+}
+
+export async function diagnoseProviderSources(
+  providerName: string,
+  roots: readonly ProbeRoot[],
+): Promise<DoctorSourceDiagnostic[]> {
+  const out: DoctorSourceDiagnostic[] = []
+  for (const root of roots) {
+    if (providerName === 'cursor' && root.label === 'global-state') out.push(cursorSqlite(root.path))
+    else if (providerName === 'cursor' && root.label === 'workspace-storage') out.push(await cursorWorkspace(root.path))
+    else if (providerName === 'kiro') out.push(await kiroDirectory(root.path, root.label))
+    else if (providerName === 'copilot' && root.label === 'otel-agent-traces') {
+      const probe = inspectReadonlySqlite(root.path, ['spans', 'span_attributes'], db => {
+        const rows = db.query<{ count: number }>('SELECT COUNT(*) AS count FROM spans')
+        return Number(rows[0]?.count ?? 0) > 0
+          ? { state: 'PRESENT', reason: 'recognized Copilot OTel store has spans' }
+          : { state: 'PRESENT_EMPTY', reason: 'recognized Copilot OTel store has no spans' }
+      })
+      out.push(diagnostic(root.label, root.path, probe, overrideNameFor('copilot', root.label)))
+    } else if (providerName === 'copilot' && root.label === 'cli-session-state') {
+      const row = await copilotJsonDirectory(root.path, root.label, false)
+      out.push({ ...row, ...(overrideNameFor('copilot', root.label) ? { override: overrideNameFor('copilot', root.label) } : {}) })
+    } else if (providerName === 'copilot' && root.label === 'vscode-workspace-storage') {
+      const row = await copilotJsonDirectory(root.path, root.label, true)
+      out.push({ ...row, ...(overrideNameFor('copilot', root.label) ? { override: overrideNameFor('copilot', root.label) } : {}) })
+    } else if (providerName === 'copilot' && root.label === 'empty-window-global-storage') {
+      const row = await copilotJsonDirectory(root.path, root.label, false)
+      out.push({ ...row, ...(overrideNameFor('copilot', root.label) ? { override: overrideNameFor('copilot', root.label) } : {}) })
+    } else if (providerName === 'copilot' && root.label === 'jetbrains') {
+      const row = await copilotJetBrains(root.path)
+      out.push({ ...row, ...(overrideNameFor('copilot', root.label) ? { override: overrideNameFor('copilot', root.label) } : {}) })
+    } else {
+      out.push(diagnostic(root.label, root.path, await inspectPath(root.path)))
+    }
+  }
+  return out
+}
+
+export function doctorProbePath(diagnosticRow: DoctorSourceDiagnostic): { path: string; label: string; exists: boolean; state: DoctorSourceState; reason: string } {
+  return {
+    path: diagnosticRow.root,
+    label: diagnosticRow.family,
+    exists: diagnosticRow.state === 'PRESENT' || diagnosticRow.state === 'PRESENT_EMPTY',
+    state: diagnosticRow.state,
+    reason: diagnosticRow.reason,
+  }
+}

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -7,6 +7,15 @@ import { Chalk } from 'chalk'
 import { getClaudeConfigDirs } from './providers/claude.js'
 import { getAllProviders } from './providers/index.js'
 import type { Provider } from './providers/types.js'
+import { COPILOT_DEFERRED_ENV_FINGERPRINTS, ensureProviderEnvFingerprintAuthorities } from './provider-parse-authorities.js'
+import {
+  diagnoseProviderSources,
+  doctorProbePath,
+  redactPath,
+  redactText,
+  type DoctorSourceDiagnostic,
+  type DoctorSourceState,
+} from './doctor-source-diagnostics.js'
 import {
   PROVIDER_ENV_VARS,
   PROVIDER_PARSE_VERSIONS,
@@ -21,11 +30,12 @@ export type DoctorProbePath = {
   path: string
   label: string
   exists: boolean
+  state?: DoctorSourceState
+  reason?: string
 }
 
 export type DoctorEnvOverride = {
   name: string
-  value: string
 }
 
 export type DoctorStatus = 'ok' | 'empty' | 'errors' | 'error' | 'network'
@@ -37,6 +47,8 @@ export type DoctorProviderReport = {
   /** Directories/dbs the provider scans, with existence checked (may be empty
    *  for providers that do not expose probeRoots). */
   probePaths: DoctorProbePath[]
+  /** Bounded, family-level source diagnostics. Paths are always redacted. */
+  families: DoctorSourceDiagnostic[]
   /** Env overrides that are actually set for this provider. */
   envOverrides: DoctorEnvOverride[]
   parseVersion?: string
@@ -112,29 +124,26 @@ const NON_DISCOVERY_ENV_VARS = new Set([
 // must be fingerprinted, but do not represent deliberate user overrides.
 const AMBIENT_ENV_VARS = new Set(['APPDATA', 'LOCALAPPDATA'])
 
-// Credential presence is useful diagnostic state; the value is a live secret
-// and must never reach text or JSON doctor output.
-const SECRET_ENV_VARS = new Set(['AI_GATEWAY_API_KEY', 'VERCEL_OIDC_TOKEN'])
+const COPILOT_DIAGNOSTIC_ENV_OVERRIDES = [
+  ...COPILOT_DEFERRED_ENV_FINGERPRINTS,
+  'METRORA_COPILOT_GLOBAL_STORAGE_DIR',
+] as const
 
 // ── Collect (pure, testable) ─────────────────────────────────────────────
 
 function collectEnvOverrides(providerName: string): DoctorEnvOverride[] {
-  const vars = PROVIDER_ENV_VARS[providerName] ?? []
+  ensureProviderEnvFingerprintAuthorities()
+  const vars = [
+    ...(PROVIDER_ENV_VARS[providerName] ?? []),
+    ...(providerName === 'copilot' ? COPILOT_DIAGNOSTIC_ENV_OVERRIDES : []),
+  ]
   const out: DoctorEnvOverride[] = []
-  for (const name of vars) {
+  for (const name of new Set(vars)) {
     if (AMBIENT_ENV_VARS.has(name)) continue
     const value = process.env[name]
-    if (value !== undefined && value !== '') {
-      out.push(SECRET_ENV_VARS.has(name) ? { name, value: '<set>' } : { name, value })
-    }
+    if (value !== undefined && value !== '') out.push({ name })
   }
   return out
-}
-
-async function collectProbePaths(provider: Provider): Promise<DoctorProbePath[]> {
-  if (!provider.probeRoots) return []
-  const roots = await provider.probeRoots()
-  return roots.map(r => ({ path: r.path, label: r.label, exists: existsSync(r.path) }))
 }
 
 // A discovered source path can carry a virtual suffix (`<db>#cursor-ws=...`,
@@ -156,7 +165,13 @@ function derivePathsFromSources(sourcePaths: string[]): DoctorProbePath[] {
     const real = realPathOf(sp)
     dirs.add(existsSync(real) ? dirname(real) : real)
   }
-  return [...dirs].sort().map(path => ({ path, label: 'discovered', exists: existsSync(path) }))
+  return [...dirs].sort().map(path => ({
+    path: redactPath(path),
+    label: 'discovered',
+    exists: existsSync(path),
+    state: existsSync(path) ? 'PRESENT' : 'MISSING',
+    reason: existsSync(path) ? 'discovered source is present' : 'discovered source is absent',
+  }))
 }
 
 function pluralSessions(n: number): string {
@@ -164,10 +179,11 @@ function pluralSessions(n: number): string {
 }
 
 function emptyVerdict(
+  providerName: string,
   probePaths: DoctorProbePath[],
   envOverrides: DoctorEnvOverride[],
 ): string {
-  const discoveryOverrides = envOverrides.filter(o => !NON_DISCOVERY_ENV_VARS.has(o.name))
+  const discoveryOverrides = envOverrides.filter(o => !NON_DISCOVERY_ENV_VARS.has(o.name) && !(providerName === 'cursor' && o.name === 'XDG_DATA_HOME'))
   const overrideNames = discoveryOverrides.map(o => o.name).join(', ')
   const hasOverride = discoveryOverrides.length > 0
   const known = probePaths.filter(p => p.label !== 'discovered')
@@ -177,21 +193,21 @@ function emptyVerdict(
   // No known probe roots to check: honest, override-aware fallback.
   if (known.length === 0) {
     return hasOverride
-      ? `NOTHING FOUND (override ${overrideNames} set, but nothing was discovered)`
+      ? `NOTHING FOUND (override ${overrideNames} set, but no source was discovered)`
       : 'NOTHING FOUND (tool likely not installed or no history yet)'
   }
   // With an override set, a missing probed path is the likely culprit; name it
   // so the row itself points at the misconfiguration (Details lists them all).
   if (hasOverride) {
     return missing.length > 0
-      ? `NOTHING FOUND (override ${overrideNames} set; ${missing[0]!.path} does not exist)`
-      : `NOTHING FOUND (override ${overrideNames} set; ${present[0]!.path} holds no sessions)`
+      ? `NOTHING FOUND (override ${overrideNames} set; source is missing)`
+      : `NOTHING FOUND (override ${overrideNames} set; source is readable but empty)`
   }
   // No override. If every probed path is missing, the tool is likely not
   // installed; if some exist, the data dir is there but empty (no history).
   return present.length === 0
-    ? `NOTHING FOUND (${missing[0]!.path} does not exist; tool likely not installed)`
-    : `NOTHING FOUND (${present[0]!.path} exists but holds no sessions; no history yet)`
+    ? 'NOTHING FOUND (configured sources are missing; tool likely not installed)'
+    : 'NOTHING FOUND (configured sources are readable but empty; no history yet)'
 }
 
 async function collectOneProvider(
@@ -204,6 +220,7 @@ async function collectOneProvider(
     displayName: provider.displayName,
     status: 'ok',
     probePaths: [],
+    families: [],
     envOverrides: collectEnvOverrides(provider.name),
     parseVersion: PROVIDER_PARSE_VERSIONS[provider.name],
     candidatesFound: 0,
@@ -226,13 +243,17 @@ async function collectOneProvider(
   // Any single provider throwing (probe, discovery, or a parser) must never
   // crash doctor or blank the other rows: catch and report it as an ERROR row.
   try {
-    base.probePaths = await collectProbePaths(provider)
+    const roots = provider.probeRoots ? await provider.probeRoots() : []
+    base.families = await diagnoseProviderSources(provider.name, roots)
+    base.probePaths = base.families.map(doctorProbePath)
 
     const sources = await provider.discoverSessions()
     base.candidatesFound = sources.length
     if (base.probePaths.length === 0) {
       base.probePaths = derivePathsFromSources(sources.map(s => s.path))
     }
+
+    const diagnosticFailures = base.families.filter(f => ['INACCESSIBLE', 'MALFORMED', 'UNSUPPORTED_VARIANT', 'UNKNOWN'].includes(f.state))
 
     // Network providers fetch on parse; doctor runs offline, so we never parse
     // them. Discovery for the one network provider is offline (it only checks
@@ -270,19 +291,21 @@ async function collectOneProvider(
       }
     }
 
-    if (base.parseFailed > 0) {
+    if (diagnosticFailures.length > 0 || base.parseFailed > 0) {
       base.status = 'errors'
-      base.verdict = `ERRORS (${base.parseFailed}/${base.sampled} sampled file${base.sampled === 1 ? '' : 's'} failed to parse)`
+      base.verdict = diagnosticFailures.length > 0
+        ? `ERRORS (${diagnosticFailures.length} source diagnostic${diagnosticFailures.length === 1 ? '' : 's'} need attention)`
+        : `ERRORS (${base.parseFailed}/${base.sampled} sampled file${base.sampled === 1 ? '' : 's'} failed to parse)`
     } else if (base.candidatesFound === 0) {
       base.status = 'empty'
-      base.verdict = emptyVerdict(base.probePaths, base.envOverrides)
+      base.verdict = emptyVerdict(provider.name, base.probePaths, base.envOverrides)
     } else {
       base.status = 'ok'
       base.verdict = `OK (${pluralSessions(base.candidatesFound)})`
     }
   } catch (err) {
     base.status = 'error'
-    base.error = err instanceof Error ? err.message : String(err)
+    base.error = redactText(err instanceof Error ? err.message : String(err))
     base.verdict = `ERROR (${base.error})`
   }
 
@@ -345,12 +368,12 @@ async function collectClaudeRetention(): Promise<ClaudeRetentionNote | undefined
       const parsed: unknown = JSON.parse(raw)
       const days = (parsed as Record<string, unknown> | null)?.['cleanupPeriodDays']
       if (typeof days === 'number' && Number.isFinite(days)) {
-        return { effectiveDays: days, configured: true, settingsPath }
+        return { effectiveDays: days, configured: true, settingsPath: redactPath(settingsPath) }
       }
-      return { effectiveDays: CLAUDE_DEFAULT_CLEANUP_DAYS, configured: false, settingsPath }
+      return { effectiveDays: CLAUDE_DEFAULT_CLEANUP_DAYS, configured: false, settingsPath: redactPath(settingsPath) }
     } catch {
       // Unparseable settings: report the default; Claude Code would apply it too.
-      return { effectiveDays: CLAUDE_DEFAULT_CLEANUP_DAYS, configured: false, settingsPath }
+      return { effectiveDays: CLAUDE_DEFAULT_CLEANUP_DAYS, configured: false, settingsPath: redactPath(settingsPath) }
     }
   }
   return undefined
@@ -408,6 +431,7 @@ export function renderDoctorTable(
     r =>
       r.status === 'error' ||
       r.status === 'errors' ||
+      r.families.length > 0 ||
       r.envOverrides.length > 0 ||
       r.cachedFailed > 0 ||
       r.probePaths.some(p => p.label !== 'discovered'),
@@ -418,15 +442,20 @@ export function renderDoctorTable(
     for (const r of detail) {
       out.push('  ' + c.bold(r.displayName))
       for (const o of r.envOverrides) {
-        out.push('    ' + c.dim('override ') + `${o.name}=${o.value}`)
+        out.push('    ' + c.dim('override ') + o.name)
       }
-      for (const p of r.probePaths) {
-        const mark = p.exists ? c.green('exists') : c.red('missing')
+      for (const family of r.families) {
+        const color = family.state === 'PRESENT' ? c.green : family.state === 'PRESENT_EMPTY' ? c.yellow : family.state === 'MISSING' ? c.dim : c.red
+        const override = family.override ? c.dim(` [${family.override}]`) : ''
+        out.push('    ' + c.dim(`${family.family}: `) + color(family.state) + ` ${family.root} ` + c.dim(`(${family.reason})`) + override)
+      }
+      if (r.families.length === 0) for (const p of r.probePaths) {
+        const mark = p.exists ? c.green('present') : c.red('missing')
         out.push('    ' + c.dim(`${p.label}: `) + p.path + ' ' + c.dim('(') + mark + c.dim(')'))
       }
       if (r.parseVersion) out.push('    ' + c.dim('parser: ') + r.parseVersion)
       if (r.cachedFailed > 0) out.push('    ' + c.dim('cached parse failures: ') + String(r.cachedFailed))
-      if (r.error) out.push('    ' + c.red('error: ') + r.error)
+      if (r.error) out.push('    ' + c.red('error: ') + redactText(r.error))
     }
   }
 

--- a/src/providers/copilot-paths.ts
+++ b/src/providers/copilot-paths.ts
@@ -1,0 +1,105 @@
+import { existsSync } from 'node:fs'
+import { homedir, platform } from 'node:os'
+import { join, posix, win32 } from 'node:path'
+
+import type { ProbeRoot } from './types.js'
+
+export function getCopilotSessionStateDir(override?: string): string {
+  return override ?? process.env['METRORA_COPILOT_SESSION_STATE_DIR'] ?? join(homedir(), '.copilot', 'session-state')
+}
+
+export function getVSCodeWorkspaceStorageDirs(home: string, os: string): string[] {
+  const j = os === 'win32' ? win32.join : posix.join
+  if (os === 'darwin') {
+    return [
+      j(home, 'Library', 'Application Support', 'Code', 'User', 'workspaceStorage'),
+      j(home, 'Library', 'Application Support', 'Code - Insiders', 'User', 'workspaceStorage'),
+      j(home, 'Library', 'Application Support', 'VSCodium', 'User', 'workspaceStorage'),
+    ]
+  }
+  if (os === 'linux') {
+    return [
+      j(home, '.config', 'Code', 'User', 'workspaceStorage'),
+      j(home, '.config', 'Code - Insiders', 'User', 'workspaceStorage'),
+      j(home, '.config', 'VSCodium', 'User', 'workspaceStorage'),
+    ]
+  }
+  return [
+    j(home, 'AppData', 'Roaming', 'Code', 'User', 'workspaceStorage'),
+    j(home, 'AppData', 'Roaming', 'Code - Insiders', 'User', 'workspaceStorage'),
+    j(home, 'AppData', 'Roaming', 'VSCodium', 'User', 'workspaceStorage'),
+  ]
+}
+
+export function getVSCodeGlobalStorageDirs(home: string, os: string): string[] {
+  const j = os === 'win32' ? win32.join : posix.join
+  if (os === 'darwin') {
+    return [
+      j(home, 'Library', 'Application Support', 'Code', 'User', 'globalStorage'),
+      j(home, 'Library', 'Application Support', 'Code - Insiders', 'User', 'globalStorage'),
+      j(home, 'Library', 'Application Support', 'VSCodium', 'User', 'globalStorage'),
+    ]
+  }
+  if (os === 'linux') {
+    return [
+      j(home, '.config', 'Code', 'User', 'globalStorage'),
+      j(home, '.config', 'Code - Insiders', 'User', 'globalStorage'),
+      j(home, '.config', 'VSCodium', 'User', 'globalStorage'),
+    ]
+  }
+  return [
+    j(home, 'AppData', 'Roaming', 'Code', 'User', 'globalStorage'),
+    j(home, 'AppData', 'Roaming', 'Code - Insiders', 'User', 'globalStorage'),
+    j(home, 'AppData', 'Roaming', 'VSCodium', 'User', 'globalStorage'),
+  ]
+}
+
+export function getAgentTracesDbCandidates(): string[] {
+  const override = process.env['METRORA_COPILOT_OTEL_DB']
+  if (override) return [override]
+  const os = platform()
+  const globalStorageDirs = os === 'win32' && process.env['APPDATA']
+    ? ['Code', 'Code - Insiders', 'VSCodium'].map(variant => join(process.env['APPDATA']!, variant, 'User', 'globalStorage'))
+    : getVSCodeGlobalStorageDirs(homedir(), os)
+  return globalStorageDirs
+    .map(root => join(root, 'github.copilot-chat', 'agent-traces.db'))
+}
+
+export function getAgentTracesDbPath(): string | null {
+  return getAgentTracesDbCandidates().find(existsSync) ?? null
+}
+
+export function getJetBrainsCopilotRoot(override?: string): string {
+  const envOverride = override ?? process.env['METRORA_COPILOT_JETBRAINS_DIR']
+  if (envOverride) return envOverride
+  const xdg = process.env['XDG_CONFIG_HOME']
+  if (xdg && (posix.isAbsolute(xdg) || win32.isAbsolute(xdg))) return join(xdg, 'github-copilot')
+  if (platform() === 'win32') {
+    return join(process.env['LOCALAPPDATA'] ?? join(homedir(), 'AppData', 'Local'), 'github-copilot')
+  }
+  return join(homedir(), '.config', 'github-copilot')
+}
+
+export function getCopilotDoctorProbeRoots(
+  sessionStateDir?: string,
+  workspaceStorageDir?: string,
+  globalStorageDir?: string,
+  jetbrainsDir?: string,
+): ProbeRoot[] {
+  const roots: ProbeRoot[] = getAgentTracesDbCandidates().map(path => ({ path, label: 'otel-agent-traces' }))
+  roots.push({ path: getCopilotSessionStateDir(sessionStateDir), label: 'cli-session-state' })
+  const workspaceRoots = workspaceStorageDir !== undefined
+    ? [workspaceStorageDir]
+    : process.env['METRORA_COPILOT_WS_STORAGE_DIR']
+      ? [process.env['METRORA_COPILOT_WS_STORAGE_DIR']!]
+      : getVSCodeWorkspaceStorageDirs(homedir(), platform())
+  roots.push(...workspaceRoots.map(path => ({ path, label: 'vscode-workspace-storage' })))
+  const globalRoots = globalStorageDir !== undefined
+    ? [globalStorageDir]
+    : process.env['METRORA_COPILOT_GLOBAL_STORAGE_DIR']
+      ? [process.env['METRORA_COPILOT_GLOBAL_STORAGE_DIR']!]
+      : getVSCodeGlobalStorageDirs(homedir(), platform())
+  roots.push(...globalRoots.map(path => ({ path: join(path, 'emptyWindowChatSessions'), label: 'empty-window-global-storage' })))
+  roots.push({ path: getJetBrainsCopilotRoot(jetbrainsDir), label: 'jetbrains' })
+  return roots
+}

--- a/src/providers/copilot.ts
+++ b/src/providers/copilot.ts
@@ -59,7 +59,7 @@
 
 import { readdir, stat } from 'fs/promises'
 import { homedir, platform } from 'os'
-import { join, basename, dirname, posix, win32 } from 'path'
+import { join, basename, dirname } from 'path'
 import { existsSync } from 'fs'
 import { createHash } from 'crypto'
 import { readSessionFile } from '../fs-utils.js'
@@ -72,6 +72,14 @@ import type {
   SessionParser,
   ParsedProviderCall,
 } from './types.js'
+import {
+  getAgentTracesDbPath,
+  getCopilotDoctorProbeRoots,
+  getCopilotSessionStateDir,
+  getJetBrainsCopilotRoot,
+  getVSCodeGlobalStorageDirs,
+  getVSCodeWorkspaceStorageDirs,
+} from './copilot-paths.js'
 
 // ---------------------------------------------------------------------------
 // Model display names (unchanged from original)
@@ -251,10 +259,6 @@ interface SpanAttributes {
 
 // ---------------------------------------------------------------------------
 
-function getCopilotSessionStateDir(override?: string): string {
-  return override ?? process.env['METRORA_COPILOT_SESSION_STATE_DIR'] ?? join(homedir(), '.copilot', 'session-state')
-}
-
 /**
  * Locate the agent-traces.db file.
  *
@@ -263,47 +267,6 @@ function getCopilotSessionStateDir(override?: string): string {
  *   2. Platform-specific default VS Code global storage path
  *   3. VSCodium variant paths
  */
-function getAgentTracesDbPath(): string | null {
-  // Allow explicit override
-  const envOverride = process.env['METRORA_COPILOT_OTEL_DB']
-  if (envOverride) {
-    return existsSync(envOverride) ? envOverride : null
-  }
-
-  const home = homedir()
-  const candidates: string[] = []
-
-  const p = platform()
-  if (p === 'darwin') {
-    // macOS: VS Code, VS Code Insiders, VSCodium
-    candidates.push(
-      join(home, 'Library', 'Application Support', 'Code', 'User', 'globalStorage', 'github.copilot-chat', 'agent-traces.db'),
-      join(home, 'Library', 'Application Support', 'Code - Insiders', 'User', 'globalStorage', 'github.copilot-chat', 'agent-traces.db'),
-      join(home, 'Library', 'Application Support', 'VSCodium', 'User', 'globalStorage', 'github.copilot-chat', 'agent-traces.db'),
-    )
-  } else if (p === 'linux') {
-    // Linux: VS Code, VS Code Insiders, VSCodium
-    candidates.push(
-      join(home, '.config', 'Code', 'User', 'globalStorage', 'github.copilot-chat', 'agent-traces.db'),
-      join(home, '.config', 'Code - Insiders', 'User', 'globalStorage', 'github.copilot-chat', 'agent-traces.db'),
-      join(home, '.config', 'VSCodium', 'User', 'globalStorage', 'github.copilot-chat', 'agent-traces.db'),
-    )
-  } else if (p === 'win32') {
-    // Windows
-    const appdata = process.env['APPDATA'] ?? join(home, 'AppData', 'Roaming')
-    candidates.push(
-      join(appdata, 'Code', 'User', 'globalStorage', 'github.copilot-chat', 'agent-traces.db'),
-      join(appdata, 'Code - Insiders', 'User', 'globalStorage', 'github.copilot-chat', 'agent-traces.db'),
-      join(appdata, 'VSCodium', 'User', 'globalStorage', 'github.copilot-chat', 'agent-traces.db'),
-    )
-  }
-
-  for (const candidate of candidates) {
-    if (existsSync(candidate)) return candidate
-  }
-  return null
-}
-
 /**
  * Locate the GitHub Copilot config root used by the JetBrains IDE plugin
  * (IntelliJ IDEA, PyCharm, RubyMine, …). The JetBrains Copilot agent persists
@@ -321,23 +284,6 @@ function getAgentTracesDbPath(): string | null {
  * Ultimate, `intellij` for the community edition) containing
  * chat-agent-sessions/, chat-sessions/, and chat-edit-sessions/.
  */
-function getJetBrainsCopilotRoot(override?: string): string {
-  const envOverride = override ?? process.env['METRORA_COPILOT_JETBRAINS_DIR']
-  if (envOverride) return envOverride
-
-  const xdg = process.env['XDG_CONFIG_HOME']
-  if (xdg && (posix.isAbsolute(xdg) || win32.isAbsolute(xdg))) {
-    return join(xdg, 'github-copilot')
-  }
-
-  if (platform() === 'win32') {
-    const local = process.env['LOCALAPPDATA'] ?? join(homedir(), 'AppData', 'Local')
-    return join(local, 'github-copilot')
-  }
-
-  return join(homedir(), '.config', 'github-copilot')
-}
-
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -2037,60 +1983,7 @@ async function resolveJetBrainsProjectNames(
 // Provider factory
 // ---------------------------------------------------------------------------
 
-/**
- * Returns the VS Code workspaceStorage directories for all VS Code variants
- * (Code, Code Insiders, VSCodium) on the given platform. Used to discover
- * transcript sessions written by the Copilot Chat extension.
- *
- * Accepts explicit `home` and `os` arguments so callers (and tests) can pass
- * custom values without relying on process-level globals.
- */
-export function getVSCodeWorkspaceStorageDirs(home: string, os: string): string[] {
-  const j = os === 'win32' ? win32.join : posix.join
-  if (os === 'darwin') {
-    return [
-      j(home, 'Library', 'Application Support', 'Code', 'User', 'workspaceStorage'),
-      j(home, 'Library', 'Application Support', 'Code - Insiders', 'User', 'workspaceStorage'),
-      j(home, 'Library', 'Application Support', 'VSCodium', 'User', 'workspaceStorage'),
-    ]
-  }
-  if (os === 'linux') {
-    return [
-      j(home, '.config', 'Code', 'User', 'workspaceStorage'),
-      j(home, '.config', 'Code - Insiders', 'User', 'workspaceStorage'),
-      j(home, '.config', 'VSCodium', 'User', 'workspaceStorage'),
-    ]
-  }
-  // win32
-  return [
-    j(home, 'AppData', 'Roaming', 'Code', 'User', 'workspaceStorage'),
-    j(home, 'AppData', 'Roaming', 'Code - Insiders', 'User', 'workspaceStorage'),
-    j(home, 'AppData', 'Roaming', 'VSCodium', 'User', 'workspaceStorage'),
-  ]
-}
-
-export function getVSCodeGlobalStorageDirs(home: string, os: string): string[] {
-  const j = os === 'win32' ? win32.join : posix.join
-  if (os === 'darwin') {
-    return [
-      j(home, 'Library', 'Application Support', 'Code', 'User', 'globalStorage'),
-      j(home, 'Library', 'Application Support', 'Code - Insiders', 'User', 'globalStorage'),
-      j(home, 'Library', 'Application Support', 'VSCodium', 'User', 'globalStorage'),
-    ]
-  }
-  if (os === 'linux') {
-    return [
-      j(home, '.config', 'Code', 'User', 'globalStorage'),
-      j(home, '.config', 'Code - Insiders', 'User', 'globalStorage'),
-      j(home, '.config', 'VSCodium', 'User', 'globalStorage'),
-    ]
-  }
-  return [
-    j(home, 'AppData', 'Roaming', 'Code', 'User', 'globalStorage'),
-    j(home, 'AppData', 'Roaming', 'Code - Insiders', 'User', 'globalStorage'),
-    j(home, 'AppData', 'Roaming', 'VSCodium', 'User', 'globalStorage'),
-  ]
-}
+export { getVSCodeGlobalStorageDirs, getVSCodeWorkspaceStorageDirs } from './copilot-paths.js'
 
 async function resolveWorkspaceProject(wsDir: string, hashDir: string): Promise<string> {
   let project = hashDir
@@ -2290,6 +2183,7 @@ export function createCopilotProvider(
     name: 'copilot',
     displayName: 'Copilot',
     durableSources: true,
+    probeRoots: async () => getCopilotDoctorProbeRoots(sessionStateDir, workspaceStorageDir, globalStorageDir, jetbrainsDir),
 
     modelDisplayName(model: string): string {
       for (const [key, display] of modelDisplayEntries) {

--- a/src/providers/cursor-paths.ts
+++ b/src/providers/cursor-paths.ts
@@ -1,0 +1,26 @@
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+
+import type { ProbeRoot } from './types.js'
+
+export function getCursorDbPath(): string {
+  if (process.platform === 'darwin') {
+    return join(homedir(), 'Library', 'Application Support', 'Cursor', 'User', 'globalStorage', 'state.vscdb')
+  }
+  if (process.platform === 'win32') {
+    return join(homedir(), 'AppData', 'Roaming', 'Cursor', 'User', 'globalStorage', 'state.vscdb')
+  }
+  return join(homedir(), '.config', 'Cursor', 'User', 'globalStorage', 'state.vscdb')
+}
+
+export function getCursorWorkspaceStorageDir(globalDbPath: string): string {
+  return join(globalDbPath, '..', '..', 'workspaceStorage')
+}
+
+export function getCursorDoctorProbeRoots(dbPathOverride?: string): ProbeRoot[] {
+  const dbPath = dbPathOverride ?? getCursorDbPath()
+  return [
+    { path: dbPath, label: 'global-state' },
+    { path: getCursorWorkspaceStorageDir(dbPath), label: 'workspace-storage' },
+  ]
+}

--- a/src/providers/cursor.ts
+++ b/src/providers/cursor.ts
@@ -1,6 +1,5 @@
 import { existsSync, readdirSync, readFileSync, statSync } from 'fs'
 import { join } from 'path'
-import { homedir } from 'os'
 
 import { calculateCost } from '../models.js'
 import { extractBashCommands } from '../bash-utils.js'
@@ -9,6 +8,7 @@ import { isSqliteAvailable, isSqliteBusyError, getSqliteLoadError, openDatabase,
 import { estimateTokensFromChars } from '../token-estimate.js'
 import type { DateRange } from '../types.js'
 import type { Provider, SessionSource, SessionParser, ParsedProviderCall } from './types.js'
+import { getCursorDbPath, getCursorDoctorProbeRoots, getCursorWorkspaceStorageDir } from './cursor-paths.js'
 
 /** Default scan cap for Cursor when the caller did not request a range. */
 const CURSOR_MAX_LOOKBACK_MONTHS = 6
@@ -73,26 +73,6 @@ type AgentKvRow = {
 // contention does not change the main file's stat).
 function rethrowBusy(err: unknown): void {
   if (isSqliteBusyError(err)) throw err
-}
-
-function getCursorDbPath(): string {
-  if (process.platform === 'darwin') {
-    return join(homedir(), 'Library', 'Application Support', 'Cursor', 'User', 'globalStorage', 'state.vscdb')
-  }
-  if (process.platform === 'win32') {
-    return join(homedir(), 'AppData', 'Roaming', 'Cursor', 'User', 'globalStorage', 'state.vscdb')
-  }
-  return join(homedir(), '.config', 'Cursor', 'User', 'globalStorage', 'state.vscdb')
-}
-
-function getCursorWorkspaceStorageDir(globalDbPath: string): string {
-  // Sibling of globalStorage. Cursor lays out User/{globalStorage,workspaceStorage}/.
-  // We derive the workspaceStorage path from the global DB path so a test or
-  // override can supply both consistently from one root.
-  // globalDbPath = .../User/globalStorage/state.vscdb
-  // workspaceStorage = .../User/workspaceStorage
-  const userDir = join(globalDbPath, '..', '..')
-  return join(userDir, 'workspaceStorage')
 }
 
 /// Per-conversation workspace lookup table. Cursor stores each chat as
@@ -1073,6 +1053,8 @@ export function createCursorProvider(dbPathOverride?: string): Provider {
       })
       return sources
     },
+
+    probeRoots: async () => getCursorDoctorProbeRoots(dbPathOverride),
 
     createSessionParser(source: SessionSource, seenKeys: Set<string>, dateRange?: DateRange): SessionParser {
       return createParser(source, seenKeys, dateRange)

--- a/src/providers/kiro-paths.ts
+++ b/src/providers/kiro-paths.ts
@@ -1,0 +1,77 @@
+import { existsSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { dirname, join } from 'node:path'
+
+import type { ProbeRoot } from './types.js'
+
+export function getKiroAgentDir(override?: string): string[] {
+  if (override) return [override]
+  if (process.platform === 'darwin') {
+    return [join(homedir(), 'Library', 'Application Support', 'Kiro', 'User', 'globalStorage', 'kiro.kiroagent')]
+  }
+  if (process.platform === 'win32') {
+    return [join(homedir(), 'AppData', 'Roaming', 'Kiro', 'User', 'globalStorage', 'kiro.kiroagent')]
+  }
+  const paths: string[] = []
+  const kiroServer = join(homedir(), '.kiro-server', 'data', 'User', 'globalStorage', 'kiro.kiroagent')
+  const kiroConfig = join(homedir(), '.config', 'Kiro', 'User', 'globalStorage', 'kiro.kiroagent')
+  if (existsSync(kiroServer)) paths.push(kiroServer)
+  if (existsSync(kiroConfig)) paths.push(kiroConfig)
+  return paths.length > 0 ? paths : [kiroConfig]
+}
+
+export function getKiroWorkspaceStorageDir(override?: string): string {
+  if (override) return override
+  if (process.platform === 'darwin') {
+    return join(homedir(), 'Library', 'Application Support', 'Kiro', 'User', 'workspaceStorage')
+  }
+  if (process.platform === 'win32') {
+    return join(homedir(), 'AppData', 'Roaming', 'Kiro', 'User', 'workspaceStorage')
+  }
+  return join(homedir(), '.config', 'Kiro', 'User', 'workspaceStorage')
+}
+
+export function getKiroCliSessionsDir(agentDirOverride?: string, cliSessionsDirOverride?: string): string {
+  return cliSessionsDirOverride ?? (
+    agentDirOverride
+      ? join(agentDirOverride, '..', 'cli-sessions')
+      : join(process.env['KIRO_HOME'] || join(homedir(), '.kiro'), 'sessions', 'cli')
+  )
+}
+
+export function getKiroV2SessionsRoot(
+  agentDirOverride: string | undefined,
+  cliSessionsDirOverride: string | undefined,
+  v2SessionsRootOverride: string | undefined,
+  cliSessionsDir: string,
+): string | undefined {
+  return v2SessionsRootOverride ?? (
+    cliSessionsDirOverride
+      ? dirname(cliSessionsDir)
+      : agentDirOverride
+        ? undefined
+        : dirname(cliSessionsDir)
+  )
+}
+
+export function getKiroDoctorProbeRoots(
+  agentDirOverride?: string,
+  workspaceStorageDirOverride?: string,
+  cliSessionsDirOverride?: string,
+  v2SessionsRootOverride?: string,
+): ProbeRoot[] {
+  const agentDirs = getKiroAgentDir(agentDirOverride)
+  const workspaceStorageDir = getKiroWorkspaceStorageDir(workspaceStorageDirOverride)
+  const cliSessionsDir = getKiroCliSessionsDir(agentDirOverride, cliSessionsDirOverride)
+  const v2Root = getKiroV2SessionsRoot(agentDirOverride, cliSessionsDirOverride, v2SessionsRootOverride, cliSessionsDir)
+  const roots: ProbeRoot[] = agentDirs.map(path => ({
+    path,
+    label: path.includes('.kiro-server') ? 'legacy-ide-server' : 'legacy-ide',
+  }))
+  roots.push(
+    { path: workspaceStorageDir, label: 'workspace-storage' },
+    { path: cliSessionsDir, label: 'cli' },
+  )
+  if (v2Root) roots.push({ path: v2Root, label: 'kiro-v2' })
+  return roots
+}

--- a/src/providers/kiro.ts
+++ b/src/providers/kiro.ts
@@ -9,6 +9,13 @@ import { calculateCost } from '../models.js'
 import { estimateTokensFromChars } from '../token-estimate.js'
 import type { ToolCall } from '../types.js'
 import type { Provider, SessionSource, SessionParser, ParsedProviderCall } from './types.js'
+import {
+  getKiroAgentDir,
+  getKiroCliSessionsDir,
+  getKiroDoctorProbeRoots,
+  getKiroV2SessionsRoot,
+  getKiroWorkspaceStorageDir,
+} from './kiro-paths.js'
 
 // Kiro bills in credits: individual plans are $20/mo for 1,000 credits and
 // overage is billed at $0.04 per additional credit. We price credits at the
@@ -908,38 +915,6 @@ function createParser(source: SessionSource, seenKeys: Set<string>): SessionPars
 
 // --- Discovery ---
 
-function getKiroAgentDir(override?: string): string[] {
-  if (override) return [override]
-  if (process.platform === 'darwin') {
-    return [join(homedir(), 'Library', 'Application Support', 'Kiro', 'User', 'globalStorage', 'kiro.kiroagent')]
-  }
-  if (process.platform === 'win32') {
-    return [join(homedir(), 'AppData', 'Roaming', 'Kiro', 'User', 'globalStorage', 'kiro.kiroagent')]
-  }
-  // On Linux, scan both ~/.kiro-server/data/... (remote dev boxes) and
-  // ~/.config/Kiro/... (local installs). Both can have data simultaneously
-  // if the user switches between local and remote, or if .kiro-server exists
-  // but is stale while .config/Kiro has current sessions.
-  const paths: string[] = []
-  const kiroServer = join(homedir(), '.kiro-server', 'data', 'User', 'globalStorage', 'kiro.kiroagent')
-  const kiroConfig = join(homedir(), '.config', 'Kiro', 'User', 'globalStorage', 'kiro.kiroagent')
-  if (existsSync(kiroServer)) paths.push(kiroServer)
-  if (existsSync(kiroConfig)) paths.push(kiroConfig)
-  // Fallback to config path if neither exists (will just find nothing)
-  return paths.length > 0 ? paths : [kiroConfig]
-}
-
-function getKiroWorkspaceStorageDir(override?: string): string {
-  if (override) return override
-  if (process.platform === 'darwin') {
-    return join(homedir(), 'Library', 'Application Support', 'Kiro', 'User', 'workspaceStorage')
-  }
-  if (process.platform === 'win32') {
-    return join(homedir(), 'AppData', 'Roaming', 'Kiro', 'User', 'workspaceStorage')
-  }
-  return join(homedir(), '.config', 'Kiro', 'User', 'workspaceStorage')
-}
-
 async function readWorkspaceProject(workspaceDir: string): Promise<string> {
   try {
     const raw = await readFile(join(workspaceDir, 'workspace.json'), 'utf-8')
@@ -1109,15 +1084,13 @@ export function createKiroProvider(agentDirOverride?: string, workspaceStorageDi
   const agentDirs = getKiroAgentDir(agentDirOverride)
   const wsDir = getKiroWorkspaceStorageDir(workspaceStorageDirOverride)
   // When overrides are provided (tests), don't scan real CLI sessions unless explicitly given
-  const cliDir = cliSessionsDirOverride ?? (agentDirOverride ? join(agentDirOverride, '..', 'cli-sessions') : join(process.env['KIRO_HOME'] || join(homedir(), '.kiro'), 'sessions', 'cli'))
+  const cliDir = getKiroCliSessionsDir(agentDirOverride, cliSessionsDirOverride)
   // v2 IDE sessions live under ~/.kiro/sessions/<hash>/sess_*/, a sibling of the
   // CLI store (.../sessions/cli). Derive the root from cliDir ONLY when cliDir was
   // itself explicit (default path or cliSessionsDirOverride). When only
   // agentDirOverride is set (tests), the derived cliDir parent would point at an
   // arbitrary directory (e.g. the system tmpdir) — scan nothing in that case.
-  const v2Root = v2SessionsRootOverride ??
-    (cliSessionsDirOverride ? dirname(cliSessionsDirOverride) :
-      agentDirOverride ? undefined : dirname(cliDir))
+  const v2Root = getKiroV2SessionsRoot(agentDirOverride, cliSessionsDirOverride, v2SessionsRootOverride, cliDir)
 
   return {
     name: 'kiro',
@@ -1153,6 +1126,8 @@ export function createKiroProvider(agentDirOverride?: string, workspaceStorageDi
         return true
       })
     },
+
+    probeRoots: async () => getKiroDoctorProbeRoots(agentDirOverride, workspaceStorageDirOverride, cliSessionsDirOverride, v2SessionsRootOverride),
 
     createSessionParser(source: SessionSource, seenKeys: Set<string>): SessionParser {
       return createParser(source, seenKeys)

--- a/tests/doctor-bounded-sources.test.ts
+++ b/tests/doctor-bounded-sources.test.ts
@@ -1,0 +1,217 @@
+import { createRequire } from 'node:module'
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { collectDoctorReport, renderDoctorJson, renderDoctorTable } from '../src/doctor.js'
+import { classifyDoctorError, DOCTOR_SOURCE_STATES, redactText } from '../src/doctor-source-diagnostics.js'
+import { getCopilotDoctorProbeRoots } from '../src/providers/copilot-paths.js'
+import { createCopilotProvider } from '../src/providers/copilot.js'
+import { getCursorDoctorProbeRoots, getCursorWorkspaceStorageDir } from '../src/providers/cursor-paths.js'
+import { createCursorProvider } from '../src/providers/cursor.js'
+import { getKiroDoctorProbeRoots } from '../src/providers/kiro-paths.js'
+import { createKiroProvider } from '../src/providers/kiro.js'
+import { PROVIDER_ENV_VARS, emptyCache } from '../src/session-cache.js'
+import type { Provider } from '../src/providers/types.js'
+
+const requireForTest = createRequire(import.meta.url)
+type TestDb = { exec(sql: string): void; close(): void }
+
+function createDb(path: string, sql: string): void {
+  const { DatabaseSync } = requireForTest('node:sqlite') as { DatabaseSync: new (path: string) => TestDb }
+  const db = new DatabaseSync(path)
+  db.exec(sql)
+  db.close()
+}
+
+function only(report: Awaited<ReturnType<typeof collectDoctorReport>>, name: string) {
+  const row = report.providers.find(provider => provider.provider === name)
+  if (!row) throw new Error(`missing Doctor row for ${name}`)
+  return row
+}
+
+let root = ''
+
+beforeEach(async () => {
+  root = await mkdtemp(join(tmpdir(), 'metrora-doctor-bounded-'))
+})
+
+afterEach(async () => {
+  vi.unstubAllEnvs()
+  await rm(root, { recursive: true, force: true })
+})
+
+describe('bounded source diagnostic primitive', () => {
+  it('keeps all state categories explicit and does not leak unknown paths', async () => {
+    expect(DOCTOR_SOURCE_STATES).toEqual([
+      'PRESENT', 'PRESENT_EMPTY', 'MISSING', 'INACCESSIBLE', 'MALFORMED', 'UNSUPPORTED_VARIANT', 'UNKNOWN',
+    ])
+    expect(classifyDoctorError({ code: 'EACCES' }).state).toBe('INACCESSIBLE')
+    expect(classifyDoctorError(new SyntaxError('invalid JSON')).state).toBe('MALFORMED')
+    expect(classifyDoctorError({ message: 'database is locked' }).state).toBe('UNKNOWN')
+    expect(redactText("open 'C:\\Users\\alice\\Private Workspace\\cache.json'"))
+      .not.toContain('alice')
+    const provider: Provider = {
+      name: 'codex',
+      displayName: 'Codex',
+      modelDisplayName: model => model,
+      toolDisplayName: tool => tool,
+      probeRoots: async () => [
+        { path: join(root, 'missing'), label: 'missing-family' },
+        { path: root, label: 'empty-family' },
+      ],
+      discoverSessions: async () => [],
+      createSessionParser: () => ({ async *parse() {} }),
+    }
+    const row = only(await collectDoctorReport('codex', { providers: [provider], cache: emptyCache() }), 'codex')
+    expect(row.families.map(family => family.state)).toEqual(['MISSING', 'PRESENT_EMPTY'])
+    expect(row.families.every(family => family.root === '<redacted-path>')).toBe(true)
+  })
+
+  it('redacts override values and source paths in both output modes', async () => {
+    const secretPath = 'C:\\Users\\alice\\Private Workspace\\cache.json'
+    vi.stubEnv('CODEX_HOME', secretPath)
+    const provider: Provider = {
+      name: 'codex',
+      displayName: 'Codex',
+      modelDisplayName: model => model,
+      toolDisplayName: tool => tool,
+      probeRoots: async () => [{ path: secretPath, label: 'sessions' }],
+      discoverSessions: async () => [],
+      createSessionParser: () => ({ async *parse() {} }),
+    }
+    const report = await collectDoctorReport('codex', { providers: [provider], cache: emptyCache() })
+    expect(report.providers[0]?.envOverrides).toEqual([{ name: 'CODEX_HOME' }])
+    expect(renderDoctorJson(report)).not.toContain('alice')
+    expect(renderDoctorTable(report, { color: false })).not.toContain('Private Workspace')
+  })
+})
+
+describe('Cursor Doctor families', () => {
+  it('uses global state plus sibling workspace storage and ignores XDG_DATA_HOME for discovery', async () => {
+    const dbPath = join(root, 'Cursor', 'User', 'globalStorage', 'state.vscdb')
+    vi.stubEnv('XDG_DATA_HOME', join(root, 'wrong-xdg-data'))
+    expect(getCursorDoctorProbeRoots(dbPath)).toEqual([
+      { path: dbPath, label: 'global-state' },
+      { path: getCursorWorkspaceStorageDir(dbPath), label: 'workspace-storage' },
+    ])
+    expect(getCursorDoctorProbeRoots(dbPath).every(probe => !probe.path.includes('wrong-xdg-data'))).toBe(true)
+  })
+
+  it('classifies missing, empty, present, malformed and unsupported global state', async () => {
+    const dbPath = join(root, 'Cursor', 'User', 'globalStorage', 'state.vscdb')
+    const provider = createCursorProvider(dbPath)
+
+    let row = only(await collectDoctorReport('cursor', { providers: [provider], cache: emptyCache(), sampleLimit: 0 }), 'cursor')
+    expect(row.families.find(family => family.family === 'global-state')?.state).toBe('MISSING')
+
+    await mkdir(join(root, 'Cursor', 'User', 'globalStorage'), { recursive: true })
+    createDb(dbPath, 'CREATE TABLE cursorDiskKV (key TEXT, value TEXT)')
+    row = only(await collectDoctorReport('cursor', { providers: [provider], cache: emptyCache(), sampleLimit: 0 }), 'cursor')
+    expect(row.families.find(family => family.family === 'global-state')?.state).toBe('PRESENT_EMPTY')
+
+    createDb(dbPath, "INSERT INTO cursorDiskKV (key, value) VALUES ('bubbleId:composer:uuid', '{}')")
+    row = only(await collectDoctorReport('cursor', { providers: [provider], cache: emptyCache(), sampleLimit: 0 }), 'cursor')
+    expect(row.families.find(family => family.family === 'global-state')?.state).toBe('PRESENT')
+
+    await writeFile(dbPath, 'not a sqlite database')
+    row = only(await collectDoctorReport('cursor', { providers: [provider], cache: emptyCache(), sampleLimit: 0 }), 'cursor')
+    expect(row.families.find(family => family.family === 'global-state')?.state).toBe('MALFORMED')
+
+    const unsupportedPath = join(root, 'Cursor', 'User', 'globalStorage', 'unsupported.vscdb')
+    createDb(unsupportedPath, 'CREATE TABLE unrelated (id INTEGER)')
+    row = only(await collectDoctorReport('cursor', {
+      providers: [createCursorProvider(unsupportedPath)],
+      cache: emptyCache(),
+      sampleLimit: 0,
+    }), 'cursor')
+    expect(row.families.find(family => family.family === 'global-state')?.state).toBe('UNSUPPORTED_VARIANT')
+  })
+})
+
+describe('Kiro Doctor families', () => {
+  it('reports legacy, workspace, CLI and v2 roots separately without making optional absence fatal', async () => {
+    const agent = join(root, 'kiro-agent')
+    const workspace = join(root, 'workspace-storage')
+    const cli = join(root, 'sessions', 'cli')
+    const v2 = join(root, 'sessions')
+    await mkdir(agent, { recursive: true })
+    await mkdir(workspace, { recursive: true })
+    await mkdir(cli, { recursive: true })
+    await mkdir(v2, { recursive: true })
+    const paths = getKiroDoctorProbeRoots(agent, workspace, cli, v2)
+    expect(paths.map(path => path.label)).toEqual(['legacy-ide', 'workspace-storage', 'cli', 'kiro-v2'])
+    const row = only(await collectDoctorReport('kiro', {
+      providers: [createKiroProvider(agent, workspace, cli, v2)],
+      cache: emptyCache(),
+      sampleLimit: 0,
+    }), 'kiro')
+    expect(row.families.map(family => family.state)).toEqual(['PRESENT_EMPTY', 'PRESENT_EMPTY', 'PRESENT_EMPTY', 'PRESENT_EMPTY'])
+    expect(row.status).toBe('empty')
+    expect(PROVIDER_ENV_VARS.kiro).toContain('KIRO_HOME')
+  })
+
+  it('classifies malformed CLI JSON without changing Kiro discovery', async () => {
+    const agent = join(root, 'kiro-agent')
+    const workspace = join(root, 'workspace-storage')
+    const cli = join(root, 'sessions', 'cli')
+    await mkdir(cli, { recursive: true })
+    await writeFile(join(cli, 'broken.jsonl'), '{broken\n')
+    const row = only(await collectDoctorReport('kiro', {
+      providers: [createKiroProvider(agent, workspace, cli, join(root, 'sessions'))],
+      cache: emptyCache(),
+      sampleLimit: 0,
+    }), 'kiro')
+    expect(row.families.find(family => family.family === 'cli')?.state).toBe('MALFORMED')
+    expect(row.families.some(family => family.family === 'workspace-storage' && family.state === 'MISSING')).toBe(true)
+  })
+})
+
+describe('Copilot Doctor families', () => {
+  it('keeps OTel, CLI, VS Code, empty-window and JetBrains lanes separate', async () => {
+    const otel = join(root, 'agent-traces.db')
+    const cli = join(root, 'cli')
+    const workspace = join(root, 'workspace')
+    const global = join(root, 'global')
+    const jetbrains = join(root, 'jetbrains')
+    await mkdir(cli, { recursive: true })
+    await mkdir(workspace, { recursive: true })
+    await mkdir(global, { recursive: true })
+    await mkdir(join(global, 'emptyWindowChatSessions'), { recursive: true })
+    await mkdir(jetbrains, { recursive: true })
+    createDb(otel, `
+      CREATE TABLE spans (span_id TEXT PRIMARY KEY, trace_id TEXT NOT NULL, operation_name TEXT, start_time_ms INTEGER, response_model TEXT);
+      CREATE TABLE span_attributes (id INTEGER PRIMARY KEY, span_id TEXT, key TEXT, value TEXT);
+    `)
+    vi.stubEnv('METRORA_COPILOT_OTEL_DB', otel)
+    const roots = getCopilotDoctorProbeRoots(cli, workspace, global, jetbrains)
+    expect(roots.map(root => root.label)).toEqual([
+      'otel-agent-traces', 'cli-session-state', 'vscode-workspace-storage',
+      'empty-window-global-storage', 'jetbrains',
+    ])
+    const row = only(await collectDoctorReport('copilot', {
+      providers: [createCopilotProvider(cli, workspace, global, jetbrains)],
+      cache: emptyCache(),
+      sampleLimit: 0,
+    }), 'copilot')
+    expect(row.families.find(family => family.family === 'otel-agent-traces')?.state).toBe('PRESENT_EMPTY')
+    expect(row.families.filter(family => family.family !== 'otel-agent-traces').every(family => family.state === 'PRESENT_EMPTY')).toBe(true)
+  })
+
+  it('fails closed for a corrupt OTel database but keeps other lanes diagnostic', async () => {
+    const otel = join(root, 'agent-traces.db')
+    const cli = join(root, 'cli')
+    await mkdir(cli, { recursive: true })
+    await writeFile(otel, 'corrupt')
+    vi.stubEnv('METRORA_COPILOT_OTEL_DB', otel)
+    const row = only(await collectDoctorReport('copilot', {
+      providers: [createCopilotProvider(cli, join(root, 'workspace'), join(root, 'global'), join(root, 'jetbrains'))],
+      cache: emptyCache(),
+      sampleLimit: 0,
+    }), 'copilot')
+    expect(row.families.find(family => family.family === 'otel-agent-traces')?.state).toBe('MALFORMED')
+    expect(row.families.find(family => family.family === 'cli-session-state')?.state).toBe('PRESENT_EMPTY')
+    expect(row.families.some(family => family.family === 'jetbrains')).toBe(true)
+  })
+})

--- a/tests/doctor-env-safety.test.ts
+++ b/tests/doctor-env-safety.test.ts
@@ -44,10 +44,7 @@ describe('doctor env authority safety', () => {
       cache: emptyCache(),
     })
 
-    expect(report.providers[0]?.envOverrides).toContainEqual({
-      name: 'AI_GATEWAY_API_KEY',
-      value: '<set>',
-    })
+    expect(report.providers[0]?.envOverrides).toContainEqual({ name: 'AI_GATEWAY_API_KEY' })
     expect(JSON.stringify(report)).not.toContain(secret)
     expect(renderDoctorJson(report)).not.toContain(secret)
     expect(renderDoctorTable(report, { color: false })).not.toContain(secret)
@@ -73,7 +70,7 @@ describe('doctor env authority safety', () => {
       cache: emptyCache(),
     })
     const row = report.providers[0]!
-    expect(row.envOverrides).toContainEqual({ name: 'METRORA_CURSOR_MAX_BUBBLES', value: '50' })
+    expect(row.envOverrides).toContainEqual({ name: 'METRORA_CURSOR_MAX_BUBBLES' })
     expect(row.verdict).not.toContain('override METRORA_CURSOR_MAX_BUBBLES')
   })
 })

--- a/tests/doctor.test.ts
+++ b/tests/doctor.test.ts
@@ -91,7 +91,7 @@ describe('collectDoctorReport - codex fixture dirs', () => {
     expect(sessions?.exists).toBe(true)
   })
 
-  it('empty: sessions dir exists but holds nothing -> NOTHING FOUND (no sessions)', async () => {
+  it('empty: sessions dir exists but holds nothing -> readable but empty', async () => {
     await mkdir(join(tmpDir, 'sessions'), { recursive: true })
     const provider = createCodexProvider(tmpDir)
     const report = await collectDoctorReport('all', { providers: [provider], cache: emptyCache() })
@@ -99,11 +99,11 @@ describe('collectDoctorReport - codex fixture dirs', () => {
 
     expect(r.status).toBe('empty')
     expect(r.candidatesFound).toBe(0)
-    expect(r.verdict).toContain('holds no sessions')
+    expect(r.verdict).toContain('readable but empty')
     expect(r.probePaths.find(p => p.label === 'sessions')?.exists).toBe(true)
   })
 
-  it('missing: no sessions dir -> NOTHING FOUND names the missing path', async () => {
+  it('missing: no sessions dir -> NOTHING FOUND classifies the missing path', async () => {
     // tmpDir has no `sessions` subdir at all.
     const provider = createCodexProvider(tmpDir)
     const report = await collectDoctorReport('all', { providers: [provider], cache: emptyCache() })
@@ -111,11 +111,9 @@ describe('collectDoctorReport - codex fixture dirs', () => {
 
     expect(r.status).toBe('empty')
     expect(r.candidatesFound).toBe(0)
-    // Mutation guard: if the exists-check is broken to always return true, this
-    // flips to false and the verdict drops "does not exist".
     expect(r.probePaths.find(p => p.label === 'sessions')?.exists).toBe(false)
-    expect(r.verdict).toContain('does not exist')
-    expect(r.verdict).toContain(join(tmpDir, 'sessions'))
+    expect(r.probePaths.find(p => p.label === 'sessions')?.state).toBe('MISSING')
+    expect(r.verdict).toContain('configured sources are missing')
   })
 })
 
@@ -132,10 +130,10 @@ describe('collectDoctorReport - env override', () => {
       const report = await collectDoctorReport('all', { providers: [provider], cache: emptyCache() })
       const r = only(report, 'codex')
 
-      expect(r.envOverrides).toEqual([{ name: 'CODEX_HOME', value: bogus }])
+      expect(r.envOverrides).toEqual([{ name: 'CODEX_HOME' }])
       expect(r.status).toBe('empty')
       expect(r.verdict).toContain('override CODEX_HOME set')
-      expect(r.verdict).toContain('does not exist')
+      expect(r.verdict).toContain('source is missing')
     } finally {
       if (prev === undefined) delete process.env['CODEX_HOME']
       else process.env['CODEX_HOME'] = prev
@@ -240,7 +238,7 @@ describe('collectDoctorReport - isolation and edge cases', () => {
 // ── Rendering ──────────────────────────────────────────────────────────────
 
 describe('doctor rendering', () => {
-  it('renders a plain-text table naming the override and missing path', async () => {
+  it('renders a compact privacy-safe table naming the override and missing family', async () => {
     const provider = fakeProvider({
       name: 'claude',
       displayName: 'Claude',
@@ -254,9 +252,9 @@ describe('doctor rendering', () => {
       const out = renderDoctorTable(report, { color: false })
       expect(out).toContain('Metrora doctor')
       expect(out).toContain('NOTHING FOUND')
-      expect(out).toContain('CLAUDE_CONFIG_DIR=/nonexistent')
-      expect(out).toContain('/nonexistent/projects')
-      expect(out).toContain('missing')
+      expect(out).toContain('override CLAUDE_CONFIG_DIR')
+      expect(out).toContain('projects: MISSING')
+      expect(out).not.toContain('/nonexistent/projects')
       // no-color mode emits no ANSI escapes
       // eslint-disable-next-line no-control-regex
       expect(out).not.toMatch(/\[/)


### PR DESCRIPTION
## What changed

Adds a bounded, privacy-safe Doctor source diagnostic layer for Cursor, Kiro, and Copilot.

- Classifies source families as PRESENT, PRESENT_EMPTY, MISSING, INACCESSIBLE, MALFORMED, UNSUPPORTED_VARIANT, or UNKNOWN.
- Keeps provider discovery and accounting precedence unchanged; Cursor still uses global state.vscdb plus sibling workspaceStorage, and XDG_DATA_HOME remains only a fingerprint input.
- Covers Kiro legacy IDE/workspace/CLI/v2 roots and Copilot OTel, CLI, VS Code chat/transcript, empty-window, and JetBrains lanes.
- Redacts paths and emits override names only; Doctor remains read-only and suppresses parser cache writes.

## Validation

- 191 targeted Doctor/Cursor/Kiro/Copilot tests pass.
- 330 historical pricing/cache/provider regression tests pass.
- `npx tsc --noEmit`
- `npm run build:cli`
- source-size ratchet
- `git diff --check`

Base is `main` at `9905724a7469ef1a91db7944cb424dc9edbb6f2b`, which already includes the reviewed #162 merge.