### PR TITLE
fix: allow bounded live Codex activity revisions in C3 shadow

### DIFF
--- a/docs/CANONICAL_HISTORY_PARITY_OBSERVER_V1.md
+++ b/docs/CANONICAL_HISTORY_PARITY_OBSERVER_V1.md
@@ -83,6 +83,11 @@ This comparison includes:
 
 The observation collection and daily snapshots remain separate authorities and are never added together.
 
+When a live turn extends an existing activity, the shadow reconciliation marks
+the activity as `revised`. This is a projection revision only: observations
+remain source-identity stable, daily totals remain a separate non-additive
+authority, and the observer does not add a second accounting record.
+
 ## Publication rule
 
 The order is strict:

--- a/docs/CANONICAL_HISTORY_READ_PROJECTION_V1.md
+++ b/docs/CANONICAL_HISTORY_READ_PROJECTION_V1.md
@@ -55,6 +55,15 @@ Private session identity is hashed and never emitted. Local day, timezone, cache
 
 A timezone change may therefore move a daily snapshot boundary without changing observation or activity identity.
 
+The activity identity is a stable logical source identity, not an immutable
+payload digest. A live turn may receive more source observations between two
+projection snapshots. Such a revision is valid only when the new ordered
+observation list preserves the previous list as an exact prefix. The current
+head represents the current activity projection; earlier content-addressed
+snapshots remain immutable audit evidence. A reordered, shortened or otherwise
+conflicting activity payload fails closed, as does a conflicting observation
+payload under an existing observation identity.
+
 ## Accounting evidence
 
 Each observation preserves:

--- a/docs/CANONICAL_HISTORY_SHADOW_STORE_V1.md
+++ b/docs/CANONICAL_HISTORY_SHADOW_STORE_V1.md
@@ -50,13 +50,23 @@ When a distinct projection becomes current:
 - the head advances to the new digest;
 - reconciliation reports identities that were added, unchanged or retained only in the previous head.
 
+Activities are the one identity whose payload may revise across snapshots. A
+current activity may extend a retained activity only by appending observations
+to its existing ordered list; the reconciliation reports that as `revised`.
+Shortening, reordering, changing the collector or timestamp, or introducing a
+non-prefix payload for the same activity identity fails closed. Observations
+and daily snapshots remain immutable across all retained snapshots.
+
 Retained-only observations or activities are not silently copied into the new projection. Their earlier immutable snapshot remains available for later C3 reconciliation work.
 
 ## Historical conflict detection
 
 Before accepting a new projection, the store scans all retained snapshots.
 
-One observation, activity or daily-snapshot identity may not resolve to different canonical payloads anywhere in retained shadow history.
+One observation or daily-snapshot identity may not resolve to different
+canonical payloads anywhere in retained shadow history. Activity revisions are
+accepted only as one ordered prefix chain, with the current head selecting the
+current payload; the historical activity payloads are never rewritten.
 
 A conflicting reuse fails closed and does not advance the head.
 

--- a/src/local-state/canonical-history-parity-observer.test.ts
+++ b/src/local-state/canonical-history-parity-observer.test.ts
@@ -143,7 +143,7 @@ function persisted() {
     projectionSha256: 'a'.repeat(64),
     reconciliation: {
       observations: { added: 1, unchanged: 0, retainedOnly: 0 },
-      activities: { added: 1, unchanged: 0, retainedOnly: 0 },
+      activities: { added: 1, unchanged: 0, revised: 0, retainedOnly: 0 },
       dailySnapshots: { added: 1, unchanged: 0, retainedOnly: 0 },
     },
   }

--- a/src/local-state/canonical-history-shadow-store.test.ts
+++ b/src/local-state/canonical-history-shadow-store.test.ts
@@ -99,6 +99,26 @@ function projection(character = 'a'): CanonicalHistoryReadProjectionV1 {
   }
 }
 
+function liveTurnProjection(observationCharacters: string[]): CanonicalHistoryReadProjectionV1 {
+  const value = projection('a')
+  const activityId = `activity-v1:${hex('z')}`
+  const observationIds = observationCharacters.map(character => `observation-v1:${hex(character)}`)
+  value.observations = observationCharacters.map((character, index) => ({
+    ...structuredClone(value.observations[0]!),
+    observationId: `observation-v1:${hex(character)}`,
+    activityId,
+    sourceFingerprintSha256: hex(character),
+    model: `live-model-${index}`,
+  }))
+  value.activities = [{
+    activityId,
+    collector: 'codex',
+    timestamp: '2026-08-01T21:00:00.000Z',
+    observationIds,
+  }]
+  return value
+}
+
 describe('canonical history shadow store v1', () => {
   it('publishes one immutable content-addressed snapshot and remains idempotent', async () => {
     const dataDir = await temporaryDataDir()
@@ -136,7 +156,7 @@ describe('canonical history shadow store v1', () => {
     expect(second.previousProjectionSha256).toBe(first.projectionSha256)
     expect(second.reconciliation).toEqual({
       observations: { added: 1, unchanged: 0, retainedOnly: 1 },
-      activities: { added: 1, unchanged: 0, retainedOnly: 1 },
+      activities: { added: 1, unchanged: 0, revised: 0, retainedOnly: 1 },
       dailySnapshots: { added: 1, unchanged: 0, retainedOnly: 1 },
     })
     expect((await readdir(paths.snapshots)).sort()).toEqual([
@@ -144,6 +164,53 @@ describe('canonical history shadow store v1', () => {
       `${second.projectionSha256}.json`,
     ].sort())
     expect((await readCanonicalHistoryShadowHeadV1({ dataDir }))?.projectionSha256).toBe(second.projectionSha256)
+  })
+
+  it('publishes ordered live-turn activity revisions without duplicating observations', async () => {
+    const dataDir = await temporaryDataDir()
+    const firstProjection = liveTurnProjection(['a'])
+    const secondProjection = liveTurnProjection(['a', 'b'])
+    const thirdProjection = liveTurnProjection(['a', 'b', 'c'])
+
+    const first = await persistCanonicalHistoryShadowV1(firstProjection, { dataDir })
+    const second = await persistCanonicalHistoryShadowV1(secondProjection, { dataDir })
+    const third = await persistCanonicalHistoryShadowV1(thirdProjection, { dataDir })
+    const paths = canonicalHistoryShadowPathsV1(dataDir)
+
+    expect(first.status).toBe('initialized')
+    expect(second.status).toBe('advanced')
+    expect(third.status).toBe('advanced')
+    expect(second.reconciliation.activities).toEqual({ added: 0, unchanged: 0, revised: 1, retainedOnly: 0 })
+    expect(third.reconciliation.activities).toEqual({ added: 0, unchanged: 0, revised: 1, retainedOnly: 0 })
+    expect(new Set([first.projectionSha256, second.projectionSha256, third.projectionSha256]).size).toBe(3)
+    expect(await readdir(paths.snapshots)).toHaveLength(3)
+    expect((await readCanonicalHistoryShadowHeadV1({ dataDir }))?.projectionSha256).toBe(third.projectionSha256)
+
+    const oldSnapshot = JSON.parse(await readFile(join(paths.snapshots, `${first.projectionSha256}.json`), 'utf8')) as {
+      projection: CanonicalHistoryReadProjectionV1
+    }
+    expect(oldSnapshot.projection.activities[0]!.observationIds).toEqual(firstProjection.activities[0]!.observationIds)
+    expect(new Set(thirdProjection.observations.map(observation => observation.observationId)).size).toBe(3)
+
+    const unchanged = await persistCanonicalHistoryShadowV1(thirdProjection, { dataDir })
+    expect(unchanged.status).toBe('unchanged')
+    expect(await readdir(paths.snapshots)).toHaveLength(3)
+
+    const conflictingObservation = liveTurnProjection(['a', 'b', 'c'])
+    conflictingObservation.observations[0]!.model = 'conflicting-immutable-payload'
+    await expect(persistCanonicalHistoryShadowV1(conflictingObservation, { dataDir }))
+      .rejects.toThrow(CanonicalHistoryShadowStoreIntegrityError)
+
+    const reorderedActivity = liveTurnProjection(['b', 'a', 'c'])
+    await expect(persistCanonicalHistoryShadowV1(reorderedActivity, { dataDir }))
+      .rejects.toThrow(CanonicalHistoryShadowStoreIntegrityError)
+
+    const unrelatedActivityCollision = liveTurnProjection(['x'])
+    await expect(persistCanonicalHistoryShadowV1(unrelatedActivityCollision, { dataDir }))
+      .rejects.toThrow(CanonicalHistoryShadowStoreIntegrityError)
+
+    expect((await readCanonicalHistoryShadowHeadV1({ dataDir }))?.projectionSha256).toBe(third.projectionSha256)
+    expect(await readdir(paths.snapshots)).toHaveLength(3)
   })
 
   it('rejects conflicting reuse of an observation identity and leaves the previous head unchanged', async () => {

--- a/src/local-state/canonical-history-shadow-store.ts
+++ b/src/local-state/canonical-history-shadow-store.ts
@@ -51,9 +51,13 @@ export type CanonicalHistoryShadowEntityReconciliationV1 = {
   retainedOnly: number
 }
 
+export type CanonicalHistoryShadowActivityReconciliationV1 = CanonicalHistoryShadowEntityReconciliationV1 & {
+  revised: number
+}
+
 export type CanonicalHistoryShadowReconciliationV1 = {
   observations: CanonicalHistoryShadowEntityReconciliationV1
-  activities: CanonicalHistoryShadowEntityReconciliationV1
+  activities: CanonicalHistoryShadowActivityReconciliationV1
   dailySnapshots: CanonicalHistoryShadowEntityReconciliationV1
 }
 
@@ -76,6 +80,12 @@ type EntityIndex = Map<string, string>
 type ProjectionIndex = {
   observations: EntityIndex
   activities: EntityIndex
+  dailySnapshots: EntityIndex
+}
+
+type RetainedProjectionIndex = {
+  observations: EntityIndex
+  activities: Map<string, string[]>
   dailySnapshots: EntityIndex
 }
 
@@ -192,8 +202,8 @@ function mergeEntityIndex(target: EntityIndex, incoming: EntityIndex, label: str
 
 async function readRetainedIndex(
   paths: ReturnType<typeof canonicalHistoryShadowPathsV1>,
-): Promise<ProjectionIndex> {
-  const retained: ProjectionIndex = {
+): Promise<RetainedProjectionIndex> {
+  const retained: RetainedProjectionIndex = {
     observations: new Map(),
     activities: new Map(),
     dailySnapshots: new Map(),
@@ -216,19 +226,29 @@ async function readRetainedIndex(
     }
     const parsed = parseSnapshot(bytes, digest)
     mergeEntityIndex(retained.observations, parsed.index.observations, 'observation')
-    mergeEntityIndex(retained.activities, parsed.index.activities, 'activity')
+    for (const [id, payload] of parsed.index.activities) {
+      const history = retained.activities.get(id) ?? []
+      for (const prior of history) {
+        if (!activityPayloadsCanBeRevisions(prior, payload)) {
+          throw new CanonicalHistoryShadowStoreIntegrityError(
+            `activity identity ${id} conflicts with retained shadow history`,
+          )
+        }
+      }
+      if (!history.includes(payload)) history.push(payload)
+      retained.activities.set(id, history)
+    }
     mergeEntityIndex(retained.dailySnapshots, parsed.index.dailySnapshots, 'daily snapshot')
   }
   return retained
 }
 
 function assertCompatibleWithRetainedHistory(
-  retained: ProjectionIndex,
+  retained: RetainedProjectionIndex,
   current: ProjectionIndex,
 ): void {
   for (const [label, previous, next] of [
     ['observation', retained.observations, current.observations],
-    ['activity', retained.activities, current.activities],
     ['daily snapshot', retained.dailySnapshots, current.dailySnapshots],
   ] as const) {
     for (const [id, payload] of next) {
@@ -238,6 +258,80 @@ function assertCompatibleWithRetainedHistory(
           `${label} identity ${id} conflicts with retained shadow history`,
         )
       }
+    }
+  }
+}
+
+type ActivityPayload = {
+  collector: string
+  timestamp: string
+  observationIds: string[]
+}
+
+function decodeActivityPayload(payload: string): ActivityPayload {
+  let value: unknown
+  try {
+    value = JSON.parse(payload)
+  } catch {
+    throw new CanonicalHistoryShadowStoreIntegrityError('retained activity payload is not valid JSON')
+  }
+  const record = objectRecord(value, 'retained activity')
+  const collector = record.collector
+  const timestamp = record.timestamp
+  const observationIds = record.observationIds
+  if (
+    typeof collector !== 'string'
+    || typeof timestamp !== 'string'
+    || !Array.isArray(observationIds)
+    || observationIds.some(id => typeof id !== 'string')
+  ) {
+    throw new CanonicalHistoryShadowStoreIntegrityError('retained activity payload is malformed')
+  }
+  return { collector, timestamp, observationIds: [...observationIds] as string[] }
+}
+
+function activityPayloadIsOrderedExtension(
+  priorPayload: string,
+  nextPayload: string,
+): boolean {
+  const prior = decodeActivityPayload(priorPayload)
+  const next = decodeActivityPayload(nextPayload)
+  if (prior.collector !== next.collector || prior.timestamp !== next.timestamp) return false
+  return prior.observationIds.length <= next.observationIds.length
+    && prior.observationIds.every((id, index) => next.observationIds[index] === id)
+}
+
+function activityPayloadsCanBeRevisions(leftPayload: string, rightPayload: string): boolean {
+  return activityPayloadIsOrderedExtension(leftPayload, rightPayload)
+    || activityPayloadIsOrderedExtension(rightPayload, leftPayload)
+}
+
+function assertActivitiesCompatibleWithRetainedHistory(
+  retained: Map<string, string[]>,
+  previous: EntityIndex | undefined,
+  current: EntityIndex,
+): void {
+  for (const [id, payload] of current) {
+    const history = retained.get(id) ?? []
+    for (const prior of history) {
+      // A current activity may be unchanged or may append observations to a
+      // retained revision. Regressing to a weaker payload is not a refresh;
+      // it would lose an observation from the current canonical projection.
+      if (prior !== payload && !activityPayloadIsOrderedExtension(prior, payload)) {
+        throw new CanonicalHistoryShadowStoreIntegrityError(
+          `activity identity ${id} conflicts with retained shadow history`,
+        )
+      }
+    }
+    const previousPayload = previous?.get(id)
+    if (
+      previousPayload !== undefined
+      && previousPayload !== payload
+      && !activityPayloadIsOrderedExtension(previousPayload, payload)
+    ) {
+      throw new CanonicalHistoryShadowStoreIntegrityError(
+        `activity identity ${id} resolved to a non-monotonic revision`,
+      )
     }
   }
 }
@@ -272,11 +366,44 @@ function reconcileProjection(
   previous: ProjectionIndex | undefined,
   current: ProjectionIndex,
 ): CanonicalHistoryShadowReconciliationV1 {
+  const activities = reconcileActivities(previous?.activities, current.activities)
   return {
     observations: reconcileEntities(previous?.observations, current.observations, 'observation'),
-    activities: reconcileEntities(previous?.activities, current.activities, 'activity'),
+    activities,
     dailySnapshots: reconcileEntities(previous?.dailySnapshots, current.dailySnapshots, 'daily snapshot'),
   }
+}
+
+function reconcileActivities(
+  previous: EntityIndex | undefined,
+  current: EntityIndex,
+): CanonicalHistoryShadowActivityReconciliationV1 {
+  if (!previous) return { added: current.size, unchanged: 0, revised: 0, retainedOnly: 0 }
+  let added = 0
+  let unchanged = 0
+  let revised = 0
+  for (const [id, payload] of current) {
+    const prior = previous.get(id)
+    if (prior === undefined) {
+      added++
+      continue
+    }
+    if (prior === payload) {
+      unchanged++
+      continue
+    }
+    if (!activityPayloadIsOrderedExtension(prior, payload)) {
+      throw new CanonicalHistoryShadowStoreIntegrityError(
+        `activity identity ${id} resolved to a conflicting payload`,
+      )
+    }
+    revised++
+  }
+  let retainedOnly = 0
+  for (const id of previous.keys()) {
+    if (!current.has(id)) retainedOnly++
+  }
+  return { added, unchanged, revised, retainedOnly }
 }
 
 export function canonicalHistoryShadowPathsV1(dataDir: string) {
@@ -356,6 +483,7 @@ export async function persistCanonicalHistoryShadowV1(
     const previous = await readHeadSnapshot(paths)
     const retained = await readRetainedIndex(paths)
     assertCompatibleWithRetainedHistory(retained, currentIndex)
+    assertActivitiesCompatibleWithRetainedHistory(retained.activities, previous?.index.activities, currentIndex.activities)
     const previousDigest = previous?.head.projectionSha256
     const targetPath = snapshotPath(paths, projectionSha256)
     const targetBytes = await readOptionalPrivateFile(targetPath)


### PR DESCRIPTION
## Scope

Stacked on `fix/c3-claude-native-observation-reconciliation` (#167); draft only. This PR changes only the C3 activity revision contract and shadow-store reconciliation. It does not change parser semantics, accounting, cost assignment, session/daily cache versions, observation identity, or consumers.

## Forensic classification

The live Codex blocker is `LIVE_TURN_APPEND`, not a collision or parser defect.

Privacy-safe evidence:
- activity ID digest: `d499679392a992af6c99287c38bd2a27b4859e36254f874457f0ee004f8df097`
- retained shadow activity observations: 62
- authority cache before the isolated refresh: 66
- normal refresh result: 243 (the source continued naturally while the run was in progress)
- observation identity relation: ordered prefix append; no removals
- session identity, turn timestamp, and first-observation identity: equal
- source fingerprint changed; source size increased by 3,061,901 bytes
- raw cached timing fields matured (`activeDurationMs`, `activeGeneratedTokens`, `toolWaitMs`), but those fields are outside the immutable C3 observation payload

Codex JSONL groups calls by logical turn; later source events can complete/append to a prior live turn. The existing activity ID therefore remains the stable logical identity.

## Contract

- exact unchanged projection is idempotent
- a live activity may revise only by an exact ordered-prefix extension of observation IDs
- observations and daily snapshots remain immutable and non-additive
- reordered, shortened, conflicting, or unrelated identity reuse fails closed
- snapshots remain content-addressed and immutable; only the current head moves atomically
- source deletion retains old snapshots and does not create duplicate accounting
- restart and discovery order are deterministic

The fix is bounded to `src/local-state/canonical-history-shadow-store.ts` plus focused tests and contract documentation.

## Controlled fixture

A -> A,B -> A,B,C:
- 3 immutable snapshots
- 2 deterministic head transitions
- unique observations preserved
- exact retry produces no new snapshot
- old snapshot remains readable
- immutable payload conflict and unrelated collision fail closed
- reorder/shortening fail closed

## Real isolated reviewed-production/parity path

Using the real local corpus and isolated authority/shadow state, with no raw-source or default-state mutation:
- publication 1: head `f67432a3bd223b3893eb871fcad939fb4026987029a2255749c50838f7ec059c`, 1 snapshot, 92,065 observations, 23,718 activities, 146 daily snapshots
- separate cold restart/read with frozen authority: same digest/counts, no head movement, no extra snapshot
- natural live refresh: head `2302d0b370d0f2564068aef3fb9f9f7929427c4efb9299c7c9f6bc7b4f6a9e43`, 2 snapshots, 92,068 observations, 23,718 activities, 146 daily snapshots; 3 observations added and 1 activity revision, with no parity errors
- all candidate scans completed without failed candidates

## Validation

- full `tests`: 229 files passed, 2,612 tests passed; 2 files / 5 tests intentionally skipped
- `src/local-state`, `src/pricing`, `src/providers`: 42 files, 245 tests passed
- `npx tsc --noEmit`: passed
- `npm run build:cli`: passed
- source-size ratchet against #167 base: passed
- `git diff --check`: passed

Keep draft and do not merge automatically.