### PR TITLE
docs: converge current runtime documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,12 @@
 
 This file records Metrora-originated public changes. Required third-party notices and licence texts are maintained separately in [`THIRD_PARTY_NOTICES.md`](THIRD_PARTY_NOTICES.md) and [`LICENSES/`](LICENSES/).
 
-## `1.0.0-rc.10` — Microsoft Store submission source line
+## `1.0.0-rc.10` — Microsoft Store published line (frozen)
 
-RC10 is the exact source line associated with the Microsoft Store submission. Submission, certification and publication are separate gates. Post-RC10 development is separate from the submitted package.
+RC10 is the exact frozen source line for the live Microsoft Store
+distribution published by Vensent. Post-RC10 development is separate from
+the published package; any future Store update requires its own acceptance,
+submission and publication decision.
 
 ### Source completeness and durable history
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,6 +44,10 @@ npm --prefix app run typecheck
 npm --prefix app run build
 ```
 
+### Android companion contributions
+
+The Android companion is implemented and physically accepted for the bounded local LAN scope, but it is not a public Android distribution. Follow [Getting started](docs/GETTING_STARTED.md#build-and-validate-the-android-companion) for the Java 17, Gradle 9.6.1/API 36 build path and [the Android foundation](docs/ANDROID_COMPANION_FOUNDATION.md) plus [local API contract](docs/LOCAL_COMPANION_API.md) for boundaries. Ordinary contributors do not need QA signing secrets; physical-acceptance signing is a trusted same-repository CI concern, and release/F-Droid/Play signing is separate.
+
 ## Contribution principles
 
 - Keep each pull request bounded to one primary concern.

--- a/README.md
+++ b/README.md
@@ -151,11 +151,13 @@ Historical API-equivalent pricing is date-effective and non-retroactive by defau
 | Desktop | Primary local analysis and configuration | **Available on Microsoft Store for Windows** |
 | CLI | Automation, inspection, export and keyboard-first analysis | Bundled with the Windows Store app; also available from source for development |
 | Local web dashboard | Browser view served from the local machine | Available locally |
-| Android companion | Read-only local-network companion foundation | Experimental |
+| Android companion | Read-only local-network companion for a paired Desktop | **Implemented and physically accepted for the local companion scope; public Android distribution not released** |
 | macOS menubar | Compact local usage view | Development source retained; not an official Metrora distribution |
 | GNOME extension | Compact Linux panel view | Development source retained; not an official Metrora distribution |
 
 Windows is the first supported public desktop distribution. Source support for other platforms does not imply that an accepted public package exists for those platforms.
+
+The Android companion is available in the source tree for local build and validation. It pairs with Metrora Desktop on the same LAN, can show a fresh Desktop-generated usage overview or an encrypted offline snapshot, and has passed the bounded Windows↔Samsung physical-acceptance scope. It is not yet a public Android release or store distribution.
 
 ## Privacy model
 
@@ -187,6 +189,8 @@ Start from the [documentation index](docs/README.md):
 - [Pricing history](docs/PRICING_HISTORY.md)
 - [Workspace v1](docs/WORKSPACE_V1.md)
 - [Public contracts v1](docs/PUBLIC_CONTRACTS_V1.md)
+- [Android companion foundation](docs/ANDROID_COMPANION_FOUNDATION.md)
+- [Local companion API v1](docs/LOCAL_COMPANION_API.md)
 - [Windows distribution boundary](docs/WINDOWS_DISTRIBUTION.md)
 
 ## Repository map
@@ -195,7 +199,7 @@ Start from the [documentation index](docs/README.md):
 src/       collection, parsing, canonical records, CLI, analytics and sharing
 app/       Electron desktop application
 dash/      local React web dashboard
-android/   experimental Android companion
+android/   implemented local Android companion; no public Android distribution yet
 mac/       macOS menubar application
 gnome/     GNOME extension
 tests/     core test suite

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,6 +1,9 @@
 # Releasing Metrora
 
-Metrora does not yet have an official stable desktop release. This document defines the current public release boundary.
+Metrora does not yet have an official stable desktop release. Windows is
+currently distributed publicly through the Microsoft Store, published by
+Vensent, with RC10 as the frozen Store authority. This document defines the
+current public release boundary.
 
 ## Canonical identity
 
@@ -8,7 +11,7 @@ Metrora does not yet have an official stable desktop release. This document defi
 - Domain: **metrora.eu**
 - Repository: `maikolsiragusaa/metrora`
 - Canonical command: `metrora`
-- Current source candidate: `1.0.0-rc.10`
+- Published Store source line: `1.0.0-rc.10`
 - Current desktop build version: `1.0.0.10`
 - Latest published GitHub technical preview: `1.0.0-rc.7`
 
@@ -20,11 +23,22 @@ The root npm package is private and must not be published from this repository.
 
 ## Current engineering authority
 
-`1.0.0-rc.10` is the **Microsoft Store submission source line**. It advances RC9 because audited source-completeness and durable-history reconciliation materially changed user-visible accounting after the RC9 candidate was established. RC9 had already introduced the explicit durable-vs-surviving-detail accounting boundary and the sealed packaged Store CLI runtime. Post-RC10 development is separate from the submitted package. Submission, certification and publication are distinct gates.
+`1.0.0-rc.10` is the **frozen Microsoft Store source line** for the live
+Windows distribution published by Vensent. It advances RC9 because audited
+source-completeness and durable-history reconciliation materially changed
+user-visible accounting after the RC9 candidate was established. RC9 had
+already introduced the explicit durable-vs-surviving-detail accounting
+boundary and the sealed packaged Store CLI runtime. Post-RC10 development is
+separate from the published package; any future Store update requires its own
+candidate, acceptance, submission and publication decision.
 
 `1.0.0-rc.7` remains the latest published GitHub Windows technical preview. That channel is unsigned, manually updated and not Microsoft Store certified. Its source, release assets, manifests and checksums remain immutable historical publication evidence.
 
-The Microsoft Store path is separate. Metrora has an assigned Store identity and a non-publishing AppX build/local-acceptance workflow. The RC10 candidate passed its local and physical acceptance boundary and is the source line associated with the submission. This guidance makes no certification, publication or Store-availability claim.
+The Microsoft Store path is separate from source builds and GitHub technical
+pre-releases. Metrora has an assigned Store identity, and RC10 passed its
+source-bound package and physical acceptance boundary before publication.
+The live Store listing is the supported public Windows install path; later
+source work does not retroactively change the frozen RC10 authority.
 
 Exact source commits and artifact digests belong in the applicable workflow/release acceptance evidence rather than being copied into general release guidance.
 

--- a/docs/ANDROID_COMPANION_FOUNDATION.md
+++ b/docs/ANDROID_COMPANION_FOUNDATION.md
@@ -1,5 +1,7 @@
 # Metrora Android companion foundation
 
+**Current status:** Implemented in public `main` and physically accepted for the bounded Windows↔Samsung local companion scope. This is a source/build surface, not a public Android release or distribution channel.
+
 The Android application is a private local companion to Metrora Desktop. It does not collect AI usage itself and does not introduce a second gateway, parser, provider registry or analytics engine.
 
 ## Authority and data flow
@@ -47,13 +49,32 @@ Pairing credentials and the last successful usage snapshot are encrypted with an
 
 When the desktop is unreachable, the app continues to show the most recent encrypted snapshot and marks it as cached. The retrieval timestamp remains visible.
 
+## Accepted physical scope
+
+The merged implementation has passed the bounded Windows↔Samsung physical-acceptance matrix for:
+
+- secure LAN transport, mutual TLS and certificate pinning;
+- pairing approval and SAS confirmation;
+- encrypted snapshot display, offline behavior and reconnect refresh;
+- revoke, local forget and re-pair recovery;
+- force-stop and reboot persistence;
+- first post-pair usage and restored-state remediation, including neutral cached-state semantics.
+
+This acceptance covers the current local companion contract. It does not claim a public Android release, Google Play/F-Droid distribution or mainstream Android product experience.
+
+## QA signing boundary
+
+Physical acceptance uses one dedicated non-production QA identity for the update-compatible `githubDebug` artifact. The identity is available only to trusted same-repository CI runs through protected secrets; fork pull requests do not receive those secrets and can run ordinary tests and builds without publishing the signed acceptance artifact. Private key material is never stored in Git.
+
+Release, F-Droid and Play signing are separate identities and release processes. Ordinary contributors do not need QA signing secrets to build, test, lint or inspect the Android companion.
+
 ## Data minimization
 
 The companion does not request prompts, assistant messages, source code, patches, tool arguments, secrets or unrestricted filesystem paths.
 
 ## Validation boundary
 
-The repository includes contract tests, a real Node mutual-TLS lifecycle test and blocking Android build, unit-test and lint jobs. A physical-device Windows-to-Android pairing run is still required before calling the companion a release-ready alpha.
+The repository includes contract tests, a real Node mutual-TLS lifecycle test and blocking Android build, unit-test and lint jobs. The current physical-device Windows-to-Samsung pairing and persistence matrix has passed for the local companion scope. Public Android distribution and release-readiness work remain separate product gates.
 
 ## Deliberate exclusions
 

--- a/docs/CANONICAL_HISTORY_CLI_DUAL_READ_V1.md
+++ b/docs/CANONICAL_HISTORY_CLI_DUAL_READ_V1.md
@@ -1,5 +1,7 @@
 # Metrora CLI status C3 dual-read v1
 
+**Status:** Implemented C3 foundation / progressive migration. The compact terminal headline is the first bounded production consumer; exact parity gates use of the derived result and every unsupported or mismatched case falls back to the legacy path.
+
 ## Problem
 
 Metrora needs a fast, fail-safe read boundary for the compact terminal

--- a/docs/CANONICAL_HISTORY_PARITY_OBSERVER_V1.md
+++ b/docs/CANONICAL_HISTORY_PARITY_OBSERVER_V1.md
@@ -157,7 +157,7 @@ Deleting the complete `history-shadow/v1` directory must leave current product b
 This observer does not authorize:
 
 - consumer parity claims based on real-world observation duration;
-- CLI or desktop cutover;
+- additional CLI or desktop consumer cutover beyond the bounded terminal headline;
 - replacement of session or daily caches;
 - migration or historical backfill;
 - database introduction;

--- a/docs/CANONICAL_HISTORY_READ_PROJECTION_V1.md
+++ b/docs/CANONICAL_HISTORY_READ_PROJECTION_V1.md
@@ -1,6 +1,6 @@
 # Canonical history read projection v1
 
-**Status:** C3-P0.A shadow read contract; implemented without consumer cutover.
+**Status:** C3-P0.A implemented shadow read contract within progressive migration. The separately derived, parity-gated terminal headline is the first bounded production consumer; this projection remains non-authoritative for other consumers.
 
 This contract makes source-observation and activity identity explicit while the existing trusted daily cache remains authoritative for user-visible historical totals.
 
@@ -126,9 +126,9 @@ C3-P0.A does not provide:
 - persistent canonical-history storage;
 - cache-schema changes;
 - migration or backfill;
-- report, CLI, desktop, Workspace or Android cutover;
+- report, desktop, Workspace or Android cutover beyond the bounded terminal headline;
 - server ingestion or synchronization;
 - account, team, billing or managed infrastructure;
 - a second collector, parser, pricing or evidence implementation.
 
-A later shadow-persistence tranche must prove parity and rollback independently before any consumer can change authority.
+A later migration tranche must prove consumer-specific parity and rollback independently before any additional consumer can change authority.

--- a/docs/CANONICAL_HISTORY_SHADOW_STORE_V1.md
+++ b/docs/CANONICAL_HISTORY_SHADOW_STORE_V1.md
@@ -95,6 +95,8 @@ C3-P0.B is mechanically non-authoritative for product consumers:
 - CLI, desktop, Workspace and Android do not read the shadow store;
 - removing `history-shadow/v1` does not change existing product behavior.
 
+The bounded terminal consumer reads a separately generated, generation-sealed headline index after exact parity; it does not read shadow-store snapshots. The shadow store therefore remains a removable migration/evidence boundary, not a terminal or global consumer authority.
+
 The store is evidence for future parity and migration decisions, not a migration itself.
 
 ## Failure and recovery
@@ -123,7 +125,7 @@ This tranche does not provide:
 - session-cache or daily-cache migration;
 - automatic backfill;
 - unioned canonical consumer reads;
-- CLI, desktop, Workspace or Android cutover;
+- direct shadow-store reads or cutover for CLI, desktop, Workspace or Android;
 - server ingestion or synchronization;
 - account, billing or managed infrastructure;
 - a second parser, pricing or evidence engine.

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -148,6 +148,32 @@ Development builds are not official Store-signed releases. Windows is the first 
 
 See [Windows distribution](WINDOWS_DISTRIBUTION.md), [Versioning authority](VERSIONING.md) and [`RELEASING.md`](../RELEASING.md).
 
+## Build and validate the Android companion
+
+The Android companion is a source/build surface for the implemented local LAN contract. Its current scope is physically accepted, but it is not a public Android release. Ordinary contributors do not need private QA signing material.
+
+Use:
+
+- Java 17;
+- Gradle 9.6.1, or the project-supported equivalent;
+- Android SDK Platform 36.
+
+The canonical contributor checks are:
+
+```bash
+gradle -p android --no-daemon :app:testGithubDebugUnitTest :app:lint :app:assembleGithubDebug
+```
+
+To validate the unsigned distribution channels used by the repository workflow:
+
+```bash
+gradle -p android --no-daemon :app:assembleGithubRelease :app:assembleFdroidRelease :app:bundlePlayRelease
+```
+
+The dedicated non-production QA identity is used only for trusted same-repository physical-acceptance CI and is not required for these commands. Fork pull requests do not receive QA secrets. Release, F-Droid and Play signing remain separate; no private signing material belongs in Git.
+
+See [Android companion foundation](ANDROID_COMPANION_FOUNDATION.md) for the accepted Windows↔Samsung matrix and [Local companion API v1](LOCAL_COMPANION_API.md) for the protocol boundary.
+
 ## Local files and compatibility
 
 The current package publishes only the `metrora` command. Fresh installations

--- a/docs/LOCAL_COMPANION_API.md
+++ b/docs/LOCAL_COMPANION_API.md
@@ -1,5 +1,7 @@
 # Metrora local companion API v1
 
+**Status:** Implemented local contract used by the accepted Android companion scope. It does not define public Android distribution or remote/managed access.
+
 Metrora exposes a local HTTPS protocol for first-party companion applications and trusted devices. The desktop remains the authority for collection and analysis; companions read a content-minimal versioned summary over the local network.
 
 ## Compatibility

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,11 @@ This index separates user guidance, current product guarantees, public contracts
 - [Supported tools](SUPPORTED_TOOLS.md) — local collector coverage and evidence boundaries.
 - [Provider documentation](providers/) — source locations, formats, limitations and parser notes for individual integrations.
 
+## Connect devices locally
+
+- [Android companion foundation](ANDROID_COMPANION_FOUNDATION.md) — implemented and physically accepted Windows↔Samsung local companion scope, its boundaries and validation status; public Android distribution remains separate.
+- [Local companion API v1](LOCAL_COMPANION_API.md) — stable local HTTPS endpoints and the content-minimal usage contract used by first-party companions.
+
 ## Understand the product
 
 - [Product principles](PRODUCT_PRINCIPLES.md) — stable local-first, privacy, evidence and portability commitments.
@@ -16,6 +21,7 @@ This index separates user guidance, current product guarantees, public contracts
 - [Canonical history read projection v1](CANONICAL_HISTORY_READ_PROJECTION_V1.md) — shadow observation/activity identity and trusted daily-history boundary.
 - [Canonical history shadow store v1](CANONICAL_HISTORY_SHADOW_STORE_V1.md) — removable content-addressed persistence and cross-refresh reconciliation.
 - [Canonical history parity observer v1](CANONICAL_HISTORY_PARITY_OBSERVER_V1.md) — non-authoritative cache-to-shadow parity validation before snapshot publication.
+- [CLI status C3 dual-read v1](CANONICAL_HISTORY_CLI_DUAL_READ_V1.md) — the bounded terminal consumer, exact parity gate and legacy fallback boundary.
 - [Accounting and pricing](ACCOUNTING_AND_PRICING.md) — user-facing semantics for historical rates, cache and context tiers, durable totals and evidence-aware cost valuation.
 - [Pricing history](PRICING_HISTORY.md) — generated reviewed rate history and date-effective records used by the accounting path.
 - [Collector inventory v1](COLLECTOR_INVENTORY_V1.md) — generated technical inventory of registered collectors and signed-measurement eligibility.

--- a/docs/VERSIONING.md
+++ b/docs/VERSIONING.md
@@ -4,7 +4,7 @@ Metrora uses semantic versioning for public product identity and separate numeri
 
 ## Current line
 
-- Current source candidate: `1.0.0-rc.10`
+- Published Store source line: `1.0.0-rc.10`
 - Desktop build version: `1.0.0.10`
 - Latest published GitHub technical preview: `1.0.0-rc.7`
 - First intended stable release: `1.0.0`
@@ -37,9 +37,12 @@ For the current `1.0.0` Store-associated source line:
 
 - source/product candidate: `1.0.0-rc.10`;
 - desktop build version: `1.0.0.10`;
-- non-publishing Store AppX identity version: `1.0.0.0`.
+- published Store AppX identity version: `1.0.0.0`.
 
-A locally validated `1.0.0.0` AppX does not by itself mean that version was submitted, certified or published. Submission, certification and publication are separate gates. Later Store updates must advance according to the Store's package-version rules rather than reusing an already submitted identity.
+The published Store authority is the frozen RC10 line under Vensent. A local
+build with the same identity version is not, by itself, evidence of the live
+listing; later Store updates must advance according to the Store's
+package-version rules and pass their own acceptance and publication gates.
 
 ## Ordering
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -72,7 +72,7 @@ The dashboard renders canonical local analytical payloads in a browser surface s
 ### Native companions — `mac/`, `gnome/`, `android/`
 
 - macOS and GNOME surfaces are lightweight local companions over the canonical CLI/runtime;
-- Android is a companion foundation and does not own collection, pricing or evidence authority;
+- Android is an implemented and physically accepted local companion for the current LAN scope; it does not own collection, pricing or evidence authority;
 - inherited module names, UUIDs and storage paths may remain where migration would otherwise break installed state.
 
 Compatibility identifiers are governed by [`TECHNICAL_IDENTITY_COMPATIBILITY.md`](TECHNICAL_IDENTITY_COMPATIBILITY.md), not treated as product branding.
@@ -136,7 +136,7 @@ Contract evolution requires:
 
 ## Distribution integrity
 
-Official desktop distribution is in preparation. Technical candidates remain engineering artifacts until an accepted official channel publishes them.
+Official Windows distribution is live through Microsoft Store under publisher Vensent, with RC10 as the frozen published authority. Technical candidates and non-Windows source surfaces remain engineering artifacts until their own accepted public channel publishes them.
 
 Distribution work preserves these boundaries:
 
@@ -166,7 +166,7 @@ See [`WINDOWS_DISTRIBUTION.md`](WINDOWS_DISTRIBUTION.md), [`WINDOWS_FORMAT_DERIV
 src/       canonical collection, parsing, pricing, analytics, evidence and CLI
 app/       Electron desktop application
 dash/      local browser dashboard
-android/   companion application foundation
+android/   implemented local companion; public Android distribution not released
 mac/       native macOS menubar companion
 gnome/     GNOME Shell companion
 tests/     canonical core and integration tests


### PR DESCRIPTION
## Summary

- align the public README, docs index, Android foundation and local companion API with the merged Android local-companion runtime;
- record the bounded Windows↔Samsung physical-acceptance scope without claiming a public Android release;
- add the contributor Android Java 17 / Gradle 9.6.1 / API 36 path and QA-signing boundary;
- clarify the C3 first bounded terminal consumer, exact parity gate and legacy fallback boundary;
- correct the current Windows distribution wording in the public architecture reference.

## Scope

Documentation-only. No production code, runtime, architecture, roadmap, CI gate, release or provisioning change.

## Validation

- `git diff --check`
- changed-file local Markdown link validation
- targeted stale-claim searches
- no unrelated product CI run