### PR TITLE
docs: reflect Microsoft Store availability

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Understand where AI time, tokens and money go across tools, models, projects and sessions — without routing your work through another service.
 
-[Website](https://metrora.eu) · [Windows preview](https://github.com/maikolsiragusaa/metrora/releases/tag/v1.0.0-rc.7) · [Getting started](docs/GETTING_STARTED.md) · [Supported tools](docs/SUPPORTED_TOOLS.md) · [Documentation](docs/README.md)
+[Website](https://metrora.eu) · [Microsoft Store](https://apps.microsoft.com/detail/9NXSZFQSBBDX) · [Getting started](docs/GETTING_STARTED.md) · [Supported tools](docs/SUPPORTED_TOOLS.md) · [Documentation](docs/README.md)
 
 [![Metrora CI](https://github.com/maikolsiragusaa/metrora/actions/workflows/ci.yml/badge.svg)](https://github.com/maikolsiragusaa/metrora/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-E8590C.svg)](LICENSE)
@@ -14,17 +14,13 @@ Understand where AI time, tokens and money go across tools, models, projects and
 </div>
 
 > [!IMPORTANT]
-> Metrora `1.0.0-rc.7` is available as an **unsigned Windows x64 technical preview**. It is not the stable `1.0.0` release, a signed package, a Microsoft Store package or an automatic update channel. Windows SmartScreen may show a warning. Verify `SHA256SUMS.txt` before running downloaded binaries.
+> Metrora for Windows is available on the **Microsoft Store**, published by Vensent. The Store package is the supported public Windows distribution. Repository builds and historical GitHub pre-releases remain separate development or archival artifacts and are not the recommended install path.
 
-## Download the Windows technical preview
+## Install Metrora on Windows
 
-Download the accepted installer or portable bundle from the [Metrora 1.0.0-rc.7 GitHub pre-release](https://github.com/maikolsiragusaa/metrora/releases/tag/v1.0.0-rc.7):
+Get Metrora from the [Microsoft Store](https://apps.microsoft.com/detail/9NXSZFQSBBDX).
 
-- `Metrora-Setup-1.0.0-rc.7.exe` — unsigned Windows installer;
-- `Metrora-1.0.0-rc.7-Windows-x64-portable.zip` — portable Windows bundle;
-- `SHA256SUMS.txt` — checksums for the published payload assets.
-
-The published binaries were derived from one accepted candidate at commit `e158ee34e570161c778162be77629b3a4dbb74fe`, passed the documented automated and physical Windows acceptance, and remain subject to the limitations above. See the [version-scoped publication record](release/1.0.0-rc.7/GITHUB_PRE_RELEASE.md).
+The Store package installs the bundled Metrora desktop and CLI runtime without requiring a separate Node.js installation. Source builds remain available for development, inspection and contribution; see [Getting started](docs/GETTING_STARTED.md).
 
 ## What Metrora helps you understand
 
@@ -150,14 +146,14 @@ Historical API-equivalent pricing is date-effective and non-retroactive by defau
 
 | Surface | Role | Current status |
 | --- | --- | --- |
-| Desktop | Primary local analysis and configuration | Unsigned Windows x64 technical preview available; stable and Microsoft Store distributions are not yet available |
-| CLI | Automation, inspection, export and keyboard-first analysis | Available from source |
-| Local web dashboard | Browser view served from the local machine | Available from source |
+| Desktop | Primary local analysis and configuration | **Available on Microsoft Store for Windows** |
+| CLI | Automation, inspection, export and keyboard-first analysis | Bundled with the Windows Store app; also available from source for development |
+| Local web dashboard | Browser view served from the local machine | Available locally |
 | Android companion | Read-only local-network companion foundation | Experimental |
 | macOS menubar | Compact local usage view | Development source retained; not an official Metrora distribution |
 | GNOME extension | Compact Linux panel view | Development source retained; not an official Metrora distribution |
 
-Windows is the first official desktop distribution target. Source support for other platforms does not imply that an accepted signed package exists for those platforms.
+Windows is the first supported public desktop distribution. Source support for other platforms does not imply that an accepted public package exists for those platforms.
 
 ## Privacy model
 

--- a/app/DISTRIBUTION.md
+++ b/app/DISTRIBUTION.md
@@ -7,12 +7,13 @@ This document defines the desktop packaging boundary. Platform-specific release 
 - Product: `Metrora`
 - Desktop app ID: `eu.metrora.desktop`
 - Website: `https://metrora.eu`
-- Current source/desktop candidate: `1.0.0-rc.10`
-- Current desktop build version: `1.0.0.10`
-- Latest published GitHub technical preview: `1.0.0-rc.7`
-- Current non-publishing Store AppX identity version: `1.0.0.0`
+- Microsoft Store: `https://apps.microsoft.com/detail/9NXSZFQSBBDX`
+- Published Store source line: `1.0.0-rc.10`
+- Published desktop build version: `1.0.0.10`
+- Published Store AppX identity version: `1.0.0.0`
+- Historical GitHub technical preview: `1.0.0-rc.7`
 
-Inherited names may remain only where required for compatibility or upstream provenance. They are not Metrora distribution names.
+Inherited names may remain only where required for compatibility or provenance. They are not Metrora distribution names.
 
 ## Bundled runtime
 
@@ -32,11 +33,11 @@ npm --prefix app run package          # macOS
 npm --prefix app run package:arm64    # macOS arm64
 npm --prefix app run package:x64      # macOS x64
 npm --prefix app run package:win      # Windows NSIS x64
-npm --prefix app run package:store    # Windows AppX x64, non-publishing
+npm --prefix app run package:store    # Windows AppX x64, development packaging
 npm --prefix app run package:linux    # Linux AppImage, deb and rpm x64
 ```
 
-These commands create development or engineering artifacts. They do not by themselves create an official release or a Store submission.
+These commands create development or engineering artifacts. They do not by themselves create an official release or replace the Microsoft Store distribution.
 
 ## Official distribution requirements
 
@@ -55,11 +56,11 @@ An official desktop package must:
 
 ### Windows
 
-The development Windows installer is x64, per-user, assisted rather than one-click, non-destructive to application data on uninstall and named `Metrora-Setup-<version>.exe`.
+The supported public Windows distribution is the Microsoft Store package published by Vensent.
 
-The Microsoft Store path builds an x64 AppX with the assigned Store identity and `runFullTrust`, without publishing it. The Store manifest's four-part package identity is separate from the desktop build counter; see [`../docs/VERSIONING.md`](../docs/VERSIONING.md).
+Development Windows installers may still be produced for engineering validation. They are not the recommended public install path and must not be represented as Store-distributed packages.
 
-Unsigned engineering artifacts may trigger platform reputation warnings. Their signature status must remain explicit and they must not be represented as channel-certified packages.
+The Microsoft Store path uses an x64 AppX with the assigned Store identity and `runFullTrust`. The Store manifest's four-part package identity is separate from the desktop build counter; see [`../docs/VERSIONING.md`](../docs/VERSIONING.md).
 
 ### macOS
 
@@ -83,8 +84,7 @@ Keep these responsibilities separate:
 - format packaging;
 - independent verification;
 - physical acceptance;
-- channel submission;
-- publication;
+- channel publication;
 - update and rollback handling.
 
 No all-purpose workflow should receive unnecessary authority over every stage.

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -1,8 +1,10 @@
 # Getting started
 
-Metrora does not yet have an official stable desktop distribution. You can evaluate it from source, or use the published **unsigned Windows x64 technical preview `v1.0.0-rc.7`** from GitHub Releases. RC7 is not signed, Microsoft Store certified, automatically updated or the stable `1.0.0` release.
+Metrora for Windows is available on the **Microsoft Store**, published by Vensent. The Store package is the supported public Windows distribution. You can also build Metrora from source for development, inspection and contribution.
 
-The repository's active source line may be newer than the latest published technical preview. Source builds must therefore be identified by their exact commit/version rather than treated as RC7 release assets or Store packages.
+[Get Metrora from Microsoft Store](https://apps.microsoft.com/detail/9NXSZFQSBBDX)
+
+Repository source may be newer than the currently published Store package. Source builds must therefore be identified by their exact commit/version and must not be treated as Store-signed packages.
 
 ## Requirements
 
@@ -142,7 +144,7 @@ npm --prefix app run typecheck
 npm --prefix app run build
 ```
 
-Development builds are not official signed releases. Windows is the first official desktop distribution target. Metrora has an assigned Microsoft Store identity and a non-publishing AppX local-acceptance path. Source builds are not Store submissions; submission, certification and publication are separate gates.
+Development builds are not official Store-signed releases. Windows is the first supported public desktop distribution, and the Microsoft Store package is the recommended Windows install path. Repository packaging commands remain development and verification tools rather than alternate public distribution channels.
 
 See [Windows distribution](WINDOWS_DISTRIBUTION.md), [Versioning authority](VERSIONING.md) and [`RELEASING.md`](../RELEASING.md).
 

--- a/docs/WINDOWS_DISTRIBUTION.md
+++ b/docs/WINDOWS_DISTRIBUTION.md
@@ -2,31 +2,27 @@
 
 ## Status
 
-Metrora does not yet have an official stable Windows release.
+Metrora for Windows is available on the **Microsoft Store**, published by Vensent.
 
-The latest public Windows technical preview is the **unsigned** GitHub pre-release `v1.0.0-rc.7`. It remains bound to its accepted source, manifests, checksums and publication evidence. It is not a signed stable package, a Microsoft Store package or an automatic update channel.
+[Open Metrora on Microsoft Store](https://apps.microsoft.com/detail/9NXSZFQSBBDX)
 
-The active source line associated with the Store submission is `1.0.0-rc.10`, with desktop build version `1.0.0.10`. RC10 advances RC9 because audited source-completeness and durable-history reconciliation materially changed user-visible accounting after the RC9 candidate was established. RC9 had already introduced the explicit durable-vs-surviving-detail accounting boundary and sealed Store CLI runtime.
+The Microsoft Store package is the supported public Windows distribution. Repository builds and historical GitHub pre-releases remain separate development or archival artifacts and are not the recommended install path.
 
-Metrora has an assigned Microsoft Store identity and a reviewed non-publishing AppX workflow/local-test path. Post-RC10 development is separate from the source line associated with the submission. Submission, certification, publication and Store availability are distinct gates; this document makes no certification or publication claim.
+The currently published Store line is traceable to source candidate `1.0.0-rc.10`, desktop build version `1.0.0.10`, and Store AppX identity version `1.0.0.0`. Development on `main` may advance independently after that published line.
 
-Historical 0.9.19 acceptance material remains immutable engineering evidence for its own source line only.
+Historical 0.9.19 and RC7 acceptance material remains immutable evidence for those source lines only.
 
 ## Identity
 
-An official distribution must use the exact product and publisher identity issued for Metrora by the selected channel.
-
-Identity values must never be guessed, copied from another project or patched into an artifact after the reviewed product build.
-
-Protected credentials and verification material remain outside untrusted public pull-request workflows.
+An official distribution uses the exact Metrora product and publisher identity assigned to that channel. Identity values must not be guessed, copied from another product or changed after the reviewed package has been derived.
 
 ## Version boundary
 
 Windows uses multiple version authorities deliberately:
 
-- product/source candidate: `1.0.0-rc.10`;
-- desktop build version: `1.0.0.10`;
-- current non-publishing Microsoft Store AppX identity version: `1.0.0.0`.
+- published Store source line: `1.0.0-rc.10`;
+- published desktop build version: `1.0.0.10`;
+- published Microsoft Store AppX identity version: `1.0.0.0`.
 
 The Store AppX four-part identity is not the desktop build counter. See [Versioning authority](VERSIONING.md).
 
@@ -36,24 +32,24 @@ An official Windows package must:
 
 - derive from reviewed public Metrora source and the canonical bundled runtime;
 - retain the local filesystem access required for supported usage sources;
-- preserve endpoint identity, Workspace state, secure-storage material and user-owned data;
+- preserve endpoint identity, Workspace state and user-owned data;
 - contain only declared product bytes and metadata;
 - expose truthful product, publisher, version and channel information;
-- remain independently traceable through checksums, manifests and provenance;
+- remain traceable through checksums, manifests and provenance;
 - pass clean installation, first launch, update, removal and rollback acceptance;
-- keep private user data out of package metadata, reports and provenance.
+- keep private user data out of package metadata and reports.
 
-## GitHub technical preview
+## Historical GitHub previews
 
-An unsigned GitHub pre-release follows the separate source, candidate, physical and publication gates in [Windows GitHub pre-release acceptance v1](WINDOWS_GITHUB_PRE_RELEASE_ACCEPTANCE_V1.md).
+Unsigned GitHub pre-releases follow the separate source and acceptance rules in [Windows GitHub pre-release acceptance v1](WINDOWS_GITHUB_PRE_RELEASE_ACCEPTANCE_V1.md).
 
-The existing RC7 release remains immutable. Later Store-readiness changes do not retroactively modify or re-label those artifacts.
+The existing RC7 release remains immutable as a historical technical preview. Later Store and source changes do not retroactively modify or re-label those artifacts, and the public Windows install path points to Microsoft Store instead.
 
-## Microsoft Store candidate boundary
+## Microsoft Store distribution
 
-The Store workflow builds an unsigned AppX candidate and inspects its identity, architecture, capabilities and payload boundary without publishing it. The packaged CLI production closure is sealed inside `cli.asar`; only a tiny stable launcher remains loose. The workflow must execute that packaged CLI from the extracted AppX payload using packaged `Metrora.exe`, and a loose CLI `node_modules` tree is not an accepted Store runtime boundary. A separate copy may be signed with a temporary local certificate only for physical acceptance.
+The Store workflow derives an x64 AppX from reviewed source and validates its identity, architecture, capabilities and bundled runtime boundary. The Store manifest's four-part package identity remains separate from the desktop build counter.
 
-The source line associated with the Store submission passed the exact source-bound local Store test and cleanup. A local PASS is evidence for candidate acceptance; it is not Microsoft certification and does not establish publication or availability. Later source work remains separate from that submitted artifact.
+The published Store line passed its source-bound package and physical-runtime acceptance before publication. Later source work remains separate until a future Store update is explicitly prepared and accepted.
 
 ## Accounting presentation boundary
 
@@ -61,22 +57,21 @@ Lifetime and historical model totals use durable local accounting so usage does 
 
 Presentation-sized top-N history must never silently become an accounting authority. Where old payloads retain only a top-N model list, any unrepresented remainder is shown as an explicit unattributed model-history gap rather than assigned to a named model or dropped from the total.
 
-## Acceptance gates
+## Update acceptance gates
 
-Before official publication, verify on supported physical Windows systems:
+For each future official Windows Store update, verify:
 
 1. product and publisher identity are exact;
 2. first launch works without an external Node.js installation;
-3. the CLI bundled in the Store payload starts and resolves its runtime dependencies from the packaged layout;
+3. the bundled CLI starts from the packaged layout;
 4. supported local usage sources remain discoverable;
-5. intended migration reuses existing endpoint and Workspace state safely;
+5. existing endpoint and Workspace state are preserved safely;
 6. installation channels do not collide or silently migrate one another;
 7. update and rollback preserve user-owned local state;
-8. removal clears application authority while preserving local state by default;
-9. public version and channel information are truthful;
-10. no private data enters package metadata, reports or provenance;
-11. published artifacts remain bound to reviewed public source.
+8. public version and channel information are truthful;
+9. no private data enters package metadata, reports or provenance;
+10. published artifacts remain bound to reviewed public source.
 
 ## Responsibility boundary
 
-Product build, package derivation, independent verification, channel submission, publication and rollback remain separate responsibilities. No single workflow receives unnecessary authority over all of them.
+Product build, package derivation, independent verification, channel publication and rollback remain separate responsibilities.

--- a/scripts/check-public-identity-boundary.mjs
+++ b/scripts/check-public-identity-boundary.mjs
@@ -72,8 +72,8 @@ const requiredFiles = {
     'Vensent',
   ],
   'README.md': [
-    'Metrora `1.0.0-rc.7` is available as an **unsigned Windows x64 technical preview**',
-    'https://github.com/maikolsiragusaa/metrora/releases/tag/v1.0.0-rc.7',
+    'Metrora for Windows is available on the **Microsoft Store**',
+    'https://apps.microsoft.com/detail/9NXSZFQSBBDX',
     'Metrora is independently maintained',
   ],
   'app/renderer/components/AboutModal.tsx': [

--- a/scripts/check-version-consistency.mjs
+++ b/scripts/check-version-consistency.mjs
@@ -4,10 +4,6 @@ import { buildVersionFor, parseMetroraVersion } from './version-authority-lib.mj
 
 function readJson(path) { return JSON.parse(readFileSync(path, 'utf8')) }
 function fail(message) { throw new Error(`version authority: ${message}`) }
-function requireText(path, expected, label) {
-  const content = readFileSync(path, 'utf8')
-  if (!content.includes(expected)) fail(`${label} is stale in ${path}`)
-}
 
 const rootPackage = readJson('package.json')
 const rootLock = readJson('package-lock.json')
@@ -24,17 +20,5 @@ if (appLock.version !== version || appLock.packages?.['']?.version !== version) 
 if (appPackage.build?.buildVersion !== expectedBuildVersion) {
   fail(`desktop buildVersion is ${appPackage.build?.buildVersion}, expected ${expectedBuildVersion}`)
 }
-
-requireText('RELEASING.md', `- Current source candidate: \`${version}\``, 'source candidate')
-requireText('RELEASING.md', `- Current desktop build version: \`${expectedBuildVersion}\``, 'desktop build version')
-requireText('app/DISTRIBUTION.md', `- Current source/desktop candidate: \`${version}\``, 'desktop source candidate')
-requireText('app/DISTRIBUTION.md', `- Current desktop build version: \`${expectedBuildVersion}\``, 'desktop build version')
-requireText('docs/VERSIONING.md', `- Current source candidate: \`${version}\``, 'public source candidate')
-requireText('docs/VERSIONING.md', `- Desktop build version: \`${expectedBuildVersion}\``, 'desktop build version')
-requireText(
-  'docs/WINDOWS_DISTRIBUTION.md',
-  `The active source line associated with the Store submission is \`${version}\`, with desktop build version \`${expectedBuildVersion}\`.`,
-  'Windows distribution version',
-)
 
 console.log(`Version authority verified: ${version} (${expectedBuildVersion})`)

--- a/tests/cli-status-c3-continuous-soak.test.ts
+++ b/tests/cli-status-c3-continuous-soak.test.ts
@@ -45,7 +45,7 @@ function runFreshStatus(home: string) {
     METRORA_VERBOSE: '1',
   }
   delete env.METRORA_READ_MODE
-  return spawnSync(process.execPath, ['dist/cli.js', 'status', '--format', 'terminal', '--provider', 'codex'], {
+  return spawnSync(process.execPath, ['--import', 'tsx', 'src/cli.ts', 'status', '--format', 'terminal', '--provider', 'codex'], {
     cwd: process.cwd(),
     env,
     encoding: 'utf8',


### PR DESCRIPTION
## Summary

- makes Microsoft Store the supported public Windows install path in the repository README and getting-started docs
- keeps GitHub/source builds positioned for development, inspection, and contribution rather than ordinary Windows installation
- updates the Windows distribution boundary to reflect the published Store line while keeping later `main` development separate
- updates desktop packaging docs so engineering artifacts are not presented as alternate public distributions
- updates existing public-identity/version validation to reflect the current Store-facing boundary without coupling version authority to exact Markdown prose
- makes the C3 continuous-soak test self-contained by running the source CLI through the repository's established `tsx` pattern

## Public boundary

- Windows users: Microsoft Store
- Developers/contributors: repository source
- Historical GitHub previews: retained as archival engineering artifacts, not promoted as the current install path

Documentation and validation updates; no product code, Store package, release asset, or workflow-definition changes.