### PR TITLE
fix: canonicalize internal collector identity

### DIFF
--- a/docs/CANONICAL_HISTORY_PARITY_OBSERVER_V1.md
+++ b/docs/CANONICAL_HISTORY_PARITY_OBSERVER_V1.md
@@ -48,6 +48,12 @@ The comparison covers:
 
 Exact duplicate source records are counted once. Reuse of one source identity with a conflicting payload fails closed.
 
+The cache section name is interpreted through the explicit storage-namespace
+authority used by the projection. Ordinary sections preserve their name as the
+collector; the internal Copilot journal and CLI-resume namespaces both map to
+the canonical collector `copilot`. An unregistered mismatch is an integrity
+failure, not a reason to trust the call field.
+
 ### Activity parity
 
 The observer independently reconstructs the activity partition as ordered sets of observation identities anchored to collector and turn timestamp.

--- a/docs/CANONICAL_HISTORY_READ_PROJECTION_V1.md
+++ b/docs/CANONICAL_HISTORY_READ_PROJECTION_V1.md
@@ -11,7 +11,7 @@ It is deliberately read-only. It does not create a database, migrate a cache, ch
 The projection exposes three separate collections:
 
 1. **observations** — path-free identities and content-minimal accounting evidence derived from the complete current session cache;
-2. **activities** — deterministic groupings of source-observed calls derived from provider, private session identity, source timestamp and the first source-record fingerprint;
+2. **activities** — deterministic groupings of source-observed calls derived from the canonical collector, private session identity, source timestamp and the first source-record fingerprint;
 3. **daily snapshots** — sanitized copies of the trusted complete daily cache, including carried history that can no longer be reconstructed from source files.
 
 Observation and activity collections are shadow authorities in v1. Daily snapshots remain the totals authority.
@@ -25,8 +25,15 @@ The projection reuses `canonicalSourceRecordFingerprintSha256V1`, the same endpo
 The fingerprint is derived from:
 
 - protected endpoint identity;
-- collector/provider section;
+- canonical collector identity;
 - the collector's private deduplication key.
+
+The session-cache section name is a storage/parser namespace, not automatically
+the public collector identity. Ordinary sections use the same name for both.
+The current internal Copilot journal and CLI-resume lanes are explicitly
+registered exceptions: their storage namespaces remain versioned cache
+authorities while their canonical collector identity is `copilot`. Any other
+namespace/provider mismatch fails closed.
 
 The local source path and private deduplication key are not emitted. The endpoint scope prevents identical copied source records on different endpoints from becoming a public cross-device correlation handle.
 
@@ -39,7 +46,7 @@ An activity groups the ordered observations emitted by one cached turn.
 Its identity is derived from:
 
 - protected endpoint identity;
-- collector/provider section;
+- canonical collector identity;
 - private session identity;
 - source-observed turn timestamp;
 - the first observation fingerprint.
@@ -83,7 +90,7 @@ The projection requires:
 - a complete daily cache;
 - a trusted daily watermark;
 - valid timestamps;
-- provider-section agreement;
+- explicit storage-namespace/canonical-collector agreement;
 - non-empty private source and session identities;
 - internally consistent immutable cost assignments.
 

--- a/docs/COST_ASSIGNMENT_V1.md
+++ b/docs/COST_ASSIGNMENT_V1.md
@@ -1,6 +1,6 @@
 # Metrora cost assignment v1
 
-Status: **assignment and settlement contract implemented; parser/cache wiring not enabled**.
+Status: **assignment and settlement contract implemented and wired through normalized calls and the session cache**.
 
 A historical price record is not sufficient by itself. Once one call has been valued, Metrora must preserve which evidence produced the amount so a later catalog refresh, alias update, cache rebuild, or model-price change cannot silently alter that settled call.
 
@@ -33,4 +33,8 @@ Settled values are stored as non-negative safe integer micro-USD. This matches t
 - zero plus `explicit-zero` assignment;
 - no amount plus `unavailable` when prompt-size, web-search, fast-route, or other required rate evidence is missing.
 
-The function does not change existing Metrora-derived runtime totals. The next tranche must carry this optional contract through normalized calls and the session cache, preserve old caches losslessly, and compare real Metrora and Metrora logs before historical assignments become authoritative.
+The function does not change existing Metrora-derived runtime totals. Runtime
+parsing now carries the assignment through normalized calls and the v8 session
+cache without changing the cache schema authority. Existing caches are adopted
+losslessly, and the canonical projection requires the immutable assignment
+before it can publish an observation.

--- a/src/local-state/canonical-history-canonical-identity.test.ts
+++ b/src/local-state/canonical-history-canonical-identity.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from 'vitest'
+
+import { DAILY_CACHE_VERSION, type DailyCache } from '../daily-cache.js'
+import { CACHE_VERSION, type CachedCall, type CachedFile, type SessionCache } from '../session-cache.js'
+import {
+  COPILOT_CHAT_JOURNAL_PROVIDER,
+  COPILOT_CLI_RESUME_PROVIDER,
+} from '../provider-parse-authorities.js'
+import {
+  CanonicalHistoryReadProjectionIntegrityError,
+  projectCanonicalHistoryReadV1,
+} from './canonical-history-read-projection.js'
+
+const ENDPOINT_ID = 'ep_11111111-2222-4333-8444-555555555555'
+
+function call(overrides: Partial<CachedCall> = {}): CachedCall {
+  return {
+    provider: 'copilot',
+    model: 'gpt-5.6-luna',
+    usage: {
+      inputTokens: 100,
+      outputTokens: 20,
+      cacheCreationInputTokens: 0,
+      cacheReadInputTokens: 0,
+      cachedInputTokens: 0,
+      reasoningTokens: 0,
+      webSearchRequests: 0,
+      cacheCreationOneHourTokens: 0,
+    },
+    costUSD: 0,
+    costAssignment: {
+      version: 1,
+      kind: 'explicit-zero',
+      amountMicrosUsd: 0,
+      reason: 'free-route',
+    },
+    speed: 'standard',
+    timestamp: '2026-08-01T21:00:01.000Z',
+    tools: [],
+    bashCommands: [],
+    skills: [],
+    subagentTypes: [],
+    deduplicationKey: 'copilot:source-1',
+    ...overrides,
+  }
+}
+
+function file(calls: CachedCall[], sessionId = 'session-1', timestamp = '2026-08-01T21:00:00.000Z'): CachedFile {
+  return {
+    fingerprint: { dev: 1, ino: 2, mtimeMs: 3, sizeBytes: 4 },
+    mcpInventory: [],
+    turns: [{ timestamp, sessionId, userMessage: 'private', calls }],
+  }
+}
+
+function sessionCache(sections: Record<string, CachedCall[]>): SessionCache {
+  return {
+    version: CACHE_VERSION,
+    complete: true,
+    providers: Object.fromEntries(Object.entries(sections).map(([namespace, calls], index) => [namespace, {
+      envFingerprint: `test-${index}`,
+      files: { [`/private/${index}`]: file(calls) },
+    }])),
+  }
+}
+
+function dailyCache(): DailyCache {
+  return {
+    version: DAILY_CACHE_VERSION,
+    savingsConfigHash: 'test',
+    tzKey: 'UTC',
+    lastComputedDate: null,
+    days: [],
+    complete: true,
+    watermarkTrusted: true,
+  }
+}
+
+function project(sections: Record<string, CachedCall[]>): ReturnType<typeof projectCanonicalHistoryReadV1> {
+  return projectCanonicalHistoryReadV1({
+    endpointId: ENDPOINT_ID,
+    sessionCache: sessionCache(sections),
+    dailyCache: dailyCache(),
+  })
+}
+
+const internalLanes = [
+  ['copilot', COPILOT_CHAT_JOURNAL_PROVIDER],
+  ['copilot', COPILOT_CLI_RESUME_PROVIDER],
+  [COPILOT_CHAT_JOURNAL_PROVIDER, COPILOT_CLI_RESUME_PROVIDER],
+] as const
+
+describe('canonical history Copilot namespace collision matrix', () => {
+  it.each(internalLanes)('canonicalizes %s + %s as one collector', (left, right) => {
+    const result = project({
+      [left]: [call()],
+      [right]: [call()],
+    })
+    expect(result.observations).toHaveLength(1)
+    expect(result.activities).toHaveLength(1)
+    expect(result.observations[0]!.collector).toBe('copilot')
+    expect(result.activities[0]!.collector).toBe('copilot')
+  })
+
+  it('preserves all three independent valid lanes when their source identities differ', () => {
+    const result = project({
+      copilot: [call({ deduplicationKey: 'copilot:normal' })],
+      [COPILOT_CHAT_JOURNAL_PROVIDER]: [call({ deduplicationKey: 'copilot:journal' })],
+      [COPILOT_CLI_RESUME_PROVIDER]: [call({ deduplicationKey: 'copilot:resume' })],
+    })
+    expect(result.observations).toHaveLength(3)
+    expect(result.activities).toHaveLength(3)
+    expect(new Set(result.observations.map(value => value.collector))).toEqual(new Set(['copilot']))
+  })
+
+  it('fails closed for the same source identity with a conflicting payload', () => {
+    expect(() => project({
+      copilot: [call()],
+      [COPILOT_CHAT_JOURNAL_PROVIDER]: [call({ model: 'different-model' })],
+    })).toThrow(CanonicalHistoryReadProjectionIntegrityError)
+  })
+
+  it('fails closed when the same source identity is attached to different turn/session identities', () => {
+    const first = file([call()], 'session-1', '2026-08-01T21:00:00.000Z')
+    const second = file([call()], 'session-2', '2026-08-01T21:00:00.000Z')
+    expect(() => projectCanonicalHistoryReadV1({
+      endpointId: ENDPOINT_ID,
+      sessionCache: {
+        version: CACHE_VERSION,
+        complete: true,
+        providers: {
+          copilot: { envFingerprint: 'a', files: { '/private/a': first } },
+          [COPILOT_CHAT_JOURNAL_PROVIDER]: { envFingerprint: 'b', files: { '/private/b': second } },
+        },
+      },
+      dailyCache: dailyCache(),
+    })).toThrow(CanonicalHistoryReadProjectionIntegrityError)
+  })
+
+  it('preserves different source identities with equal turn timestamps and different sessions', () => {
+    const result = project({
+      copilot: [call({ deduplicationKey: 'copilot:one' })],
+      [COPILOT_CHAT_JOURNAL_PROVIDER]: [call({ deduplicationKey: 'copilot:two' })],
+    })
+    expect(result.observations).toHaveLength(2)
+    expect(result.activities).toHaveLength(2)
+  })
+
+  it('fails closed for an artificial storage alias even when its call says copilot', () => {
+    expect(() => project({
+      'copilot-artificial-alias': [call()],
+    })).toThrow(CanonicalHistoryReadProjectionIntegrityError)
+  })
+})

--- a/src/local-state/canonical-history-parity-observer.test.ts
+++ b/src/local-state/canonical-history-parity-observer.test.ts
@@ -2,6 +2,7 @@ import { createHash } from 'node:crypto'
 import { describe, expect, it, vi } from 'vitest'
 
 import { DAILY_CACHE_VERSION, type DailyCache, type DailyEntry } from '../daily-cache.js'
+import { COPILOT_CHAT_JOURNAL_PROVIDER } from '../provider-parse-authorities.js'
 import type { CachedCall, CachedFile, SessionCache } from '../session-cache.js'
 import { projectCanonicalHistoryReadV1 } from './canonical-history-read-projection.js'
 import {
@@ -72,17 +73,15 @@ function cachedFile(calls: CachedCall[], sessionId = 'session-1'): CachedFile {
   }
 }
 
-function sessionCache(files: Record<string, CachedFile>): SessionCache {
+function sessionCache(files: Record<string, CachedFile>, namespace = 'zed'): SessionCache {
   return {
     version: 8,
     complete: true,
-    providers: {
-      zed: { envFingerprint: 'zed-test', files },
-    },
+    providers: { [namespace]: { envFingerprint: `${namespace}-test`, files } },
   }
 }
 
-function day(): DailyEntry {
+function day(provider = 'zed'): DailyEntry {
   return {
     date: '2026-08-01',
     cost: 0,
@@ -110,7 +109,7 @@ function day(): DailyEntry {
       other: { turns: 1, cost: 0, savingsUSD: 0, editTurns: 0, oneShotTurns: 0 },
     },
     providers: {
-      zed: {
+      [provider]: {
         calls: 1,
         cost: 0,
         savingsUSD: 0,
@@ -180,6 +179,20 @@ describe('canonical history parity observer v1', () => {
       dailyCache: dailyCache(),
     }, { sourceFingerprint, persist })
 
+    expect(result.counts).toEqual({ observations: 1, activities: 1, dailySnapshots: 1 })
+  })
+
+  it('uses the canonical Copilot collector for an internal journal namespace', async () => {
+    const persist = vi.fn(async () => persisted())
+    const result = await observeCanonicalHistoryParityV1({
+      endpointId: ENDPOINT_ID,
+      sessionCache: sessionCache({ '/private/copilot-journal.sqlite': cachedFile([
+        call({ provider: 'copilot', modelProvider: 'copilot', deduplicationKey: 'copilot:journal:1' }),
+      ]) }, COPILOT_CHAT_JOURNAL_PROVIDER),
+      dailyCache: dailyCache([day('copilot')]),
+    }, { sourceFingerprint, persist })
+
+    expect(persist).toHaveBeenCalledTimes(1)
     expect(result.counts).toEqual({ observations: 1, activities: 1, dailySnapshots: 1 })
   })
 

--- a/src/local-state/canonical-history-parity-observer.ts
+++ b/src/local-state/canonical-history-parity-observer.ts
@@ -11,6 +11,7 @@ import {
   costAssignmentMatchesUsdV1,
   type CostAssignmentV1,
 } from '../pricing/cost-assignment.js'
+import { assertCanonicalCollectorIdentity } from '../provider-parse-authorities.js'
 import { CACHE_VERSION, type CachedCall, type SessionCache } from '../session-cache.js'
 import { canonicalizeRfc8785 } from '../vendor/rfc8785-canonicalize.js'
 import {
@@ -157,6 +158,16 @@ function rawDailyPayload(day: DailyEntry, bucketTimeZone: string | null): DailyS
   }
 }
 
+function canonicalCollectorForCall(storageNamespace: string, callProvider: string): string {
+  try {
+    return assertCanonicalCollectorIdentity({ storageNamespace, callProvider })
+  } catch {
+    throw new CanonicalHistoryParityMismatchError(
+      'canonical cached call provider disagrees with its storage namespace',
+    )
+  }
+}
+
 function validatedCost(call: CachedCall): Pick<
   ObservationPayload,
   'costUSD' | 'costAssignment' | 'legacyCostUSD'
@@ -191,7 +202,7 @@ function validatedCost(call: CachedCall): Pick<
 
 function rawObservationPayload(input: {
   endpointId: string
-  collector: string
+  storageNamespace: string
   call: CachedCall
   sourceFingerprint: CanonicalHistoryParityObserverDependenciesV1['sourceFingerprint']
 }): ObservationPayload {
@@ -199,11 +210,7 @@ function rawObservationPayload(input: {
   if (!timestamp.success) {
     throw new CanonicalHistoryParityMismatchError('canonical cached call has an invalid timestamp')
   }
-  if (input.call.provider !== input.collector) {
-    throw new CanonicalHistoryParityMismatchError(
-      'canonical cached call provider disagrees with its provider section',
-    )
-  }
+  const collector = canonicalCollectorForCall(input.storageNamespace, input.call.provider)
   if (!input.call.deduplicationKey) {
     throw new CanonicalHistoryParityMismatchError(
       'canonical cached call has an empty private deduplication key',
@@ -211,12 +218,12 @@ function rawObservationPayload(input: {
   }
   const sourceFingerprintSha256 = input.sourceFingerprint({
     endpointId: input.endpointId,
-    provider: input.collector,
+    provider: collector,
     privateDeduplicationKey: input.call.deduplicationKey,
   })
   return {
     sourceFingerprintSha256,
-    collector: input.collector,
+    collector,
     timestamp: timestamp.data,
     model: input.call.model,
     ...(input.call.modelProvider !== undefined ? { modelProvider: input.call.modelProvider } : {}),
@@ -249,7 +256,7 @@ function expectedSessionAuthority(input: {
   const activities = new Set<string>()
   const observationActivity = new Map<string, string>()
 
-  for (const [collector, section] of Object.entries(input.sessionCache.providers)
+  for (const [storageNamespace, section] of Object.entries(input.sessionCache.providers)
     .sort(([left], [right]) => left.localeCompare(right))) {
     for (const [, file] of Object.entries(section.files)
       .sort(([left], [right]) => left.localeCompare(right))) {
@@ -260,11 +267,12 @@ function expectedSessionAuthority(input: {
         if (!timestamp.success) {
           throw new CanonicalHistoryParityMismatchError('canonical cached turn has an invalid timestamp')
         }
+        const collector = canonicalCollectorForCall(storageNamespace, turn.calls[0]!.provider)
         const observationIds: string[] = []
         for (const call of turn.calls) {
           const payload = rawObservationPayload({
             endpointId: input.endpointId,
-            collector,
+            storageNamespace,
             call,
             sourceFingerprint: input.sourceFingerprint,
           })

--- a/src/local-state/canonical-history-read-projection.ts
+++ b/src/local-state/canonical-history-read-projection.ts
@@ -13,6 +13,7 @@ import {
   type CachedUsage,
   type SessionCache,
 } from '../session-cache.js'
+import { assertCanonicalCollectorIdentity } from '../provider-parse-authorities.js'
 import { canonicalSourceRecordFingerprintSha256V1 } from './canonical-reviewed-production-scanner.js'
 
 export const CANONICAL_HISTORY_READ_PROJECTION_VERSION = 1 as const
@@ -200,28 +201,34 @@ function validatedCost(call: CachedCall): Pick<CanonicalObservationReadV1, 'cost
 
 function observationForCall(input: {
   endpointId: string
-  collector: string
+  storageNamespace: string
   activityId: string
   call: CachedCall
 }): CanonicalObservationReadV1 {
   const timestamp = TimestampSchema.safeParse(input.call.timestamp)
   if (!timestamp.success) throw new CanonicalHistoryReadProjectionIntegrityError('canonical cached call has an invalid timestamp')
-  if (input.call.provider !== input.collector) {
-    throw new CanonicalHistoryReadProjectionIntegrityError('canonical cached call provider disagrees with its provider section')
+  let collector: string
+  try {
+    collector = assertCanonicalCollectorIdentity({
+      storageNamespace: input.storageNamespace,
+      callProvider: input.call.provider,
+    })
+  } catch {
+    throw new CanonicalHistoryReadProjectionIntegrityError('canonical cached call provider disagrees with its storage namespace')
   }
   if (!input.call.deduplicationKey) {
     throw new CanonicalHistoryReadProjectionIntegrityError('canonical cached call has an empty private deduplication key')
   }
   const sourceFingerprintSha256 = canonicalSourceRecordFingerprintSha256V1({
     endpointId: input.endpointId,
-    provider: input.collector,
+    provider: collector,
     privateDeduplicationKey: input.call.deduplicationKey,
   })
   return {
     observationId: `observation-v1:${sourceFingerprintSha256}`,
     activityId: input.activityId,
     sourceFingerprintSha256,
-    collector: input.collector,
+    collector,
     timestamp: timestamp.data,
     model: input.call.model,
     ...(input.call.modelProvider !== undefined ? { modelProvider: input.call.modelProvider } : {}),
@@ -257,7 +264,7 @@ export function projectCanonicalHistoryReadV1(
   const activitiesById = new Map<string, CanonicalActivityReadV1>()
   const activityByObservation = new Map<string, string>()
 
-  for (const [collector, section] of Object.entries(sessionCache.providers).sort(([a], [b]) => a.localeCompare(b))) {
+  for (const [storageNamespace, section] of Object.entries(sessionCache.providers).sort(([a], [b]) => a.localeCompare(b))) {
     for (const [, file] of Object.entries(section.files).sort(([a], [b]) => a.localeCompare(b))) {
       if (file.failed) continue
       for (const turn of file.turns) {
@@ -269,6 +276,15 @@ export function projectCanonicalHistoryReadV1(
         const firstCall = turn.calls[0]!
         if (!firstCall.deduplicationKey) {
           throw new CanonicalHistoryReadProjectionIntegrityError('canonical cached call has an empty private deduplication key')
+        }
+        let collector: string
+        try {
+          collector = assertCanonicalCollectorIdentity({
+            storageNamespace,
+            callProvider: firstCall.provider,
+          })
+        } catch {
+          throw new CanonicalHistoryReadProjectionIntegrityError('canonical cached call provider disagrees with its storage namespace')
         }
         const firstFingerprint = canonicalSourceRecordFingerprintSha256V1({
           endpointId,
@@ -285,7 +301,7 @@ export function projectCanonicalHistoryReadV1(
 
         const observationIds: string[] = []
         for (const call of turn.calls) {
-          const observation = observationForCall({ endpointId, collector, activityId, call })
+          const observation = observationForCall({ endpointId, storageNamespace, activityId, call })
           const prior = observationsById.get(observation.observationId)
           if (prior && !sameValue(prior, observation)) {
             throw new CanonicalHistoryReadProjectionIntegrityError('one canonical source identity resolved to conflicting observations')

--- a/src/local-state/canonical-history-shadow-store.test.ts
+++ b/src/local-state/canonical-history-shadow-store.test.ts
@@ -215,6 +215,22 @@ describe('canonical history shadow store v1', () => {
 
     await expect(readCanonicalHistoryShadowHeadV1({ dataDir: missingDataDir }))
       .rejects.toThrow(CanonicalHistoryShadowStoreIntegrityError)
+
+    const malformedHeadDataDir = await temporaryDataDir()
+    const malformedHeadPaths = canonicalHistoryShadowPathsV1(malformedHeadDataDir)
+    await mkdir(malformedHeadPaths.root, { recursive: true })
+    await writeFile(malformedHeadPaths.head, '{"kind":"wrong"}')
+    await expect(readCanonicalHistoryShadowHeadV1({ dataDir: malformedHeadDataDir }))
+      .rejects.toThrow(CanonicalHistoryShadowStoreIntegrityError)
+
+    const unexpectedFileDataDir = await temporaryDataDir()
+    const unexpectedFileStored = await persistCanonicalHistoryShadowV1(projection(), { dataDir: unexpectedFileDataDir })
+    const unexpectedFilePaths = canonicalHistoryShadowPathsV1(unexpectedFileDataDir)
+    await writeFile(join(unexpectedFilePaths.snapshots, 'unexpected.jsonl'), 'unexpected')
+    await expect(persistCanonicalHistoryShadowV1(projection(), { dataDir: unexpectedFileDataDir }))
+      .rejects.toThrow(CanonicalHistoryShadowStoreIntegrityError)
+    expect((await readCanonicalHistoryShadowHeadV1({ dataDir: unexpectedFileDataDir }))?.projectionSha256)
+      .toBe(unexpectedFileStored.projectionSha256)
   })
 
   it('refuses private source material before creating persistent shadow state', async () => {

--- a/src/local-state/canonical-reviewed-production-scanner.ts
+++ b/src/local-state/canonical-reviewed-production-scanner.ts
@@ -9,6 +9,7 @@ import { normalizeExplicitModelProvider } from '../model-provider.js'
 import { cachedCallToApiCall, clearSessionCache, parseAllSessions } from '../parser.js'
 import { readCodexSessionModelProvider } from '../providers/codex-model-provider.js'
 import { getProvider } from '../providers/index.js'
+import { assertCanonicalCollectorIdentity } from '../provider-parse-authorities.js'
 import {
   isCacheComplete,
   loadCache,
@@ -190,7 +191,7 @@ export async function scanCanonicalReviewedProductionCandidatesV1(
   let withheldCount = 0
   let failedCount = 0
 
-  for (const [sectionProvider, section] of Object.entries(cache.providers).sort(([a], [b]) => a.localeCompare(b))) {
+  for (const [storageNamespace, section] of Object.entries(cache.providers).sort(([a], [b]) => a.localeCompare(b))) {
     let displayName: string | undefined
 
     for (const [sourcePath, file] of Object.entries(section.files).sort(([a], [b]) => a.localeCompare(b))) {
@@ -209,20 +210,26 @@ export async function scanCanonicalReviewedProductionCandidatesV1(
         continue
       }
 
-      const codexSourceProvider = sectionProvider === 'codex'
+      const codexSourceProvider = storageNamespace === 'codex'
         ? normalizeExplicitModelProvider(await readCodexProvider(sourcePath))
         : undefined
-      if (sectionProvider === 'codex' && !codexSourceProvider) {
+      if (storageNamespace === 'codex' && !codexSourceProvider) {
         withheldCount += scopedCalls.length
         continue
       }
 
-      displayName ??= await dependencies.providerDisplayName(sectionProvider)
+      displayName ??= await dependencies.providerDisplayName(storageNamespace)
 
       for (const cachedCall of scopedCalls) {
-        if (cachedCall.provider !== sectionProvider) {
+        let canonicalCollector: string
+        try {
+          canonicalCollector = assertCanonicalCollectorIdentity({
+            storageNamespace,
+            callProvider: cachedCall.provider,
+          })
+        } catch {
           throw new CanonicalReviewedProductionScannerIntegrityError(
-            'canonical cached call provider disagrees with its provider section',
+            'canonical cached call provider disagrees with its storage namespace',
           )
         }
         if (!cachedCall.deduplicationKey) {
@@ -234,7 +241,7 @@ export async function scanCanonicalReviewedProductionCandidatesV1(
         let call = canonicalApiCall(cachedCall)
         let explicitProvider = normalizeExplicitModelProvider(call.modelProvider)
 
-        if (sectionProvider === 'codex' && codexSourceProvider) {
+        if (storageNamespace === 'codex' && codexSourceProvider) {
           if (explicitProvider && explicitProvider !== codexSourceProvider) {
             throw new CanonicalReviewedProductionScannerIntegrityError(
               'canonical Codex call provider disagrees with source metadata',
@@ -261,7 +268,7 @@ export async function scanCanonicalReviewedProductionCandidatesV1(
               adapterVersion,
               sourceFingerprintSha256: canonicalSourceRecordFingerprintSha256V1({
                 endpointId,
-                provider: sectionProvider,
+                provider: canonicalCollector,
                 privateDeduplicationKey: cachedCall.deduplicationKey,
               }),
             },

--- a/src/provider-parse-authorities.test.ts
+++ b/src/provider-parse-authorities.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  CANONICAL_COLLECTOR_BY_STORAGE_NAMESPACE,
+  CanonicalCollectorIdentityIntegrityError,
+  COPILOT_CANONICAL_COLLECTOR,
+  COPILOT_CHAT_JOURNAL_PROVIDER,
+  COPILOT_CLI_RESUME_PROVIDER,
+  assertCanonicalCollectorIdentity,
+  canonicalCollectorForStorageNamespace,
+} from './provider-parse-authorities.js'
+
+describe('canonical collector identity authority', () => {
+  it('registers only the two intentional Copilot storage-namespace mismatches', () => {
+    expect(CANONICAL_COLLECTOR_BY_STORAGE_NAMESPACE).toEqual({
+      [COPILOT_CHAT_JOURNAL_PROVIDER]: COPILOT_CANONICAL_COLLECTOR,
+      [COPILOT_CLI_RESUME_PROVIDER]: COPILOT_CANONICAL_COLLECTOR,
+    })
+  })
+
+  it('preserves ordinary section identity', () => {
+    expect(canonicalCollectorForStorageNamespace('codex')).toBe('codex')
+    expect(assertCanonicalCollectorIdentity({
+      storageNamespace: 'codex',
+      callProvider: 'codex',
+    })).toBe('codex')
+  })
+
+  it('canonicalizes both internal Copilot lanes without changing their storage names', () => {
+    for (const storageNamespace of [COPILOT_CHAT_JOURNAL_PROVIDER, COPILOT_CLI_RESUME_PROVIDER]) {
+      expect(canonicalCollectorForStorageNamespace(storageNamespace)).toBe(COPILOT_CANONICAL_COLLECTOR)
+      expect(assertCanonicalCollectorIdentity({ storageNamespace, callProvider: 'copilot' })).toBe('copilot')
+    }
+  })
+
+  it('fails closed for unregistered aliases and contradictory registered calls', () => {
+    expect(() => assertCanonicalCollectorIdentity({
+      storageNamespace: 'copilot-artificial-alias',
+      callProvider: 'copilot',
+    })).toThrow(CanonicalCollectorIdentityIntegrityError)
+    expect(() => assertCanonicalCollectorIdentity({
+      storageNamespace: COPILOT_CHAT_JOURNAL_PROVIDER,
+      callProvider: COPILOT_CHAT_JOURNAL_PROVIDER,
+    })).toThrow(CanonicalCollectorIdentityIntegrityError)
+  })
+})

--- a/src/provider-parse-authorities.ts
+++ b/src/provider-parse-authorities.ts
@@ -7,6 +7,54 @@ export const COPILOT_CHAT_JOURNAL_AUTHORITY = 'current-chat-journal-v3'
 export const COPILOT_CHAT_JOURNAL_PROVIDER = `copilot-chat-journal-${COPILOT_CHAT_JOURNAL_AUTHORITY}`
 export const COPILOT_CLI_RESUME_AUTHORITY = 'resumed-shutdown-delta-v1'
 export const COPILOT_CLI_RESUME_PROVIDER = `copilot-cli-resume-${COPILOT_CLI_RESUME_AUTHORITY}`
+export const COPILOT_CANONICAL_COLLECTOR = 'copilot'
+
+/**
+ * Session-cache section names are parser/storage authorities. They are not
+ * automatically public collector identities. Only these two internal lanes
+ * are allowed to store Copilot calls under a distinct section name while
+ * retaining Copilot as their canonical-history collector.
+ */
+export const CANONICAL_COLLECTOR_BY_STORAGE_NAMESPACE: Readonly<Record<string, string>> = Object.freeze({
+  [COPILOT_CHAT_JOURNAL_PROVIDER]: COPILOT_CANONICAL_COLLECTOR,
+  [COPILOT_CLI_RESUME_PROVIDER]: COPILOT_CANONICAL_COLLECTOR,
+})
+
+export class CanonicalCollectorIdentityIntegrityError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'CanonicalCollectorIdentityIntegrityError'
+  }
+}
+
+/** Resolve the public collector identity for one cache/storage namespace. */
+export function canonicalCollectorForStorageNamespace(storageNamespace: string): string {
+  if (!storageNamespace) {
+    throw new CanonicalCollectorIdentityIntegrityError('storage namespace must be non-empty')
+  }
+  return CANONICAL_COLLECTOR_BY_STORAGE_NAMESPACE[storageNamespace] ?? storageNamespace
+}
+
+/**
+ * Validate the parser-emitted provider against the explicit namespace map.
+ * Ordinary sections are identity-preserving; a differing provider is valid
+ * only when the namespace is one of the registered internal lanes above.
+ */
+export function assertCanonicalCollectorIdentity(input: {
+  storageNamespace: string
+  callProvider: string
+}): string {
+  if (!input.callProvider) {
+    throw new CanonicalCollectorIdentityIntegrityError('call provider must be non-empty')
+  }
+  const canonicalCollector = canonicalCollectorForStorageNamespace(input.storageNamespace)
+  if (input.callProvider !== canonicalCollector) {
+    throw new CanonicalCollectorIdentityIntegrityError(
+      `storage namespace ${input.storageNamespace} does not authorize call provider ${input.callProvider}`,
+    )
+  }
+  return canonicalCollector
+}
 
 /**
  * Provider env reads that materially change discovery, parsing, or the account


### PR DESCRIPTION
## Summary

- add one explicit, Metrora-owned storage-namespace → canonical-collector authority
- canonicalize the Copilot chat-journal and CLI-resume lanes to `copilot`
- keep ordinary namespaces, cache v8, call.provider values, deduplication keys, journal reconciliation, and CLI resume semantics unchanged
- apply the same authority to the projection, parity observer, and reviewed-production scanner
- add adversarial collision/fail-closed coverage and shadow-store corruption cases
- correct the directly falsified Cost Assignment and canonical-history documentation

## Validation

- `npx vitest run`: 297 files passed, 2 skipped; 2,958 tests passed, 5 skipped
- `npx tsc --noEmit`
- `npm run build:cli`
- source-size ratchet
- `git diff --check`

## Controlled C3 result

The real reviewed-production/parity path remains fail-closed on two pre-existing conflicting Claude source identities. No real `history-shadow/v1` head or snapshot was promoted, and no consumer cutover is included in this PR. The follow-up Claude identity/payload conflict is intentionally outside this branch.