### PR TITLE
fix: flatten long-lived session cache strings

### DIFF
--- a/src/codex-cache.ts
+++ b/src/codex-cache.ts
@@ -5,6 +5,7 @@ import { join } from 'path'
 
 import type { ParsedProviderCall } from './providers/types.js'
 import { getMetroraCacheDir } from './product-paths.js'
+import { flattenParsedProviderCalls } from './string-retention.js'
 
 // v4: attribute MCP calls emitted as event_msg/mcp_tool_call_end (issue #478).
 // Recent Codex sessions cached under v3 dropped these, so force a re-parse.
@@ -116,7 +117,7 @@ export async function writeCachedCodexResults(
       mtimeMs: fingerprint.mtimeMs,
       sizeBytes: fingerprint.sizeBytes,
       project,
-      calls,
+      calls: flattenParsedProviderCalls(calls),
     }
   } catch {}
 }

--- a/src/cursor-cache.ts
+++ b/src/cursor-cache.ts
@@ -4,6 +4,7 @@ import { homedir } from 'os'
 import { randomBytes } from 'crypto'
 
 import type { ParsedProviderCall } from './providers/types.js'
+import { flattenParsedProviderCalls } from './string-retention.js'
 
 // Bumped to 3 for the workspace-aware breakdown change: the cursor parser
 // now derives `sessionId` from the bubble row key (the real composer id)
@@ -93,7 +94,7 @@ export async function writeCachedResults(
     dbMtimeMs: fp.mtimeMs,
     dbSizeBytes: fp.size,
     lookbackFloor,
-    calls,
+    calls: flattenParsedProviderCalls(calls),
   }
 
   // Atomic write: stage to a randomized temp file in the same directory,

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -59,7 +59,7 @@ import { claudeSlugFallbackPath, normalizeProjectPathKey, projectNameFromPath, u
 import { flushCopilotChatJournalInvalidations, queueCopilotChatJournalSource, recordCopilotChatJournalSourceChange, recordCopilotChatJournalSourceFailure } from './copilot-chat-journal-reconciliation.js'
 import { reconcileMissingProviderSources, shouldReconcileMissingProviderSources } from './parser-source-reconciliation.js'
 import { buildCwdEvidenceIndex, timeBoundCwdRefs } from './pr-attribution-time-bound.js'
-
+import { flattenString, flattenStringArray, flattenStringPrefix, flattenToolSequence } from './string-retention.js'
 
 
 
@@ -1264,10 +1264,10 @@ export function collectToolResultMeta(entry: JournalEntry, map: Map<string, Tool
 export function collectSessionMeta(entry: JournalEntry, meta: SessionMeta): void {
   if (entry.type === 'ai-title') {
     const t = (entry as Record<string, unknown>)['aiTitle']
-    if (typeof t === 'string' && t.trim()) meta.title = t.trim().slice(0, 200)
+    if (typeof t === 'string' && t.trim()) meta.title = flattenStringPrefix(t.trim(), 200)
   } else if (entry.type === 'pr-link') {
     const url = (entry as Record<string, unknown>)['prUrl']
-    if (typeof url === 'string' && url && !meta.prLinks.includes(url)) meta.prLinks.push(url)
+    if (typeof url === 'string' && url && !meta.prLinks.includes(url)) meta.prLinks.push(flattenString(url))
   }
   if (entry.isSidechain === true) {
     meta.isSidechain = true
@@ -1275,7 +1275,7 @@ export function collectSessionMeta(entry: JournalEntry, meta: SessionMeta): void
     // it (32/32 on real data; cross-checked against the owning directory at
     // stamp time). First value wins; every entry in the file carries the same id.
     const sid = (entry as Record<string, unknown>)['sessionId']
-    if (!meta.parentSessionId && typeof sid === 'string' && sid) meta.parentSessionId = sid
+    if (!meta.parentSessionId && typeof sid === 'string' && sid) meta.parentSessionId = flattenString(sid)
   }
   // Parent side: the `Agent`/`Task` spawn result records the spawned agent's id in
   // `toolUseResult.agentId`; pair it with the `tool_result` block's `tool_use_id`
@@ -1305,11 +1305,11 @@ export function collectSessionMeta(entry: JournalEntry, meta: SessionMeta): void
           const matches = results.filter(b => JSON.stringify(b['content']) === turContent)
           if (matches.length === 1) spawnId = matches[0]!['tool_use_id'] as string
         }
-        if (spawnId) meta.agentSpawnLinks[agentId] = spawnId
+        if (spawnId) meta.agentSpawnLinks[flattenString(agentId)] = flattenString(spawnId)
         // We know this parent spawned `agentId` (its result named it) but could not
         // pair the exact tool_use: record it as an AMBIGUOUS pairing so a late child
         // can still fold via the grace window. Not the same as an absent spawn.
-        else if (!meta.ambiguousSpawnAgentIds.includes(agentId)) meta.ambiguousSpawnAgentIds.push(agentId)
+        else if (!meta.ambiguousSpawnAgentIds.includes(agentId)) meta.ambiguousSpawnAgentIds.push(flattenString(agentId))
       }
     }
   }
@@ -1646,7 +1646,7 @@ export function extractMcpInventory(entries: JournalEntry[]): string[] {
     for (const name of a.addedNames) {
       if (typeof name !== 'string') continue
       if (!isMcpToolName(name)) continue
-      inventory.add(name)
+      inventory.add(flattenString(name))
     }
   }
   if (inventory.size === 0) return []
@@ -1657,7 +1657,7 @@ function extractCanonicalCwd(entries: JournalEntry[]): string | undefined {
   for (const entry of entries) {
     if (typeof entry.cwd !== 'string') continue
     const cwd = entry.cwd.trim()
-    if (cwd) return cwd
+    if (cwd) return flattenString(cwd)
   }
   return undefined
 }
@@ -1921,7 +1921,7 @@ export async function readAgentType(filePath: string): Promise<string | undefine
   const metaPath = filePath.replace(/\.jsonl$/, '.meta.json')
   try {
     const t = (JSON.parse(await readFile(metaPath, 'utf8')) as { agentType?: unknown }).agentType
-    if (typeof t === 'string' && t.trim()) return t.trim().slice(0, 100)
+    if (typeof t === 'string' && t.trim()) return flattenStringPrefix(t.trim(), 100)
   } catch { /* missing or unreadable meta */ }
   // Workflow agents always live under `subagents/workflows/`, so fall back to that
   // even when the meta sidecar is absent.
@@ -2352,7 +2352,7 @@ function summarizeProject(project: string, projectPath: string, sessions: Sessio
 // ambiguous and must never silently move spend between repositories.
 const PR_URL_IN_TEXT_RE = /https:\/\/github\.com\/[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+\/pull\/\d+/g
 export function extractPrUrlsFromText(text: string): string[] {
-  return [...new Set(text.match(PR_URL_IN_TEXT_RE) ?? [])].sort()
+  return [...new Set((text.match(PR_URL_IN_TEXT_RE) ?? []).map(flattenString))].sort()
 }
 
 export function providerCallToTurn(call: ParsedProviderCall): ParsedTurn {
@@ -2437,9 +2437,9 @@ export function providerCallToCachedCall(call: ParsedProviderCall): CachedCall {
     existingAssignment: call.costAssignment,
   })
   return {
-    provider: call.provider,
-    model: call.model,
-    ...(call.modelProvider ? { modelProvider: call.modelProvider } : {}),
+    provider: flattenString(call.provider),
+    model: flattenString(call.model),
+    ...(call.modelProvider ? { modelProvider: flattenString(call.modelProvider) } : {}),
     ...(call.reasoningLevel ? {
       reasoningLevel: call.reasoningLevel,
       reasoningLevelSource: call.reasoningLevelSource,
@@ -2450,16 +2450,16 @@ export function providerCallToCachedCall(call: ParsedProviderCall): CachedCall {
     ...(settlement.storedLegacyCostUSD !== undefined ? { legacyCostUSD: settlement.storedLegacyCostUSD } : {}),
     isEstimated: call.costIsEstimated || undefined,
     speed: call.speed,
-    timestamp: call.timestamp,
-    tools: call.tools,
-    bashCommands: call.bashCommands,
-    skills: call.skills ?? [],
-    subagentTypes: call.subagentTypes ?? [],
-    deduplicationKey: call.deduplicationKey,
-    project: call.project,
-    projectPath: call.projectPath,
-    workingDirectory: call.workingDirectory,
-    toolSequence: call.toolSequence,
+    timestamp: flattenString(call.timestamp),
+    tools: flattenStringArray(call.tools),
+    bashCommands: flattenStringArray(call.bashCommands),
+    skills: flattenStringArray(call.skills ?? []),
+    subagentTypes: flattenStringArray(call.subagentTypes ?? []),
+    deduplicationKey: flattenString(call.deduplicationKey),
+    ...(call.project !== undefined ? { project: flattenString(call.project) } : {}),
+    ...(call.projectPath !== undefined ? { projectPath: flattenString(call.projectPath) } : {}),
+    ...(call.workingDirectory !== undefined ? { workingDirectory: flattenString(call.workingDirectory) } : {}),
+    toolSequence: flattenToolSequence(call.toolSequence),
     ...(call.locAdded ? { locAdded: call.locAdded } : {}),
     ...(call.locRemoved ? { locRemoved: call.locRemoved } : {}),
     ...(call.editFailed ? { editFailed: call.editFailed } : {}),
@@ -2502,9 +2502,9 @@ export function apiCallToCachedCall(call: ParsedApiCall): CachedCall {
     existingAssignment: call.isLocalSavings ? undefined : call.costAssignment,
   })
   return {
-    provider: call.provider,
-    model: call.model,
-    ...(call.modelProvider ? { modelProvider: call.modelProvider } : {}),
+    provider: flattenString(call.provider),
+    model: flattenString(call.model),
+    ...(call.modelProvider ? { modelProvider: flattenString(call.modelProvider) } : {}),
     ...(call.reasoningLevel ? {
       reasoningLevel: call.reasoningLevel,
       reasoningLevelSource: call.reasoningLevelSource,
@@ -2515,16 +2515,16 @@ export function apiCallToCachedCall(call: ParsedApiCall): CachedCall {
     ...(settlement.storedLegacyCostUSD !== undefined ? { legacyCostUSD: settlement.storedLegacyCostUSD } : {}),
     isEstimated: call.isEstimated || undefined,
     speed: call.speed,
-    timestamp: call.timestamp,
-    tools: call.tools,
-    bashCommands: call.bashCommands,
-    skills: call.skills,
-    subagentTypes: call.subagentTypes,
-    deduplicationKey: call.deduplicationKey,
-    ...(call.nativeMessageId ? { nativeMessageId: call.nativeMessageId } : {}),
-    ...(call.nativeEmissionTimestamp ? { nativeEmissionTimestamp: call.nativeEmissionTimestamp } : {}),
+    timestamp: flattenString(call.timestamp),
+    tools: flattenStringArray(call.tools),
+    bashCommands: flattenStringArray(call.bashCommands),
+    skills: flattenStringArray(call.skills ?? []),
+    subagentTypes: flattenStringArray(call.subagentTypes ?? []),
+    deduplicationKey: flattenString(call.deduplicationKey),
+    ...(call.nativeMessageId ? { nativeMessageId: flattenString(call.nativeMessageId) } : {}),
+    ...(call.nativeEmissionTimestamp ? { nativeEmissionTimestamp: flattenString(call.nativeEmissionTimestamp) } : {}),
     ...(call.nativeSnapshotTerminal ? { nativeSnapshotTerminal: true } : {}),
-    toolSequence: call.toolSequence,
+    toolSequence: flattenToolSequence(call.toolSequence),
     ...(call.locAdded ? { locAdded: call.locAdded } : {}),
     ...(call.locRemoved ? { locRemoved: call.locRemoved } : {}),
     ...(call.interrupted ? { interrupted: true } : {}),
@@ -2538,14 +2538,14 @@ export function apiCallToCachedCall(call: ParsedApiCall): CachedCall {
 
 function parsedTurnToCachedTurn(turn: ParsedTurn): CachedTurn {
   return {
-    timestamp: turn.timestamp,
-    sessionId: turn.sessionId,
-    userMessage: turn.userMessage.slice(0, 2000),
+    timestamp: flattenString(turn.timestamp),
+    sessionId: flattenString(turn.sessionId),
+    userMessage: flattenStringPrefix(turn.userMessage, 2000),
     calls: turn.assistantCalls.map(apiCallToCachedCall),
     // Stored per-turn directly (already sorted/deduped in groupIntoTurns), unlike
     // gitBranch's change-detection dedup, so each turn's refs are self-contained.
-    ...(turn.prRefs?.length ? { prRefs: turn.prRefs } : {}),
-    ...(turn.spawnToolUseIds?.length ? { spawnToolUseIds: turn.spawnToolUseIds } : {}),
+    ...(turn.prRefs?.length ? { prRefs: flattenStringArray(turn.prRefs) } : {}),
+    ...(turn.spawnToolUseIds?.length ? { spawnToolUseIds: flattenStringArray(turn.spawnToolUseIds) } : {}),
   }
 }
 
@@ -2559,7 +2559,7 @@ export function parsedTurnsToCachedTurns(turns: ParsedTurn[]): CachedTurn[] {
   let prevBranch: string | undefined
   for (const turn of turns) {
     const cached = parsedTurnToCachedTurn(turn)
-    if (turn.gitBranch && turn.gitBranch !== prevBranch) cached.gitBranch = turn.gitBranch
+    if (turn.gitBranch && turn.gitBranch !== prevBranch) cached.gitBranch = flattenString(turn.gitBranch)
     if (turn.gitBranch) prevBranch = turn.gitBranch
     out.push(cached)
   }
@@ -2569,11 +2569,11 @@ export function parsedTurnsToCachedTurns(turns: ParsedTurn[]): CachedTurn[] {
 function providerCallToCachedTurn(call: ParsedProviderCall): CachedTurn {
   const prRefs = extractPrUrlsFromText(call.userMessage)
   return {
-    timestamp: call.timestamp,
-    sessionId: call.sessionId,
-    userMessage: call.userMessage.slice(0, 2000),
+    timestamp: flattenString(call.timestamp),
+    sessionId: flattenString(call.sessionId),
+    userMessage: flattenStringPrefix(call.userMessage, 2000),
     calls: [providerCallToCachedCall(call)],
-    ...(prRefs.length ? { prRefs } : {}),
+    ...(prRefs.length ? { prRefs: flattenStringArray(prRefs) } : {}),
   }
 }
 
@@ -2592,18 +2592,18 @@ function providerCallsToCachedTurns(calls: ParsedProviderCall[]): CachedTurn[] {
     if (!turn) {
       const prRefs = extractPrUrlsFromText(call.userMessage)
       turn = {
-        timestamp: call.timestamp,
-        sessionId: call.sessionId,
-        userMessage: call.userMessage.slice(0, 2000),
+        timestamp: flattenString(call.timestamp),
+        sessionId: flattenString(call.sessionId),
+        userMessage: flattenStringPrefix(call.userMessage, 2000),
         calls: [],
-        ...(prRefs.length ? { prRefs } : {}),
+        ...(prRefs.length ? { prRefs: flattenStringArray(prRefs) } : {}),
       }
       grouped.set(key, turn)
       turns.push(turn)
     }
     turn.calls.push(providerCallToCachedCall(call))
     const refs = extractPrUrlsFromText(call.userMessage)
-    if (refs.length) turn.prRefs = [...new Set([...(turn.prRefs ?? []), ...refs])].sort()
+    if (refs.length) turn.prRefs = flattenStringArray([...new Set([...(turn.prRefs ?? []), ...refs])].sort())
   }
 
   return turns

--- a/src/string-retention.ts
+++ b/src/string-retention.ts
@@ -1,0 +1,63 @@
+import type { ToolCall } from './types.js'
+import type { ParsedProviderCall } from './providers/types.js'
+
+/**
+ * Materialize a string without changing its JavaScript UTF-16 contents.
+ *
+ * A bounded slice of a large source string can keep that source's backing
+ * storage alive in V8. structuredClone creates an independent string while
+ * preserving lone-surrogate code units; a UTF-8 round-trip does not.
+ */
+export function flattenString(value: string): string {
+  return structuredClone(value)
+}
+
+/** Take an exact JS-string prefix, then detach it from the source string. */
+export function flattenStringPrefix(value: string, limit: number): string {
+  return flattenString(value.slice(0, limit))
+}
+
+export function flattenStringArray(values: readonly string[]): string[] {
+  return values.map(flattenString)
+}
+
+export function flattenToolSequence(
+  sequence: readonly (readonly ToolCall[])[] | undefined,
+): ToolCall[][] | undefined {
+  if (sequence === undefined) return undefined
+  return sequence.map(calls => calls.map(call => ({
+    tool: flattenString(call.tool),
+    ...(call.file !== undefined ? { file: flattenString(call.file) } : {}),
+    ...(call.command !== undefined ? { command: flattenString(call.command) } : {}),
+  })))
+}
+
+/**
+ * Detach the string-bearing fields at a provider-local result-cache boundary.
+ * Serialized values remain identical; only V8's backing-storage relationship
+ * is changed.
+ */
+export function flattenParsedProviderCall(call: ParsedProviderCall): ParsedProviderCall {
+  return {
+    ...call,
+    provider: flattenString(call.provider),
+    model: flattenString(call.model),
+    ...(call.modelProvider ? { modelProvider: flattenString(call.modelProvider) } : {}),
+    timestamp: flattenString(call.timestamp),
+    deduplicationKey: flattenString(call.deduplicationKey),
+    sessionId: flattenString(call.sessionId),
+    ...(call.project !== undefined ? { project: flattenString(call.project) } : {}),
+    ...(call.projectPath !== undefined ? { projectPath: flattenString(call.projectPath) } : {}),
+    ...(call.workingDirectory !== undefined ? { workingDirectory: flattenString(call.workingDirectory) } : {}),
+    userMessage: flattenString(call.userMessage),
+    tools: flattenStringArray(call.tools),
+    bashCommands: flattenStringArray(call.bashCommands),
+    ...(call.skills ? { skills: flattenStringArray(call.skills) } : {}),
+    ...(call.subagentTypes ? { subagentTypes: flattenStringArray(call.subagentTypes) } : {}),
+    ...(call.toolSequence ? { toolSequence: flattenToolSequence(call.toolSequence) } : {}),
+  }
+}
+
+export function flattenParsedProviderCalls(calls: readonly ParsedProviderCall[]): ParsedProviderCall[] {
+  return calls.map(flattenParsedProviderCall)
+}

--- a/tests/string-retention.test.ts
+++ b/tests/string-retention.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  flattenParsedProviderCall,
+  flattenString,
+  flattenStringPrefix,
+  flattenToolSequence,
+} from '../src/string-retention.js'
+
+function codeUnits(value: string): number[] {
+  return Array.from({ length: value.length }, (_, index) => value.charCodeAt(index))
+}
+
+describe('string retention flattening', () => {
+  it('preserves empty, short, multibyte, and lone-surrogate strings exactly', () => {
+    const samples = [
+      '',
+      'short',
+      `café ${String.fromCodePoint(0x1f600)}`,
+      String.fromCharCode(0xd800),
+      String.fromCharCode(0xdc00),
+      `A${String.fromCharCode(0xd800)}B${String.fromCodePoint(0x1f600)}é`,
+    ]
+
+    for (const sample of samples) {
+      const flattened = flattenString(sample)
+      expect(flattened).toBe(sample)
+      expect(codeUnits(flattened)).toEqual(codeUnits(sample))
+    }
+  })
+
+  it('keeps exact JavaScript code-unit prefix semantics', () => {
+    const source = `A${String.fromCodePoint(0x1f600)}B${String.fromCharCode(0xd800)}C`
+    for (const limit of [0, 1, 2, 3, 4, 5, source.length + 10]) {
+      const expected = source.slice(0, limit)
+      expect(flattenStringPrefix(source, limit)).toBe(expected)
+      expect(codeUnits(flattenStringPrefix(source, limit))).toEqual(codeUnits(expected))
+    }
+  })
+
+  it('detaches tool names, commands, and provider preview fields without changing values', () => {
+    const sequence = flattenToolSequence([[{
+      tool: 'mcp__server__tool',
+      file: 'src/é.ts',
+      command: `echo ${String.fromCharCode(0xd800)}`,
+    }]])
+    expect(sequence).toEqual([[{
+      tool: 'mcp__server__tool',
+      file: 'src/é.ts',
+      command: `echo ${String.fromCharCode(0xd800)}`,
+    }]])
+
+    const call = flattenParsedProviderCall({
+      provider: 'codex',
+      model: 'gpt-5',
+      inputTokens: 1,
+      outputTokens: 2,
+      cacheCreationInputTokens: 0,
+      cacheReadInputTokens: 0,
+      cachedInputTokens: 0,
+      reasoningTokens: 0,
+      webSearchRequests: 0,
+      costUSD: 0,
+      tools: ['mcp__server__tool'],
+      bashCommands: ['echo hi'],
+      skills: ['skill'],
+      subagentTypes: ['worker'],
+      timestamp: '2026-08-13T00:00:00.000Z',
+      speed: 'standard',
+      deduplicationKey: 'call-1',
+      userMessage: 'preview',
+      sessionId: 'session-1',
+      toolSequence: sequence,
+    })
+    expect(call.userMessage).toBe('preview')
+    expect(call.tools).toEqual(['mcp__server__tool'])
+    expect(call.toolSequence).toEqual(sequence)
+  })
+
+  it('preserves serialized provider-call semantics at a local cache boundary', () => {
+    const raw = {
+      provider: 'codex',
+      model: `model-${String.fromCharCode(0xd800)}`,
+      inputTokens: 1,
+      outputTokens: 2,
+      cacheCreationInputTokens: 3,
+      cacheReadInputTokens: 4,
+      cachedInputTokens: 5,
+      reasoningTokens: 6,
+      webSearchRequests: 7,
+      costUSD: 0.25,
+      tools: ['tool'],
+      bashCommands: ['echo'],
+      skills: ['skill'],
+      subagentTypes: ['worker'],
+      timestamp: '2026-08-13T00:00:00.000Z',
+      speed: 'standard' as const,
+      deduplicationKey: 'key',
+      userMessage: `prefix-${String.fromCharCode(0xdc00)}`,
+      sessionId: 'session',
+      project: 'project',
+      projectPath: 'C:/project',
+      workingDirectory: 'C:/project',
+      toolSequence: [[{ tool: 'tool', command: 'echo' }]],
+    }
+    expect(JSON.stringify(flattenParsedProviderCall(raw))).toBe(JSON.stringify(raw))
+  })
+})


### PR DESCRIPTION
## Summary

Fix long-lived JavaScript string retention in session-cache and provider-local cache boundaries without changing serialized cache semantics or accounting behavior.

### Changes

- add a JS-semantic-preserving string-flattening primitive;
- apply it only where small derived strings can remain reachable through long-lived cache structures;
- detach long-lived string arrays and tool sequences at the session-cache boundary;
- detach selected provider metadata and cached provider-call arrays before long-lived storage;
- preserve parser accounting, cost assignment, deduplication, cache schema/version, daily-cache version and provider semantics.

### Evidence

Synthetic retained-prefix characterization reproduced the memory-retention class and showed that explicitly detached strings release the large parent allocation while preserving exact JavaScript string contents, including multibyte text and lone-surrogate behavior.

Real local runs were used only as a safety check because the live corpus changed between measurements; no incomparable before/after performance claim is made.

### Validation

- full Vitest suite passed;
- `npx tsc --noEmit` passed;
- `npm run build:cli` passed;
- source-size ratchet passed;
- `git diff --check` passed.

No parser, pricing, release, Store, packaging or Kiro project-path behavior is changed by this PR.