### PR TITLE
fix: recover canonical history publication across local upgrades

### DIFF
--- a/src/cache-generation.ts
+++ b/src/cache-generation.ts
@@ -19,6 +19,20 @@ type FingerprintFields = {
   sqliteWal?: { mtimeMs: number; sizeBytes: number }
 }
 
+type CachePayloadEvidenceV1 = {
+  payload: string
+  payloadSha256: string
+}
+
+// The normal refresh lifecycle may hand publication a sanitized in-memory
+// object whose property insertion order is not the same as the immutable
+// bytes that were sealed by the cache save. Keep the exact completed payload
+// process-local and bind it to the object through a WeakMap. This is evidence,
+// not authority: publication still verifies the generation sidecar digest and
+// that the object has not changed since the evidence was attached.
+const sessionCachePayloadEvidence = new WeakMap<object, CachePayloadEvidenceV1>()
+const dailyCachePayloadEvidence = new WeakMap<object, CachePayloadEvidenceV1>()
+
 export type SessionSourceGenerationFileV1 = {
   pathSha256: string
   fingerprint: FingerprintFields
@@ -115,6 +129,42 @@ const DailyGenerationSchema = z.strictObject({
 
 function sha256(value: Uint8Array | string): string {
   return createHash('sha256').update(value).digest('hex')
+}
+
+function payloadText(payload: Uint8Array | string): string {
+  return typeof payload === 'string' ? payload : Buffer.from(payload).toString('utf8')
+}
+
+export function rememberSessionCachePayloadEvidenceV1(
+  cache: SessionCache,
+  payload: Uint8Array | string,
+): void {
+  const text = payloadText(payload)
+  sessionCachePayloadEvidence.set(cache, { payload: text, payloadSha256: sha256(text) })
+}
+
+export function rememberDailyCachePayloadEvidenceV1(
+  cache: DailyCache,
+  payload: Uint8Array | string,
+): void {
+  const text = payloadText(payload)
+  dailyCachePayloadEvidence.set(cache, { payload: text, payloadSha256: sha256(text) })
+}
+
+export function sessionCachePayloadEvidenceV1(cache: SessionCache): CachePayloadEvidenceV1 | undefined {
+  return sessionCachePayloadEvidence.get(cache)
+}
+
+export function dailyCachePayloadEvidenceV1(cache: DailyCache): CachePayloadEvidenceV1 | undefined {
+  return dailyCachePayloadEvidence.get(cache)
+}
+
+export function cachePayloadMatchesValueV1(payload: Uint8Array | string, value: unknown): boolean {
+  try {
+    return canonicalizeRfc8785(JSON.parse(payloadText(payload))) === canonicalizeRfc8785(value)
+  } catch {
+    return false
+  }
 }
 
 export function cachePayloadSha256V1(payload: Uint8Array | string): string {

--- a/src/daily-cache.ts
+++ b/src/daily-cache.ts
@@ -7,6 +7,7 @@ import type { DateRange, ProjectSummary } from './types.js'
 import { aggregateProjectsIntoDays, dateKeyInTz } from './day-aggregator.js'
 import { mergeTimezoneRebucketedDays } from './daily-cache-tz-reconcile.js'
 import * as core from './daily-cache-core.js'
+import { rememberDailyCachePayloadEvidenceV1 } from './cache-generation.js'
 
 export * from './daily-cache-core.js'
 
@@ -88,6 +89,12 @@ export async function loadDailyCache(): Promise<DailyCache> {
       await core.saveDailyCache(cache).catch(() => {})
     }
   }
+  try {
+    const payload = await readFile(core.dailyCachePath(), 'utf-8')
+    rememberDailyCachePayloadEvidenceV1(cache, payload)
+  } catch {
+    // The generation sidecar check below remains the publication authority.
+  }
   return cache
 }
 
@@ -99,6 +106,7 @@ export async function saveDailyCache(cache: DailyCache): Promise<void> {
     delete persisted.watermarkTrusted
   }
   await core.saveDailyCache(persisted)
+  rememberDailyCachePayloadEvidenceV1(cache, JSON.stringify(persisted))
 }
 
 export function addNewDays(cache: DailyCache, incoming: core.DailyEntry[], newestDate: string): DailyCache {

--- a/src/local-state/canonical-history-analytics-publication.test.ts
+++ b/src/local-state/canonical-history-analytics-publication.test.ts
@@ -3,10 +3,10 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
 
-import { currentTzKey, emptyCache as emptyDailyCache, saveDailyCache, type DailyCache } from '../daily-cache.js'
+import { currentTzKey, dailyCachePath, emptyCache as emptyDailyCache, loadDailyCache, saveDailyCache, type DailyCache } from '../daily-cache.js'
 import { readCurrentDailyCacheGenerationV1, readCurrentSessionCacheGenerationV1 } from '../cache-generation.js'
 import { isSnapshotReadMode } from '../read-lifecycle.js'
-import { CACHE_VERSION, emptyCache as emptySessionCache, saveCache, sessionCachePath, type CachedCall, type SessionCache } from '../session-cache.js'
+import { CACHE_VERSION, emptyCache as emptySessionCache, loadCache, saveCache, sessionCachePath, type CachedCall, type SessionCache } from '../session-cache.js'
 import { readC3CliStatusBatchV1 } from './canonical-history-cli-dual-read.js'
 import {
   canonicalSourceRecordFingerprintSha256V1,
@@ -114,6 +114,17 @@ async function setup(): Promise<{ dataDir: string; session: SessionCache; daily:
   return { dataDir, session, daily, endpointId: identity.metadata.endpointId }
 }
 
+async function setupWithoutEndpointIdentity(): Promise<{ dataDir: string; session: SessionCache; daily: DailyCache }> {
+  const root = await mkdtemp(join(tmpdir(), 'metrora-analytics-unbound-'))
+  roots.push(root)
+  process.env['METRORA_CACHE_DIR'] = join(root, 'cache')
+  const session = sessionCache()
+  const daily = dailyCache()
+  await saveCache(session)
+  await saveDailyCache(daily)
+  return { dataDir: join(root, 'data'), session, daily }
+}
+
 describe('generic canonical analytics publication boundary', () => {
   it('publishes from the exact completed cache objects and makes the bound headline readable', async () => {
     const { dataDir, session, daily, endpointId } = await setup()
@@ -160,6 +171,52 @@ describe('generic canonical analytics publication boundary', () => {
     })).toMatch(/^[a-f0-9]{64}$/u)
   })
 
+  it('seals the exact persisted objects even when normal daily hydration reordered fields', async () => {
+    const { dataDir, endpointId } = await setup()
+    const persistedSession = JSON.parse(await readFile(sessionCachePath(), 'utf8')) as SessionCache
+    const persistedDaily = JSON.parse(await readFile(dailyCachePath(), 'utf8')) as DailyCache
+
+    await expect(publishCanonicalHistoryAnalyticsV1({
+      sessionCache: persistedSession,
+      dailyCache: persistedDaily,
+      dataDir,
+      endpointId,
+      now: () => NOW,
+    })).resolves.toMatchObject({ status: 'published', parity: { outcome: 'matched' } })
+  })
+
+  it('seals the exact completed objects returned by the normal refresh loaders', async () => {
+    const { dataDir, endpointId } = await setup()
+    const loadedSession = await loadCache()
+    const loadedDaily = await loadDailyCache()
+
+    await expect(publishCanonicalHistoryAnalyticsV1({
+      sessionCache: loadedSession,
+      dailyCache: loadedDaily,
+      dataDir,
+      endpointId,
+      now: () => NOW,
+    })).resolves.toMatchObject({ status: 'published', parity: { outcome: 'matched' } })
+  })
+
+  it('fails closed without a canonical endpoint identity and does not invent one', async () => {
+    const { dataDir, session, daily } = await setupWithoutEndpointIdentity()
+    const result = await publishCanonicalHistoryAnalyticsV1({ sessionCache: session, dailyCache: daily, dataDir, now: () => NOW })
+
+    expect(result).toMatchObject({ status: 'failed', reason: 'endpoint-identity-unavailable' })
+    expect(await readFile(join(dataDir, 'identity', 'endpoint-identity.v1.json')).catch(() => undefined)).toBeUndefined()
+    expect(await readFile(join(canonicalHistoryShadowPathsV1(dataDir).root, 'head.json')).catch(() => undefined)).toBeUndefined()
+  })
+
+  it('accepts a trusted host-supplied endpoint scope without Workspace or key-material access', async () => {
+    const { dataDir, session, daily } = await setupWithoutEndpointIdentity()
+    const endpointId = 'host-supplied-endpoint-111111111111111111111111'
+    const result = await publishCanonicalHistoryAnalyticsV1({ sessionCache: session, dailyCache: daily, dataDir, endpointId, now: () => NOW })
+
+    expect(result).toMatchObject({ status: 'published', parity: { outcome: 'matched' } })
+    expect(await readFile(join(dataDir, 'identity', 'endpoint-identity.v1.json')).catch(() => undefined)).toBeUndefined()
+  })
+
   it('skips an exactly unchanged analytics generation without rebuilding the projection', async () => {
     const { dataDir, session, daily, endpointId } = await setup()
     const first = await publishCanonicalHistoryAnalyticsV1({ sessionCache: session, dailyCache: daily, dataDir, endpointId, now: () => NOW })
@@ -178,6 +235,21 @@ describe('generic canonical analytics publication boundary', () => {
     expect(second.timingsMs.parityMs).toBe(0)
     expect(second.timingsMs.shadowPersistenceMs).toBe(0)
     expect(await readFile(join(canonicalHistoryShadowPathsV1(dataDir).root, 'head.json'))).toEqual(before)
+  })
+
+  it('fails closed when a supplied endpoint scope conflicts with the established C3 scope', async () => {
+    const { dataDir, session, daily, endpointId } = await setup()
+    const first = await publishCanonicalHistoryAnalyticsV1({ sessionCache: session, dailyCache: daily, dataDir, endpointId, now: () => NOW })
+    expect(first.status).toBe('published')
+
+    const conflicting = await publishCanonicalHistoryAnalyticsV1({
+      sessionCache: session,
+      dailyCache: daily,
+      dataDir,
+      endpointId: 'bbbbbbbb-cccc-4ddd-8eee-ffffffffffff',
+      now: () => NOW,
+    })
+    expect(conflicting).toMatchObject({ status: 'failed', reason: 'endpoint-scope-mismatch' })
   })
 
   it('does not trust a same-stat mutated snapshot after a cold trust lifecycle', async () => {
@@ -329,6 +401,25 @@ describe('generic canonical analytics publication boundary', () => {
     expect(result).toMatchObject({ status: 'skipped', reason: 'snapshot-read' })
     expect(result.projectionSha256).toBeUndefined()
     expect(await readFile(join(canonicalHistoryShadowPathsV1(dataDir).root, 'head.json')).catch(() => null)).toBeNull()
+  })
+
+  it('rejects a stale in-memory object against a newer cache generation sidecar', async () => {
+    const { dataDir, session, daily, endpointId } = await setup()
+    const stale = structuredClone(session)
+    const newer = structuredClone(session)
+    const file = newer.providers.codex!.files['C:\\private\\codex-session.jsonl']!
+    file.turns[0]!.calls.push(call({ deduplicationKey: 'codex:test:newer-generation' }))
+    file.fingerprint.sizeBytes += 1
+    await saveCache(newer)
+
+    const result = await publishCanonicalHistoryAnalyticsV1({
+      sessionCache: stale,
+      dailyCache: daily,
+      dataDir,
+      endpointId,
+      now: () => NOW,
+    })
+    expect(result).toMatchObject({ status: 'failed', reason: 'generation-seal-failed' })
   })
 
   it('fails closed when the lifecycle stamps do not bind the provided objects', async () => {

--- a/src/local-state/canonical-history-analytics-publication.ts
+++ b/src/local-state/canonical-history-analytics-publication.ts
@@ -6,8 +6,11 @@ import { canonicalizeRfc8785 } from '../vendor/rfc8785-canonicalize.js'
 import { DAILY_CACHE_VERSION, dailyCachePath, type DailyCache } from '../daily-cache.js'
 import {
   authorityGenerationForSidecarV1,
+  cachePayloadMatchesValueV1,
+  dailyCachePayloadEvidenceV1,
   readDailyCacheGenerationV1,
   readSessionCacheGenerationV1,
+  sessionCachePayloadEvidenceV1,
   type CurrentCacheAuthorityGenerationV1,
 } from '../cache-generation.js'
 import { isSnapshotReadMode } from '../read-lifecycle.js'
@@ -124,6 +127,7 @@ export type CanonicalHistoryAnalyticsPublicationV1 = {
     | 'incomplete-session-authority'
     | 'untrusted-daily-authority'
     | 'endpoint-identity-unavailable'
+    | 'endpoint-scope-mismatch'
     | 'generation-seal-failed'
     | 'unchanged-generation'
     | 'parity-failed'
@@ -204,8 +208,14 @@ export async function publishCanonicalHistoryAnalyticsV1(
   const dailyForPayload = { ...options.dailyCache } as DailyCache
   if (options.dailyCache.watermarkTrusted === true) dailyForPayload.watermarkTrusted = true
   else delete dailyForPayload.watermarkTrusted
-  const sessionPayload = JSON.stringify(sessionForPayload)
-  const dailyPayload = JSON.stringify(dailyForPayload)
+  const sessionEvidence = sessionCachePayloadEvidenceV1(sessionCache)
+  const dailyEvidence = dailyCachePayloadEvidenceV1(options.dailyCache)
+  const sessionPayload = sessionEvidence
+    ? cachePayloadMatchesValueV1(sessionEvidence.payload, sessionForPayload) ? sessionEvidence.payload : undefined
+    : JSON.stringify(sessionForPayload)
+  const dailyPayload = dailyEvidence
+    ? cachePayloadMatchesValueV1(dailyEvidence.payload, dailyForPayload) ? dailyEvidence.payload : undefined
+    : JSON.stringify(dailyForPayload)
   let authorityGeneration: CurrentCacheAuthorityGenerationV1
   let generation: CanonicalHistoryAnalyticsGenerationV1
   const generationStartedAt = performance.now()
@@ -217,7 +227,7 @@ export async function publishCanonicalHistoryAnalyticsV1(
       readSessionCacheGenerationV1(sessionCachePath()),
       readDailyCacheGenerationV1(dailyCachePath()),
     ])
-    if (!session || !daily || session.payloadSha256 !== sha256(sessionPayload) || daily.payloadSha256 !== sha256(dailyPayload)) {
+    if (!session || !daily || !sessionPayload || !dailyPayload || session.payloadSha256 !== sha256(sessionPayload) || daily.payloadSha256 !== sha256(dailyPayload)) {
       throw new Error('cache generation seal did not match the completed analytics objects')
     }
     authorityGeneration = { session, daily }
@@ -253,6 +263,12 @@ export async function publishCanonicalHistoryAnalyticsV1(
   let compactForIncremental: Awaited<ReturnType<typeof readCanonicalHistoryShadowPublicationTrustV1>> | undefined
   try {
     compactForIncremental = await readCanonicalHistoryShadowPublicationTrustV1({ dataDir: options.dataDir })
+    if (
+      compactForIncremental?.headlineIndex.endpointScopeSha256 !== undefined
+      && compactForIncremental.headlineIndex.endpointScopeSha256 !== endpointScopeSha256
+    ) {
+      return failed(startedAt, 'endpoint-scope-mismatch', timings, generation)
+    }
     if (
       compactForIncremental
       && compactForIncremental.head.snapshotSha256 !== undefined

--- a/src/local-state/canonical-history-shadow-migration.test.ts
+++ b/src/local-state/canonical-history-shadow-migration.test.ts
@@ -1,0 +1,186 @@
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import type { CanonicalHistoryReadProjectionV1 } from './canonical-history-read-projection.js'
+import {
+  CANONICAL_HISTORY_SHADOW_HEAD_KIND,
+  CANONICAL_HISTORY_SHADOW_SNAPSHOT_KIND,
+  CANONICAL_HISTORY_SHADOW_STORE_VERSION,
+  canonicalHistoryShadowPathsV1,
+  migrateCanonicalHistoryShadowLegacyV1,
+  persistCanonicalHistoryShadowV1,
+  readCanonicalHistoryShadowPublicationTrustV1,
+} from './canonical-history-shadow-store.js'
+
+const roots: string[] = []
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map(path => rm(path, { recursive: true, force: true })))
+})
+
+function hex(character: string): string {
+  return character.repeat(64)
+}
+
+function projection(): CanonicalHistoryReadProjectionV1 {
+  const observationId = `observation-v1:${hex('a')}`
+  const activityId = `activity-v1:${hex('b')}`
+  const snapshotId = `history-day-v1:${hex('c')}`
+  return {
+    version: 1,
+    authority: {
+      observations: 'shadow-session-cache',
+      activities: 'shadow-session-cache',
+      totals: 'trusted-daily-cache',
+      additiveAcrossAuthorities: false,
+    },
+    observations: [{
+      observationId,
+      activityId,
+      sourceFingerprintSha256: hex('d'),
+      collector: 'codex',
+      timestamp: '2026-08-01T21:00:01.000Z',
+      model: 'gpt-test',
+      usage: {
+        inputTokens: 10,
+        outputTokens: 20,
+        cacheCreationInputTokens: 0,
+        cacheReadInputTokens: 5,
+        cachedInputTokens: 5,
+        reasoningTokens: 0,
+        webSearchRequests: 0,
+        cacheCreationOneHourTokens: 0,
+      },
+      costUSD: 1.25,
+      costAssignment: {
+        version: 1,
+        kind: 'metered',
+        amountMicrosUsd: 1_250_000,
+        source: 'provider',
+      },
+      isEstimated: false,
+      speed: 'standard',
+    }],
+    activities: [{
+      activityId,
+      collector: 'codex',
+      timestamp: '2026-08-01T21:00:00.000Z',
+      observationIds: [observationId],
+    }],
+    dailySnapshots: [{
+      snapshotId,
+      date: '2026-08-01',
+      cost: 1.25,
+      savingsUSD: 0,
+      calls: 1,
+      sessions: 1,
+      inputTokens: 10,
+      outputTokens: 20,
+      cacheReadTokens: 5,
+      cacheWriteTokens: 0,
+      editTurns: 0,
+      oneShotTurns: 1,
+      models: {},
+      categories: {},
+      providers: {},
+      bucketTimeZone: 'UTC',
+      authority: 'trusted-daily-cache',
+    }],
+  }
+}
+
+async function temporaryDataDir(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), 'metrora-history-shadow-migration-'))
+  roots.push(root)
+  return root
+}
+
+async function makeLegacyHead(dataDir: string): Promise<{
+  paths: ReturnType<typeof canonicalHistoryShadowPathsV1>
+  oldHead: Buffer
+  snapshot: Buffer
+}> {
+  await persistCanonicalHistoryShadowV1(projection(), { dataDir })
+  const paths = canonicalHistoryShadowPathsV1(dataDir)
+  const oldHead = JSON.parse(await readFile(paths.head, 'utf8')) as Record<string, unknown>
+  delete oldHead.snapshotSha256
+  const oldHeadBytes = Buffer.from(JSON.stringify(oldHead), 'utf8')
+  await writeFile(paths.head, oldHeadBytes)
+  const snapshotPath = join(paths.snapshots, `${oldHead.projectionSha256 as string}.json`)
+  const snapshot = await readFile(snapshotPath)
+  await rm(join(paths.root, 'retained-index.v1.json'), { force: true })
+  await rm(paths.headlineIndexes, { recursive: true, force: true })
+  await rm(join(paths.root, 'publication-state.v1.json'), { force: true })
+  return { paths, oldHead: oldHeadBytes, snapshot }
+}
+
+describe('canonical history legacy shadow migration', () => {
+  it('migrates a valid unsealed head without rewriting its immutable snapshot', async () => {
+    const dataDir = await temporaryDataDir()
+    const { paths, snapshot, oldHead } = await makeLegacyHead(dataDir)
+
+    const result = await migrateCanonicalHistoryShadowLegacyV1({ dataDir })
+    expect(result.status).toBe('migrated')
+    expect(result.snapshotSha256).toMatch(/^[a-f0-9]{64}$/u)
+    expect(await readFile(join(paths.snapshots, `${result.projectionSha256}.json`))).toEqual(snapshot)
+
+    const migratedHead = JSON.parse(await readFile(paths.head, 'utf8')) as Record<string, unknown>
+    expect(migratedHead.projectionSha256).toBe(JSON.parse(oldHead.toString('utf8')).projectionSha256)
+    expect(migratedHead.snapshotSha256).toBe(result.snapshotSha256)
+    expect(await readCanonicalHistoryShadowPublicationTrustV1({ dataDir })).toMatchObject({
+      deepValidated: true,
+      head: { snapshotSha256: result.snapshotSha256 },
+    })
+  })
+
+  it('fails closed for an invalid legacy snapshot and leaves the unsealed head recoverable', async () => {
+    const dataDir = await temporaryDataDir()
+    const { paths, oldHead } = await makeLegacyHead(dataDir)
+    const head = JSON.parse(oldHead.toString('utf8')) as { projectionSha256: string }
+    const snapshotPath = join(paths.snapshots, `${head.projectionSha256}.json`)
+    await writeFile(snapshotPath, '{broken')
+
+    await expect(migrateCanonicalHistoryShadowLegacyV1({ dataDir }))
+      .rejects.toThrow('canonical history shadow snapshot is invalid')
+    expect(await readFile(paths.head)).toEqual(oldHead)
+  })
+
+  it('keeps the old head recoverable when interrupted before the upgrade write', async () => {
+    const dataDir = await temporaryDataDir()
+    const { paths, oldHead, snapshot } = await makeLegacyHead(dataDir)
+
+    await expect(migrateCanonicalHistoryShadowLegacyV1({
+      dataDir,
+      onLegacyHeadMigrationBeforeWrite: () => { throw new Error('simulated migration interruption') },
+    })).rejects.toThrow('simulated migration interruption')
+    expect(await readFile(paths.head)).toEqual(oldHead)
+    expect(await readFile(join(paths.snapshots, `${JSON.parse(oldHead.toString('utf8')).projectionSha256}.json`))).toEqual(snapshot)
+
+    await expect(migrateCanonicalHistoryShadowLegacyV1({ dataDir })).resolves.toMatchObject({ status: 'migrated' })
+  })
+
+  it('deep-validates the migrated head after a cold trust restart', async () => {
+    const dataDir = await temporaryDataDir()
+    const { paths } = await makeLegacyHead(dataDir)
+    await migrateCanonicalHistoryShadowLegacyV1({ dataDir })
+    const before = await readFile(paths.head)
+
+    const cold = await readCanonicalHistoryShadowPublicationTrustV1({ dataDir })
+    expect(cold?.deepValidated).toBe(true)
+    expect(await readFile(paths.head)).toEqual(before)
+  })
+
+  it('recognizes the prior head envelope as legacy rather than inventing a new identity', async () => {
+    const dataDir = await temporaryDataDir()
+    const { paths, oldHead } = await makeLegacyHead(dataDir)
+    const parsed = JSON.parse(oldHead.toString('utf8')) as Record<string, unknown>
+    expect(parsed.kind).toBe(CANONICAL_HISTORY_SHADOW_HEAD_KIND)
+    expect(parsed.version).toBe(CANONICAL_HISTORY_SHADOW_STORE_VERSION)
+    expect(parsed.snapshotSha256).toBeUndefined()
+    const snapshot = JSON.parse((await readFile(join(paths.snapshots, `${parsed.projectionSha256}.json`))).toString('utf8')) as Record<string, unknown>
+    expect(snapshot.kind).toBe(CANONICAL_HISTORY_SHADOW_SNAPSHOT_KIND)
+    expect(snapshot.version).toBe(CANONICAL_HISTORY_SHADOW_STORE_VERSION)
+  })
+})

--- a/src/local-state/canonical-history-shadow-migration.ts
+++ b/src/local-state/canonical-history-shadow-migration.ts
@@ -1,0 +1,87 @@
+import { atomicWritePrivateFile, readOptionalPrivateFile } from './atomic-file.js'
+import {
+  canonicalHistoryShadowSnapshotSha256V1,
+  ensureCanonicalHistoryCliHeadlineIndexV1,
+} from './canonical-history-cli-headline-index-store.js'
+import type { CanonicalHistoryReadProjectionV1 } from './canonical-history-read-projection.js'
+import {
+  readCanonicalHistoryRetainedIndexV1,
+} from './canonical-history-retained-index.js'
+import { CanonicalHistoryShadowStoreIntegrityError } from './canonical-history-shadow-errors.js'
+import { withLocalStateLease } from './local-state-lease.js'
+import type {
+  CanonicalHistoryShadowHeadV1,
+  CanonicalHistoryShadowPathsV1,
+  CanonicalHistoryShadowProjectionIndexV1,
+  CanonicalHistoryShadowSnapshotV1,
+} from './canonical-history-shadow-store.js'
+
+type ParsedSnapshotV1 = {
+  record: CanonicalHistoryShadowSnapshotV1
+  index: CanonicalHistoryShadowProjectionIndexV1
+}
+
+export type CanonicalHistoryShadowLegacyMigrationOptionsV1 = {
+  dataDir: string
+  paths: CanonicalHistoryShadowPathsV1
+  now?: () => Date
+  onLegacyHeadMigrationBeforeWrite?: () => void | Promise<void>
+  parseHead: (bytes: Uint8Array) => CanonicalHistoryShadowHeadV1
+  parseSnapshot: (bytes: Uint8Array, expectedDigest: string) => ParsedSnapshotV1
+  snapshotPath: (paths: CanonicalHistoryShadowPathsV1, digest: string) => string
+  prepare: (paths: CanonicalHistoryShadowPathsV1) => Promise<void>
+}
+
+export type CanonicalHistoryShadowLegacyMigrationResultV1 = {
+  status: 'absent' | 'already-sealed' | 'migrated'
+  projectionSha256?: string
+  snapshotSha256?: string
+}
+
+/** Upgrade a valid pre-content-seal head without rewriting immutable snapshots. */
+export async function migrateCanonicalHistoryShadowLegacyAtPathsV1(
+  options: CanonicalHistoryShadowLegacyMigrationOptionsV1,
+): Promise<CanonicalHistoryShadowLegacyMigrationResultV1> {
+  const now = options.now ?? (() => new Date())
+  return withLocalStateLease(options.paths.root, async () => {
+    const headBytes = await readOptionalPrivateFile(options.paths.head)
+    if (!headBytes) return { status: 'absent' as const }
+    const head = options.parseHead(headBytes)
+    if (head.snapshotSha256 !== undefined) {
+      return {
+        status: 'already-sealed' as const,
+        projectionSha256: head.projectionSha256,
+        snapshotSha256: head.snapshotSha256,
+      }
+    }
+
+    const snapshotBytes = await readOptionalPrivateFile(options.snapshotPath(options.paths, head.projectionSha256))
+    if (!snapshotBytes) {
+      throw new CanonicalHistoryShadowStoreIntegrityError('canonical history shadow head points to a missing snapshot')
+    }
+    const parsed = options.parseSnapshot(snapshotBytes, head.projectionSha256)
+    const snapshotSha256 = canonicalHistoryShadowSnapshotSha256V1(snapshotBytes)
+
+    await options.prepare(options.paths)
+    const retained = await readCanonicalHistoryRetainedIndexV1(options.paths, options.parseSnapshot, { deepValidate: true })
+    const retainedHead = retained.snapshots.find(snapshot => snapshot.projectionSha256 === head.projectionSha256)
+    if (!retainedHead || retainedHead.snapshotSha256 !== snapshotSha256) {
+      throw new CanonicalHistoryShadowStoreIntegrityError('canonical history retained index could not seal the legacy head snapshot')
+    }
+    await ensureCanonicalHistoryCliHeadlineIndexV1({
+      dataDir: options.dataDir,
+      projection: parsed.record.projection as CanonicalHistoryReadProjectionV1,
+      projectionSha256: head.projectionSha256,
+      snapshotBytes,
+    })
+
+    await options.onLegacyHeadMigrationBeforeWrite?.()
+    const migratedHead = options.parseHead(Buffer.from(JSON.stringify({
+      ...head,
+      snapshotSha256,
+      updatedAt: now().toISOString(),
+    }), 'utf-8'))
+    await atomicWritePrivateFile(options.paths.head, JSON.stringify(migratedHead))
+    return { status: 'migrated' as const, projectionSha256: head.projectionSha256, snapshotSha256 }
+  })
+}

--- a/src/local-state/canonical-history-shadow-store.ts
+++ b/src/local-state/canonical-history-shadow-store.ts
@@ -35,6 +35,10 @@ import {
 } from './canonical-history-retained-index.js'
 import { CanonicalHistoryShadowStoreIntegrityError } from './canonical-history-shadow-errors.js'
 import {
+  migrateCanonicalHistoryShadowLegacyAtPathsV1,
+  type CanonicalHistoryShadowLegacyMigrationResultV1,
+} from './canonical-history-shadow-migration.js'
+import {
   clearCanonicalHistoryShadowTrustMemoV1 as clearPublicationTrustMemoV1,
   readCanonicalHistoryPublicationTrustV1,
   rememberCanonicalHistoryPublicationTrustV1,
@@ -77,6 +81,8 @@ export type CanonicalHistoryShadowStoreOptions = {
   endpointScopeSha256?: string
   sourceIndex?: CanonicalHistoryPublicationSourceV1[]
   previousState?: CanonicalHistoryShadowLoadedStateV1
+  /** Test/diagnostic interruption point before a legacy head is upgraded. */
+  onLegacyHeadMigrationBeforeWrite?: () => void | Promise<void>
   /** Optional diagnostic timing hook; it never changes publication semantics. */
   onHeadlineIndexPersisted?: (elapsedMs: number) => void
 }
@@ -345,6 +351,23 @@ function parseHead(bytes: Uint8Array): CanonicalHistoryShadowHeadV1 {
   }
 }
 
+export async function migrateCanonicalHistoryShadowLegacyV1(
+  options: Pick<CanonicalHistoryShadowStoreOptions, 'dataDir' | 'now' | 'onLegacyHeadMigrationBeforeWrite'> = {},
+): Promise<CanonicalHistoryShadowLegacyMigrationResultV1> {
+  const dataDir = options.dataDir ?? defaultMetroraDataDir()
+  const paths = canonicalHistoryShadowPathsV1(dataDir)
+  return migrateCanonicalHistoryShadowLegacyAtPathsV1({
+    dataDir,
+    paths,
+    now: options.now,
+    parseHead,
+    parseSnapshot,
+    snapshotPath,
+    prepare,
+    onLegacyHeadMigrationBeforeWrite: options.onLegacyHeadMigrationBeforeWrite,
+  })
+}
+
 export type { CanonicalHistoryShadowPublicationTrustV1 } from './canonical-history-publication-trust.js'
 export const clearCanonicalHistoryShadowTrustMemoV1 = clearPublicationTrustMemoV1
 
@@ -353,6 +376,7 @@ export async function readCanonicalHistoryShadowPublicationTrustV1(
 ): Promise<CanonicalHistoryShadowPublicationTrustV1 | undefined> {
   const dataDir = options.dataDir ?? defaultMetroraDataDir()
   const paths = canonicalHistoryShadowPathsV1(dataDir)
+  await migrateCanonicalHistoryShadowLegacyV1({ dataDir })
   return readCanonicalHistoryPublicationTrustV1({
     dataDir,
     paths,
@@ -400,13 +424,21 @@ export async function persistCanonicalHistoryShadowV1(
   const projection = structuredClone(projectionInput)
   const currentIndex = indexProjection(projection)
   const projectionSha256 = canonicalHistoryShadowProjectionSha256V1(projection)
+  await migrateCanonicalHistoryShadowLegacyV1({
+    dataDir,
+    now,
+    onLegacyHeadMigrationBeforeWrite: options.onLegacyHeadMigrationBeforeWrite,
+  })
   await prepare(paths)
 
   return withLocalStateLease(paths.root, async () => {
     // A compact retained index is acceleration evidence only. If this is the
     // first publication in a process with an existing head, establish the
     // canonical deep-validation trust boundary before reading it.
-    await readCanonicalHistoryShadowPublicationTrustV1({ dataDir })
+    // Legacy migration ran before this lease was acquired. Read the generic
+    // trust boundary directly here so a sealed migration is not needlessly
+    // nested under a second lease for the same shadow root.
+    await readCanonicalHistoryPublicationTrustV1({ dataDir, paths, parseHead, parseSnapshot })
     const previous = await usePreviousStateIfCurrent(paths, options.previousState)
     const retained = await readCanonicalHistoryRetainedIndexV1(paths, parseSnapshot)
     assertCompatibleWithCanonicalHistoryRetainedV1(retained, currentIndex)

--- a/src/session-cache.ts
+++ b/src/session-cache.ts
@@ -8,7 +8,7 @@ import type { CostAssignmentV1 } from './pricing/cost-assignment.js'
 import { fingerprintSourceFile, type SQLiteWalFingerprint } from './sqlite-source-fingerprint.js'
 import { getMetroraCacheDir } from './product-paths.js'
 import { validateCachedFile, validateSessionCache } from './session-cache-validation.js'
-import { writeSessionCacheGenerationFromPayloadV1 } from './cache-generation.js'
+import { rememberSessionCachePayloadEvidenceV1, writeSessionCacheGenerationFromPayloadV1 } from './cache-generation.js'
 // ── Types ──────────────────────────────────────────────────────────────
 
 export type CachedUsage = {
@@ -394,7 +394,7 @@ export async function loadCache(): Promise<SessionCache> {
   try {
     const raw = await readFile(getCachePath(), 'utf-8')
     const parsed = JSON.parse(raw)
-    if (isValidCache(parsed)) return parsed
+    if (isValidCache(parsed)) { rememberSessionCachePayloadEvidenceV1(parsed, raw); return parsed }
   } catch { /* fall through to safe adoption */ }
   return afterMissingVersionedCache()
 }
@@ -460,7 +460,7 @@ export async function saveCache(cache: SessionCache, verifyStillOwner?: () => Pr
       }
     }
     if (!renamed) throw new Error('session cache rename failed')
-    await writeSessionCacheGenerationFromPayloadV1(finalPath, cache, payload).catch(() => {})
+    rememberSessionCachePayloadEvidenceV1(cache, payload); await writeSessionCacheGenerationFromPayloadV1(finalPath, cache, payload).catch(() => {})
     return true
   } catch (err) {
     await retryCacheFileMutation(() => unlink(tempPath))


### PR DESCRIPTION
## Summary

- recover valid pre-seal canonical history heads with deep validation and atomic content seals
- bind publication to the host-supplied canonical endpoint scope and fail closed on conflicts or missing identity
- preserve exact completed cache payloads through loader normalization so generation sealing remains point-in-time
- add focused migration, recovery, generation-seal, parity, and terminal lifecycle coverage

## Why

Local upgrades could retain a valid legacy shadow head without a content seal, while normal cache hydration could reorder serialized fields and block valid publication. This change recovers derived state without rewriting immutable snapshots and keeps publication tied to the established host identity boundary.

## Checks

- focused C3 and terminal matrix: 89 tests passed
- `npx tsc --noEmit`
- `npm run build:cli`
- `npm run version:check`
- `npm run identity:public:check`
- source-size ratchet
- brand/public-boundary check
- `git diff --check`

## Notes

- terminal status remains non-publishing and falls back when parity or identity is unavailable
- draft only; not merged