### PR TITLE
perf: cache unchanged C3 publication state

### DIFF
--- a/src/local-state/canonical-history-analytics-publication.test.ts
+++ b/src/local-state/canonical-history-analytics-publication.test.ts
@@ -12,7 +12,12 @@ import {
   canonicalSourceRecordFingerprintSha256V1,
 } from './canonical-history-identity.js'
 import { publishCanonicalHistoryAnalyticsV1 } from './canonical-history-analytics-publication.js'
-import { canonicalHistoryShadowPathsV1 } from './canonical-history-shadow-store.js'
+import {
+  canonicalHistoryShadowPathsV1,
+  canonicalHistoryShadowProjectionSha256V1,
+  readCanonicalHistoryShadowProjectionV1,
+} from './canonical-history-shadow-store.js'
+import { projectCanonicalHistoryReadV1 } from './canonical-history-read-projection.js'
 import { loadOrCreateLocalEndpointIdentityV1 } from './endpoint-identity.js'
 import { Aes256GcmSecretProtector } from './secret-protector.js'
 
@@ -154,27 +159,98 @@ describe('generic canonical analytics publication boundary', () => {
     })).toMatch(/^[a-f0-9]{64}$/u)
   })
 
+  it('skips an exactly unchanged analytics generation without rebuilding the projection', async () => {
+    const { dataDir, session, daily, endpointId } = await setup()
+    const first = await publishCanonicalHistoryAnalyticsV1({ sessionCache: session, dailyCache: daily, dataDir, endpointId, now: () => NOW })
+    const before = await readFile(join(canonicalHistoryShadowPathsV1(dataDir).root, 'head.json'))
+
+    const second = await publishCanonicalHistoryAnalyticsV1({ sessionCache: session, dailyCache: daily, dataDir, endpointId, now: () => NOW })
+
+    expect(first.status).toBe('published')
+    expect(second).toMatchObject({
+      status: 'skipped',
+      reason: 'unchanged-generation',
+      projectionSha256: first.projectionSha256,
+      shadowStatus: 'unchanged',
+    })
+    expect(second.timingsMs.projectionBuildMs).toBe(0)
+    expect(second.timingsMs.parityMs).toBe(0)
+    expect(second.timingsMs.shadowPersistenceMs).toBe(0)
+    expect(await readFile(join(canonicalHistoryShadowPathsV1(dataDir).root, 'head.json'))).toEqual(before)
+  })
+
   it('keeps an existing endpoint-scoped shadow on the same scope while the generation advances', async () => {
-    const { dataDir, session, daily } = await setup()
-    const first = await publishCanonicalHistoryAnalyticsV1({ sessionCache: session, dailyCache: daily, dataDir, now: () => NOW })
+    const { dataDir, session, daily, endpointId } = await setup()
+    const first = await publishCanonicalHistoryAnalyticsV1({ sessionCache: session, dailyCache: daily, dataDir, endpointId, now: () => NOW })
     expect(first.status).toBe('published')
 
     const advancedSession = structuredClone(session)
-    advancedSession.providers.codex!.files['C:\\private\\codex-session.jsonl']!.turns[0]!.calls.push(call({
+    const advancedFile = advancedSession.providers.codex!.files['C:\\private\\codex-session.jsonl']!
+    advancedFile.turns[0]!.calls.push(call({
       deduplicationKey: 'codex:test:2',
       timestamp: '2026-08-13T10:01:00.000Z',
     }))
+    advancedFile.fingerprint.sizeBytes += 1
+    advancedFile.fingerprint.mtimeMs += 1
     await saveCache(advancedSession)
     const advanced = await publishCanonicalHistoryAnalyticsV1({
       sessionCache: advancedSession,
       dailyCache: daily,
       dataDir,
+      endpointId,
       now: () => NOW,
     })
 
     expect(advanced.status).toBe('published')
     expect(advanced.shadowStatus).toBe('advanced')
     expect(advanced.parity?.outcome).toBe('matched')
+    const projected = projectCanonicalHistoryReadV1({ endpointId, sessionCache: advancedSession, dailyCache: daily })
+    expect(advanced.projectionSha256).toBe(canonicalHistoryShadowProjectionSha256V1(projected))
+    expect((await readCanonicalHistoryShadowProjectionV1({ dataDir }))?.head.projectionSha256).toBe(advanced.projectionSha256)
+  })
+
+  it('rebuilds safely when the derived incremental state is corrupt', async () => {
+    const { dataDir, session, daily, endpointId } = await setup()
+    const first = await publishCanonicalHistoryAnalyticsV1({ sessionCache: session, dailyCache: daily, dataDir, endpointId, now: () => NOW })
+    expect(first.status).toBe('published')
+    await writeFile(join(canonicalHistoryShadowPathsV1(dataDir).root, 'publication-state.v1.json'), '{broken')
+
+    const advancedSession = structuredClone(session)
+    const advancedFile = advancedSession.providers.codex!.files['C:\\private\\codex-session.jsonl']!
+    advancedFile.turns[0]!.calls.push(call({ deduplicationKey: 'codex:test:recovery' }))
+    advancedFile.fingerprint.sizeBytes += 1
+    advancedFile.fingerprint.mtimeMs += 1
+    await saveCache(advancedSession)
+
+    const recovered = await publishCanonicalHistoryAnalyticsV1({
+      sessionCache: advancedSession,
+      dailyCache: daily,
+      dataDir,
+      endpointId,
+      now: () => NOW,
+    })
+    expect(recovered).toMatchObject({ status: 'published', shadowStatus: 'advanced', parity: { outcome: 'matched' } })
+  })
+
+  it('preserves retained-only history when a source disappears from the next generation', async () => {
+    const { dataDir, session, daily, endpointId } = await setup()
+    const first = await publishCanonicalHistoryAnalyticsV1({ sessionCache: session, dailyCache: daily, dataDir, endpointId, now: () => NOW })
+    const deletedSession = structuredClone(session)
+    delete deletedSession.providers.codex!.files['C:\\private\\codex-session.jsonl']
+    await saveCache(deletedSession)
+
+    const deleted = await publishCanonicalHistoryAnalyticsV1({
+      sessionCache: deletedSession,
+      dailyCache: daily,
+      dataDir,
+      endpointId,
+      now: () => NOW,
+    })
+    expect(deleted).toMatchObject({ status: 'published', shadowStatus: 'advanced', parity: { outcome: 'matched' } })
+    expect(deleted.parity?.reconciliation.observations.retainedOnly).toBe(1)
+    expect(deleted.parity?.reconciliation.activities.retainedOnly).toBe(1)
+    expect(deleted.projectionSha256).toBe(canonicalHistoryShadowProjectionSha256V1(projectCanonicalHistoryReadV1({ endpointId, sessionCache: deletedSession, dailyCache: daily })))
+    expect(first.projectionSha256).not.toBe(deleted.projectionSha256)
   })
 
   it('accepts a completed-generation headline after provider cache bytes advance, while standalone reads remain current-cache bound', async () => {

--- a/src/local-state/canonical-history-analytics-publication.test.ts
+++ b/src/local-state/canonical-history-analytics-publication.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { mkdtemp, readFile, rm, stat, utimes, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
@@ -15,6 +15,7 @@ import { publishCanonicalHistoryAnalyticsV1 } from './canonical-history-analytic
 import {
   canonicalHistoryShadowPathsV1,
   canonicalHistoryShadowProjectionSha256V1,
+  clearCanonicalHistoryShadowTrustMemoV1,
   readCanonicalHistoryShadowProjectionV1,
 } from './canonical-history-shadow-store.js'
 import { projectCanonicalHistoryReadV1 } from './canonical-history-read-projection.js'
@@ -177,6 +178,37 @@ describe('generic canonical analytics publication boundary', () => {
     expect(second.timingsMs.parityMs).toBe(0)
     expect(second.timingsMs.shadowPersistenceMs).toBe(0)
     expect(await readFile(join(canonicalHistoryShadowPathsV1(dataDir).root, 'head.json'))).toEqual(before)
+  })
+
+  it('does not trust a same-stat mutated snapshot after a cold trust lifecycle', async () => {
+    const { dataDir, session, daily, endpointId } = await setup()
+    const first = await publishCanonicalHistoryAnalyticsV1({ sessionCache: session, dailyCache: daily, dataDir, endpointId, now: () => NOW })
+    expect(first.status).toBe('published')
+    const paths = canonicalHistoryShadowPathsV1(dataDir)
+    const beforeHead = await readFile(paths.head)
+    const snapshotPath = join(paths.snapshots, `${first.projectionSha256}.json`)
+    const beforeBytes = await readFile(snapshotPath)
+    const beforeStat = await stat(snapshotPath)
+    const marker = Buffer.from('2026-08-13T12:00:00.000Z', 'utf8')
+    const replacement = Buffer.from('2026-08-13T13:00:00.000Z', 'utf8')
+    const offset = beforeBytes.indexOf(marker)
+    expect(offset).toBeGreaterThanOrEqual(0)
+    const mutated = Buffer.from(beforeBytes)
+    replacement.copy(mutated, offset)
+    await writeFile(snapshotPath, mutated)
+    await utimes(snapshotPath, beforeStat.atime, beforeStat.mtime)
+    const afterStat = await stat(snapshotPath)
+    expect(afterStat.size).toBe(beforeStat.size)
+    expect(afterStat.mtimeMs).toBeCloseTo(beforeStat.mtimeMs, 0)
+    if (beforeStat.ino !== 0 && afterStat.ino !== 0) expect(afterStat.ino).toBe(beforeStat.ino)
+
+    // A fresh publisher process has no prior content-validation memo.
+    clearCanonicalHistoryShadowTrustMemoV1(dataDir)
+    const restarted = await publishCanonicalHistoryAnalyticsV1({ sessionCache: session, dailyCache: daily, dataDir, endpointId, now: () => NOW })
+
+    expect(restarted.status).toBe('failed')
+    expect(restarted.reason).not.toBe('unchanged-generation')
+    expect(await readFile(paths.head)).toEqual(beforeHead)
   })
 
   it('keeps an existing endpoint-scoped shadow on the same scope while the generation advances', async () => {

--- a/src/local-state/canonical-history-analytics-publication.ts
+++ b/src/local-state/canonical-history-analytics-publication.ts
@@ -35,9 +35,9 @@ import {
   projectCanonicalHistoryReadWithSourcesV1,
   type CanonicalHistoryReadProjectionV1,
 } from './canonical-history-read-projection.js'
-import { readCanonicalHistoryShadowHeadlineIndexFastV1 } from './canonical-history-shadow-headline-index-read.js'
 import {
   persistCanonicalHistoryShadowV1,
+  readCanonicalHistoryShadowPublicationTrustV1,
   readCanonicalHistoryShadowStateV1,
   type PersistCanonicalHistoryShadowResultV1,
   type CanonicalHistoryShadowLoadedStateV1,
@@ -250,22 +250,22 @@ export async function publishCanonicalHistoryAnalyticsV1(
   }
   const endpointScopeSha256 = canonicalEndpointScopeSha256V1(endpointId)
 
-  let compactForIncremental: Awaited<ReturnType<typeof readCanonicalHistoryShadowHeadlineIndexFastV1>> | undefined
+  let compactForIncremental: Awaited<ReturnType<typeof readCanonicalHistoryShadowPublicationTrustV1>> | undefined
   try {
-    compactForIncremental = await readCanonicalHistoryShadowHeadlineIndexFastV1({ dataDir: options.dataDir })
+    compactForIncremental = await readCanonicalHistoryShadowPublicationTrustV1({ dataDir: options.dataDir })
     if (
       compactForIncremental
       && compactForIncremental.head.snapshotSha256 !== undefined
-      && compactForIncremental.index.endpointScopeSha256 === endpointScopeSha256
-      && compactForIncremental.index.projectionSha256 === compactForIncremental.head.projectionSha256
-      && compactForIncremental.index.sessionAuthorityGenerationSha256 === generation.sessionPayloadSha256
-      && compactForIncremental.index.dailyAuthorityGenerationSha256 === generation.dailyPayloadSha256
-      && compactForIncremental.index.sessionSourceManifestSha256 === generation.sourceManifestSha256
-      && compactForIncremental.index.analyticsGenerationId === generation.id
+      && compactForIncremental.headlineIndex.endpointScopeSha256 === endpointScopeSha256
+      && compactForIncremental.headlineIndex.projectionSha256 === compactForIncremental.head.projectionSha256
+      && compactForIncremental.headlineIndex.sessionAuthorityGenerationSha256 === generation.sessionPayloadSha256
+      && compactForIncremental.headlineIndex.dailyAuthorityGenerationSha256 === generation.dailyPayloadSha256
+      && compactForIncremental.headlineIndex.sessionSourceManifestSha256 === generation.sourceManifestSha256
+      && compactForIncremental.headlineIndex.analyticsGenerationId === generation.id
       && canonicalAnalyticsGenerationIdSha256V1({
-        sessionPayloadSha256: compactForIncremental.index.sessionAuthorityGenerationSha256,
-        dailyPayloadSha256: compactForIncremental.index.dailyAuthorityGenerationSha256,
-        sourceManifestSha256: compactForIncremental.index.sessionSourceManifestSha256,
+        sessionPayloadSha256: compactForIncremental.headlineIndex.sessionAuthorityGenerationSha256,
+        dailyPayloadSha256: compactForIncremental.headlineIndex.dailyAuthorityGenerationSha256,
+        sourceManifestSha256: compactForIncremental.headlineIndex.sessionSourceManifestSha256,
       }) === generation.id
     ) {
       timings.totalMs = performance.now() - startedAt
@@ -291,7 +291,7 @@ export async function publishCanonicalHistoryAnalyticsV1(
   try {
     let incrementalUsed = false
     let derived: Awaited<ReturnType<typeof readCanonicalHistoryPublicationStateV1>>
-    const sourceManifestChanged = compactForIncremental?.index.sessionSourceManifestSha256 !== generation.sourceManifestSha256
+    const sourceManifestChanged = compactForIncremental?.headlineIndex.sessionSourceManifestSha256 !== generation.sourceManifestSha256
     if (sourceManifestChanged) {
       try {
         derived = await readCanonicalHistoryPublicationStateV1(options.dataDir ?? defaultMetroraDataDir())

--- a/src/local-state/canonical-history-analytics-publication.ts
+++ b/src/local-state/canonical-history-analytics-publication.ts
@@ -1,6 +1,8 @@
 import { createHash } from 'node:crypto'
 import { performance } from 'node:perf_hooks'
 
+import { canonicalizeRfc8785 } from '../vendor/rfc8785-canonicalize.js'
+
 import { DAILY_CACHE_VERSION, dailyCachePath, type DailyCache } from '../daily-cache.js'
 import {
   authorityGenerationForSidecarV1,
@@ -13,18 +15,90 @@ import { CACHE_VERSION, sessionCachePath, type SessionCache } from '../session-c
 import { getLatestCompletedSessionCacheV1 } from '../session-cache-authority.js'
 import {
   canonicalAnalyticsGenerationIdSha256V1,
+  canonicalEndpointScopeSha256V1,
   canonicalSourceRecordFingerprintSha256V1,
 } from './canonical-history-identity.js'
-import { readLocalEndpointIdentityMetadataV1 } from './endpoint-identity.js'
+import { projectCanonicalHistoryIncrementalV1 } from './canonical-history-incremental.js'
 import {
+  readCanonicalHistoryPublicationStateV1,
+  type CanonicalHistoryPublicationSourceV1,
+} from './canonical-history-publication-state.js'
+import { defaultMetroraDataDir, readLocalEndpointIdentityMetadataV1 } from './endpoint-identity.js'
+import {
+  canonicalHistorySessionAuthorityForProjectionV1,
+  expectedCanonicalHistorySessionAuthorityForSourcesV1,
   observeCanonicalHistoryParityV1,
+  type CanonicalHistorySessionAuthorityV1,
   type CanonicalHistoryParityObservationV1,
 } from './canonical-history-parity-observer.js'
-import { projectCanonicalHistoryReadV1 } from './canonical-history-read-projection.js'
+import {
+  projectCanonicalHistoryReadWithSourcesV1,
+  type CanonicalHistoryReadProjectionV1,
+} from './canonical-history-read-projection.js'
+import { readCanonicalHistoryShadowHeadlineIndexFastV1 } from './canonical-history-shadow-headline-index-read.js'
 import {
   persistCanonicalHistoryShadowV1,
+  readCanonicalHistoryShadowStateV1,
   type PersistCanonicalHistoryShadowResultV1,
+  type CanonicalHistoryShadowLoadedStateV1,
 } from './canonical-history-shadow-store.js'
+
+function publicationSourceIndexV1(
+  sources: Array<{ provider: string; pathSha256: string; observationIds: string[]; activityIds: string[] }>,
+  authorityGeneration: CurrentCacheAuthorityGenerationV1,
+): CanonicalHistoryPublicationSourceV1[] {
+  return sources.map(source => {
+    const provider = authorityGeneration.session.providers.find(value => value.provider === source.provider)
+    const file = provider?.files.find(value => value.pathSha256 === source.pathSha256)
+    if (!provider || !file) throw new Error('canonical history source index is not covered by the session generation')
+    return {
+      ...source,
+      envFingerprint: provider.envFingerprint,
+      fingerprint: structuredClone(file.fingerprint),
+    }
+  })
+}
+
+function incrementalParityAuthorityV1(input: {
+  endpointId: string
+  sessionCache: SessionCache
+  previousProjection: CanonicalHistoryReadProjectionV1
+  previousState: NonNullable<Awaited<ReturnType<typeof readCanonicalHistoryPublicationStateV1>>>
+  changedSourceKeys: ReadonlySet<string>
+}): CanonicalHistorySessionAuthorityV1 {
+  const previous = canonicalHistorySessionAuthorityForProjectionV1(input.previousProjection)
+  const observations = new Map(previous.observations)
+  const affectedActivityIds = new Set<string>()
+  for (const source of input.previousState.sources) {
+    const key = `${source.provider}\0${source.pathSha256}`
+    if (!input.changedSourceKeys.has(key)) continue
+    source.observationIds.forEach(id => observations.delete(id))
+    source.activityIds.forEach(id => affectedActivityIds.add(id))
+  }
+  const previousActivities = new Map(input.previousProjection.activities.map(activity => [activity.activityId, activity]))
+  const activities = new Set(previous.activities)
+  for (const activityId of affectedActivityIds) {
+    const activity = previousActivities.get(activityId)
+    if (!activity) throw new Error('incremental parity state names a missing prior activity')
+    const { activityId: _activityId, ...payload } = activity
+    activities.delete(canonicalizeRfc8785(payload))
+  }
+  const changed = expectedCanonicalHistorySessionAuthorityForSourcesV1({
+    endpointId: input.endpointId,
+    sessionCache: input.sessionCache,
+    sourceFingerprint: canonicalSourceRecordFingerprintSha256V1,
+    sourceKeys: input.changedSourceKeys,
+  })
+  for (const [id, payload] of changed.observations) {
+    const prior = observations.get(id)
+    if (prior && canonicalizeRfc8785(prior) !== canonicalizeRfc8785(payload)) {
+      throw new Error('incremental parity source identity resolved to a conflicting observation')
+    }
+    observations.set(id, prior ?? payload)
+  }
+  for (const activity of changed.activities) activities.add(activity)
+  return { observations, activities }
+}
 
 export type CanonicalHistoryAnalyticsPublicationTimingsV1 = {
   generationSealMs: number
@@ -51,6 +125,7 @@ export type CanonicalHistoryAnalyticsPublicationV1 = {
     | 'untrusted-daily-authority'
     | 'endpoint-identity-unavailable'
     | 'generation-seal-failed'
+    | 'unchanged-generation'
     | 'parity-failed'
     | 'shadow-persistence-failed'
   generation?: CanonicalHistoryAnalyticsGenerationV1
@@ -173,10 +248,100 @@ export async function publishCanonicalHistoryAnalyticsV1(
   if (endpointId === undefined || endpointId.trim() === '') {
     return failed(startedAt, 'endpoint-identity-unavailable', timings, generation)
   }
-  let projection: ReturnType<typeof projectCanonicalHistoryReadV1>
+  const endpointScopeSha256 = canonicalEndpointScopeSha256V1(endpointId)
+
+  let compactForIncremental: Awaited<ReturnType<typeof readCanonicalHistoryShadowHeadlineIndexFastV1>> | undefined
+  try {
+    compactForIncremental = await readCanonicalHistoryShadowHeadlineIndexFastV1({ dataDir: options.dataDir })
+    if (
+      compactForIncremental
+      && compactForIncremental.head.snapshotSha256 !== undefined
+      && compactForIncremental.index.endpointScopeSha256 === endpointScopeSha256
+      && compactForIncremental.index.projectionSha256 === compactForIncremental.head.projectionSha256
+      && compactForIncremental.index.sessionAuthorityGenerationSha256 === generation.sessionPayloadSha256
+      && compactForIncremental.index.dailyAuthorityGenerationSha256 === generation.dailyPayloadSha256
+      && compactForIncremental.index.sessionSourceManifestSha256 === generation.sourceManifestSha256
+      && compactForIncremental.index.analyticsGenerationId === generation.id
+      && canonicalAnalyticsGenerationIdSha256V1({
+        sessionPayloadSha256: compactForIncremental.index.sessionAuthorityGenerationSha256,
+        dailyPayloadSha256: compactForIncremental.index.dailyAuthorityGenerationSha256,
+        sourceManifestSha256: compactForIncremental.index.sessionSourceManifestSha256,
+      }) === generation.id
+    ) {
+      timings.totalMs = performance.now() - startedAt
+      return {
+        status: 'skipped',
+        reason: 'unchanged-generation',
+        generation,
+        projectionSha256: compactForIncremental.head.projectionSha256,
+        shadowStatus: 'unchanged',
+        timingsMs: timings,
+      }
+    }
+  } catch {
+    // A missing/corrupt derived fast artifact falls through to the canonical
+    // projection and retained-history validation path.
+  }
+
+  let projection: CanonicalHistoryReadProjectionV1
+  let sourceIndex: CanonicalHistoryPublicationSourceV1[] | undefined
+  let previousState: CanonicalHistoryShadowLoadedStateV1 | undefined
+  let incrementalParityAuthority: CanonicalHistorySessionAuthorityV1 | undefined
   const projectionStartedAt = performance.now()
   try {
-    projection = projectCanonicalHistoryReadV1({ endpointId, sessionCache, dailyCache: options.dailyCache })
+    let incrementalUsed = false
+    let derived: Awaited<ReturnType<typeof readCanonicalHistoryPublicationStateV1>>
+    const sourceManifestChanged = compactForIncremental?.index.sessionSourceManifestSha256 !== generation.sourceManifestSha256
+    if (sourceManifestChanged) {
+      try {
+        derived = await readCanonicalHistoryPublicationStateV1(options.dataDir ?? defaultMetroraDataDir())
+      } catch {
+        derived = undefined
+      }
+    }
+    if (sourceManifestChanged && derived && derived.endpointScopeSha256 === endpointScopeSha256) {
+      try {
+        const loaded = await readCanonicalHistoryShadowStateV1({ dataDir: options.dataDir })
+        if (
+          loaded
+          && derived.projectionSha256 === loaded.head.projectionSha256
+          && derived.snapshotSha256 === loaded.head.snapshotSha256
+          && canonicalAnalyticsGenerationIdSha256V1({
+            sessionPayloadSha256: derived.sessionPayloadSha256,
+            dailyPayloadSha256: derived.dailyPayloadSha256,
+            sourceManifestSha256: derived.sourceManifestSha256,
+          }) === derived.analyticsGenerationId
+        ) {
+          const incremental = projectCanonicalHistoryIncrementalV1({
+            endpointId,
+            sessionCache,
+            dailyCache: options.dailyCache,
+            sessionGeneration: authorityGeneration.session,
+            previousProjection: loaded.snapshot.projection as CanonicalHistoryReadProjectionV1,
+            previousState: derived,
+          })
+          projection = incremental.projection
+          sourceIndex = incremental.sources
+          previousState = loaded
+          incrementalParityAuthority = incrementalParityAuthorityV1({
+            endpointId,
+            sessionCache,
+            previousProjection: loaded.snapshot.projection as CanonicalHistoryReadProjectionV1,
+            previousState: derived,
+            changedSourceKeys: new Set(incremental.changedSourceKeys),
+          })
+          incrementalUsed = true
+        }
+      } catch {
+        // Derived state is an acceleration artifact. Rebuild from the
+        // canonical session/daily authorities when it is absent or invalid.
+      }
+    }
+    if (!incrementalUsed) {
+      const projected = projectCanonicalHistoryReadWithSourcesV1({ endpointId, sessionCache, dailyCache: options.dailyCache })
+      projection = projected.projection
+      sourceIndex = publicationSourceIndexV1(projected.sources, authorityGeneration)
+    }
   } catch {
     timings.projectionBuildMs = performance.now() - projectionStartedAt
     return failed(startedAt, 'parity-failed', timings, generation)
@@ -195,6 +360,9 @@ export async function publishCanonicalHistoryAnalyticsV1(
         // observer still owns all parity assertions; this avoids a second
         // projection walk while preserving the established contract.
         project: () => projection,
+        ...(incrementalParityAuthority
+          ? { expectedSessionAuthority: () => incrementalParityAuthority! }
+          : {}),
         persist: async value => {
           timings.parityMs = performance.now() - parityStartedAt
           const shadowStartedAt = performance.now()
@@ -203,6 +371,9 @@ export async function publishCanonicalHistoryAnalyticsV1(
             now: options.now,
             authorityGeneration,
             analyticsGenerationId: generation.id,
+            endpointScopeSha256,
+            sourceIndex,
+            previousState,
             onHeadlineIndexPersisted: elapsedMs => { headlineIndexPersistenceMs = elapsedMs },
           })
           timings.shadowPersistenceMs = performance.now() - shadowStartedAt

--- a/src/local-state/canonical-history-cli-headline-index-store.ts
+++ b/src/local-state/canonical-history-cli-headline-index-store.ts
@@ -9,6 +9,7 @@ import {
 } from './atomic-file.js'
 import {
   buildCanonicalHistoryCliHeadlineIndexV1,
+  buildCanonicalHistoryCliHeadlineIndexIncrementalV1,
   parseCanonicalHistoryCliHeadlineIndexV1,
   type CanonicalHistoryCliHeadlineIndexV1,
 } from './canonical-history-cli-headline-index.js'
@@ -37,13 +38,41 @@ export async function ensureCanonicalHistoryCliHeadlineIndexV1(input: {
     dailyPayloadSha256: string
     sourceManifestSha256: string
     analyticsGenerationId?: string
+    endpointScopeSha256?: string
+  }
+  previous?: {
+    projection: CanonicalHistoryReadProjectionV1
+    projectionSha256: string
+    snapshotSha256: string
   }
 }): Promise<void> {
-  const index = buildCanonicalHistoryCliHeadlineIndexV1({
+  const snapshotSha256 = canonicalHistoryShadowSnapshotSha256V1(input.snapshotBytes)
+  const authorityGeneration = input.authorityGeneration
+  let index: CanonicalHistoryCliHeadlineIndexV1 | undefined
+  if (input.previous && input.previous.projectionSha256 !== input.projectionSha256) {
+    try {
+      const previous = await readCanonicalHistoryCliHeadlineIndexFastV1({
+        dataDir: input.dataDir,
+        projectionSha256: input.previous.projectionSha256,
+        snapshotSha256: input.previous.snapshotSha256,
+      })
+      index = buildCanonicalHistoryCliHeadlineIndexIncrementalV1({
+        previous,
+        previousProjection: input.previous.projection,
+        projection: input.projection,
+        projectionSha256: input.projectionSha256,
+        snapshotSha256,
+        authorityGeneration,
+      })
+    } catch {
+      index = undefined
+    }
+  }
+  index ??= buildCanonicalHistoryCliHeadlineIndexV1({
     projection: input.projection,
     projectionSha256: input.projectionSha256,
-    snapshotSha256: canonicalHistoryShadowSnapshotSha256V1(input.snapshotBytes),
-    authorityGeneration: input.authorityGeneration,
+    snapshotSha256,
+    authorityGeneration,
   })
   const path = indexPath(input.dataDir, input.projectionSha256)
   const existingBytes = await readOptionalPrivateFile(path)
@@ -57,6 +86,7 @@ export async function ensureCanonicalHistoryCliHeadlineIndexV1(input: {
         && existing.dailyAuthorityGenerationSha256 === index.dailyAuthorityGenerationSha256
         && existing.sessionSourceManifestSha256 === index.sessionSourceManifestSha256
         && existing.analyticsGenerationId === index.analyticsGenerationId
+        && existing.endpointScopeSha256 === index.endpointScopeSha256
       ) return
     } catch {
       // Regenerate a derived index from the immutable canonical projection.

--- a/src/local-state/canonical-history-cli-headline-index.ts
+++ b/src/local-state/canonical-history-cli-headline-index.ts
@@ -39,6 +39,7 @@ export type CanonicalHistoryCliHeadlineIndexV1 = {
   dailyAuthorityGenerationSha256?: string
   sessionSourceManifestSha256?: string
   analyticsGenerationId?: string
+  endpointScopeSha256?: string
   indexSha256: string
   timeZone: string
   dailySnapshots: CanonicalHistoryCliHeadlineDayV1[]
@@ -79,6 +80,7 @@ const IndexWithoutDigestSchema = z.strictObject({
   dailyAuthorityGenerationSha256: DigestSchema.optional(),
   sessionSourceManifestSha256: DigestSchema.optional(),
   analyticsGenerationId: DigestSchema.optional(),
+  endpointScopeSha256: DigestSchema.optional(),
   timeZone: z.string().min(1),
   dailySnapshots: z.array(DaySchema),
   activityDays: z.array(DaySchema),
@@ -196,26 +198,20 @@ function activityDay(
   }
 }
 
-export function buildCanonicalHistoryCliHeadlineIndexV1(input: {
-  projection: CanonicalHistoryReadProjectionV1
-  projectionSha256: string
-  snapshotSha256: string
-  authorityGeneration?: {
-    sessionPayloadSha256: string
-    dailyPayloadSha256: string
-    sourceManifestSha256: string
-    analyticsGenerationId?: string
-  }
-}): CanonicalHistoryCliHeadlineIndexV1 {
-  const timeZone = input.projection.dailySnapshots.find(day => day.bucketTimeZone)?.bucketTimeZone ?? localTimeZone()
-  const observations = new Map(input.projection.observations.map(observation => [observation.observationId, observation]))
+function activityDaysForProjection(
+  projection: CanonicalHistoryReadProjectionV1,
+  timeZone: string,
+  onlyDates?: ReadonlySet<string>,
+): CanonicalHistoryCliHeadlineDayV1[] {
+  const observations = new Map(projection.observations.map(observation => [observation.observationId, observation]))
   const activityTotals = new Map<string, CanonicalHistoryCliHeadlineTotalsV1>()
   const activityProviders = new Map<string, Record<string, CanonicalHistoryCliHeadlineTotalsV1>>()
   const unpricedDates = new Set<string>()
   const unpricedProvidersByDate = new Map<string, Set<string>>()
 
-  for (const activity of input.projection.activities) {
+  for (const activity of projection.activities) {
     const date = dateKeyInTimeZone(activity.timestamp, timeZone)
+    if (onlyDates && !onlyDates.has(date)) continue
     const totals = activityTotals.get(date) ?? emptyTotals()
     const providers = activityProviders.get(date) ?? {}
     for (const observationId of activity.observationIds) {
@@ -245,7 +241,7 @@ export function buildCanonicalHistoryCliHeadlineIndexV1(input: {
     activityProviders.set(date, providers)
   }
 
-  const activityDays = [...activityTotals.keys()].sort().map(date => activityDay(
+  return [...activityTotals.keys()].sort().map(date => activityDay(
     date,
     timeZone,
     activityTotals.get(date)!,
@@ -253,6 +249,22 @@ export function buildCanonicalHistoryCliHeadlineIndexV1(input: {
     unpricedDates.has(date),
     [...(unpricedProvidersByDate.get(date) ?? [])].sort(),
   ))
+}
+
+export function buildCanonicalHistoryCliHeadlineIndexV1(input: {
+  projection: CanonicalHistoryReadProjectionV1
+  projectionSha256: string
+  snapshotSha256: string
+  authorityGeneration?: {
+    sessionPayloadSha256: string
+    dailyPayloadSha256: string
+    sourceManifestSha256: string
+    analyticsGenerationId?: string
+    endpointScopeSha256?: string
+  }
+}): CanonicalHistoryCliHeadlineIndexV1 {
+  const timeZone = input.projection.dailySnapshots.find(day => day.bucketTimeZone)?.bucketTimeZone ?? localTimeZone()
+  const activityDays = activityDaysForProjection(input.projection, timeZone)
   const unsigned: Omit<CanonicalHistoryCliHeadlineIndexV1, 'indexSha256'> = {
     kind: CANONICAL_HISTORY_CLI_HEADLINE_INDEX_KIND,
     version: CANONICAL_HISTORY_CLI_HEADLINE_INDEX_VERSION,
@@ -265,6 +277,9 @@ export function buildCanonicalHistoryCliHeadlineIndexV1(input: {
       ...(input.authorityGeneration.analyticsGenerationId
         ? { analyticsGenerationId: input.authorityGeneration.analyticsGenerationId }
         : {}),
+      ...(input.authorityGeneration.endpointScopeSha256
+        ? { endpointScopeSha256: input.authorityGeneration.endpointScopeSha256 }
+        : {}),
     } : {}),
     timeZone,
     dailySnapshots: input.projection.dailySnapshots.map(projectionDay),
@@ -274,6 +289,65 @@ export function buildCanonicalHistoryCliHeadlineIndexV1(input: {
     ...unsigned,
     indexSha256: digest(unsigned),
   }
+}
+
+export function buildCanonicalHistoryCliHeadlineIndexIncrementalV1(input: {
+  previous: CanonicalHistoryCliHeadlineIndexV1
+  previousProjection: CanonicalHistoryReadProjectionV1
+  projection: CanonicalHistoryReadProjectionV1
+  projectionSha256: string
+  snapshotSha256: string
+  authorityGeneration?: {
+    sessionPayloadSha256: string
+    dailyPayloadSha256: string
+    sourceManifestSha256: string
+    analyticsGenerationId?: string
+    endpointScopeSha256?: string
+  }
+}): CanonicalHistoryCliHeadlineIndexV1 | undefined {
+  const timeZone = input.projection.dailySnapshots.find(day => day.bucketTimeZone)?.bucketTimeZone ?? localTimeZone()
+  if (timeZone !== input.previous.timeZone) return undefined
+
+  const previousActivities = new Map(input.previousProjection.activities.map(activity => [activity.activityId, activity]))
+  const currentActivities = new Map(input.projection.activities.map(activity => [activity.activityId, activity]))
+  const affectedDates = new Set<string>()
+  const activityIds = new Set([...previousActivities.keys(), ...currentActivities.keys()])
+  for (const activityId of activityIds) {
+    const prior = previousActivities.get(activityId)
+    const next = currentActivities.get(activityId)
+    if (prior && next && canonicalizeRfc8785(prior) === canonicalizeRfc8785(next)) continue
+    if (prior) affectedDates.add(dateKeyInTimeZone(prior.timestamp, timeZone))
+    if (next) affectedDates.add(dateKeyInTimeZone(next.timestamp, timeZone))
+  }
+
+  const rebuilt = affectedDates.size === 0
+    ? []
+    : activityDaysForProjection(input.projection, timeZone, affectedDates)
+  const activityDays = [
+    ...input.previous.activityDays.filter(day => !affectedDates.has(day.date)),
+    ...rebuilt,
+  ].sort((left, right) => left.date.localeCompare(right.date))
+  const unsigned: Omit<CanonicalHistoryCliHeadlineIndexV1, 'indexSha256'> = {
+    kind: CANONICAL_HISTORY_CLI_HEADLINE_INDEX_KIND,
+    version: CANONICAL_HISTORY_CLI_HEADLINE_INDEX_VERSION,
+    projectionSha256: input.projectionSha256,
+    snapshotSha256: input.snapshotSha256,
+    ...(input.authorityGeneration ? {
+      sessionAuthorityGenerationSha256: input.authorityGeneration.sessionPayloadSha256,
+      dailyAuthorityGenerationSha256: input.authorityGeneration.dailyPayloadSha256,
+      sessionSourceManifestSha256: input.authorityGeneration.sourceManifestSha256,
+      ...(input.authorityGeneration.analyticsGenerationId
+        ? { analyticsGenerationId: input.authorityGeneration.analyticsGenerationId }
+        : {}),
+      ...(input.authorityGeneration.endpointScopeSha256
+        ? { endpointScopeSha256: input.authorityGeneration.endpointScopeSha256 }
+        : {}),
+    } : {}),
+    timeZone,
+    dailySnapshots: input.projection.dailySnapshots.map(projectionDay),
+    activityDays,
+  }
+  return { ...unsigned, indexSha256: digest(unsigned) }
 }
 
 export function parseCanonicalHistoryCliHeadlineIndexV1(bytes: Uint8Array): CanonicalHistoryCliHeadlineIndexV1 {

--- a/src/local-state/canonical-history-identity.ts
+++ b/src/local-state/canonical-history-identity.ts
@@ -1,5 +1,17 @@
 import { createHash } from 'node:crypto'
 
+/**
+ * Compact endpoint-scope seal for derived publication state. The endpoint id
+ * remains private to the identity boundary; only this digest is persisted.
+ */
+export function canonicalEndpointScopeSha256V1(endpointId: string): string {
+  if (endpointId.trim() === '') throw new Error('canonical endpoint scope has an empty endpoint id')
+  return createHash('sha256')
+    .update('metrora-canonical-endpoint-scope-v1\0')
+    .update(endpointId)
+    .digest('hex')
+}
+
 export function canonicalAnalyticsGenerationIdSha256V1(input: {
   sessionPayloadSha256: string
   dailyPayloadSha256: string

--- a/src/local-state/canonical-history-incremental.ts
+++ b/src/local-state/canonical-history-incremental.ts
@@ -1,0 +1,254 @@
+import type {
+  SessionCacheGenerationV1,
+  SessionSourceGenerationFileV1,
+  SessionSourceGenerationProviderV1,
+} from '../cache-generation.js'
+import type { DailyCache } from '../daily-cache.js'
+import { canonicalizeRfc8785 } from '../vendor/rfc8785-canonicalize.js'
+import {
+  projectCanonicalHistoryReadWithSourcesV1,
+  type CanonicalHistoryReadProjectionInputV1,
+  type CanonicalHistoryReadProjectionSourceV1,
+  type CanonicalHistoryReadProjectionV1,
+} from './canonical-history-read-projection.js'
+import type { CanonicalHistoryPublicationSourceV1, CanonicalHistoryPublicationStateV1 } from './canonical-history-publication-state.js'
+import type { SessionCache } from '../session-cache.js'
+
+export class CanonicalHistoryIncrementalProjectionUnavailableError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'CanonicalHistoryIncrementalProjectionUnavailableError'
+  }
+}
+
+export type CanonicalHistoryIncrementalProjectionResultV1 = {
+  projection: CanonicalHistoryReadProjectionV1
+  sources: CanonicalHistoryPublicationSourceV1[]
+  changedSourceCount: number
+  changedSourceKeys: string[]
+}
+
+type SourceKey = string
+
+function sourceKey(provider: string, pathSha256: string): SourceKey {
+  return `${provider}\0${pathSha256}`
+}
+
+function sameValue(left: unknown, right: unknown): boolean {
+  return canonicalizeRfc8785(left) === canonicalizeRfc8785(right)
+}
+
+function deepFreeze<T>(value: T): T {
+  if (!value || typeof value !== 'object' || Object.isFrozen(value)) return value
+  Object.freeze(value)
+  for (const child of Object.values(value as Record<string, unknown>)) deepFreeze(child)
+  return value
+}
+
+function sourceFingerprint(value: SessionSourceGenerationFileV1['fingerprint']): string {
+  return canonicalizeRfc8785(value)
+}
+
+function currentSourceDescriptors(
+  generation: SessionCacheGenerationV1,
+): CanonicalHistoryPublicationSourceV1[] {
+  return generation.providers.flatMap((provider: SessionSourceGenerationProviderV1) => provider.files.map(file => ({
+    provider: provider.provider,
+    pathSha256: file.pathSha256,
+    envFingerprint: provider.envFingerprint,
+    fingerprint: structuredClone(file.fingerprint),
+    observationIds: [],
+    activityIds: [],
+  })))
+}
+
+function mapSources(sources: readonly CanonicalHistoryPublicationSourceV1[]): Map<SourceKey, CanonicalHistoryPublicationSourceV1> {
+  const result = new Map<SourceKey, CanonicalHistoryPublicationSourceV1>()
+  for (const source of sources) {
+    const key = sourceKey(source.provider, source.pathSha256)
+    if (result.has(key)) throw new CanonicalHistoryIncrementalProjectionUnavailableError('incremental source state contains duplicate source keys')
+    result.set(key, source)
+  }
+  return result
+}
+
+function validateCoverage(
+  previousProjection: CanonicalHistoryReadProjectionV1,
+  previousSources: Map<SourceKey, CanonicalHistoryPublicationSourceV1>,
+): void {
+  const observations = new Set(previousProjection.observations.map(value => value.observationId))
+  const activities = new Set(previousProjection.activities.map(value => value.activityId))
+  const claimedObservations = new Set<string>()
+  const claimedActivities = new Set<string>()
+  for (const source of previousSources.values()) {
+    for (const id of source.observationIds) {
+      if (!observations.has(id)) throw new CanonicalHistoryIncrementalProjectionUnavailableError('incremental source state names a missing observation')
+      claimedObservations.add(id)
+    }
+    for (const id of source.activityIds) {
+      if (!activities.has(id)) throw new CanonicalHistoryIncrementalProjectionUnavailableError('incremental source state names a missing activity')
+      claimedActivities.add(id)
+    }
+  }
+  if (claimedObservations.size !== observations.size || [...observations].some(id => !claimedObservations.has(id))) {
+    throw new CanonicalHistoryIncrementalProjectionUnavailableError('incremental source state does not cover the previous observations')
+  }
+  if (claimedActivities.size !== activities.size || [...activities].some(id => !claimedActivities.has(id))) {
+    throw new CanonicalHistoryIncrementalProjectionUnavailableError('incremental source state does not cover the previous activities')
+  }
+}
+
+function changedSources(
+  previous: Map<SourceKey, CanonicalHistoryPublicationSourceV1>,
+  current: Map<SourceKey, CanonicalHistoryPublicationSourceV1>,
+): Set<SourceKey> {
+  const changed = new Set<SourceKey>()
+  for (const [key, source] of current) {
+    const prior = previous.get(key)
+    if (!prior || prior.envFingerprint !== source.envFingerprint || sourceFingerprint(prior.fingerprint) !== sourceFingerprint(source.fingerprint)) {
+      changed.add(key)
+    }
+  }
+  for (const key of previous.keys()) if (!current.has(key)) changed.add(key)
+
+  const providers = new Set([...previous.values(), ...current.values()].map(source => source.provider))
+  for (const provider of providers) {
+    const priorEnv = [...previous.values()].find(source => source.provider === provider)?.envFingerprint
+    const currentEnv = [...current.values()].find(source => source.provider === provider)?.envFingerprint
+    if (priorEnv !== currentEnv) {
+      for (const [key, source] of previous) if (source.provider === provider) changed.add(key)
+      for (const [key, source] of current) if (source.provider === provider) changed.add(key)
+    }
+  }
+
+  // Claude native reconciliation can select a different winner in an
+  // unchanged file when any Claude source changes. Re-evaluate that provider
+  // as one bounded reconciliation domain.
+  if ([...changed].some(key => (previous.get(key) ?? current.get(key))?.provider === 'claude')) {
+    for (const [key, source] of previous) if (source.provider === 'claude') changed.add(key)
+    for (const [key, source] of current) if (source.provider === 'claude') changed.add(key)
+  }
+  let expanded = true
+  while (expanded) {
+    expanded = false
+    const affectedObservationIds = new Set<string>()
+    const affectedActivityIds = new Set<string>()
+    for (const key of changed) {
+      previous.get(key)?.observationIds.forEach(id => affectedObservationIds.add(id))
+      previous.get(key)?.activityIds.forEach(id => affectedActivityIds.add(id))
+      current.get(key)?.observationIds.forEach(id => affectedObservationIds.add(id))
+      current.get(key)?.activityIds.forEach(id => affectedActivityIds.add(id))
+    }
+    for (const [key, source] of [...previous, ...current]) {
+      if (changed.has(key)) continue
+      if (
+        source.observationIds.some(id => affectedObservationIds.has(id))
+        || source.activityIds.some(id => affectedActivityIds.has(id))
+      ) {
+        changed.add(key)
+        expanded = true
+      }
+    }
+  }
+  return changed
+}
+
+function sourceProjectionMap(
+  sources: readonly CanonicalHistoryReadProjectionSourceV1[],
+): Map<SourceKey, CanonicalHistoryReadProjectionSourceV1> {
+  return new Map(sources.map(source => [sourceKey(source.provider, source.pathSha256), source]))
+}
+
+function mergeEntities<T>(
+  previous: readonly T[],
+  delta: readonly T[],
+  keepIds: ReadonlySet<string>,
+  idOf: (value: T) => string,
+): T[] {
+  const merged = new Map<string, T>()
+  for (const value of previous) {
+    const id = idOf(value)
+    if (keepIds.has(id)) merged.set(id, value)
+  }
+  for (const value of delta) {
+    const id = idOf(value)
+    const prior = merged.get(id)
+    if (prior && !sameValue(prior, value)) {
+      throw new CanonicalHistoryIncrementalProjectionUnavailableError('canonical entity changed across an incremental source boundary')
+    }
+    merged.set(id, prior ?? value)
+  }
+  return [...merged.values()].sort((left, right) => idOf(left).localeCompare(idOf(right)))
+}
+
+function buildSources(
+  current: Map<SourceKey, CanonicalHistoryPublicationSourceV1>,
+  previous: Map<SourceKey, CanonicalHistoryPublicationSourceV1>,
+  changed: ReadonlySet<SourceKey>,
+  delta: Map<SourceKey, CanonicalHistoryReadProjectionSourceV1>,
+): CanonicalHistoryPublicationSourceV1[] {
+  return [...current.entries()]
+    .map(([key, source]) => {
+      const ids = changed.has(key) ? delta.get(key) : previous.get(key)
+      return {
+        ...source,
+        observationIds: [...(ids?.observationIds ?? [])].sort(),
+        activityIds: [...(ids?.activityIds ?? [])].sort(),
+      }
+    })
+    .sort((left, right) => left.provider.localeCompare(right.provider) || left.pathSha256.localeCompare(right.pathSha256))
+}
+
+export function projectCanonicalHistoryIncrementalV1(input: {
+  endpointId: string
+  sessionCache: SessionCache
+  dailyCache: DailyCache
+  sessionGeneration: SessionCacheGenerationV1
+  previousProjection: CanonicalHistoryReadProjectionV1
+  previousState: CanonicalHistoryPublicationStateV1
+}): CanonicalHistoryIncrementalProjectionResultV1 {
+  if (input.sessionGeneration.sourceManifestSha256 === input.previousState.sourceManifestSha256
+    && input.sessionGeneration.payloadSha256 !== input.previousState.sessionPayloadSha256) {
+    throw new CanonicalHistoryIncrementalProjectionUnavailableError('session payload changed without a changed source manifest')
+  }
+
+  const previous = mapSources(input.previousState.sources)
+  validateCoverage(input.previousProjection, previous)
+  const current = mapSources(currentSourceDescriptors(input.sessionGeneration))
+  const changed = changedSources(previous, current)
+  const delta = projectCanonicalHistoryReadWithSourcesV1(
+    { endpointId: input.endpointId, sessionCache: input.sessionCache, dailyCache: input.dailyCache } satisfies CanonicalHistoryReadProjectionInputV1,
+    { sourceKeys: changed },
+  )
+  const deltaSources = sourceProjectionMap(delta.sources)
+
+  const preservedObservationIds = new Set<string>()
+  const preservedActivityIds = new Set<string>()
+  for (const [key, source] of previous) {
+    if (changed.has(key) || !current.has(key)) continue
+    source.observationIds.forEach(id => preservedObservationIds.add(id))
+    source.activityIds.forEach(id => preservedActivityIds.add(id))
+  }
+  const observations = mergeEntities(input.previousProjection.observations, delta.projection.observations, preservedObservationIds, value => value.observationId)
+  const activities = mergeEntities(input.previousProjection.activities, delta.projection.activities, preservedActivityIds, value => value.activityId)
+  const observationIds = new Set(observations.map(value => value.observationId))
+  for (const activity of activities) {
+    if (activity.observationIds.some(id => !observationIds.has(id))) {
+      throw new CanonicalHistoryIncrementalProjectionUnavailableError('incremental activity delta references a missing observation')
+    }
+  }
+
+  const projection: CanonicalHistoryReadProjectionV1 = {
+    version: delta.projection.version,
+    authority: delta.projection.authority,
+    observations,
+    activities,
+    dailySnapshots: delta.projection.dailySnapshots,
+  }
+  return {
+    projection: deepFreeze(projection),
+    sources: buildSources(current, previous, changed, deltaSources),
+    changedSourceCount: changed.size,
+    changedSourceKeys: [...changed].sort(),
+  }
+}

--- a/src/local-state/canonical-history-parity-observer.ts
+++ b/src/local-state/canonical-history-parity-observer.ts
@@ -35,6 +35,7 @@ import {
   cachePayloadSha256V1,
   readCurrentDailyCacheGenerationV1,
   readCurrentSessionCacheGenerationV1,
+  sessionGenerationSourcePathSha256V1,
 } from '../cache-generation.js'
 import { dailyCachePath } from '../daily-cache.js'
 import { sessionCachePath } from '../session-cache.js'
@@ -69,6 +70,9 @@ export type CanonicalHistoryParityObserverDependenciesV1 = {
   persist?: (
     projection: CanonicalHistoryReadProjectionV1,
   ) => Promise<PersistCanonicalHistoryShadowResultV1>
+  expectedSessionAuthority?: (
+    input: CanonicalHistoryReadProjectionInputV1,
+  ) => CanonicalHistorySessionAuthorityV1
 }
 
 export class CanonicalHistoryParityMismatchError extends Error {
@@ -88,6 +92,11 @@ type DailySnapshotPayload = Omit<
   CanonicalHistoryReadProjectionV1['dailySnapshots'][number],
   'snapshotId'
 >
+
+export type CanonicalHistorySessionAuthorityV1 = {
+  observations: Map<string, ObservationPayload>
+  activities: Set<string>
+}
 
 function canonical(value: unknown): string {
   try {
@@ -264,7 +273,8 @@ function expectedSessionAuthority(input: {
   endpointId: string
   sessionCache: SessionCache
   sourceFingerprint: CanonicalHistoryParityObserverDependenciesV1['sourceFingerprint']
-}): { observations: Map<string, ObservationPayload>; activities: Set<string> } {
+  sourceKeys?: ReadonlySet<string>
+}): CanonicalHistorySessionAuthorityV1 {
   const observations = new Map<string, ObservationPayload>()
   const activities = new Set<string>()
   const observationActivity = new Map<string, string>()
@@ -277,8 +287,9 @@ function expectedSessionAuthority(input: {
 
   for (const [storageNamespace, section] of Object.entries(input.sessionCache.providers)
     .sort(([left], [right]) => left.localeCompare(right))) {
-    for (const [, file] of Object.entries(section.files)
+    for (const [path, file] of Object.entries(section.files)
       .sort(([left], [right]) => left.localeCompare(right))) {
+      if (input.sourceKeys && !input.sourceKeys.has(`${storageNamespace}\0${sessionGenerationSourcePathSha256V1(storageNamespace, path)}`)) continue
       if (file.failed) continue
       for (const turn of file.turns) {
         const calls = storageNamespace === 'claude'
@@ -327,7 +338,7 @@ function expectedSessionAuthority(input: {
 
 function projectedSessionAuthority(
   projection: CanonicalHistoryReadProjectionV1,
-): { observations: Map<string, ObservationPayload>; activities: Set<string> } {
+): CanonicalHistorySessionAuthorityV1 {
   const observations = new Map<string, ObservationPayload>()
   for (const observation of projection.observations) {
     const { observationId, activityId: _activityId, ...payload } = observation
@@ -364,6 +375,21 @@ function projectedSessionAuthority(
     )
   }
   return { observations, activities }
+}
+
+export function canonicalHistorySessionAuthorityForProjectionV1(
+  projection: CanonicalHistoryReadProjectionV1,
+): CanonicalHistorySessionAuthorityV1 {
+  return projectedSessionAuthority(projection)
+}
+
+export function expectedCanonicalHistorySessionAuthorityForSourcesV1(input: {
+  endpointId: string
+  sessionCache: SessionCache
+  sourceFingerprint: CanonicalHistoryParityObserverDependenciesV1['sourceFingerprint']
+  sourceKeys: ReadonlySet<string>
+}): CanonicalHistorySessionAuthorityV1 {
+  return expectedSessionAuthority(input)
 }
 
 function assertMapParity<T>(
@@ -452,11 +478,13 @@ export async function observeCanonicalHistoryParityV1(
     })
   })
   const projection = project(input)
-  const expected = expectedSessionAuthority({
-    endpointId: input.endpointId,
-    sessionCache: input.sessionCache,
-    sourceFingerprint: dependencies.sourceFingerprint,
-  })
+  const expected = dependencies.expectedSessionAuthority
+    ? dependencies.expectedSessionAuthority(input)
+    : expectedSessionAuthority({
+        endpointId: input.endpointId,
+        sessionCache: input.sessionCache,
+        sourceFingerprint: dependencies.sourceFingerprint,
+      })
   const actual = projectedSessionAuthority(projection)
 
   assertMapParity(expected.observations, actual.observations, 'observation')

--- a/src/local-state/canonical-history-publication-state.ts
+++ b/src/local-state/canonical-history-publication-state.ts
@@ -1,0 +1,151 @@
+import { createHash } from 'node:crypto'
+import { join } from 'node:path'
+import * as z from 'zod/v4'
+
+import { Sha256DigestSchema } from '../contracts/v1/common.js'
+import {
+  atomicWritePrivateFile,
+  readOptionalPrivateFile,
+} from './atomic-file.js'
+import { canonicalizeRfc8785 } from '../vendor/rfc8785-canonicalize.js'
+
+export const CANONICAL_HISTORY_PUBLICATION_STATE_KIND = 'metrora.canonical-history-publication-state' as const
+export const CANONICAL_HISTORY_PUBLICATION_STATE_VERSION = 1 as const
+
+export type CanonicalHistoryPublicationSourceV1 = {
+  provider: string
+  pathSha256: string
+  envFingerprint: string
+  fingerprint: {
+    dev: number
+    ino: number
+    mtimeMs: number
+    sizeBytes: number
+    sqliteWal?: { mtimeMs: number; sizeBytes: number }
+  }
+  observationIds: string[]
+  activityIds: string[]
+}
+
+export type CanonicalHistoryPublicationStateV1 = {
+  kind: typeof CANONICAL_HISTORY_PUBLICATION_STATE_KIND
+  version: typeof CANONICAL_HISTORY_PUBLICATION_STATE_VERSION
+  endpointScopeSha256: string
+  analyticsGenerationId: string
+  sessionPayloadSha256: string
+  dailyPayloadSha256: string
+  sourceManifestSha256: string
+  projectionSha256: string
+  snapshotSha256: string
+  sources: CanonicalHistoryPublicationSourceV1[]
+  stateSha256: string
+}
+
+const FingerprintSchema = z.strictObject({
+  dev: z.number().finite(),
+  ino: z.number().finite(),
+  mtimeMs: z.number().finite(),
+  sizeBytes: z.number().finite(),
+  sqliteWal: z.strictObject({
+    mtimeMs: z.number().finite(),
+    sizeBytes: z.number().finite(),
+  }).optional(),
+})
+const StateWithoutDigestSchema = z.strictObject({
+  kind: z.literal(CANONICAL_HISTORY_PUBLICATION_STATE_KIND),
+  version: z.literal(CANONICAL_HISTORY_PUBLICATION_STATE_VERSION),
+  endpointScopeSha256: Sha256DigestSchema,
+  analyticsGenerationId: Sha256DigestSchema,
+  sessionPayloadSha256: Sha256DigestSchema,
+  dailyPayloadSha256: Sha256DigestSchema,
+  sourceManifestSha256: Sha256DigestSchema,
+  projectionSha256: Sha256DigestSchema,
+  snapshotSha256: Sha256DigestSchema,
+  sources: z.array(z.strictObject({
+    provider: z.string().min(1),
+    pathSha256: Sha256DigestSchema,
+    envFingerprint: z.string(),
+    fingerprint: FingerprintSchema,
+    observationIds: z.array(z.string().min(1)),
+    activityIds: z.array(z.string().min(1)),
+  })),
+})
+const StateSchema = StateWithoutDigestSchema.extend({ stateSha256: Sha256DigestSchema })
+
+export class CanonicalHistoryPublicationStateIntegrityError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'CanonicalHistoryPublicationStateIntegrityError'
+  }
+}
+
+function digest(value: unknown): string {
+  return createHash('sha256')
+    .update('metrora-canonical-history-publication-state-v1')
+    .update('\0')
+    .update(canonicalizeRfc8785(value))
+    .digest('hex')
+}
+
+function withoutDigest(value: CanonicalHistoryPublicationStateV1): Omit<CanonicalHistoryPublicationStateV1, 'stateSha256'> {
+  const { stateSha256: _stateSha256, ...rest } = value
+  return rest
+}
+
+export function canonicalHistoryPublicationStatePathV1(dataDir: string): string {
+  return join(dataDir, 'history-shadow', 'v1', 'publication-state.v1.json')
+}
+
+export function buildCanonicalHistoryPublicationStateV1(input: Omit<CanonicalHistoryPublicationStateV1, 'kind' | 'version' | 'stateSha256'>): CanonicalHistoryPublicationStateV1 {
+  const unsigned: Omit<CanonicalHistoryPublicationStateV1, 'stateSha256'> = {
+    kind: CANONICAL_HISTORY_PUBLICATION_STATE_KIND,
+    version: CANONICAL_HISTORY_PUBLICATION_STATE_VERSION,
+    endpointScopeSha256: input.endpointScopeSha256,
+    analyticsGenerationId: input.analyticsGenerationId,
+    sessionPayloadSha256: input.sessionPayloadSha256,
+    dailyPayloadSha256: input.dailyPayloadSha256,
+    sourceManifestSha256: input.sourceManifestSha256,
+    projectionSha256: input.projectionSha256,
+    snapshotSha256: input.snapshotSha256,
+    sources: input.sources
+      .map(source => ({
+        ...source,
+        observationIds: [...new Set(source.observationIds)].sort(),
+        activityIds: [...new Set(source.activityIds)].sort(),
+      }))
+      .sort((left, right) => left.provider.localeCompare(right.provider) || left.pathSha256.localeCompare(right.pathSha256)),
+  }
+  return { ...unsigned, stateSha256: digest(unsigned) }
+}
+
+export async function writeCanonicalHistoryPublicationStateV1(
+  dataDir: string,
+  state: CanonicalHistoryPublicationStateV1,
+): Promise<void> {
+  await atomicWritePrivateFile(canonicalHistoryPublicationStatePathV1(dataDir), JSON.stringify(state))
+}
+
+export async function readCanonicalHistoryPublicationStateV1(
+  dataDir: string,
+): Promise<CanonicalHistoryPublicationStateV1 | undefined> {
+  const bytes = await readOptionalPrivateFile(canonicalHistoryPublicationStatePathV1(dataDir))
+  if (!bytes) return undefined
+  let parsed: CanonicalHistoryPublicationStateV1
+  try {
+    parsed = StateSchema.parse(JSON.parse(Buffer.from(bytes).toString('utf8')))
+  } catch {
+    throw new CanonicalHistoryPublicationStateIntegrityError('canonical history publication state is invalid')
+  }
+  if (digest(withoutDigest(parsed)) !== parsed.stateSha256) {
+    throw new CanonicalHistoryPublicationStateIntegrityError('canonical history publication state digest does not match its contents')
+  }
+  const seen = new Set<string>()
+  for (const source of parsed.sources) {
+    const key = `${source.provider}\0${source.pathSha256}`
+    if (seen.has(key)) {
+      throw new CanonicalHistoryPublicationStateIntegrityError('canonical history publication state contains duplicate sources')
+    }
+    seen.add(key)
+  }
+  return parsed
+}

--- a/src/local-state/canonical-history-publication-trust.ts
+++ b/src/local-state/canonical-history-publication-trust.ts
@@ -1,0 +1,221 @@
+import { readdir, stat } from 'node:fs/promises'
+import { join } from 'node:path'
+
+import { readOptionalPrivateFile } from './atomic-file.js'
+import {
+  parseCanonicalHistoryCliHeadlineIndexV1,
+  type CanonicalHistoryCliHeadlineIndexV1,
+} from './canonical-history-cli-headline-index.js'
+import { canonicalHistoryShadowSnapshotSha256V1 } from './canonical-history-cli-headline-index-store.js'
+import type {
+  CanonicalHistoryShadowHeadV1,
+  CanonicalHistoryShadowPathsV1,
+  CanonicalHistoryShadowProjectionIndexV1,
+} from './canonical-history-shadow-store.js'
+import { CanonicalHistoryShadowStoreIntegrityError } from './canonical-history-shadow-errors.js'
+import {
+  readCanonicalHistoryRetainedIndexV1,
+  type CanonicalHistoryRetainedProjectionIndexV1,
+} from './canonical-history-retained-index.js'
+
+type CanonicalHistoryShadowTrustSnapshotV1 = {
+  projectionSha256: string
+  snapshotSha256: string
+  dev: number
+  ino: number
+  mtimeMs: number
+  sizeBytes: number
+}
+
+type CanonicalHistoryShadowTrustMemoV1 = {
+  headProjectionSha256: string
+  headSnapshotSha256: string
+  snapshots: CanonicalHistoryShadowTrustSnapshotV1[]
+  retainedIndex: CanonicalHistoryShadowTrustFileIdentityV1
+}
+
+type CanonicalHistoryShadowTrustFileIdentityV1 = {
+  dev: number
+  ino: number
+  mtimeMs: number
+  sizeBytes: number
+}
+
+export type CanonicalHistoryShadowPublicationTrustV1 = {
+  head: CanonicalHistoryShadowHeadV1
+  headlineIndex: CanonicalHistoryCliHeadlineIndexV1
+  deepValidated: boolean
+}
+
+const canonicalHistoryShadowTrustMemo = new Map<string, CanonicalHistoryShadowTrustMemoV1>()
+
+function snapshotPath(paths: CanonicalHistoryShadowPathsV1, digest: string): string {
+  return join(paths.snapshots, `${digest}.json`)
+}
+
+function trustFileIdentity(info: { dev: number; ino: number; mtimeMs: number; size: number }): CanonicalHistoryShadowTrustFileIdentityV1 {
+  return { dev: info.dev, ino: info.ino, mtimeMs: info.mtimeMs, sizeBytes: info.size }
+}
+
+function trustFileIdentityMatches(
+  expected: CanonicalHistoryShadowTrustFileIdentityV1,
+  actual: CanonicalHistoryShadowTrustFileIdentityV1,
+): boolean {
+  return expected.dev === actual.dev
+    && expected.ino === actual.ino
+    && expected.mtimeMs === actual.mtimeMs
+    && expected.sizeBytes === actual.sizeBytes
+}
+
+async function snapshotTrustSeals(
+  paths: CanonicalHistoryShadowPathsV1,
+): Promise<CanonicalHistoryShadowTrustSnapshotV1[]> {
+  const entries = await readdir(paths.snapshots, { withFileTypes: true })
+  const seals: CanonicalHistoryShadowTrustSnapshotV1[] = []
+  for (const entry of entries.sort((left, right) => left.name.localeCompare(right.name))) {
+    if (!entry.isFile() || entry.name.includes('.metrora-tmp-')) continue
+    const match = /^([a-f0-9]{64})\.json$/u.exec(entry.name)
+    if (!match) {
+      throw new CanonicalHistoryShadowStoreIntegrityError(`canonical history shadow contains unexpected snapshot file ${entry.name}`)
+    }
+    const info = await stat(join(paths.snapshots, entry.name))
+    seals.push({
+      projectionSha256: match[1]!,
+      snapshotSha256: '',
+      ...trustFileIdentity(info),
+    })
+  }
+  return seals.sort((left, right) => left.projectionSha256.localeCompare(right.projectionSha256))
+}
+
+function trustSnapshotMetadataMatches(
+  expected: CanonicalHistoryShadowTrustSnapshotV1[],
+  actual: CanonicalHistoryShadowTrustSnapshotV1[],
+): boolean {
+  return expected.length === actual.length && expected.every((left, index) => {
+    const right = actual[index]
+    return right !== undefined
+      && left.projectionSha256 === right.projectionSha256
+      && left.dev === right.dev
+      && left.ino === right.ino
+      && left.mtimeMs === right.mtimeMs
+      && left.sizeBytes === right.sizeBytes
+  })
+}
+
+async function readPublisherHeadlineIndex(
+  paths: CanonicalHistoryShadowPathsV1,
+  head: CanonicalHistoryShadowHeadV1,
+): Promise<CanonicalHistoryCliHeadlineIndexV1> {
+  const bytes = await readOptionalPrivateFile(join(paths.headlineIndexes, `${head.projectionSha256}.json`))
+  if (!bytes) throw new CanonicalHistoryShadowStoreIntegrityError('canonical history shadow headline index is missing')
+  let index: CanonicalHistoryCliHeadlineIndexV1
+  try {
+    index = parseCanonicalHistoryCliHeadlineIndexV1(bytes)
+  } catch (error) {
+    throw new CanonicalHistoryShadowStoreIntegrityError(error instanceof Error ? error.message : 'canonical history shadow headline index is invalid')
+  }
+  if (index.projectionSha256 !== head.projectionSha256) {
+    throw new CanonicalHistoryShadowStoreIntegrityError('canonical history shadow headline index names a different projection')
+  }
+  if (head.snapshotSha256 === undefined || index.snapshotSha256 !== head.snapshotSha256) {
+    throw new CanonicalHistoryShadowStoreIntegrityError('canonical history shadow headline index snapshot seal does not match the head')
+  }
+  return index
+}
+
+export async function rememberCanonicalHistoryPublicationTrustV1(
+  dataDir: string,
+  paths: CanonicalHistoryShadowPathsV1,
+  head: CanonicalHistoryShadowHeadV1,
+  retained: CanonicalHistoryRetainedProjectionIndexV1,
+): Promise<void> {
+  if (head.snapshotSha256 === undefined) return
+  const retainedIndexInfo = await stat(join(paths.root, 'retained-index.v1.json'))
+  canonicalHistoryShadowTrustMemo.set(dataDir, {
+    headProjectionSha256: head.projectionSha256,
+    headSnapshotSha256: head.snapshotSha256,
+    snapshots: retained.snapshots
+      .map(snapshot => ({ ...snapshot }))
+      .sort((left, right) => left.projectionSha256.localeCompare(right.projectionSha256)),
+    retainedIndex: trustFileIdentity(retainedIndexInfo),
+  })
+}
+
+/** Clear the process-local memo; a real process restart starts empty. */
+export function clearCanonicalHistoryShadowTrustMemoV1(dataDir?: string): void {
+  if (dataDir === undefined) canonicalHistoryShadowTrustMemo.clear()
+  else canonicalHistoryShadowTrustMemo.delete(dataDir)
+}
+
+/**
+ * Canonical publisher trust boundary. Unlike the terminal fast reader, a cold
+ * lifecycle hashes the head and deeply validates every retained snapshot
+ * against its prior content seal before acceleration state can authorize a
+ * publication decision.
+ */
+export async function readCanonicalHistoryPublicationTrustV1(input: {
+  dataDir: string
+  paths: CanonicalHistoryShadowPathsV1
+  parseHead: (bytes: Uint8Array) => CanonicalHistoryShadowHeadV1
+  parseSnapshot: (bytes: Uint8Array, expectedDigest: string) => { index: CanonicalHistoryShadowProjectionIndexV1 }
+}): Promise<CanonicalHistoryShadowPublicationTrustV1 | undefined> {
+  const { dataDir, paths } = input
+  const headBytes = await readOptionalPrivateFile(paths.head)
+  if (!headBytes) {
+    clearCanonicalHistoryShadowTrustMemoV1(dataDir)
+    return undefined
+  }
+  const head = input.parseHead(headBytes)
+  if (head.snapshotSha256 === undefined) {
+    clearCanonicalHistoryShadowTrustMemoV1(dataDir)
+    throw new CanonicalHistoryShadowStoreIntegrityError('canonical history shadow head has no snapshot content seal')
+  }
+
+  const snapshotInfo = await stat(snapshotPath(paths, head.projectionSha256)).catch(() => undefined)
+  if (!snapshotInfo || !snapshotInfo.isFile()) {
+    clearCanonicalHistoryShadowTrustMemoV1(dataDir)
+    throw new CanonicalHistoryShadowStoreIntegrityError('canonical history shadow head points to a missing snapshot')
+  }
+  const retainedIndexInfo = await stat(join(paths.root, 'retained-index.v1.json')).catch(() => undefined)
+  const memo = canonicalHistoryShadowTrustMemo.get(dataDir)
+  if (
+    memo
+    && memo.headProjectionSha256 === head.projectionSha256
+    && memo.headSnapshotSha256 === head.snapshotSha256
+    && retainedIndexInfo
+    && trustFileIdentityMatches(memo.retainedIndex, trustFileIdentity(retainedIndexInfo))
+  ) {
+    const currentSnapshots = await snapshotTrustSeals(paths)
+    if (trustSnapshotMetadataMatches(memo.snapshots, currentSnapshots)) {
+      return {
+        head,
+        headlineIndex: await readPublisherHeadlineIndex(paths, head),
+        deepValidated: false,
+      }
+    }
+  }
+
+  const snapshotBytes = await readOptionalPrivateFile(snapshotPath(paths, head.projectionSha256))
+  if (!snapshotBytes) throw new CanonicalHistoryShadowStoreIntegrityError('canonical history shadow head points to a missing snapshot')
+  input.parseSnapshot(snapshotBytes, head.projectionSha256)
+  const snapshotSha256 = canonicalHistoryShadowSnapshotSha256V1(snapshotBytes)
+  if (snapshotSha256 !== head.snapshotSha256) {
+    clearCanonicalHistoryShadowTrustMemoV1(dataDir)
+    throw new CanonicalHistoryShadowStoreIntegrityError('canonical history shadow head snapshot content seal does not match its bytes')
+  }
+
+  const retained = await readCanonicalHistoryRetainedIndexV1(paths, input.parseSnapshot, { deepValidate: true })
+  const retainedHead = retained.snapshots.find(snapshot => snapshot.projectionSha256 === head.projectionSha256)
+  if (!retainedHead || retainedHead.snapshotSha256 !== snapshotSha256) {
+    clearCanonicalHistoryShadowTrustMemoV1(dataDir)
+    throw new CanonicalHistoryShadowStoreIntegrityError('canonical history retained index does not seal the current head snapshot')
+  }
+  const headlineIndex = await readPublisherHeadlineIndex(paths, head)
+  if (headlineIndex.snapshotSha256 !== snapshotSha256) {
+    clearCanonicalHistoryShadowTrustMemoV1(dataDir)
+    throw new CanonicalHistoryShadowStoreIntegrityError('canonical history shadow headline index does not seal the current snapshot bytes')
+  }
+  await rememberCanonicalHistoryPublicationTrustV1(dataDir, paths, head, retained)
+  return { head, headlineIndex, deepValidated: true }
+}

--- a/src/local-state/canonical-history-read-projection.ts
+++ b/src/local-state/canonical-history-read-projection.ts
@@ -18,6 +18,7 @@ import {
   type CachedUsage,
   type SessionCache,
 } from '../session-cache.js'
+import { sessionGenerationSourcePathSha256V1 } from '../cache-generation.js'
 import { assertCanonicalCollectorIdentity } from '../provider-parse-authorities.js'
 import { canonicalSourceRecordFingerprintSha256V1 } from './canonical-history-identity.js'
 
@@ -70,6 +71,18 @@ export type CanonicalHistoryReadProjectionV1 = {
   observations: CanonicalObservationReadV1[]
   activities: CanonicalActivityReadV1[]
   dailySnapshots: CanonicalHistoryDaySnapshotV1[]
+}
+
+export type CanonicalHistoryReadProjectionSourceV1 = {
+  provider: string
+  pathSha256: string
+  observationIds: string[]
+  activityIds: string[]
+}
+
+export type CanonicalHistoryReadProjectionWithSourcesV1 = {
+  projection: CanonicalHistoryReadProjectionV1
+  sources: CanonicalHistoryReadProjectionSourceV1[]
 }
 
 export type CanonicalHistoryReadProjectionInputV1 = {
@@ -248,9 +261,10 @@ function sameValue(left: unknown, right: unknown): boolean {
   return stableJson(left) === stableJson(right)
 }
 
-export function projectCanonicalHistoryReadV1(
+export function projectCanonicalHistoryReadWithSourcesV1(
   inputValue: CanonicalHistoryReadProjectionInputV1,
-): CanonicalHistoryReadProjectionV1 {
+  options: { sourceKeys?: ReadonlySet<string> } = {},
+): CanonicalHistoryReadProjectionWithSourcesV1 {
   const endpointId = OpaqueIdSchema.parse(inputValue.endpointId)
   const { sessionCache, dailyCache } = inputValue
 
@@ -270,9 +284,15 @@ export function projectCanonicalHistoryReadV1(
   const activityByObservation = new Map<string, string>()
   const claudeNativeReconciliation = reconcileClaudeNativeSessionCache(sessionCache)
   assertClaudeNativeReconciliationSafe(claudeNativeReconciliation)
+  const sources = new Map<string, CanonicalHistoryReadProjectionSourceV1>()
 
   for (const [storageNamespace, section] of Object.entries(sessionCache.providers).sort(([a], [b]) => a.localeCompare(b))) {
-    for (const [, file] of Object.entries(section.files).sort(([a], [b]) => a.localeCompare(b))) {
+    for (const [path, file] of Object.entries(section.files).sort(([a], [b]) => a.localeCompare(b))) {
+      const pathSha256 = sessionGenerationSourcePathSha256V1(storageNamespace, path)
+      const sourceKey = `${storageNamespace}\0${pathSha256}`
+      const source: CanonicalHistoryReadProjectionSourceV1 = { provider: storageNamespace, pathSha256, observationIds: [], activityIds: [] }
+      sources.set(sourceKey, source)
+      if (options.sourceKeys && !options.sourceKeys.has(sourceKey)) continue
       if (file.failed) continue
       for (const turn of file.turns) {
         if (!turn.sessionId) throw new CanonicalHistoryReadProjectionIntegrityError('canonical cached turn has an empty private session id')
@@ -323,6 +343,7 @@ export function projectCanonicalHistoryReadV1(
           observationsById.set(observation.observationId, prior ?? observation)
           activityByObservation.set(observation.observationId, activityId)
           if (!observationIds.includes(observation.observationId)) observationIds.push(observation.observationId)
+          if (!source.observationIds.includes(observation.observationId)) source.observationIds.push(observation.observationId)
         }
 
         const activity: CanonicalActivityReadV1 = {
@@ -336,6 +357,7 @@ export function projectCanonicalHistoryReadV1(
           throw new CanonicalHistoryReadProjectionIntegrityError('one canonical activity identity resolved to conflicting observations')
         }
         activitiesById.set(activityId, priorActivity ?? activity)
+        if (!source.activityIds.includes(activityId)) source.activityIds.push(activityId)
       }
     }
   }
@@ -354,5 +376,20 @@ export function projectCanonicalHistoryReadV1(
       .map(day => projectDailySnapshot(day, dailyCache.tzKey ?? null))
       .sort((a, b) => a.date.localeCompare(b.date) || a.snapshotId.localeCompare(b.snapshotId)),
   }
-  return deepFreeze(projection)
+  return {
+    projection: deepFreeze(projection),
+    sources: [...sources.values()]
+      .map(source => ({
+        ...source,
+        observationIds: [...source.observationIds].sort(),
+        activityIds: [...source.activityIds].sort(),
+      }))
+      .sort((left, right) => left.provider.localeCompare(right.provider) || left.pathSha256.localeCompare(right.pathSha256)),
+  }
+}
+
+export function projectCanonicalHistoryReadV1(
+  inputValue: CanonicalHistoryReadProjectionInputV1,
+): CanonicalHistoryReadProjectionV1 {
+  return projectCanonicalHistoryReadWithSourcesV1(inputValue).projection
 }

--- a/src/local-state/canonical-history-retained-index.ts
+++ b/src/local-state/canonical-history-retained-index.ts
@@ -45,6 +45,10 @@ export type CanonicalHistoryRetainedProjectionIndexV1 = {
 type RetainedHistoryPathsV1 = { root: string; snapshots: string }
 type RetainedHistoryIndexV1 = z.infer<typeof RetainedHistoryIndexV1Schema>
 
+export type CanonicalHistoryRetainedIndexReadOptionsV1 = {
+  deepValidate?: boolean
+}
+
 function snapshotPath(paths: RetainedHistoryPathsV1, digest: string): string {
   return join(paths.snapshots, `${digest}.json`)
 }
@@ -101,16 +105,8 @@ function snapshotNamesFromSeals(seals: readonly z.infer<typeof RetainedSnapshotS
 }
 
 async function readCompactRetainedIndex(paths: RetainedHistoryPathsV1): Promise<CanonicalHistoryRetainedProjectionIndexV1 | undefined> {
-  const bytes = await readOptionalPrivateFile(retainedIndexPath(paths))
-  if (!bytes) return undefined
-  let parsed: RetainedHistoryIndexV1
-  try {
-    parsed = RetainedHistoryIndexV1Schema.parse(JSON.parse(Buffer.from(bytes).toString('utf8')))
-    const { indexSha256: _indexSha256, ...unsigned } = parsed
-    if (retainedIndexDigest(unsigned) !== parsed.indexSha256) return undefined
-  } catch {
-    return undefined
-  }
+  const parsed = await readStoredRetainedIndex(paths)
+  if (!parsed) return undefined
   const entries = await readdir(paths.snapshots, { withFileTypes: true })
   const actualNames = entries.filter(entry => entry.isFile() && !entry.name.includes('.metrora-tmp-')).map(entry => entry.name).sort()
   if (actualNames.length !== parsed.snapshots.length || actualNames.some((name, index) => name !== snapshotNamesFromSeals(parsed.snapshots)[index])) return undefined
@@ -122,20 +118,97 @@ async function readCompactRetainedIndex(paths: RetainedHistoryPathsV1): Promise<
     const info = await stat(snapshotPath(paths, seal.projectionSha256)).catch(() => undefined)
     if (!info || !info.isFile() || info.dev !== seal.dev || info.ino !== seal.ino || info.mtimeMs !== seal.mtimeMs || info.size !== seal.sizeBytes) return undefined
   }
-  const retained: CanonicalHistoryRetainedProjectionIndexV1 = {
+  const retained = retainedProjectionFromStoredIndex(parsed)
+  for (const history of retained.activities.values()) for (const payload of history) decodeActivityPayload(payload)
+  return retained
+}
+
+async function readStoredRetainedIndex(paths: RetainedHistoryPathsV1): Promise<RetainedHistoryIndexV1 | undefined> {
+  const bytes = await readOptionalPrivateFile(retainedIndexPath(paths))
+  if (!bytes) return undefined
+  try {
+    const parsed = RetainedHistoryIndexV1Schema.parse(JSON.parse(Buffer.from(bytes).toString('utf8')))
+    const { indexSha256: _indexSha256, ...unsigned } = parsed
+    if (retainedIndexDigest(unsigned) !== parsed.indexSha256) return undefined
+    return parsed
+  } catch {
+    return undefined
+  }
+}
+
+function retainedProjectionFromStoredIndex(parsed: RetainedHistoryIndexV1): CanonicalHistoryRetainedProjectionIndexV1 {
+  return {
     observations: new Map(Object.entries(parsed.observations)),
     activities: new Map(Object.entries(parsed.activities)),
     dailySnapshots: new Map(Object.entries(parsed.dailySnapshots)),
     snapshots: parsed.snapshots,
   }
-  for (const history of retained.activities.values()) for (const payload of history) decodeActivityPayload(payload)
+}
+
+async function readDeepRetainedIndex(
+  paths: RetainedHistoryPathsV1,
+  parseSnapshot: (bytes: Uint8Array, expectedDigest: string) => { index: CanonicalHistoryShadowProjectionIndexV1 },
+): Promise<CanonicalHistoryRetainedProjectionIndexV1> {
+  const stored = await readStoredRetainedIndex(paths)
+  const expectedSnapshots = new Map(stored?.snapshots.map(snapshot => [snapshot.projectionSha256, snapshot]) ?? [])
+  const retained: CanonicalHistoryRetainedProjectionIndexV1 = {
+    observations: new Map(),
+    activities: new Map(),
+    dailySnapshots: new Map(),
+    snapshots: [],
+  }
+  const entries = await readdir(paths.snapshots, { withFileTypes: true })
+  const actualProjectionDigests = new Set<string>()
+  for (const entry of entries.sort((a, b) => a.name.localeCompare(b.name))) {
+    if (!entry.isFile() || entry.name.includes('.metrora-tmp-')) continue
+    const match = /^([a-f0-9]{64})\.json$/u.exec(entry.name)
+    if (!match) {
+      throw new CanonicalHistoryShadowStoreIntegrityError(`canonical history shadow contains unexpected snapshot file ${entry.name}`)
+    }
+    const digest = match[1]!
+    actualProjectionDigests.add(digest)
+    const path = join(paths.snapshots, entry.name)
+    const bytes = await readOptionalPrivateFile(path)
+    if (!bytes) throw new CanonicalHistoryShadowStoreIntegrityError(`canonical history shadow snapshot ${entry.name} disappeared during validation`)
+    const parsed = parseSnapshot(bytes, digest)
+    const info = await stat(path)
+    const snapshotSha256 = canonicalHistoryShadowSnapshotSha256V1(bytes)
+    const expected = expectedSnapshots.get(digest)
+    if (expected && expected.snapshotSha256 !== snapshotSha256) {
+      throw new CanonicalHistoryShadowStoreIntegrityError(`canonical history shadow snapshot ${entry.name} changed since its retained seal`)
+    }
+    retained.snapshots.push({
+      projectionSha256: digest,
+      snapshotSha256,
+      dev: info.dev,
+      ino: info.ino,
+      mtimeMs: info.mtimeMs,
+      sizeBytes: info.size,
+    })
+    mergeRetainedEntityIndex(retained.observations, parsed.index.observations, 'observation')
+    for (const [id, payload] of parsed.index.activities) {
+      const history = retained.activities.get(id) ?? []
+      for (const prior of history) if (!activityPayloadsCanBeRevisions(prior, payload)) throw new CanonicalHistoryShadowStoreIntegrityError(`activity identity ${id} conflicts with retained shadow history`)
+      if (!history.includes(payload)) history.push(payload)
+      retained.activities.set(id, history)
+    }
+    mergeRetainedEntityIndex(retained.dailySnapshots, parsed.index.dailySnapshots, 'daily snapshot')
+  }
+  for (const expected of expectedSnapshots.values()) {
+    if (!actualProjectionDigests.has(expected.projectionSha256)) {
+      throw new CanonicalHistoryShadowStoreIntegrityError(`canonical history shadow snapshot ${expected.projectionSha256}.json is missing during validation`)
+    }
+  }
+  await writeCanonicalHistoryRetainedIndexV1(paths, retained)
   return retained
 }
 
 export async function readCanonicalHistoryRetainedIndexV1(
   paths: RetainedHistoryPathsV1,
   parseSnapshot: (bytes: Uint8Array, expectedDigest: string) => { index: CanonicalHistoryShadowProjectionIndexV1 },
+  options: CanonicalHistoryRetainedIndexReadOptionsV1 = {},
 ): Promise<CanonicalHistoryRetainedProjectionIndexV1> {
+  if (options.deepValidate) return readDeepRetainedIndex(paths, parseSnapshot)
   const compact = await readCompactRetainedIndex(paths)
   if (compact) return compact
   const retained: CanonicalHistoryRetainedProjectionIndexV1 = { observations: new Map(), activities: new Map(), dailySnapshots: new Map(), snapshots: [] }

--- a/src/local-state/canonical-history-retained-index.ts
+++ b/src/local-state/canonical-history-retained-index.ts
@@ -1,0 +1,222 @@
+import { createHash } from 'node:crypto'
+import { readdir, stat } from 'node:fs/promises'
+import { join } from 'node:path'
+import * as z from 'zod/v4'
+
+import { Sha256DigestSchema } from '../contracts/v1/common.js'
+import { atomicWritePrivateFile, readOptionalPrivateFile } from './atomic-file.js'
+import { canonicalHistoryShadowSnapshotSha256V1 } from './canonical-history-cli-headline-index-store.js'
+import { canonicalizeRfc8785 } from '../vendor/rfc8785-canonicalize.js'
+import { CanonicalHistoryShadowStoreIntegrityError } from './canonical-history-shadow-errors.js'
+
+const RetainedSnapshotSealV1Schema = z.strictObject({
+  projectionSha256: Sha256DigestSchema,
+  snapshotSha256: Sha256DigestSchema,
+  dev: z.number().finite(),
+  ino: z.number().finite(),
+  mtimeMs: z.number().finite(),
+  sizeBytes: z.number().finite(),
+})
+const RetainedHistoryIndexWithoutDigestV1Schema = z.strictObject({
+  kind: z.literal('metrora.canonical-history-retained-index'),
+  version: z.literal(1),
+  snapshots: z.array(RetainedSnapshotSealV1Schema),
+  observations: z.record(z.string(), Sha256DigestSchema),
+  activities: z.record(z.string(), z.array(z.string())),
+  dailySnapshots: z.record(z.string(), Sha256DigestSchema),
+})
+const RetainedHistoryIndexV1Schema = RetainedHistoryIndexWithoutDigestV1Schema.extend({
+  indexSha256: Sha256DigestSchema,
+})
+
+export type CanonicalHistoryShadowProjectionIndexV1 = {
+  observations: Map<string, string>
+  activities: Map<string, string>
+  dailySnapshots: Map<string, string>
+}
+
+export type CanonicalHistoryRetainedProjectionIndexV1 = {
+  observations: Map<string, string>
+  activities: Map<string, string[]>
+  dailySnapshots: Map<string, string>
+  snapshots: Array<z.infer<typeof RetainedSnapshotSealV1Schema>>
+}
+
+type RetainedHistoryPathsV1 = { root: string; snapshots: string }
+type RetainedHistoryIndexV1 = z.infer<typeof RetainedHistoryIndexV1Schema>
+
+function snapshotPath(paths: RetainedHistoryPathsV1, digest: string): string {
+  return join(paths.snapshots, `${digest}.json`)
+}
+
+function retainedPayloadSha256(payload: string): string {
+  return createHash('sha256')
+    .update('metrora-canonical-history-retained-entity-v1')
+    .update('\0')
+    .update(payload)
+    .digest('hex')
+}
+
+function mergeRetainedEntityIndex(target: Map<string, string>, incoming: Map<string, string>, label: string): void {
+  for (const [id, payload] of incoming) {
+    const digest = retainedPayloadSha256(payload)
+    const prior = target.get(id)
+    if (prior !== undefined && prior !== digest) {
+      throw new CanonicalHistoryShadowStoreIntegrityError(`${label} identity ${id} conflicts with retained shadow history`)
+    }
+    target.set(id, prior ?? digest)
+  }
+}
+
+function retainedIndexPath(paths: RetainedHistoryPathsV1): string {
+  return join(paths.root, 'retained-index.v1.json')
+}
+
+function retainedIndexDigest(value: Omit<RetainedHistoryIndexV1, 'indexSha256'>): string {
+  return createHash('sha256')
+    .update('metrora-canonical-history-retained-index-v1')
+    .update('\0')
+    .update(canonicalizeRfc8785(value))
+    .digest('hex')
+}
+
+function retainedIndexForWrite(retained: CanonicalHistoryRetainedProjectionIndexV1): RetainedHistoryIndexV1 {
+  const unsigned: Omit<RetainedHistoryIndexV1, 'indexSha256'> = {
+    kind: 'metrora.canonical-history-retained-index',
+    version: 1,
+    snapshots: [...retained.snapshots].sort((left, right) => left.projectionSha256.localeCompare(right.projectionSha256)),
+    observations: Object.fromEntries([...retained.observations.entries()].sort(([left], [right]) => left.localeCompare(right))),
+    activities: Object.fromEntries([...retained.activities.entries()].sort(([left], [right]) => left.localeCompare(right))),
+    dailySnapshots: Object.fromEntries([...retained.dailySnapshots.entries()].sort(([left], [right]) => left.localeCompare(right))),
+  }
+  return { ...unsigned, indexSha256: retainedIndexDigest(unsigned) }
+}
+
+export async function writeCanonicalHistoryRetainedIndexV1(paths: RetainedHistoryPathsV1, retained: CanonicalHistoryRetainedProjectionIndexV1): Promise<void> {
+  await atomicWritePrivateFile(retainedIndexPath(paths), JSON.stringify(retainedIndexForWrite(retained)))
+}
+
+function snapshotNamesFromSeals(seals: readonly z.infer<typeof RetainedSnapshotSealV1Schema>[]): string[] {
+  return seals.map(seal => `${seal.projectionSha256}.json`).sort()
+}
+
+async function readCompactRetainedIndex(paths: RetainedHistoryPathsV1): Promise<CanonicalHistoryRetainedProjectionIndexV1 | undefined> {
+  const bytes = await readOptionalPrivateFile(retainedIndexPath(paths))
+  if (!bytes) return undefined
+  let parsed: RetainedHistoryIndexV1
+  try {
+    parsed = RetainedHistoryIndexV1Schema.parse(JSON.parse(Buffer.from(bytes).toString('utf8')))
+    const { indexSha256: _indexSha256, ...unsigned } = parsed
+    if (retainedIndexDigest(unsigned) !== parsed.indexSha256) return undefined
+  } catch {
+    return undefined
+  }
+  const entries = await readdir(paths.snapshots, { withFileTypes: true })
+  const actualNames = entries.filter(entry => entry.isFile() && !entry.name.includes('.metrora-tmp-')).map(entry => entry.name).sort()
+  if (actualNames.length !== parsed.snapshots.length || actualNames.some((name, index) => name !== snapshotNamesFromSeals(parsed.snapshots)[index])) return undefined
+  for (const entry of entries) {
+    if (!entry.isFile() || entry.name.includes('.metrora-tmp-')) continue
+    if (!/^([a-f0-9]{64})\.json$/u.test(entry.name)) return undefined
+  }
+  for (const seal of parsed.snapshots) {
+    const info = await stat(snapshotPath(paths, seal.projectionSha256)).catch(() => undefined)
+    if (!info || !info.isFile() || info.dev !== seal.dev || info.ino !== seal.ino || info.mtimeMs !== seal.mtimeMs || info.size !== seal.sizeBytes) return undefined
+  }
+  const retained: CanonicalHistoryRetainedProjectionIndexV1 = {
+    observations: new Map(Object.entries(parsed.observations)),
+    activities: new Map(Object.entries(parsed.activities)),
+    dailySnapshots: new Map(Object.entries(parsed.dailySnapshots)),
+    snapshots: parsed.snapshots,
+  }
+  for (const history of retained.activities.values()) for (const payload of history) decodeActivityPayload(payload)
+  return retained
+}
+
+export async function readCanonicalHistoryRetainedIndexV1(
+  paths: RetainedHistoryPathsV1,
+  parseSnapshot: (bytes: Uint8Array, expectedDigest: string) => { index: CanonicalHistoryShadowProjectionIndexV1 },
+): Promise<CanonicalHistoryRetainedProjectionIndexV1> {
+  const compact = await readCompactRetainedIndex(paths)
+  if (compact) return compact
+  const retained: CanonicalHistoryRetainedProjectionIndexV1 = { observations: new Map(), activities: new Map(), dailySnapshots: new Map(), snapshots: [] }
+  const entries = await readdir(paths.snapshots, { withFileTypes: true })
+  for (const entry of entries.sort((a, b) => a.name.localeCompare(b.name))) {
+    if (!entry.isFile() || entry.name.includes('.metrora-tmp-')) continue
+    const match = /^([a-f0-9]{64})\.json$/u.exec(entry.name)
+    if (!match) throw new CanonicalHistoryShadowStoreIntegrityError(`canonical history shadow contains unexpected snapshot file ${entry.name}`)
+    const digest = match[1]!
+    const bytes = await readOptionalPrivateFile(join(paths.snapshots, entry.name))
+    if (!bytes) throw new CanonicalHistoryShadowStoreIntegrityError(`canonical history shadow snapshot ${entry.name} disappeared during reconciliation`)
+    const parsed = parseSnapshot(bytes, digest)
+    const info = await stat(join(paths.snapshots, entry.name))
+    retained.snapshots.push({ projectionSha256: digest, snapshotSha256: canonicalHistoryShadowSnapshotSha256V1(bytes), dev: info.dev, ino: info.ino, mtimeMs: info.mtimeMs, sizeBytes: info.size })
+    mergeRetainedEntityIndex(retained.observations, parsed.index.observations, 'observation')
+    for (const [id, payload] of parsed.index.activities) {
+      const history = retained.activities.get(id) ?? []
+      for (const prior of history) if (!activityPayloadsCanBeRevisions(prior, payload)) throw new CanonicalHistoryShadowStoreIntegrityError(`activity identity ${id} conflicts with retained shadow history`)
+      if (!history.includes(payload)) history.push(payload)
+      retained.activities.set(id, history)
+    }
+    mergeRetainedEntityIndex(retained.dailySnapshots, parsed.index.dailySnapshots, 'daily snapshot')
+  }
+  await writeCanonicalHistoryRetainedIndexV1(paths, retained)
+  return retained
+}
+
+type ActivityPayload = { collector: string; timestamp: string; observationIds: string[] }
+
+function decodeActivityPayload(payload: string): ActivityPayload {
+  let value: unknown
+  try { value = JSON.parse(payload) } catch { throw new CanonicalHistoryShadowStoreIntegrityError('retained activity payload is not valid JSON') }
+  if (!value || typeof value !== 'object' || Array.isArray(value)) throw new CanonicalHistoryShadowStoreIntegrityError('retained activity must be an object')
+  const record = value as Record<string, unknown>
+  if (typeof record.collector !== 'string' || typeof record.timestamp !== 'string' || !Array.isArray(record.observationIds) || record.observationIds.some(id => typeof id !== 'string')) throw new CanonicalHistoryShadowStoreIntegrityError('retained activity payload is malformed')
+  return { collector: record.collector, timestamp: record.timestamp, observationIds: [...record.observationIds] as string[] }
+}
+
+export function canonicalHistoryActivityPayloadIsOrderedExtensionV1(priorPayload: string, nextPayload: string): boolean {
+  const prior = decodeActivityPayload(priorPayload)
+  const next = decodeActivityPayload(nextPayload)
+  return prior.collector === next.collector && prior.timestamp === next.timestamp
+    && prior.observationIds.length <= next.observationIds.length
+    && prior.observationIds.every((id, index) => next.observationIds[index] === id)
+}
+
+function activityPayloadsCanBeRevisions(leftPayload: string, rightPayload: string): boolean {
+  return canonicalHistoryActivityPayloadIsOrderedExtensionV1(leftPayload, rightPayload) || canonicalHistoryActivityPayloadIsOrderedExtensionV1(rightPayload, leftPayload)
+}
+
+export function assertCompatibleWithCanonicalHistoryRetainedV1(retained: CanonicalHistoryRetainedProjectionIndexV1, current: CanonicalHistoryShadowProjectionIndexV1): void {
+  for (const [label, previous, next] of [['observation', retained.observations, current.observations], ['daily snapshot', retained.dailySnapshots, current.dailySnapshots]] as const) {
+    for (const [id, payload] of next) if (previous.get(id) !== undefined && previous.get(id) !== retainedPayloadSha256(payload)) throw new CanonicalHistoryShadowStoreIntegrityError(`${label} identity ${id} conflicts with retained shadow history`)
+  }
+}
+
+export function assertActivitiesCompatibleWithCanonicalHistoryRetainedV1(retained: Map<string, string[]>, previous: Map<string, string> | undefined, current: Map<string, string>): void {
+  for (const [id, payload] of current) {
+    for (const prior of retained.get(id) ?? []) if (prior !== payload && !canonicalHistoryActivityPayloadIsOrderedExtensionV1(prior, payload)) throw new CanonicalHistoryShadowStoreIntegrityError(`activity identity ${id} conflicts with retained shadow history`)
+    const previousPayload = previous?.get(id)
+    if (previousPayload !== undefined && previousPayload !== payload && !canonicalHistoryActivityPayloadIsOrderedExtensionV1(previousPayload, payload)) throw new CanonicalHistoryShadowStoreIntegrityError(`activity identity ${id} resolved to a non-monotonic revision`)
+  }
+}
+
+export function addCurrentProjectionToCanonicalHistoryRetainedV1(
+  retained: CanonicalHistoryRetainedProjectionIndexV1,
+  current: CanonicalHistoryShadowProjectionIndexV1,
+  projectionSha256: string,
+  snapshotSha256: string,
+  info: { dev: number; ino: number; mtimeMs: number; size: number },
+): void {
+  mergeRetainedEntityIndex(retained.observations, current.observations, 'observation')
+  for (const [id, payload] of current.activities) {
+    const history = retained.activities.get(id) ?? []
+    for (const prior of history) if (!activityPayloadsCanBeRevisions(prior, payload)) throw new CanonicalHistoryShadowStoreIntegrityError(`activity identity ${id} conflicts with retained shadow history`)
+    if (!history.includes(payload)) history.push(payload)
+    retained.activities.set(id, history)
+  }
+  mergeRetainedEntityIndex(retained.dailySnapshots, current.dailySnapshots, 'daily snapshot')
+  const prior = retained.snapshots.find(value => value.projectionSha256 === projectionSha256)
+  if (prior) {
+    if (prior.snapshotSha256 !== snapshotSha256 || prior.dev !== info.dev || prior.ino !== info.ino || prior.mtimeMs !== info.mtimeMs || prior.sizeBytes !== info.size) throw new CanonicalHistoryShadowStoreIntegrityError('retained snapshot seal changed unexpectedly')
+  } else retained.snapshots.push({ projectionSha256: projectionSha256, snapshotSha256, dev: info.dev, ino: info.ino, mtimeMs: info.mtimeMs, sizeBytes: info.size })
+}

--- a/src/local-state/canonical-history-shadow-errors.ts
+++ b/src/local-state/canonical-history-shadow-errors.ts
@@ -1,0 +1,6 @@
+export class CanonicalHistoryShadowStoreIntegrityError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'CanonicalHistoryShadowStoreIntegrityError'
+  }
+}

--- a/src/local-state/canonical-history-shadow-store.test.ts
+++ b/src/local-state/canonical-history-shadow-store.test.ts
@@ -146,6 +146,20 @@ describe('canonical history shadow store v1', () => {
     expect(await readdir(paths.snapshots)).toEqual([`${first.projectionSha256}.json`])
   })
 
+  it('reconstructs the retained seal when the derived index is corrupt', async () => {
+    const dataDir = await temporaryDataDir()
+    const value = projection()
+    const first = await persistCanonicalHistoryShadowV1(value, { dataDir })
+    const paths = canonicalHistoryShadowPathsV1(dataDir)
+    await writeFile(join(paths.root, 'retained-index.v1.json'), '{broken')
+
+    const second = await persistCanonicalHistoryShadowV1(value, { dataDir })
+
+    expect(second.status).toBe('unchanged')
+    expect((await readFile(join(paths.root, 'retained-index.v1.json'), 'utf8'))).toContain('metrora.canonical-history-retained-index')
+    expect((await readCanonicalHistoryShadowHeadV1({ dataDir }))?.projectionSha256).toBe(first.projectionSha256)
+  })
+
   it('advances the head without deleting earlier snapshots and reports retained-only identities', async () => {
     const dataDir = await temporaryDataDir()
     const first = await persistCanonicalHistoryShadowV1(projection('a'), { dataDir })

--- a/src/local-state/canonical-history-shadow-store.ts
+++ b/src/local-state/canonical-history-shadow-store.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'node:crypto'
-import { readdir } from 'node:fs/promises'
+import { stat } from 'node:fs/promises'
 import { join } from 'node:path'
 import * as z from 'zod/v4'
 
@@ -20,9 +20,24 @@ import {
   ensureCanonicalHistoryCliHeadlineIndexV1,
   prepareCanonicalHistoryCliHeadlineIndexStoreV1,
 } from './canonical-history-cli-headline-index-store.js'
+import {
+  buildCanonicalHistoryPublicationStateV1,
+  writeCanonicalHistoryPublicationStateV1,
+  type CanonicalHistoryPublicationSourceV1,
+} from './canonical-history-publication-state.js'
+import {
+  addCurrentProjectionToCanonicalHistoryRetainedV1,
+  assertActivitiesCompatibleWithCanonicalHistoryRetainedV1,
+  assertCompatibleWithCanonicalHistoryRetainedV1,
+  canonicalHistoryActivityPayloadIsOrderedExtensionV1,
+  readCanonicalHistoryRetainedIndexV1,
+  writeCanonicalHistoryRetainedIndexV1,
+} from './canonical-history-retained-index.js'
+import { CanonicalHistoryShadowStoreIntegrityError } from './canonical-history-shadow-errors.js'
 import { defaultMetroraDataDir } from './endpoint-identity.js'
 import { withLocalStateLease } from './local-state-lease.js'
 import { canonicalizeRfc8785 } from '../vendor/rfc8785-canonicalize.js'
+
 export const CANONICAL_HISTORY_SHADOW_SNAPSHOT_KIND = 'metrora.canonical-history-shadow-snapshot' as const
 export const CANONICAL_HISTORY_SHADOW_HEAD_KIND = 'metrora.canonical-history-shadow-head' as const
 export const CANONICAL_HISTORY_SHADOW_STORE_VERSION = 1 as const
@@ -53,6 +68,9 @@ export type CanonicalHistoryShadowStoreOptions = {
   now?: () => Date
   authorityGeneration?: CurrentCacheAuthorityGenerationV1
   analyticsGenerationId?: string
+  endpointScopeSha256?: string
+  sourceIndex?: CanonicalHistoryPublicationSourceV1[]
+  previousState?: CanonicalHistoryShadowLoadedStateV1
   /** Optional diagnostic timing hook; it never changes publication semantics. */
   onHeadlineIndexPersisted?: (elapsedMs: number) => void
 }
@@ -80,25 +98,20 @@ export type PersistCanonicalHistoryShadowResultV1 = {
   reconciliation: CanonicalHistoryShadowReconciliationV1
 }
 
-export class CanonicalHistoryShadowStoreIntegrityError extends Error {
-  constructor(message: string) {
-    super(message)
-    this.name = 'CanonicalHistoryShadowStoreIntegrityError'
-  }
-}
+export { CanonicalHistoryShadowStoreIntegrityError } from './canonical-history-shadow-errors.js'
 
 type EntityIndex = Map<string, string>
 
-type ProjectionIndex = {
+export type CanonicalHistoryShadowProjectionIndexV1 = {
   observations: EntityIndex
   activities: EntityIndex
   dailySnapshots: EntityIndex
 }
 
-type RetainedProjectionIndex = {
-  observations: EntityIndex
-  activities: Map<string, string[]>
-  dailySnapshots: EntityIndex
+export type CanonicalHistoryShadowLoadedStateV1 = {
+  head: CanonicalHistoryShadowHeadV1
+  snapshot: CanonicalHistoryShadowSnapshotV1
+  index: CanonicalHistoryShadowProjectionIndexV1
 }
 
 const FORBIDDEN_PERSISTED_KEYS = new Set([
@@ -178,7 +191,7 @@ function indexEntities(
   return index
 }
 
-function indexProjection(value: unknown): ProjectionIndex {
+function indexProjection(value: unknown): CanonicalHistoryShadowProjectionIndexV1 {
   const projection = objectRecord(value, 'projection')
   if (projection.version !== CANONICAL_HISTORY_READ_PROJECTION_VERSION) {
     throw new CanonicalHistoryShadowStoreIntegrityError('shadow projection has an unsupported version')
@@ -197,154 +210,6 @@ function indexProjection(value: unknown): ProjectionIndex {
     observations: indexEntities(projection.observations, 'projection.observations', 'observationId'),
     activities: indexEntities(projection.activities, 'projection.activities', 'activityId'),
     dailySnapshots: indexEntities(projection.dailySnapshots, 'projection.dailySnapshots', 'snapshotId'),
-  }
-}
-
-function mergeEntityIndex(target: EntityIndex, incoming: EntityIndex, label: string): void {
-  for (const [id, payload] of incoming) {
-    const prior = target.get(id)
-    if (prior !== undefined && prior !== payload) {
-      throw new CanonicalHistoryShadowStoreIntegrityError(
-        `${label} identity ${id} conflicts with retained shadow history`,
-      )
-    }
-    target.set(id, prior ?? payload)
-  }
-}
-
-async function readRetainedIndex(
-  paths: ReturnType<typeof canonicalHistoryShadowPathsV1>,
-): Promise<RetainedProjectionIndex> {
-  const retained: RetainedProjectionIndex = {
-    observations: new Map(),
-    activities: new Map(),
-    dailySnapshots: new Map(),
-  }
-  const entries = await readdir(paths.snapshots, { withFileTypes: true })
-  for (const entry of entries.sort((a, b) => a.name.localeCompare(b.name))) {
-    if (!entry.isFile() || entry.name.includes('.metrora-tmp-')) continue
-    const match = /^([a-f0-9]{64})\.json$/u.exec(entry.name)
-    if (!match) {
-      throw new CanonicalHistoryShadowStoreIntegrityError(
-        `canonical history shadow contains unexpected snapshot file ${entry.name}`,
-      )
-    }
-    const digest = match[1]!
-    const bytes = await readOptionalPrivateFile(join(paths.snapshots, entry.name))
-    if (!bytes) {
-      throw new CanonicalHistoryShadowStoreIntegrityError(
-        `canonical history shadow snapshot ${entry.name} disappeared during reconciliation`,
-      )
-    }
-    const parsed = parseSnapshot(bytes, digest)
-    mergeEntityIndex(retained.observations, parsed.index.observations, 'observation')
-    for (const [id, payload] of parsed.index.activities) {
-      const history = retained.activities.get(id) ?? []
-      for (const prior of history) {
-        if (!activityPayloadsCanBeRevisions(prior, payload)) {
-          throw new CanonicalHistoryShadowStoreIntegrityError(
-            `activity identity ${id} conflicts with retained shadow history`,
-          )
-        }
-      }
-      if (!history.includes(payload)) history.push(payload)
-      retained.activities.set(id, history)
-    }
-    mergeEntityIndex(retained.dailySnapshots, parsed.index.dailySnapshots, 'daily snapshot')
-  }
-  return retained
-}
-
-function assertCompatibleWithRetainedHistory(
-  retained: RetainedProjectionIndex,
-  current: ProjectionIndex,
-): void {
-  for (const [label, previous, next] of [
-    ['observation', retained.observations, current.observations],
-    ['daily snapshot', retained.dailySnapshots, current.dailySnapshots],
-  ] as const) {
-    for (const [id, payload] of next) {
-      const prior = previous.get(id)
-      if (prior !== undefined && prior !== payload) {
-        throw new CanonicalHistoryShadowStoreIntegrityError(
-          `${label} identity ${id} conflicts with retained shadow history`,
-        )
-      }
-    }
-  }
-}
-
-type ActivityPayload = {
-  collector: string
-  timestamp: string
-  observationIds: string[]
-}
-
-function decodeActivityPayload(payload: string): ActivityPayload {
-  let value: unknown
-  try {
-    value = JSON.parse(payload)
-  } catch {
-    throw new CanonicalHistoryShadowStoreIntegrityError('retained activity payload is not valid JSON')
-  }
-  const record = objectRecord(value, 'retained activity')
-  const collector = record.collector
-  const timestamp = record.timestamp
-  const observationIds = record.observationIds
-  if (
-    typeof collector !== 'string'
-    || typeof timestamp !== 'string'
-    || !Array.isArray(observationIds)
-    || observationIds.some(id => typeof id !== 'string')
-  ) {
-    throw new CanonicalHistoryShadowStoreIntegrityError('retained activity payload is malformed')
-  }
-  return { collector, timestamp, observationIds: [...observationIds] as string[] }
-}
-
-function activityPayloadIsOrderedExtension(
-  priorPayload: string,
-  nextPayload: string,
-): boolean {
-  const prior = decodeActivityPayload(priorPayload)
-  const next = decodeActivityPayload(nextPayload)
-  if (prior.collector !== next.collector || prior.timestamp !== next.timestamp) return false
-  return prior.observationIds.length <= next.observationIds.length
-    && prior.observationIds.every((id, index) => next.observationIds[index] === id)
-}
-
-function activityPayloadsCanBeRevisions(leftPayload: string, rightPayload: string): boolean {
-  return activityPayloadIsOrderedExtension(leftPayload, rightPayload)
-    || activityPayloadIsOrderedExtension(rightPayload, leftPayload)
-}
-
-function assertActivitiesCompatibleWithRetainedHistory(
-  retained: Map<string, string[]>,
-  previous: EntityIndex | undefined,
-  current: EntityIndex,
-): void {
-  for (const [id, payload] of current) {
-    const history = retained.get(id) ?? []
-    for (const prior of history) {
-      // A current activity may be unchanged or may append observations to a
-      // retained revision. Regressing to a weaker payload is not a refresh;
-      // it would lose an observation from the current canonical projection.
-      if (prior !== payload && !activityPayloadIsOrderedExtension(prior, payload)) {
-        throw new CanonicalHistoryShadowStoreIntegrityError(
-          `activity identity ${id} conflicts with retained shadow history`,
-        )
-      }
-    }
-    const previousPayload = previous?.get(id)
-    if (
-      previousPayload !== undefined
-      && previousPayload !== payload
-      && !activityPayloadIsOrderedExtension(previousPayload, payload)
-    ) {
-      throw new CanonicalHistoryShadowStoreIntegrityError(
-        `activity identity ${id} resolved to a non-monotonic revision`,
-      )
-    }
   }
 }
 
@@ -375,8 +240,8 @@ function reconcileEntities(
 }
 
 function reconcileProjection(
-  previous: ProjectionIndex | undefined,
-  current: ProjectionIndex,
+  previous: CanonicalHistoryShadowProjectionIndexV1 | undefined,
+  current: CanonicalHistoryShadowProjectionIndexV1,
 ): CanonicalHistoryShadowReconciliationV1 {
   const activities = reconcileActivities(previous?.activities, current.activities)
   return {
@@ -404,7 +269,7 @@ function reconcileActivities(
       unchanged++
       continue
     }
-    if (!activityPayloadIsOrderedExtension(prior, payload)) {
+    if (!canonicalHistoryActivityPayloadIsOrderedExtensionV1(prior, payload)) {
       throw new CanonicalHistoryShadowStoreIntegrityError(
         `activity identity ${id} resolved to a conflicting payload`,
       )
@@ -442,7 +307,7 @@ async function prepare(paths: ReturnType<typeof canonicalHistoryShadowPathsV1>):
 function parseSnapshot(
   bytes: Uint8Array,
   expectedDigest: string,
-): { record: CanonicalHistoryShadowSnapshotV1; index: ProjectionIndex } {
+): { record: CanonicalHistoryShadowSnapshotV1; index: CanonicalHistoryShadowProjectionIndexV1 } {
   let record: CanonicalHistoryShadowSnapshotV1
   try {
     record = CanonicalHistoryShadowSnapshotV1Schema.parse(JSON.parse(Buffer.from(bytes).toString('utf-8')))
@@ -469,7 +334,7 @@ function parseHead(bytes: Uint8Array): CanonicalHistoryShadowHeadV1 {
 
 async function readHeadSnapshot(
   paths: ReturnType<typeof canonicalHistoryShadowPathsV1>,
-): Promise<{ head: CanonicalHistoryShadowHeadV1; snapshot: CanonicalHistoryShadowSnapshotV1; index: ProjectionIndex } | undefined> {
+): Promise<CanonicalHistoryShadowLoadedStateV1 | undefined> {
   const headBytes = await readOptionalPrivateFile(paths.head)
   if (!headBytes) return undefined
   const head = parseHead(headBytes)
@@ -479,6 +344,21 @@ async function readHeadSnapshot(
   }
   const parsed = parseSnapshot(snapshotBytes, head.projectionSha256)
   return { head, snapshot: parsed.record, index: parsed.index }
+}
+
+async function usePreviousStateIfCurrent(
+  paths: ReturnType<typeof canonicalHistoryShadowPathsV1>,
+  candidate: CanonicalHistoryShadowLoadedStateV1 | undefined,
+): Promise<CanonicalHistoryShadowLoadedStateV1 | undefined> {
+  if (!candidate) return readHeadSnapshot(paths)
+  const headBytes = await readOptionalPrivateFile(paths.head)
+  if (!headBytes) return readHeadSnapshot(paths)
+  const head = parseHead(headBytes)
+  if (
+    head.projectionSha256 === candidate.head.projectionSha256
+    && head.snapshotSha256 === candidate.head.snapshotSha256
+  ) return candidate
+  return readHeadSnapshot(paths)
 }
 
 export async function persistCanonicalHistoryShadowV1(
@@ -494,11 +374,12 @@ export async function persistCanonicalHistoryShadowV1(
   await prepare(paths)
 
   return withLocalStateLease(paths.root, async () => {
-    const previous = await readHeadSnapshot(paths)
-    const retained = await readRetainedIndex(paths)
-    assertCompatibleWithRetainedHistory(retained, currentIndex)
-    assertActivitiesCompatibleWithRetainedHistory(retained.activities, previous?.index.activities, currentIndex.activities)
+    const previous = await usePreviousStateIfCurrent(paths, options.previousState)
+    const retained = await readCanonicalHistoryRetainedIndexV1(paths, parseSnapshot)
+    assertCompatibleWithCanonicalHistoryRetainedV1(retained, currentIndex)
+    assertActivitiesCompatibleWithCanonicalHistoryRetainedV1(retained.activities, previous?.index.activities, currentIndex.activities)
     const previousDigest = previous?.head.projectionSha256
+    const reconciliation = reconcileProjection(previous?.index, currentIndex)
     const targetPath = snapshotPath(paths, projectionSha256)
     const targetBytes = await readOptionalPrivateFile(targetPath)
     const target = targetBytes ? parseSnapshot(targetBytes, projectionSha256) : undefined
@@ -506,8 +387,6 @@ export async function persistCanonicalHistoryShadowV1(
     if (target && canonicalProjectionJson(target.record.projection) !== canonicalProjectionJson(projection)) {
       throw new CanonicalHistoryShadowStoreIntegrityError('canonical history shadow digest collision')
     }
-
-    const reconciliation = reconcileProjection(previous?.index, currentIndex)
 
     let immutableSnapshotBytes = targetBytes
     if (!target) {
@@ -523,6 +402,9 @@ export async function persistCanonicalHistoryShadowV1(
     }
     if (!immutableSnapshotBytes) throw new CanonicalHistoryShadowStoreIntegrityError('canonical history shadow snapshot bytes are unavailable')
     const snapshotSha256 = canonicalHistoryShadowSnapshotSha256V1(immutableSnapshotBytes)
+    const targetInfo = await stat(targetPath)
+    addCurrentProjectionToCanonicalHistoryRetainedV1(retained, currentIndex, projectionSha256, snapshotSha256, targetInfo)
+    await writeCanonicalHistoryRetainedIndexV1(paths, retained)
 
     const headlineIndexStartedAt = performance.now()
     await ensureCanonicalHistoryCliHeadlineIndexV1({
@@ -534,10 +416,39 @@ export async function persistCanonicalHistoryShadowV1(
         ? {
             ...authorityGenerationForSidecarV1(options.authorityGeneration),
             ...(options.analyticsGenerationId ? { analyticsGenerationId: options.analyticsGenerationId } : {}),
+            ...(options.endpointScopeSha256 ? { endpointScopeSha256: options.endpointScopeSha256 } : {}),
+          }
+        : undefined,
+      previous: previous
+        ? {
+            projection: previous.snapshot.projection as CanonicalHistoryReadProjectionV1,
+            projectionSha256: previous.head.projectionSha256,
+            snapshotSha256: previous.head.snapshotSha256 ?? canonicalHistoryShadowSnapshotSha256V1(
+              Buffer.from(JSON.stringify(previous.snapshot), 'utf8'),
+            ),
           }
         : undefined,
     })
     options.onHeadlineIndexPersisted?.(performance.now() - headlineIndexStartedAt)
+
+    if (
+      options.authorityGeneration
+      && options.analyticsGenerationId
+      && options.endpointScopeSha256
+      && options.sourceIndex
+    ) {
+      const state = buildCanonicalHistoryPublicationStateV1({
+        endpointScopeSha256: options.endpointScopeSha256,
+        analyticsGenerationId: options.analyticsGenerationId,
+        sessionPayloadSha256: options.authorityGeneration.session.payloadSha256,
+        dailyPayloadSha256: options.authorityGeneration.daily.payloadSha256,
+        sourceManifestSha256: options.authorityGeneration.session.sourceManifestSha256,
+        projectionSha256,
+        snapshotSha256,
+        sources: options.sourceIndex,
+      })
+      await writeCanonicalHistoryPublicationStateV1(dataDir, state)
+    }
 
     if (previousDigest === projectionSha256 && previous?.head.snapshotSha256 === snapshotSha256) {
       return {
@@ -575,6 +486,13 @@ export async function readCanonicalHistoryShadowHeadV1(
   const paths = canonicalHistoryShadowPathsV1(options.dataDir ?? defaultMetroraDataDir())
   const loaded = await readHeadSnapshot(paths)
   return loaded?.head
+}
+
+export async function readCanonicalHistoryShadowStateV1(
+  options: Pick<CanonicalHistoryShadowStoreOptions, 'dataDir'> = {},
+): Promise<CanonicalHistoryShadowLoadedStateV1 | undefined> {
+  const paths = canonicalHistoryShadowPathsV1(options.dataDir ?? defaultMetroraDataDir())
+  return readHeadSnapshot(paths)
 }
 
 export function parseCanonicalHistoryShadowHeadV1(bytes: Uint8Array): CanonicalHistoryShadowHeadV1 {

--- a/src/local-state/canonical-history-shadow-store.ts
+++ b/src/local-state/canonical-history-shadow-store.ts
@@ -34,6 +34,12 @@ import {
   writeCanonicalHistoryRetainedIndexV1,
 } from './canonical-history-retained-index.js'
 import { CanonicalHistoryShadowStoreIntegrityError } from './canonical-history-shadow-errors.js'
+import {
+  clearCanonicalHistoryShadowTrustMemoV1 as clearPublicationTrustMemoV1,
+  readCanonicalHistoryPublicationTrustV1,
+  rememberCanonicalHistoryPublicationTrustV1,
+  type CanonicalHistoryShadowPublicationTrustV1,
+} from './canonical-history-publication-trust.js'
 import { defaultMetroraDataDir } from './endpoint-identity.js'
 import { withLocalStateLease } from './local-state-lease.js'
 import { canonicalizeRfc8785 } from '../vendor/rfc8785-canonicalize.js'
@@ -283,7 +289,14 @@ function reconcileActivities(
   return { added, unchanged, revised, retainedOnly }
 }
 
-export function canonicalHistoryShadowPathsV1(dataDir: string) {
+export type CanonicalHistoryShadowPathsV1 = {
+  root: string
+  snapshots: string
+  headlineIndexes: string
+  head: string
+}
+
+export function canonicalHistoryShadowPathsV1(dataDir: string): CanonicalHistoryShadowPathsV1 {
   const root = join(dataDir, 'history-shadow', 'v1')
   return {
     root,
@@ -332,6 +345,22 @@ function parseHead(bytes: Uint8Array): CanonicalHistoryShadowHeadV1 {
   }
 }
 
+export type { CanonicalHistoryShadowPublicationTrustV1 } from './canonical-history-publication-trust.js'
+export const clearCanonicalHistoryShadowTrustMemoV1 = clearPublicationTrustMemoV1
+
+export async function readCanonicalHistoryShadowPublicationTrustV1(
+  options: Pick<CanonicalHistoryShadowStoreOptions, 'dataDir'> = {},
+): Promise<CanonicalHistoryShadowPublicationTrustV1 | undefined> {
+  const dataDir = options.dataDir ?? defaultMetroraDataDir()
+  const paths = canonicalHistoryShadowPathsV1(dataDir)
+  return readCanonicalHistoryPublicationTrustV1({
+    dataDir,
+    paths,
+    parseHead,
+    parseSnapshot,
+  })
+}
+
 async function readHeadSnapshot(
   paths: ReturnType<typeof canonicalHistoryShadowPathsV1>,
 ): Promise<CanonicalHistoryShadowLoadedStateV1 | undefined> {
@@ -374,6 +403,10 @@ export async function persistCanonicalHistoryShadowV1(
   await prepare(paths)
 
   return withLocalStateLease(paths.root, async () => {
+    // A compact retained index is acceleration evidence only. If this is the
+    // first publication in a process with an existing head, establish the
+    // canonical deep-validation trust boundary before reading it.
+    await readCanonicalHistoryShadowPublicationTrustV1({ dataDir })
     const previous = await usePreviousStateIfCurrent(paths, options.previousState)
     const retained = await readCanonicalHistoryRetainedIndexV1(paths, parseSnapshot)
     assertCompatibleWithCanonicalHistoryRetainedV1(retained, currentIndex)
@@ -450,6 +483,21 @@ export async function persistCanonicalHistoryShadowV1(
       await writeCanonicalHistoryPublicationStateV1(dataDir, state)
     }
 
+    let head: CanonicalHistoryShadowHeadV1
+    if (previousDigest === projectionSha256 && previous?.head.snapshotSha256 === snapshotSha256) {
+      head = previous.head
+    } else {
+      head = CanonicalHistoryShadowHeadV1Schema.parse({
+        kind: CANONICAL_HISTORY_SHADOW_HEAD_KIND,
+        version: CANONICAL_HISTORY_SHADOW_STORE_VERSION,
+        projectionSha256,
+        snapshotSha256,
+        updatedAt: now().toISOString(),
+      })
+      await atomicWritePrivateFile(paths.head, JSON.stringify(head))
+    }
+    await rememberCanonicalHistoryPublicationTrustV1(dataDir, paths, head, retained)
+
     if (previousDigest === projectionSha256 && previous?.head.snapshotSha256 === snapshotSha256) {
       return {
         status: 'unchanged' as const,
@@ -457,15 +505,6 @@ export async function persistCanonicalHistoryShadowV1(
         reconciliation,
       }
     }
-
-    const head = CanonicalHistoryShadowHeadV1Schema.parse({
-      kind: CANONICAL_HISTORY_SHADOW_HEAD_KIND,
-      version: CANONICAL_HISTORY_SHADOW_STORE_VERSION,
-      projectionSha256,
-      snapshotSha256,
-      updatedAt: now().toISOString(),
-    })
-    await atomicWritePrivateFile(paths.head, JSON.stringify(head))
 
     return {
       status: previous


### PR DESCRIPTION
## Summary

- Cache the exact unchanged C3 publication state after canonical content has been deep-validated.
- Deep-validate the head snapshot and retained snapshot set at a cold process trust boundary before using durable acceleration state.
- Rebuild the derived retained index safely when it is missing or malformed, while rejecting snapshot content that no longer matches its prior seal.
- Preserve bounded source-delta publication for ordinary appends, canonical identity/parity, retained history, activity revisions, source deletion, and the terminal consumer boundary.

## Scope

This change is primarily an exact-unchanged publication optimization. Ordinary append publication remains a partial acceleration path; the full immutable snapshot format is unchanged.

## Performance evidence

On the same real local corpus:

- Same-process unchanged publication: approximately 0.84s after trust is established.
- Cold/restart trust validation: approximately 16.8s and includes cryptographic validation of the retained snapshot set.
- Ordinary small append: approximately 20.6s, unchanged from the prior scope.
- The prior main baseline was approximately 37.7s for unchanged publication and 25.1s for a small append.

## Integrity and validation

- Terminal fast reads remain compact, parity-gated, and do not hash the full snapshot.
- The canonical publisher does not use the terminal fast reader as an integrity authority.
- Adversarial same-length, same-stat snapshot mutation after clearing the process trust memo is rejected without advancing the head.
- Focused canonical publication, retained-history, projection/parity, headline, CLI lifecycle, and five-generation terminal soak tests pass.
- TypeScript, CLI build, source-size, version, public identity, public boundary, and whitespace checks pass.

No terminal consumer, Store/release asset, or CI gate changes are included.