### PR TITLE
brand: converge Metrora on Graphite and Signal Cyan

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Understand where AI time, tokens and money go across tools, models, projects and
 [![Metrora CI](https://github.com/maikolsiragusaa/metrora/actions/workflows/ci.yml/badge.svg)](https://github.com/maikolsiragusaa/metrora/actions/workflows/ci.yml)
 [![Microsoft Store](https://img.shields.io/badge/Microsoft%20Store-Download-0078D4?logo=microsoft&logoColor=white)](https://apps.microsoft.com/detail/9NXSZFQSBBDX)
 [![Fluxer Community](https://img.shields.io/badge/Fluxer-Community-4641D9?logo=fluxer&logoColor=white)](https://metrora.eu/community)
-[![License: MIT](https://img.shields.io/badge/License-MIT-E8590C.svg)](LICENSE)
+[![License: MIT](https://img.shields.io/badge/License-MIT-0F1115.svg)](LICENSE)
 
 </div>
 
@@ -220,7 +220,7 @@ Security issues must be reported privately according to [SECURITY.md](SECURITY.m
 
 <img src="./assets/brand/third-party/fluxer-symbol-color.svg" alt="Fluxer" width="48" />
 
-The Metrora community is opening soon on **Fluxer** for product discussion, questions, feedback and contributor conversation. Use [metrora.eu/community](https://metrora.eu/community) as the stable entry point; the public join link will be published there when the channel opens.
+The public Metrora community is open on **Fluxer** for product discussion, questions, feedback and contributor conversation. Join through [metrora.eu/community](https://metrora.eu/community), the stable Metrora community entry point.
 
 Technical issues and pull requests stay on GitHub. Security reports must continue to follow the private process in [SECURITY.md](SECURITY.md).
 
@@ -228,7 +228,7 @@ Technical issues and pull requests stay on GitHub. Security reports must continu
 
 Metrora™ is the product and user-facing brand. Signal Grid™ is its canonical visual identity. Vensent™ is the publisher identity used for official Metrora distribution.
 
-Metrora is independently maintained and distributed under the MIT License. Product and repository surfaces use the assets and Graphite + Signal Orange palette documented in [`assets/brand`](assets/brand/README.md).
+Metrora is independently maintained and distributed under the MIT License. Product and repository surfaces use the assets and Graphite + Signal Cyan palette documented in [`assets/brand`](assets/brand/README.md).
 
 See the [project notices](NOTICE.md), [brand policy](BRAND_POLICY.md) and [licence](LICENSE).
 

--- a/app/renderer/styles/brand.css
+++ b/app/renderer/styles/brand.css
@@ -1,28 +1,34 @@
-/* Metrora visual identity — graphite surfaces + restrained indigo signal.
-   Orange remains a warning color in the base design system; it is no longer the
-   product accent. Keep this layer small and semantic so components inherit the
-   identity instead of accumulating page-specific hex values. */
+/* Metrora visual identity — Graphite surfaces + Signal Cyan.
+   Orange remains available only for genuine warning/categorical semantics; it
+   is not a product accent. Keep this layer small and semantic so components
+   inherit the identity instead of accumulating page-specific hex values. */
 :root {
-  --accent: #5948d8;
-  --accent-text: #4d3bc6;
-  --grad: linear-gradient(135deg, #5948d8 0%, #7567e8 100%);
+  --accent: #007a99;
+  --accent-text: #00657d;
+  --accent-control-ink: #ffffff;
+  --grad: var(--accent);
+  --grad-bar: linear-gradient(to top, #007a99, #00d4ff);
+  --pg-line: rgba(0, 122, 153, .10);
   --canvas: #f6f7f9;
   --bg: #f6f7f9;
   --side: #f1f2f6;
   --phead: #f7f7fa;
-  --hover: #f0effa;
+  --hover: #e6f9fd;
   --card-shadow: 0 1px 2px rgba(23, 25, 36, .045), 0 4px 14px rgba(23, 25, 36, .035);
-  --brand-boot: #101116;
-  --brand-boot-soft: #171720;
-  --brand-boot-ink: #f4f3f8;
-  --brand-boot-muted: #aaa6b8;
+  --brand-boot: #0f1115;
+  --brand-boot-soft: #15191d;
+  --brand-boot-ink: #faf7f2;
+  --brand-boot-muted: #a7b1b8;
 }
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --accent: #8e85ff;
-    --accent-text: #a39cff;
-    --grad: linear-gradient(135deg, #8177f4 0%, #9c94ff 100%);
+    --accent: #00d4ff;
+    --accent-text: #66e6ff;
+    --accent-control-ink: #0f1115;
+    --grad: var(--accent);
+    --grad-bar: linear-gradient(to top, #007a99, #00d4ff);
+    --pg-line: rgba(0, 212, 255, .10);
     --canvas: #0d0f13;
     --bg: #0d0f13;
     --side: #111318;
@@ -31,15 +37,18 @@
     --line: #282b34;
     --line2: #20232a;
     --fill: #1d2027;
-    --hover: #20212c;
+    --hover: #15242a;
     --card-shadow: 0 1px 2px rgba(0, 0, 0, .24), 0 5px 18px rgba(0, 0, 0, .16);
   }
 }
 
 :root[data-theme='dark'] {
-  --accent: #8e85ff;
-  --accent-text: #a39cff;
-  --grad: linear-gradient(135deg, #8177f4 0%, #9c94ff 100%);
+  --accent: #00d4ff;
+  --accent-text: #66e6ff;
+  --accent-control-ink: #0f1115;
+  --grad: var(--accent);
+  --grad-bar: linear-gradient(to top, #007a99, #00d4ff);
+  --pg-line: rgba(0, 212, 255, .10);
   --canvas: #0d0f13;
   --bg: #0d0f13;
   --side: #111318;
@@ -48,14 +57,17 @@
   --line: #282b34;
   --line2: #20232a;
   --fill: #1d2027;
-  --hover: #20212c;
+  --hover: #15242a;
   --card-shadow: 0 1px 2px rgba(0, 0, 0, .24), 0 5px 18px rgba(0, 0, 0, .16);
 }
 
 :root[data-theme='light'] {
-  --accent: #5948d8;
-  --accent-text: #4d3bc6;
-  --grad: linear-gradient(135deg, #5948d8 0%, #7567e8 100%);
+  --accent: #007a99;
+  --accent-text: #00657d;
+  --accent-control-ink: #ffffff;
+  --grad: var(--accent);
+  --grad-bar: linear-gradient(to top, #007a99, #00d4ff);
+  --pg-line: rgba(0, 122, 153, .10);
   --canvas: #f6f7f9;
   --bg: #f6f7f9;
   --side: #f1f2f6;
@@ -64,9 +76,36 @@
   --line: #e4e5eb;
   --line2: #ececf1;
   --fill: #f0f1f4;
-  --hover: #f0effa;
+  --hover: #e6f9fd;
   --card-shadow: 0 1px 2px rgba(23, 25, 36, .045), 0 4px 14px rgba(23, 25, 36, .035);
 }
+
+/* The imported wireframe layer predates the canonical identity. Reassert the
+   small set of brand-bearing primitives here instead of duplicating page CSS. */
+body {
+  background:
+    radial-gradient(90% 60% at 8% -10%, color-mix(in srgb, var(--accent) 7%, transparent), transparent 55%),
+    radial-gradient(80% 60% at 100% 115%, color-mix(in srgb, var(--accent) 5%, transparent), transparent 55%),
+    var(--pg);
+}
+.win {
+  background:
+    radial-gradient(70% 50% at 85% -8%, color-mix(in srgb, var(--accent) 6%, transparent), transparent 60%),
+    var(--canvas);
+  box-shadow: 0 0 0 1px var(--pg-line), 0 34px 70px -30px rgba(0,0,0,.95);
+}
+.ni.on {
+  background: linear-gradient(90deg, color-mix(in srgb, var(--accent) 13%, transparent), color-mix(in srgb, var(--accent) 4%, transparent));
+}
+.ni.on::before,
+.track i,
+.tglon { background: var(--accent); }
+.btn-p {
+  background: var(--accent);
+  color: var(--accent-control-ink);
+  box-shadow: 0 2px 12px color-mix(in srgb, var(--accent) 28%, transparent), inset 0 1px 0 rgba(255,255,255,.22);
+}
+.tglon { box-shadow: 0 1px 8px color-mix(in srgb, var(--accent) 28%, transparent); }
 
 .metrora-mark {
   display: block;
@@ -87,14 +126,14 @@
 .splash,
 .onboard {
   background:
-    radial-gradient(70% 60% at 50% 38%, color-mix(in srgb, var(--accent) 16%, transparent), transparent 74%),
+    radial-gradient(70% 60% at 50% 38%, color-mix(in srgb, #00d4ff 14%, transparent), transparent 74%),
     linear-gradient(180deg, var(--brand-boot-soft), var(--brand-boot));
 }
 .splash-mark::before {
-  background: radial-gradient(circle, color-mix(in srgb, var(--accent) 38%, transparent), transparent 68%);
+  background: radial-gradient(circle, color-mix(in srgb, #00d4ff 34%, transparent), transparent 68%);
 }
 .splash-word,
-.onboard-glyph { color: #9b93ff; }
+.onboard-glyph { color: #66e6ff; }
 .splash-version,
 .splash-status-note,
 .onboard-body,
@@ -105,17 +144,17 @@
 .splash-status-note { opacity: .72; }
 
 .onboard-btn.primary {
-  background: #6657dc;
-  border-color: #6657dc;
-  color: #fff;
+  background: #00d4ff;
+  border-color: #00d4ff;
+  color: #0f1115;
 }
-.onboard-btn.primary:hover { background: #7568e5; }
+.onboard-btn.primary:hover { background: #33ddff; }
 .onboard-btn:focus-visible,
-.switch:focus-visible { outline-color: #9188ff; }
+.switch:focus-visible { outline-color: #00d4ff; }
 .onboard-dot.on,
 .switch.on {
-  background: #6657dc;
-  border-color: #6657dc;
+  background: #00d4ff;
+  border-color: #00d4ff;
 }
 
 /* Make the main surfaces feel less like isolated spreadsheet boxes while

--- a/assets/brand/README.md
+++ b/assets/brand/README.md
@@ -1,4 +1,4 @@
-# Metrora visual identity — v1.0
+# Metrora visual identity — v1.1
 
 **Status:** canonical for product-facing Metrora surfaces.
 
@@ -13,12 +13,15 @@ Metrora™ is the product brand. Vensent™ is the publisher identity used for o
 - `metrora-lockup.svg` — preferred horizontal lockup.
 - `metrora-app-icon.svg` — canonical desktop/mobile icon.
 
+The primary mark and app icon remain deliberately monochrome. Signal Cyan is an interaction and measured-signal accent; it is not a required fill inside the logo.
+
 ## Palette
 
 | Token | Hex | Use |
 | --- | --- | --- |
-| Signal Orange | `#F2701C` | actions, data highlights and active states on dark surfaces |
-| Signal Orange Deep | `#E8590C` | actions, data highlights and active states on light surfaces |
+| Signal Cyan | `#00D4FF` | signature signal on Graphite/dark surfaces, focus, active highlights and selected data emphasis |
+| Signal Cyan Deep | `#007A99` | accessible actions and text accents on light surfaces |
+| Signal Cyan Soft | `#E6F9FD` | restrained active fills and low-emphasis signal backgrounds |
 | Graphite | `#0F1115` | primary mark, headings and dark surfaces |
 | Slate | `#47505A` | secondary text and supporting UI |
 | Panel Gray | `#E6E9EE` | dividers and neutral panels |
@@ -29,11 +32,14 @@ Metrora™ is the product brand. Vensent™ is the publisher identity used for o
 - Prefer the monochrome Graphite mark on light backgrounds.
 - Prefer the Warm Off-White mark on Graphite backgrounds.
 - Keep clear space equal to at least one bar width.
-- Do not rotate, skew, outline, add gradients or recolor individual bars.
+- Do not rotate, skew, outline, add decorative gradients or recolor individual bars.
 - Minimum standalone size is 16 px; 24–32 px is preferred in product UI.
-- Use Signal Orange for interaction and data, not as a mandatory fill inside the primary logo.
+- Use Signal Cyan for interaction and measured-signal emphasis, not as a mandatory logo fill.
+- On light surfaces, use Signal Cyan Deep where contrast is required; bright Signal Cyan is strongest against Graphite.
+- If bright Signal Cyan is used as a filled control, pair it with Graphite text rather than white text.
+- Orange is not a Metrora identity color. It may remain only where it carries a genuine semantic warning or independent categorical meaning.
 - Use official names and canonical assets exactly as documented.
 
-The public website and product surfaces derive their visual identity from these files. Compatibility identifiers inherited from upstream may remain internally where changing them would break state, packaging or integrations; they must not appear as the product-facing identity.
+The public website and product surfaces derive their visual identity from these files. Compatibility identifiers inherited from earlier implementations may remain internally where changing them would break state, packaging or integrations; they must not appear as the product-facing identity.
 
 The MIT licence does not grant permission to impersonate the official project or imply endorsement by Metrora or Vensent. See [`BRAND_POLICY.md`](../../BRAND_POLICY.md).

--- a/dash/src/index.css
+++ b/dash/src/index.css
@@ -2,13 +2,17 @@
 
 @custom-variant dark (&:is(.dark *));
 
-/* Metrora visual identity v1 — Signal Grid.
- * Warm editorial surfaces, Graphite text and Signal Orange interactions.
+/* Metrora visual identity v1.1 — Signal Grid.
+ * Warm editorial surfaces, Graphite text and Signal Cyan interactions.
  * Semantic success/warning colors remain distinct from the brand accent.
  */
 :root {
   font-family: Inter, ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   --radius: 0.5rem;
+
+  --signal-cyan: #00d4ff;
+  --signal-cyan-deep: #007a99;
+  --signal-cyan-soft: #e6f9fd;
 
   --background: #faf7f2;
   --outer-background: #e6e9ee;
@@ -26,16 +30,16 @@
   --interactive-secondary: rgba(15, 17, 21, 0.045);
   --interactive-secondary-hover: rgba(15, 17, 21, 0.085);
   --active-primary: #ffffff;
-  --accent: #fff1e8;
+  --accent: var(--signal-cyan-soft);
   --accent-foreground: #0f1115;
   --subtle: #7b828d;
-  --primary: #e8590c;
-  --primary-foreground: #0f1115;
-  --ring: #e8590c;
+  --primary: var(--signal-cyan-deep);
+  --primary-foreground: #ffffff;
+  --ring: var(--signal-cyan);
   --positive: #16805c;
 
-  --chart-1: #e8590c;
-  --chart-2: #f28c45;
+  --chart-1: #007a99;
+  --chart-2: #00d4ff;
   --chart-3: #47505a;
   --chart-4: #2aa198;
   --chart-5: #8a68d6;
@@ -111,8 +115,11 @@
     margin: 0;
   }
   ::selection {
-    background: var(--primary);
-    color: var(--primary-foreground);
+    background: var(--signal-cyan);
+    color: #0f1115;
+  }
+  input[type='checkbox'] {
+    accent-color: var(--primary) !important;
   }
   * {
     scrollbar-width: thin;

--- a/gnome/stylesheet.css
+++ b/gnome/stylesheet.css
@@ -52,7 +52,7 @@
 .metrora-brand-accent {
   font-weight: 700;
   font-size: 18px;
-  color: #e8590c;
+  color: #00d4ff;
 }
 .metrora-brand-subhead {
   font-size: 10.5px;
@@ -81,13 +81,13 @@
 }
 .metrora-tab:hover,
 .metrora-period:hover {
-  background: rgba(232, 89, 12, 0.08);
+  background: rgba(0, 212, 255, 0.08);
   opacity: 1;
 }
 .metrora-tab-active,
 .metrora-period-active {
-  background: rgba(232, 89, 12, 0.18);
-  color: #e8590c;
+  background: rgba(0, 212, 255, 0.18);
+  color: #00d4ff;
   opacity: 1;
   font-weight: 600;
 }
@@ -97,8 +97,8 @@
 .metrora-agent-badge {
   padding: 3px 10px;
   border-radius: 10px;
-  background: rgba(232, 89, 12, 0.12);
-  color: #e8590c;
+  background: rgba(0, 212, 255, 0.12);
+  color: #00d4ff;
   font-size: 10.5px;
   font-weight: 500;
 }
@@ -115,7 +115,7 @@
   width: 6px;
   height: 6px;
   border-radius: 3px;
-  background-color: #e8590c;
+  background-color: #00d4ff;
   margin-top: 7px;
 }
 .metrora-hero-label {
@@ -126,7 +126,7 @@
 .metrora-hero-amount {
   font-size: 28px;
   font-weight: 700;
-  color: #f2701c;
+  color: #00d4ff;
 }
 .metrora-hero-meta {
   font-size: 11px;
@@ -179,7 +179,7 @@
   font-size: 11.5px;
   font-family: monospace;
   font-weight: 600;
-  color: #f2701c;
+  color: #00d4ff;
   min-width: 64px;
 }
 .metrora-activity-turns {
@@ -203,7 +203,7 @@
 .metrora-bar-fill {
   height: 4px;
   border-radius: 2px;
-  background-color: #e8590c;
+  background-color: #00d4ff;
 }
 .metrora-empty {
   font-style: italic;
@@ -217,11 +217,11 @@
   spacing: 10px;
 }
 .metrora-skeleton-bar {
-  background-color: rgba(232, 89, 12, 0.15);
+  background-color: rgba(0, 212, 255, 0.15);
   border-radius: 4px;
 }
 .metrora-light .metrora-skeleton-bar {
-  background-color: rgba(232, 89, 12, 0.12);
+  background-color: rgba(0, 122, 153, 0.12);
 }
 
 /* ---- findings CTA ---- */
@@ -229,12 +229,12 @@
   margin: 2px 16px 10px 16px;
   padding: 9px 11px;
   border-radius: 8px;
-  background: rgba(232, 89, 12, 0.12);
+  background: rgba(0, 212, 255, 0.12);
   border: none;
   transition-duration: 120ms;
 }
 .metrora-findings:hover {
-  background: rgba(232, 89, 12, 0.2);
+  background: rgba(0, 212, 255, 0.2);
 }
 .metrora-findings-inner {
   spacing: 8px;
@@ -242,12 +242,12 @@
 .metrora-findings-count {
   font-size: 11.5px;
   font-weight: 600;
-  color: #e8590c;
+  color: #00d4ff;
 }
 .metrora-findings-savings {
   font-size: 11.5px;
   font-weight: 500;
-  color: #e8590c;
+  color: #00d4ff;
   opacity: 0.8;
 }
 
@@ -293,19 +293,19 @@
   border: none;
 }
 .metrora-currency-item:hover {
-  background: rgba(232, 89, 12, 0.12);
+  background: rgba(0, 212, 255, 0.12);
 }
 .metrora-currency-item-active {
-  background: rgba(232, 89, 12, 0.2);
-  color: #e8590c;
+  background: rgba(0, 212, 255, 0.2);
+  color: #00d4ff;
   font-weight: 600;
 }
 .metrora-footer-cta {
-  background: #bf4808;
+  background: #007a99;
   color: #ffffff;
 }
 .metrora-footer-cta:hover {
-  background: #e8590c;
+  background: #00657d;
 }
 .metrora-updated {
   font-size: 10px;
@@ -329,12 +329,12 @@
   transition-duration: 80ms;
 }
 .metrora-insight-pill:hover {
-  background: rgba(232, 89, 12, 0.08);
+  background: rgba(0, 212, 255, 0.08);
   opacity: 1;
 }
 .metrora-insight-pill-active {
-  background: rgba(232, 89, 12, 0.18);
-  color: #e8590c;
+  background: rgba(0, 212, 255, 0.18);
+  color: #00d4ff;
   opacity: 1;
   font-weight: 600;
 }
@@ -356,7 +356,7 @@
   font-family: monospace;
   font-size: 11px;
   opacity: 0.7;
-  color: #e8590c;
+  color: #00d4ff;
 }
 .metrora-chart-bars {
   spacing: 2px;
@@ -369,11 +369,11 @@
   background: transparent;
 }
 .metrora-chart-bar {
-  background-color: #e8590c;
+  background-color: #00d4ff;
   border-radius: 2px 2px 0 0;
 }
 .metrora-chart-bar-hover {
-  background-color: #f2701c;
+  background-color: #66e6ff;
 }
 .metrora-chart-total-hover {
   font-weight: 600;
@@ -404,7 +404,7 @@
   font-family: monospace;
   font-size: 11.5px;
   font-weight: 600;
-  color: #f2701c;
+  color: #00d4ff;
 }
 .metrora-trend-calls {
   font-size: 10.5px;
@@ -420,13 +420,13 @@
 .metrora-pulse-tile {
   padding: 10px 8px;
   border-radius: 8px;
-  background: rgba(232, 89, 12, 0.08);
+  background: rgba(0, 212, 255, 0.08);
   spacing: 2px;
 }
 .metrora-pulse-value {
   font-size: 16px;
   font-weight: 700;
-  color: #e8590c;
+  color: #00d4ff;
   font-family: monospace;
 }
 .metrora-pulse-label {
@@ -450,7 +450,7 @@
 .metrora-model-cost {
   font-family: monospace;
   font-size: 11.5px;
-  color: #f2701c;
+  color: #00d4ff;
   min-width: 64px;
 }
 .metrora-model-calls {
@@ -544,8 +544,9 @@
 .metrora-light .metrora-hero-meta {
   color: rgba(0, 0, 0, 0.6);
 }
+.metrora-light .metrora-brand-accent,
 .metrora-light .metrora-hero-amount {
-  color: #bf4808;
+  color: #007a99;
 }
 .metrora-light .metrora-section-title,
 .metrora-light .metrora-th,
@@ -561,8 +562,12 @@
 .metrora-light .metrora-activity-cost,
 .metrora-light .metrora-model-cost,
 .metrora-light .metrora-trend-cost,
-.metrora-light .metrora-kv-value {
-  color: #bf4808;
+.metrora-light .metrora-kv-value,
+.metrora-light .metrora-findings-count,
+.metrora-light .metrora-findings-savings,
+.metrora-light .metrora-chart-total,
+.metrora-light .metrora-pulse-value {
+  color: #007a99;
 }
 .metrora-light .metrora-activity-turns,
 .metrora-light .metrora-model-calls,
@@ -575,11 +580,30 @@
 .metrora-light .metrora-bar-track {
   background-color: rgba(0, 0, 0, 0.08);
 }
-.metrora-light .metrora-bar-fill {
-  background-color: #bf4808;
-}
+.metrora-light .metrora-bar-fill,
 .metrora-light .metrora-chart-bar {
-  background-color: #bf4808;
+  background-color: #007a99;
+}
+.metrora-light .metrora-tab:hover,
+.metrora-light .metrora-period:hover,
+.metrora-light .metrora-insight-pill:hover {
+  background: rgba(0, 122, 153, 0.08);
+}
+.metrora-light .metrora-tab-active,
+.metrora-light .metrora-period-active,
+.metrora-light .metrora-insight-pill-active {
+  background: rgba(0, 122, 153, 0.14);
+  color: #007a99;
+}
+.metrora-light .metrora-agent-badge,
+.metrora-light .metrora-findings,
+.metrora-light .metrora-currency-item:hover {
+  background: rgba(0, 122, 153, 0.10);
+  color: #007a99;
+}
+.metrora-light .metrora-currency-item-active {
+  background: rgba(0, 122, 153, 0.16);
+  color: #007a99;
 }
 .metrora-light .metrora-footer-btn {
   background: rgba(0, 0, 0, 0.06);
@@ -600,7 +624,7 @@
   color: rgba(0, 0, 0, 0.65);
 }
 .metrora-light .metrora-pulse-tile {
-  background: rgba(232, 89, 12, 0.1);
+  background: rgba(0, 122, 153, 0.10);
 }
 .metrora-light .metrora-updated {
   color: rgba(0, 0, 0, 0.4);

--- a/mac/README.md
+++ b/mac/README.md
@@ -58,11 +58,12 @@ mac/
 
 Metrora Menubar uses the Signal Grid icon generated from `assets/brand` and the canonical palette:
 
-- Signal Orange `#F2701C`
-- Signal Orange Deep `#E8590C`
+- Signal Cyan `#00D4FF`
+- Signal Cyan Deep `#007A99`
+- Signal Cyan Soft `#E6F9FD`
 - Graphite `#0F1115`
 - Slate `#47505A`
 - Panel Gray `#E6E9EE`
 - Warm Off-White `#FAF7F2`
 
-Semantic success, warning and danger colors remain separate from the brand accent.
+The default macOS accent uses the accessible deep cyan on light surfaces and the brighter Signal Cyan family for highlights and glow. Semantic success, warning and danger colors remain separate from the brand accent.

--- a/mac/Sources/MetroraMenubar/Theme/Theme.swift
+++ b/mac/Sources/MetroraMenubar/Theme/Theme.swift
@@ -4,8 +4,8 @@ import SwiftUI
 @MainActor
 enum Theme {
     // The property name is retained for source compatibility; the canonical
-    // brand color is Metrora Signal Blue.
-    static let brandEmber        = Color(red: 0x25/255.0, green: 0x63/255.0, blue: 0xEB/255.0)
+    // brand signal is Metrora Signal Cyan.
+    static let brandEmber        = Color(red: 0x00/255.0, green: 0xD4/255.0, blue: 0xFF/255.0)
 
     static var brandAccent: Color { ThemeState.shared.preset.base }
     static var brandAccentLight: Color { ThemeState.shared.preset.light }

--- a/mac/Sources/MetroraMenubar/Theme/ThemeState.swift
+++ b/mac/Sources/MetroraMenubar/Theme/ThemeState.swift
@@ -2,7 +2,9 @@ import SwiftUI
 import Observation
 
 enum AccentPreset: String, CaseIterable, Identifiable {
-    case ember    = "Signal Blue"
+    // `ember` is retained as an internal compatibility case for persisted
+    // preferences and source references; its user-facing identity is Signal Cyan.
+    case ember    = "Signal Cyan"
     case blue     = "System Blue"
     case purple   = "Purple"
     case pink     = "Pink"
@@ -16,7 +18,7 @@ enum AccentPreset: String, CaseIterable, Identifiable {
 
     var base: Color {
         switch self {
-        case .ember:    Color(red: 0x25/255, green: 0x63/255, blue: 0xEB/255)
+        case .ember:    Color(red: 0x00/255, green: 0x7A/255, blue: 0x99/255)
         case .blue:     Color(red: 0x0A/255, green: 0x84/255, blue: 0xFF/255)
         case .purple:   Color(red: 0xBF/255, green: 0x5A/255, blue: 0xF2/255)
         case .pink:     Color(red: 0xFF/255, green: 0x37/255, blue: 0x5F/255)
@@ -30,7 +32,7 @@ enum AccentPreset: String, CaseIterable, Identifiable {
 
     var light: Color {
         switch self {
-        case .ember:    Color(red: 0x60/255, green: 0xA5/255, blue: 0xFA/255)
+        case .ember:    Color(red: 0x00/255, green: 0xD4/255, blue: 0xFF/255)
         case .blue:     Color(red: 0x40/255, green: 0x9C/255, blue: 0xFF/255)
         case .purple:   Color(red: 0xDA/255, green: 0x8F/255, blue: 0xF7/255)
         case .pink:     Color(red: 0xFF/255, green: 0x6E/255, blue: 0x8C/255)
@@ -44,7 +46,7 @@ enum AccentPreset: String, CaseIterable, Identifiable {
 
     var deep: Color {
         switch self {
-        case .ember:    Color(red: 0x1D/255, green: 0x4E/255, blue: 0xD8/255)
+        case .ember:    Color(red: 0x00/255, green: 0x65/255, blue: 0x7D/255)
         case .blue:     Color(red: 0x06/255, green: 0x52/255, blue: 0xB3/255)
         case .purple:   Color(red: 0x7C/255, green: 0x38/255, blue: 0xA8/255)
         case .pink:     Color(red: 0xB3/255, green: 0x26/255, blue: 0x42/255)
@@ -58,7 +60,7 @@ enum AccentPreset: String, CaseIterable, Identifiable {
 
     var glow: Color {
         switch self {
-        case .ember:    Color(red: 0x93/255, green: 0xC5/255, blue: 0xFD/255)
+        case .ember:    Color(red: 0x66/255, green: 0xE6/255, blue: 0xFF/255)
         case .blue:     Color(red: 0x80/255, green: 0xC0/255, blue: 0xFF/255)
         case .purple:   Color(red: 0xE0/255, green: 0xB8/255, blue: 0xFA/255)
         case .pink:     Color(red: 0xFF/255, green: 0x99/255, blue: 0xB0/255)
@@ -82,6 +84,8 @@ final class ThemeState {
 
     private init() {
         let saved = UserDefaults.standard.string(forKey: "MetroraAccentPreset") ?? ""
-        self.preset = saved == "Ember" ? .ember : (AccentPreset(rawValue: saved) ?? .ember)
+        self.preset = ["Ember", "Signal Blue"].contains(saved)
+            ? .ember
+            : (AccentPreset(rawValue: saved) ?? .ember)
     }
 }


### PR DESCRIPTION
## Summary

Converges Metrora's product-facing visual identity on the user-confirmed Graphite + Signal Cyan direction.

- makes Signal Cyan `#00D4FF` the canonical bright signal, with `#007A99` for accessible light-surface actions and `#E6F9FD` for restrained fills
- updates the effective desktop brand layer, local web dashboard, macOS default accent, GNOME development surface, README and brand documentation
- keeps the Signal Grid/app icon deliberately monochrome
- removes orange as a Metrora identity color while preserving genuine semantic warning/categorical uses
- updates the public Community copy to the now-live Fluxer community

## Accessibility and compatibility

- bright Signal Cyan is paired with Graphite on filled controls; accessible deep cyan is used where white/light-surface contrast is required
- legacy/internal names such as the macOS `.ember` compatibility case are retained where changing them would churn persisted state or source boundaries
- closed-schema/historical Windows acceptance identifiers that contain `signalOrange` are intentionally not renamed in this brand pass
- legacy base design layers may still contain semantic/compatibility color tokens; the later canonical brand layer owns the rendered product accent

## Scope

No pricing-policy files from the parallel PR are touched. No package identity, Store metadata or release packaging changes are included.