### PR TITLE
fix: reconcile Claude native snapshots in C3 projection

### DIFF
--- a/src/claude-native-reconciliation.ts
+++ b/src/claude-native-reconciliation.ts
@@ -1,4 +1,4 @@
-import type { CachedCall } from './session-cache.js'
+import type { CachedCall, SessionCache } from './session-cache.js'
 
 /**
  * A Claude JSONL message id is a native accounting identity, not a file-local
@@ -25,14 +25,31 @@ export type ClaudeNativeIdentityAmbiguity = {
   candidates: ClaudeNativeCallCandidate[]
 }
 
+export type ClaudeNativeEvidenceIssue = {
+  candidate: ClaudeNativeCallCandidate
+  reason: 'empty-native-message-id' | 'invalid-native-emission-timestamp' | 'invalid-native-terminal-marker'
+}
+
 export type ClaudeNativeReconciliation = {
   winners: Map<string, ClaudeNativeCallCandidate>
   ambiguities: ClaudeNativeIdentityAmbiguity[]
+  malformed: ClaudeNativeEvidenceIssue[]
+}
+
+export class ClaudeNativeReconciliationIntegrityError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'ClaudeNativeReconciliationIntegrityError'
+  }
 }
 
 export function getClaudeNativeIdentity(call: Pick<CachedCall, 'provider' | 'deduplicationKey' | 'nativeMessageId'>): string | undefined {
   if (call.provider !== 'claude') return undefined
-  if (call.nativeMessageId) return call.nativeMessageId
+  if (call.nativeMessageId !== undefined) {
+    return typeof call.nativeMessageId === 'string' && call.nativeMessageId.trim().length > 0
+      ? call.nativeMessageId
+      : undefined
+  }
   // Support a one-run projection of a pre-migration cache. Advisor calls use a
   // derived `:advisor:` key and are deliberately excluded from this fallback.
   if (call.deduplicationKey.startsWith('claude:') || call.deduplicationKey.includes(':advisor:')) return undefined
@@ -56,8 +73,26 @@ function nativeAccountingTuple(call: CachedCall): string {
 
 function nativeEmissionMs(call: CachedCall): number | undefined {
   const raw = call.nativeEmissionTimestamp ?? call.timestamp
+  if (typeof raw !== 'string') return undefined
   const ms = Date.parse(raw)
   return Number.isFinite(ms) ? ms : undefined
+}
+
+function nativeEvidenceIssue(call: CachedCall): ClaudeNativeEvidenceIssue['reason'] | undefined {
+  if (call.nativeMessageId !== undefined && (
+    typeof call.nativeMessageId !== 'string' || call.nativeMessageId.trim().length === 0
+  )) {
+    return 'empty-native-message-id'
+  }
+  if (call.nativeEmissionTimestamp !== undefined && (
+    typeof call.nativeEmissionTimestamp !== 'string' || !Number.isFinite(Date.parse(call.nativeEmissionTimestamp))
+  )) {
+    return 'invalid-native-emission-timestamp'
+  }
+  if (call.nativeSnapshotTerminal !== undefined && typeof call.nativeSnapshotTerminal !== 'boolean') {
+    return 'invalid-native-terminal-marker'
+  }
+  return undefined
 }
 
 function nativeStableKey(candidate: ClaudeNativeCallCandidate): string {
@@ -82,13 +117,17 @@ export function reconcileClaudeNativeCalls(
   files: ReadonlyArray<{ filePath: string; calls: readonly CachedCall[] }>,
 ): ClaudeNativeReconciliation {
   const groups = new Map<string, ClaudeNativeCallCandidate[]>()
+  const malformed: ClaudeNativeEvidenceIssue[] = []
   for (const file of files) {
     let ordinal = 0
     for (const call of file.calls) {
+      const candidate = { filePath: file.filePath, call, ordinal: ordinal++ }
+      const issue = call.provider === 'claude' ? nativeEvidenceIssue(call) : undefined
+      if (issue) malformed.push({ candidate, reason: issue })
       const identity = getClaudeNativeIdentity(call)
       if (!identity) continue
       const group = groups.get(identity) ?? []
-      group.push({ filePath: file.filePath, call, ordinal: ordinal++ })
+      group.push(candidate)
       groups.set(identity, group)
     }
   }
@@ -107,5 +146,44 @@ export function reconcileClaudeNativeCalls(
     if (tuples.size > 1) ambiguities.push({ identity, candidates: equallyAuthoritative })
     winners.set(identity, winner)
   }
-  return { winners, ambiguities }
+  return { winners, ambiguities, malformed }
+}
+
+/** Build the one Claude authority view shared by parser-adjacent consumers. */
+export function reconcileClaudeNativeSessionCache(
+  cache: Pick<SessionCache, 'providers'>,
+): ClaudeNativeReconciliation {
+  const section = cache.providers['claude']
+  return reconcileClaudeNativeCalls(
+    Object.entries(section?.files ?? {}).map(([filePath, file]) => ({
+      filePath,
+      calls: file.turns.flatMap(turn => turn.calls),
+    })),
+  )
+}
+
+/**
+ * C3 must observe the same selected call as production, but it cannot mint a
+ * deterministic answer for malformed evidence or equal-authority accounting
+ * disagreement. The production parser keeps its existing diagnostic behavior;
+ * this assertion is the fail-closed boundary for canonical history.
+ */
+export function assertClaudeNativeReconciliationSafe(
+  reconciliation: ClaudeNativeReconciliation,
+): void {
+  if (reconciliation.malformed.length > 0) {
+    throw new ClaudeNativeReconciliationIntegrityError('Claude native evidence is malformed')
+  }
+  if (reconciliation.ambiguities.length > 0) {
+    throw new ClaudeNativeReconciliationIntegrityError('Claude native evidence has equally authoritative conflicting accounting')
+  }
+}
+
+export function isClaudeNativeReconciliationWinner(
+  call: CachedCall,
+  reconciliation: ClaudeNativeReconciliation,
+): boolean {
+  const identity = getClaudeNativeIdentity(call)
+  if (!identity) return true
+  return reconciliation.winners.get(identity)?.call === call
 }

--- a/src/local-state/canonical-history-parity-observer.test.ts
+++ b/src/local-state/canonical-history-parity-observer.test.ts
@@ -182,6 +182,62 @@ describe('canonical history parity observer v1', () => {
     expect(result.counts).toEqual({ observations: 1, activities: 1, dailySnapshots: 1 })
   })
 
+  it('keeps parity with the production Claude snapshot winner', async () => {
+    const partial = call({
+      provider: 'claude',
+      modelProvider: undefined,
+      nativeMessageId: 'native-clash',
+      nativeEmissionTimestamp: '2026-08-01T21:00:00.000Z',
+      nativeSnapshotTerminal: false,
+      deduplicationKey: 'native-clash',
+      usage: { ...call().usage, outputTokens: 2 },
+    })
+    const final = call({
+      provider: 'claude',
+      modelProvider: undefined,
+      nativeMessageId: 'native-clash',
+      nativeEmissionTimestamp: '2026-08-01T21:00:00.000Z',
+      nativeSnapshotTerminal: true,
+      deduplicationKey: 'native-clash',
+      usage: { ...call().usage, outputTokens: 20 },
+    })
+    const persist = vi.fn(async () => persisted())
+    const result = await observeCanonicalHistoryParityV1({
+      endpointId: ENDPOINT_ID,
+      sessionCache: sessionCache({
+        '/private/parent.jsonl': cachedFile([partial], 'parent-session'),
+        '/private/sidechain.jsonl': cachedFile([final], 'sidechain-session'),
+      }, 'claude'),
+      dailyCache: dailyCache([day('claude')]),
+    }, { sourceFingerprint, persist })
+
+    expect(result.counts).toEqual({ observations: 1, activities: 1, dailySnapshots: 1 })
+    expect(persist).toHaveBeenCalledTimes(1)
+  })
+
+  it('fails parity closed for equal-authority Claude accounting disagreement', async () => {
+    const a = call({
+      provider: 'claude',
+      modelProvider: undefined,
+      nativeMessageId: 'native-ambiguous',
+      nativeEmissionTimestamp: '2026-08-01T21:00:00.000Z',
+      nativeSnapshotTerminal: true,
+      deduplicationKey: 'native-ambiguous',
+      usage: { ...call().usage, outputTokens: 2 },
+    })
+    const b = { ...a, usage: { ...a.usage, outputTokens: 3 } }
+    const persist = vi.fn(async () => persisted())
+    await expect(observeCanonicalHistoryParityV1({
+      endpointId: ENDPOINT_ID,
+      sessionCache: sessionCache({
+        '/private/a.jsonl': cachedFile([a], 'a-session'),
+        '/private/b.jsonl': cachedFile([b], 'b-session'),
+      }, 'claude'),
+      dailyCache: dailyCache([day('claude')]),
+    }, { sourceFingerprint, persist })).rejects.toThrow('Claude native evidence')
+    expect(persist).not.toHaveBeenCalled()
+  })
+
   it('uses the canonical Copilot collector for an internal journal namespace', async () => {
     const persist = vi.fn(async () => persisted())
     const result = await observeCanonicalHistoryParityV1({

--- a/src/local-state/canonical-history-parity-observer.ts
+++ b/src/local-state/canonical-history-parity-observer.ts
@@ -12,6 +12,11 @@ import {
   type CostAssignmentV1,
 } from '../pricing/cost-assignment.js'
 import { assertCanonicalCollectorIdentity } from '../provider-parse-authorities.js'
+import {
+  assertClaudeNativeReconciliationSafe,
+  isClaudeNativeReconciliationWinner,
+  reconcileClaudeNativeSessionCache,
+} from '../claude-native-reconciliation.js'
 import { CACHE_VERSION, type CachedCall, type SessionCache } from '../session-cache.js'
 import { canonicalizeRfc8785 } from '../vendor/rfc8785-canonicalize.js'
 import {
@@ -255,6 +260,12 @@ function expectedSessionAuthority(input: {
   const observations = new Map<string, ObservationPayload>()
   const activities = new Set<string>()
   const observationActivity = new Map<string, string>()
+  const claudeNativeReconciliation = reconcileClaudeNativeSessionCache(input.sessionCache)
+  try {
+    assertClaudeNativeReconciliationSafe(claudeNativeReconciliation)
+  } catch {
+    throw new CanonicalHistoryParityMismatchError('Claude native evidence cannot establish a canonical authority')
+  }
 
   for (const [storageNamespace, section] of Object.entries(input.sessionCache.providers)
     .sort(([left], [right]) => left.localeCompare(right))) {
@@ -262,14 +273,17 @@ function expectedSessionAuthority(input: {
       .sort(([left], [right]) => left.localeCompare(right))) {
       if (file.failed) continue
       for (const turn of file.turns) {
-        if (turn.calls.length === 0) continue
+        const calls = storageNamespace === 'claude'
+          ? turn.calls.filter(call => isClaudeNativeReconciliationWinner(call, claudeNativeReconciliation))
+          : turn.calls
+        if (calls.length === 0) continue
         const timestamp = TimestampSchema.safeParse(turn.timestamp)
         if (!timestamp.success) {
           throw new CanonicalHistoryParityMismatchError('canonical cached turn has an invalid timestamp')
         }
-        const collector = canonicalCollectorForCall(storageNamespace, turn.calls[0]!.provider)
+        const collector = canonicalCollectorForCall(storageNamespace, calls[0]!.provider)
         const observationIds: string[] = []
-        for (const call of turn.calls) {
+        for (const call of calls) {
           const payload = rawObservationPayload({
             endpointId: input.endpointId,
             storageNamespace,

--- a/src/local-state/canonical-history-read-projection.test.ts
+++ b/src/local-state/canonical-history-read-projection.test.ts
@@ -178,6 +178,74 @@ describe('canonical history read projection v1', () => {
     })).toThrow(CanonicalHistoryReadProjectionIntegrityError)
   })
 
+  it('projects the production Claude winner instead of retaining a weaker native snapshot', () => {
+    const partial = call({
+      provider: 'claude',
+      modelProvider: undefined,
+      nativeMessageId: 'native-clash',
+      nativeEmissionTimestamp: '2026-08-01T21:00:00.000Z',
+      nativeSnapshotTerminal: false,
+      deduplicationKey: 'native-clash',
+      usage: { ...call().usage, outputTokens: 2 },
+    })
+    const final = call({
+      provider: 'claude',
+      modelProvider: undefined,
+      nativeMessageId: 'native-clash',
+      nativeEmissionTimestamp: '2026-08-01T21:00:00.000Z',
+      nativeSnapshotTerminal: true,
+      deduplicationKey: 'native-clash',
+      usage: { ...call().usage, outputTokens: 20 },
+    })
+    const projection = project({
+      sessions: {
+        version: CACHE_VERSION,
+        complete: true,
+        providers: {
+          claude: {
+            envFingerprint: 'claude-test',
+            files: {
+              '/private/parent.jsonl': cachedFile([partial]),
+              '/private/sidechain.jsonl': cachedFile([final]),
+            },
+          },
+        },
+      },
+    })
+
+    expect(projection.observations).toHaveLength(1)
+    expect(projection.activities).toHaveLength(1)
+    expect(projection.observations[0]!.usage.outputTokens).toBe(20)
+  })
+
+  it('fails closed when Claude candidates have equal authority but conflicting accounting', () => {
+    const a = call({
+      provider: 'claude',
+      modelProvider: undefined,
+      nativeMessageId: 'native-ambiguous',
+      nativeEmissionTimestamp: '2026-08-01T21:00:00.000Z',
+      nativeSnapshotTerminal: true,
+      deduplicationKey: 'native-ambiguous',
+      usage: { ...call().usage, outputTokens: 2 },
+    })
+    const b = { ...a, usage: { ...a.usage, outputTokens: 3 } }
+    expect(() => project({
+      sessions: {
+        version: CACHE_VERSION,
+        complete: true,
+        providers: {
+          claude: {
+            envFingerprint: 'claude-test',
+            files: {
+              '/private/a.jsonl': cachedFile([a]),
+              '/private/b.jsonl': cachedFile([b]),
+            },
+          },
+        },
+      },
+    })).toThrow('equally authoritative')
+  })
+
   it('preserves source-less carried history without inventing observations or activities', () => {
     const projection = project({
       sessions: {

--- a/src/local-state/canonical-history-read-projection.ts
+++ b/src/local-state/canonical-history-read-projection.ts
@@ -8,6 +8,11 @@ import {
   type CostAssignmentV1,
 } from '../pricing/cost-assignment.js'
 import {
+  assertClaudeNativeReconciliationSafe,
+  isClaudeNativeReconciliationWinner,
+  reconcileClaudeNativeSessionCache,
+} from '../claude-native-reconciliation.js'
+import {
   CACHE_VERSION,
   type CachedCall,
   type CachedUsage,
@@ -263,6 +268,8 @@ export function projectCanonicalHistoryReadV1(
   const observationsById = new Map<string, CanonicalObservationReadV1>()
   const activitiesById = new Map<string, CanonicalActivityReadV1>()
   const activityByObservation = new Map<string, string>()
+  const claudeNativeReconciliation = reconcileClaudeNativeSessionCache(sessionCache)
+  assertClaudeNativeReconciliationSafe(claudeNativeReconciliation)
 
   for (const [storageNamespace, section] of Object.entries(sessionCache.providers).sort(([a], [b]) => a.localeCompare(b))) {
     for (const [, file] of Object.entries(section.files).sort(([a], [b]) => a.localeCompare(b))) {
@@ -271,9 +278,12 @@ export function projectCanonicalHistoryReadV1(
         if (!turn.sessionId) throw new CanonicalHistoryReadProjectionIntegrityError('canonical cached turn has an empty private session id')
         const turnTimestamp = TimestampSchema.safeParse(turn.timestamp)
         if (!turnTimestamp.success) throw new CanonicalHistoryReadProjectionIntegrityError('canonical cached turn has an invalid timestamp')
-        if (turn.calls.length === 0) continue
+        const calls = storageNamespace === 'claude'
+          ? turn.calls.filter(call => isClaudeNativeReconciliationWinner(call, claudeNativeReconciliation))
+          : turn.calls
+        if (calls.length === 0) continue
 
-        const firstCall = turn.calls[0]!
+        const firstCall = calls[0]!
         if (!firstCall.deduplicationKey) {
           throw new CanonicalHistoryReadProjectionIntegrityError('canonical cached call has an empty private deduplication key')
         }
@@ -300,7 +310,7 @@ export function projectCanonicalHistoryReadV1(
         ])}`
 
         const observationIds: string[] = []
-        for (const call of turn.calls) {
+        for (const call of calls) {
           const observation = observationForCall({ endpointId, storageNamespace, activityId, call })
           const prior = observationsById.get(observation.observationId)
           if (prior && !sameValue(prior, observation)) {

--- a/tests/r2-claude-native-identity-reconciliation.test.ts
+++ b/tests/r2-claude-native-identity-reconciliation.test.ts
@@ -9,6 +9,11 @@ import {
   reconcileClaudeNativeCalls,
 } from '../src/parser.js'
 import { getDailyCacheConfigHash } from '../src/daily-cache-config.js'
+import {
+  assertClaudeNativeReconciliationSafe,
+  isClaudeNativeReconciliationWinner,
+  reconcileClaudeNativeSessionCache,
+} from '../src/claude-native-reconciliation.js'
 import { computeEnvFingerprint, PROVIDER_PARSE_VERSIONS, type CachedCall } from '../src/session-cache.js'
 import type { JournalEntry } from '../src/types.js'
 
@@ -193,6 +198,97 @@ describe('R2 Claude native message identity reconciliation', () => {
     ]
     expect(outputOf(files)).toBe(6)
     expect(outputOf(files)).toBe(6)
+  })
+
+  it('uses nativeMessageId before any legacy deduplication key', () => {
+    expect(getClaudeNativeIdentity(makeCall({
+      nativeMessageId: 'native-authority',
+      deduplicationKey: 'legacy-local-key',
+    }))).toBe('native-authority')
+  })
+
+  it('keeps the pre-migration deduplication fallback and excludes advisor calls', () => {
+    expect(getClaudeNativeIdentity(makeCall({
+      nativeMessageId: undefined,
+      deduplicationKey: 'legacy-native-key',
+    }))).toBe('legacy-native-key')
+    expect(getClaudeNativeIdentity(makeCall({
+      nativeMessageId: undefined,
+      deduplicationKey: 'legacy:advisor:call',
+    }))).toBeUndefined()
+  })
+
+  it('prefers known native emission evidence over a missing emission timestamp', () => {
+    const missing = makeCall({
+      nativeEmissionTimestamp: undefined,
+      nativeSnapshotTerminal: false,
+    })
+    const known = withOutput(makeCall({
+      nativeEmissionTimestamp: '2026-04-03T13:30:37.000Z',
+      nativeSnapshotTerminal: false,
+    }), 376)
+    const result = reconcileClaudeNativeCalls([
+      { filePath: 'known.jsonl', calls: [known] },
+      { filePath: 'missing.jsonl', calls: [missing] },
+    ])
+    expect(result.ambiguities).toHaveLength(0)
+    expect(result.winners.get('native-message-1')?.call).toBe(known)
+  })
+
+  it('selects the strongest of three snapshots independent of input order', () => {
+    const partial = withOutput(makeCall({
+      nativeEmissionTimestamp: '2026-04-03T13:30:36.000Z',
+      nativeSnapshotTerminal: false,
+    }), 5)
+    const intermediate = withOutput(makeCall({
+      nativeEmissionTimestamp: '2026-04-03T13:30:37.000Z',
+      nativeSnapshotTerminal: false,
+    }), 100)
+    const final = withOutput(makeCall({
+      nativeEmissionTimestamp: '2026-04-03T13:30:37.000Z',
+      nativeSnapshotTerminal: true,
+    }), 376)
+    const orders = [
+      [partial, intermediate, final],
+      [final, partial, intermediate],
+      [intermediate, final, partial],
+    ]
+    for (const order of orders) {
+      const result = reconcileClaudeNativeCalls(order.map((call, index) => ({
+        filePath: `candidate-${index}.jsonl`,
+        calls: [call],
+      })))
+      expect(result.winners.get('native-message-1')?.call.usage.outputTokens).toBe(376)
+      expect(result.ambiguities).toHaveLength(0)
+    }
+  })
+
+  it('fails closed for malformed native evidence at the canonical boundary', () => {
+    const malformed = makeCall({ nativeEmissionTimestamp: 'not-a-timestamp' })
+    const result = reconcileClaudeNativeCalls([{ filePath: 'malformed.jsonl', calls: [malformed] }])
+    expect(result.malformed).toHaveLength(1)
+    expect(() => assertClaudeNativeReconciliationSafe(result)).toThrow('malformed')
+  })
+
+  it('replays the same winner after a cache reload', () => {
+    const partial = makeCall({ nativeSnapshotTerminal: false })
+    const final = withOutput(makeCall({ nativeSnapshotTerminal: true }), 376)
+    const cache = {
+      providers: {
+        claude: {
+          envFingerprint: 'test',
+          files: {
+            'parent.jsonl': { turns: [{ calls: [partial] }] },
+            'sidechain.jsonl': { turns: [{ calls: [final] }] },
+          },
+        },
+      },
+    }
+    const first = reconcileClaudeNativeSessionCache(cache as never)
+    const reloaded = reconcileClaudeNativeSessionCache(structuredClone(cache) as never)
+    expect(first.winners.get('native-message-1')?.call.usage.outputTokens).toBe(376)
+    expect(reloaded.winners.get('native-message-1')?.call.usage.outputTokens).toBe(376)
+    expect(isClaudeNativeReconciliationWinner(reloaded.winners.get('native-message-1')!.call, reloaded)).toBe(true)
   })
 
   it('bumps both Claude parse and daily authorities for stale-cache self-healing', () => {


### PR DESCRIPTION
## What changed
- Reuse the existing Claude native winner-selection authority in canonical-history projection and parity validation.
- Keep exact duplicates idempotent, choose stronger terminal/native snapshots deterministically, and fail closed for malformed evidence or equal-authority accounting conflicts.
- Add adversarial coverage for native IDs, pre-migration fallback, advisor exclusion, missing timestamps, three-candidate ordering, restart/reload, projection, and parity.

## Rebase and evidence
- Main authority: `99c4e4b780addb6921a7d29b6c2ea0d35d8d7a14` (#168 included).
- Rebasing from the prior HEAD produced `29c1cdee980fe5eef48c495aa820a0fb8d17aa29`.
- Pre/post rebase patch digest is identical: `97ac801e297cfd0a3ffdd11f095c1400b038d427`.
- Focused Claude/C3 validation: 33 tests passed.
- First real shadow publication: 91,610 observations, 23,713 activities, 146 daily snapshots.
- A later live-corpus retry exposed a separate Codex activity-revision contract blocker; it remains fail-closed and is handled by the stacked draft PR.

## Scope
- No parser semantics, token accounting, cost assignment, cache schema/version, daily cache version, or consumer authority changes.
- Draft only; do not merge as part of this wave.