### PR TITLE
perf: bypass full CLI import for version

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -14,7 +14,19 @@ if (major < 22 || (major === 22 && minor < 13)) {
   process.exit(1)
 }
 
-import('./main.js').catch((err) => {
+async function launch() {
+  // `--version` is a metadata-only request. Keep it ahead of the Commander
+  // graph so a one-line health check does not load the full CLI bundle.
+  if (process.argv[2] === '--version' || process.argv[2] === '-V') {
+    const { readFile } = await import('node:fs/promises')
+    const packageJson = JSON.parse(await readFile(new URL('../package.json', import.meta.url), 'utf8'))
+    process.stdout.write(`${typeof packageJson.version === 'string' ? packageJson.version : ''}\n`)
+    return
+  }
+  await import('./main.js')
+}
+
+launch().catch((err) => {
   process.stderr.write(String(err?.message ?? err) + '\n')
   process.exit(1)
 })


### PR DESCRIPTION
## What changed

Adds a minimal launcher fast path for `metrora --version` and `metrora -V`.

The metadata-only request now reads package metadata and exits before importing the full Commander/provider/reporting graph. All other commands continue through the existing `main.ts` path with unchanged semantics, output, and errors.

## Characterization

On the local 100 MB cache/dataset, the built CLI `--version` median improved from about 1,178 ms to about 43 ms. Status, Doctor, sharing, and export were characterized separately; their remaining cost is dominated by data work and shared application imports, so no broader lazy split was introduced.

## Validation

- 41 pertinent CLI/status/report/export/provider/settings tests pass.
- 265 pertinent cost-assignment/session-cache/historical-pricing/daily-cache/PR-correlation regression tests pass.
- `npx tsc --noEmit`
- `npm run build:cli`
- source-size ratchet against `origin/main`
- `git diff --check`

Rebased linearly onto `main` at `7fb7dd40878b2037182add776c0b9e1e9e6cee0c`. The patch remains limited to `src/cli.ts`.