### PR TITLE
feat: preserve verified pricing evidence by route

### DIFF
--- a/docs/providers/codewhale.md
+++ b/docs/providers/codewhale.md
@@ -88,6 +88,12 @@ Shell commands, edited/read file paths, skill names, and subagent types are
 retained when present. `metadata.workspace` supplies both project grouping and
 worktree canonicalization.
 
+## Pricing evidence
+
+The persisted aggregate cost snapshot is bound as client-metered evidence when
+present, including an explicit zero. `model_provider` is retained as source
+inference-provider evidence and is not promoted to a billing authority.
+
 ## Caching and deduplication
 
 The shared session cache fingerprints each JSON file and includes

--- a/docs/providers/hermes.md
+++ b/docs/providers/hermes.md
@@ -53,6 +53,12 @@ Terminal command arguments are exposed as `bashCommands` for Metrora's command b
 
 The shared session cache fingerprints Hermes state DB files. `HERMES_HOME` is included in the provider environment fingerprint so changing the runtime home invalidates stale cached results.
 
+## Pricing evidence
+
+`actual_cost_usd` is bound as client-metered evidence when present, including
+an explicit zero. `estimated_cost_usd` and token-table reconstruction remain
+estimated; `billing_provider` is preserved as source provider evidence only.
+
 ## Quirks
 
 - The provider is aggregate-first because Hermes' stable accounting lives in `sessions`. Do not infer per-turn usage from message text.

--- a/docs/providers/opencode.md
+++ b/docs/providers/opencode.md
@@ -33,6 +33,12 @@ SQLite (older builds) or file-based JSON (OpenCode 1.1+, under `storage/`).
 
 None.
 
+## Pricing evidence
+
+When present, the raw `providerID` is preserved as `pricingContext.route` (and
+the legacy `modelProvider` field). It identifies the recorded route, not a
+pricing authority; the source `cost` remains route-specific source valuation.
+
 ## Deduplication
 
 Per `<sessionId>:<messageId>`.

--- a/docs/providers/quickdesk.md
+++ b/docs/providers/quickdesk.md
@@ -31,6 +31,12 @@ The on-disk schema is reverse-engineered. AWS officially documents the `.quickwo
 
 Quick Desktop is an eager provider using the shared session cache. Each metrics file and profile database is a separate cache source. The `QUICKWORK_HOME` value and the Quick Desktop parser version participate in the provider cache fingerprint. Sources are durable because Quick Desktop may prune its managed store; cached records are retained when a previously discovered source disappears.
 
+## Pricing evidence
+
+A numeric `CostUSD` is source-reported client-metered evidence. Rows without
+that field remain token-estimated; the Quick Desktop product name and model
+label do not establish a pricing authority.
+
 ## Deduplication
 
 Metrics calls with a session use `quickdesk:<session_id>:<timestamp>:<model>:<input>:<output>`. Session-less calls use `quickdesk:<profile>:<file>:<timestamp>:<model>:<input>:<output>`. Estimated database-only sessions use `quickdesk-est:<session_id>`. All keys are stable across runs.

--- a/docs/providers/vercel-gateway.md
+++ b/docs/providers/vercel-gateway.md
@@ -27,6 +27,14 @@ Set one of:
 
 None. Each parse issues one API request for the requested date range.
 
+## Pricing evidence
+
+The report source is preserved as the explicit
+`pricingContext.gateway = vercel-ai-gateway`. A non-negative `total_cost`
+is bound as exact billing-export evidence. Rows without `total_cost` remain
+estimated/unavailable and do not receive a synthetic metered zero; no
+downstream model provider is inferred as the billing authority.
+
 ## Deduplication
 
 Per `vercel-gateway:<day>:<model>`.

--- a/docs/providers/zed.md
+++ b/docs/providers/zed.md
@@ -4,7 +4,7 @@ Zed's built-in AI agent.
 
 - **Source:** `src/providers/zed.ts`
 - **Loading:** lazy via `src/providers/index.ts`
-- **Parser version:** `sqlite-zstd-ledger-v1-model-provider-v1`
+- **Parser version:** `sqlite-zstd-ledger-v1-model-provider-v1-pricing-context-v1`
 - **Blocking tests:** Zed SQLite/zstd tests on Node 22.15 on Ubuntu and Windows
 - **Signed sharing:** approved only for the two reviewed paths described below
 

--- a/src/contracts/v1/collector-provenance.ts
+++ b/src/contracts/v1/collector-provenance.ts
@@ -78,9 +78,9 @@ export type CollectorCostProvenanceV1 = z.infer<typeof CollectorCostProvenanceSc
 export type CollectorProvenanceProfileV1 = z.infer<typeof CollectorProvenanceProfileV1Schema>
 
 const CLAUDE_PARSER_VERSION = 'advisor-usage-v1-skills-rich-capture-v1-cross-provider-pr-v1-native-id-reconciliation-v1'
-const CODEX_PARSER_VERSION = 'mcp-attribution-v5-est-cost-active-timing-mcp-wait-rich-capture-v1-cross-provider-pr-v1-reasoning-attribution-v1-pricing-context-tags-v1'
+const CODEX_PARSER_VERSION = 'mcp-attribution-v5-est-cost-active-timing-mcp-wait-rich-capture-v1-cross-provider-pr-v1-reasoning-attribution-v1-pricing-context-tags-v1-pricing-evidence-provider-routes-v1'
 const GEMINI_PARSER_VERSION = 'message-token-ledger-v1'
-const ZED_PARSER_VERSION = 'sqlite-zstd-ledger-v1-model-provider-v1'
+const ZED_PARSER_VERSION = 'sqlite-zstd-ledger-v1-model-provider-v1-pricing-context-v1'
 
 function deepFreeze<T>(value: T): T {
   if (value === null || typeof value !== 'object' || Object.isFrozen(value)) return value

--- a/src/model-provider-propagation.test.ts
+++ b/src/model-provider-propagation.test.ts
@@ -7,12 +7,14 @@ import {
   providerCallToTurn,
 } from './parser.js'
 import type { ParsedProviderCall } from './providers/types.js'
+import type { HistoricalPricingContextV1 } from './pricing/pricing-context.js'
 
-function providerCall(modelProvider?: string): ParsedProviderCall {
+function providerCall(modelProvider?: string, pricingContext?: HistoricalPricingContextV1): ParsedProviderCall {
   return {
     provider: 'zed',
     model: 'gpt-5',
     ...(modelProvider ? { modelProvider } : {}),
+    ...(pricingContext ? { pricingContext } : {}),
     inputTokens: 10,
     outputTokens: 20,
     cacheCreationInputTokens: 3,
@@ -44,6 +46,30 @@ describe('model provider propagation', () => {
     const apiCached = apiCallToCachedCall(turnCall)
     expect(apiCached.modelProvider).toBe('openai')
     expect(cachedCallToApiCall(apiCached).modelProvider).toBe('openai')
+  })
+
+  it('preserves structured route, tier, region, and authority dimensions across cache round-trips', () => {
+    const pricingContext = {
+      modelIdentity: 'gpt-5',
+      modelOwner: 'openai',
+      inferenceProvider: 'openai',
+      pricingAuthority: 'openrouter',
+      gateway: 'openrouter',
+      route: 'standard',
+      billingTier: 'pro',
+      region: 'eu-west',
+    } satisfies HistoricalPricingContextV1
+    const call = providerCall('openai', pricingContext)
+    const turnCall = providerCallToTurn(call).assistantCalls[0]!
+    expect(turnCall.pricingContext).toEqual(pricingContext)
+
+    const providerCached = providerCallToCachedCall(call)
+    expect(providerCached.pricingContext).toEqual(pricingContext)
+    expect(cachedCallToApiCall(providerCached).pricingContext).toEqual(pricingContext)
+
+    const apiCached = apiCallToCachedCall(turnCall)
+    expect(apiCached.pricingContext).toEqual(pricingContext)
+    expect(cachedCallToApiCall(apiCached).pricingContext).toEqual(pricingContext)
   })
 
   it('does not invent a provider when the collector did not record one', () => {

--- a/src/pricing/runtime-cost-assignment.test.ts
+++ b/src/pricing/runtime-cost-assignment.test.ts
@@ -56,6 +56,7 @@ describe('runtime historical cost assignment', () => {
     const result = assignRuntimeCostV1(input('2026-07-31T00:00:00Z', {
       provider: 'vercel-gateway',
       legacyCostUSD: 9.876543,
+      meteredCost: { amountUSD: 9.876543, source: 'billing-export' as const },
     }))
     expect(result.storedCostUSD).toBe(9.876543)
     expect(result.storedAssignment).toMatchObject({ kind: 'metered', source: 'billing-export' })
@@ -95,6 +96,42 @@ describe('runtime historical cost assignment', () => {
     expect(routed.storedAssignment.kind).toBe('legacy-frozen')
   })
 
+  it('does not let gateway evidence borrow the original model-provider price', () => {
+    const routed = assignRuntimeCostV1(input('2026-07-31T00:00:00Z', {
+      modelProvider: 'openai',
+      pricingContext: { gateway: 'openrouter' },
+    }))
+    expect(routed.storedAssignment.kind).toBe('legacy-frozen')
+  })
+
+  it('does not treat explicit inference-provider evidence as pricing authority', () => {
+    const observed = assignRuntimeCostV1(input('2026-07-31T00:00:00Z', {
+      modelProvider: 'openai',
+      pricingContext: { inferenceProvider: 'openai' },
+    }))
+    expect(observed.storedAssignment.kind).toBe('legacy-frozen')
+
+    const modelOnly = assignRuntimeCostV1(input('2026-07-31T00:00:00Z', {
+      modelProvider: undefined,
+      pricingContext: undefined,
+    }))
+    expect(modelOnly.storedAssignment.kind).toBe('legacy-frozen')
+  })
+
+  it('does not promote model owner or collector branding to pricing authority', () => {
+    const ownerOnly = assignRuntimeCostV1(input('2026-07-31T00:00:00Z', {
+      modelProvider: 'openai',
+      pricingContext: { modelOwner: 'openai' },
+    }))
+    expect(ownerOnly.storedAssignment.kind).toBe('legacy-frozen')
+
+    const brandOnly = assignRuntimeCostV1(input('2026-07-31T00:00:00Z', {
+      provider: 'copilot',
+      modelProvider: undefined,
+      pricingContext: undefined,
+    }))
+    expect(brandOnly.storedAssignment.kind).toBe('legacy-frozen')
+  })
   it('supports compare and rollback views without mutating the stored historical settlement', () => {
     process.env['METRORA_HISTORICAL_PRICING'] = 'compare'
     const compared = assignRuntimeCostV1(input('2026-07-31T00:00:00Z'))

--- a/src/pricing/runtime-cost-assignment.ts
+++ b/src/pricing/runtime-cost-assignment.ts
@@ -195,16 +195,6 @@ function explicitZeroAssignment(reason: 'free-route' | 'local-inference' | 'manu
   })
 }
 
-function meteredSource(
-  provider: string,
-  isEstimated: boolean | undefined,
-): 'provider' | 'client' | 'billing-export' | undefined {
-  if (provider === 'vercel-gateway') return 'billing-export'
-  if (isEstimated === true) return undefined
-  if (provider === 'hermes' || provider === 'codewhale' || provider === 'quickdesk') return 'client'
-  return undefined
-}
-
 function meteredAssignment(costUSD: number, source: 'provider' | 'client' | 'billing-export'): CostAssignmentV1 {
   return CostAssignmentV1Schema.parse({
     version: 1,
@@ -270,7 +260,15 @@ function resolveHistoricalRecord(
 ): ReturnType<typeof resolveHistoricalPriceAcrossBooksV1> {
   const pricingModel = getHistoricalPricingModelKey(input.model)
   const pricingContext = contextForInput(input)
-  const pricingAuthority = normalizeAuthority(pricingContext?.pricingAuthority ?? input.modelProvider)
+  // Once a collector supplies structured pricing context, modelProvider stays
+  // descriptive. It must not become a pricing authority by fallback, because
+  // a route/gateway or inference-provider identity can be hosted by another
+  // billing authority. The legacy fallback remains only for older callers
+  // that have no pricing context at all.
+  const pricingAuthority = normalizeAuthority(
+    pricingContext?.pricingAuthority
+      ?? (input.pricingContext === undefined ? input.modelProvider : undefined),
+  )
 
   // An observed authority is required. In particular, a gateway/router name
   // must not silently fall back to the model owner's direct API price.
@@ -405,16 +403,6 @@ export function assignRuntimeCostV1(inputValue: RuntimeCostAssignmentInputV1): R
     }
   }
 
-  const inferredMetered = meteredSource(inputValue.provider, inputValue.isEstimated)
-  if (!existing && inferredMetered !== undefined) {
-    const assignment = meteredAssignment(legacyCostUSD, inferredMetered)
-    return {
-      storedCostUSD: legacyCostUSD,
-      storedAssignment: assignment,
-      runtimeCostUSD: legacyCostUSD,
-      runtimeAssignment: assignment,
-    }
-  }
 
   const zeroReason = explicitZeroReasonForModel(inputValue.model)
   if (zeroReason) {

--- a/src/providers/antigravity-accounting.ts
+++ b/src/providers/antigravity-accounting.ts
@@ -141,6 +141,7 @@ export function buildCallsFromGeneratorMetadata(
 
       results.push({
         provider: 'antigravity', model, ...(modelProvider ? { modelProvider } : {}),
+        ...(modelProvider ? { pricingContext: { inferenceProvider: modelProvider } } : {}),
         inputTokens, outputTokens: responseTokens,
         cacheCreationInputTokens: cacheCreationTokens, cacheReadInputTokens: cacheReadTokens,
         cachedInputTokens: 0, reasoningTokens: thinkingTokens, webSearchRequests: 0, costUSD,

--- a/src/providers/codewhale.ts
+++ b/src/providers/codewhale.ts
@@ -8,6 +8,7 @@ import { normalizeExplicitModelProvider } from '../model-provider.js'
 import { calculateCost, getShortModelName } from '../models.js'
 import type { ToolCall } from '../types.js'
 import type { ParsedProviderCall, Provider, SessionParser, SessionSource } from './types.js'
+import { sourceMeteredCostAssignment } from './cost-evidence.js'
 
 const METADATA_PREFIX_BYTES = 64 * 1024
 
@@ -361,8 +362,16 @@ function reportedCost(cost: CodeWhaleCost | undefined): { value: number; exact: 
   const hasSessionCost = Object.prototype.hasOwnProperty.call(cost, 'session_cost_usd')
   const hasSubagentCost = Object.prototype.hasOwnProperty.call(cost, 'subagent_cost_usd')
   if (!hasSessionCost && !hasSubagentCost) return { value: 0, exact: false }
+  const sessionCost = cost.session_cost_usd
+  const subagentCost = cost.subagent_cost_usd
+  if (hasSessionCost && (typeof sessionCost !== 'number' || !Number.isFinite(sessionCost) || sessionCost < 0)) {
+    return { value: 0, exact: false }
+  }
+  if (hasSubagentCost && (typeof subagentCost !== 'number' || !Number.isFinite(subagentCost) || subagentCost < 0)) {
+    return { value: 0, exact: false }
+  }
   return {
-    value: safeNonNegativeNumber(cost.session_cost_usd) + safeNonNegativeNumber(cost.subagent_cost_usd),
+    value: (sessionCost ?? 0) + (subagentCost ?? 0),
     exact: true,
   }
 }
@@ -412,6 +421,7 @@ function createParser(source: SessionSource, seenKeys: Set<string>): SessionPars
       yield {
         provider: 'codewhale',
         model, ...(modelProvider ? { modelProvider } : {}),
+        ...(modelProvider ? { pricingContext: { inferenceProvider: modelProvider } } : {}),
         // CodeWhale persists only one aggregate token counter. Preserve it
         // losslessly in the input column instead of inventing a split.
         inputTokens: totalTokens,
@@ -423,6 +433,7 @@ function createParser(source: SessionSource, seenKeys: Set<string>): SessionPars
         webSearchRequests,
         costUSD,
         costIsEstimated: !localCost.exact,
+        ...(localCost.exact ? { costAssignment: sourceMeteredCostAssignment(localCost.value, 'client') } : {}),
         tools,
         bashCommands,
         skills,

--- a/src/providers/codex-model-provider.test.ts
+++ b/src/providers/codex-model-provider.test.ts
@@ -98,6 +98,7 @@ describe('Codex source-recorded model provider', () => {
     for await (const value of parsed) values.push(value)
     expect(values).toHaveLength(1)
     expect(values[0]?.modelProvider).toBe('openai')
+    expect(values[0]?.pricingContext).toEqual({ inferenceProvider: 'openai' })
   })
 
   it('never overwrites or hides a contradictory parser provider', async () => {

--- a/src/providers/codex-model-provider.ts
+++ b/src/providers/codex-model-provider.ts
@@ -79,7 +79,17 @@ export function withCodexModelProvider(
             if (call.modelProvider && call.modelProvider !== sourceProvider) {
               throw new CodexModelProviderContradictionError()
             }
-            yield call.modelProvider ? call : { ...call, modelProvider: sourceProvider }
+            if (call.pricingContext?.inferenceProvider && call.pricingContext.inferenceProvider !== sourceProvider) {
+              throw new CodexModelProviderContradictionError()
+            }
+            yield {
+              ...call,
+              ...(call.modelProvider ? {} : { modelProvider: sourceProvider }),
+              pricingContext: {
+                ...(call.pricingContext ?? {}),
+                inferenceProvider: sourceProvider,
+              },
+            }
           }
         },
       }

--- a/src/providers/cost-evidence.ts
+++ b/src/providers/cost-evidence.ts
@@ -1,0 +1,22 @@
+import {
+  CostAssignmentV1Schema,
+  costUsdToMicrosV1,
+  type CostAssignmentV1,
+} from '../pricing/cost-assignment.js'
+
+/**
+ * Bind a non-estimated source-reported amount to the collector that recorded
+ * it. The caller is responsible for proving that the source field is an exact
+ * amount before calling this helper.
+ */
+export function sourceMeteredCostAssignment(
+  amountUSD: number,
+  source: 'provider' | 'client' | 'billing-export',
+): CostAssignmentV1 {
+  return CostAssignmentV1Schema.parse({
+    version: 1,
+    kind: 'metered',
+    amountMicrosUsd: costUsdToMicrosV1(amountUSD),
+    source,
+  })
+}

--- a/src/providers/hermes.ts
+++ b/src/providers/hermes.ts
@@ -6,6 +6,7 @@ import { calculateCost, getShortModelName } from '../models.js'
 import { normalizeExplicitModelProvider } from '../model-provider.js'
 import { isSqliteAvailable, getSqliteLoadError, openDatabase, isSqliteBusyError, type SqliteDatabase } from '../sqlite.js'
 import type { Provider, SessionSource, SessionParser, ParsedProviderCall } from './types.js'
+import { sourceMeteredCostAssignment } from './cost-evidence.js'
 import type { ToolCall } from '../types.js'
 
 type HermesSessionRow = {
@@ -377,8 +378,8 @@ function createParser(source: SessionSource, seenKeys: Set<string>, hermesHome: 
         const cacheWriteTokens = row.cache_write_tokens ?? 0
         const reasoningTokens = row.reasoning_tokens ?? 0
         const hasRecordedCost =
-          (typeof row.actual_cost_usd === 'number' && Number.isFinite(row.actual_cost_usd)) ||
-          (typeof row.estimated_cost_usd === 'number' && Number.isFinite(row.estimated_cost_usd))
+          (typeof row.actual_cost_usd === 'number' && Number.isFinite(row.actual_cost_usd) && row.actual_cost_usd >= 0) ||
+          (typeof row.estimated_cost_usd === 'number' && Number.isFinite(row.estimated_cost_usd) && row.estimated_cost_usd >= 0)
         if (inputTokens + outputTokens + cacheReadTokens + cacheWriteTokens + reasoningTokens === 0 && !hasRecordedCost) return
 
         const model = row.model ?? 'unknown'
@@ -407,8 +408,8 @@ function createParser(source: SessionSource, seenKeys: Set<string>, hermesHome: 
           cacheReadTokens,
           0,
         )
-        const hasActualCost = typeof row.actual_cost_usd === 'number' && Number.isFinite(row.actual_cost_usd)
-        const hasEstimatedCost = typeof row.estimated_cost_usd === 'number' && Number.isFinite(row.estimated_cost_usd)
+        const hasActualCost = typeof row.actual_cost_usd === 'number' && Number.isFinite(row.actual_cost_usd) && row.actual_cost_usd >= 0
+        const hasEstimatedCost = typeof row.estimated_cost_usd === 'number' && Number.isFinite(row.estimated_cost_usd) && row.estimated_cost_usd >= 0
         const recordedCost = hasActualCost
           ? row.actual_cost_usd
           : hasEstimatedCost ? row.estimated_cost_usd : null
@@ -421,6 +422,7 @@ function createParser(source: SessionSource, seenKeys: Set<string>, hermesHome: 
           provider: 'hermes',
           model,
           ...(modelProvider ? { modelProvider } : {}),
+          ...(modelProvider ? { pricingContext: { inferenceProvider: modelProvider } } : {}),
           inputTokens,
           outputTokens,
           cacheCreationInputTokens: cacheWriteTokens,
@@ -430,6 +432,7 @@ function createParser(source: SessionSource, seenKeys: Set<string>, hermesHome: 
           webSearchRequests: 0,
           costUSD,
           costIsEstimated,
+          ...(hasActualCost ? { costAssignment: sourceMeteredCostAssignment(costUSD, 'client') } : {}),
           tools,
           bashCommands,
           timestamp,

--- a/src/providers/quickdesk.ts
+++ b/src/providers/quickdesk.ts
@@ -7,6 +7,7 @@ import { estimateTokensFromChars } from '../token-estimate.js'
 import { blobToText, isSqliteAvailable, openDatabase } from '../sqlite.js'
 import type { SqliteDatabase } from '../sqlite.js'
 import type { ParsedProviderCall, ProbeRoot, Provider, SessionParser, SessionSource } from './types.js'
+import { sourceMeteredCostAssignment } from './cost-evidence.js'
 
 const METRICS_FILE_RE = /^metrics-(\d{4})-(\d{2})-(\d{2})\.jsonl$/
 
@@ -470,6 +471,7 @@ function createMetricsParser(source: SessionSource, seenKeys: Set<string>): Sess
           outputTokens,
           costUSD: recordedCost ?? calculateCost(model, inputTokens, outputTokens, 0, 0, 0),
           costIsEstimated,
+          ...(recordedCost !== undefined ? { costAssignment: sourceMeteredCostAssignment(recordedCost, 'client') } : {}),
           tools,
           timestamp,
           deduplicationKey,

--- a/src/providers/session-message.ts
+++ b/src/providers/session-message.ts
@@ -157,6 +157,7 @@ export function buildAssistantCall(opts: {
     provider: opts.providerName,
     model,
     ...(modelProvider ? { modelProvider } : {}),
+    ...(modelProvider ? { pricingContext: { route: modelProvider } } : {}),
     inputTokens: tokens.input,
     outputTokens: tokens.output,
     cacheCreationInputTokens: tokens.cacheWrite,

--- a/src/providers/vercel-gateway.ts
+++ b/src/providers/vercel-gateway.ts
@@ -1,5 +1,6 @@
 import type { DateRange } from '../types.js'
 import type { Provider, SessionSource, SessionParser, ParsedProviderCall } from './types.js'
+import { sourceMeteredCostAssignment } from './cost-evidence.js'
 import { fetchWithTimeout } from '../fetch-utils.js'
 
 const REPORT_URL = 'https://ai-gateway.vercel.sh/v1/report'
@@ -83,7 +84,7 @@ function createParser(
       for (const row of rows) {
         const day = row.day ?? ''
         const model = row.model ?? 'unknown'
-        const sourceCost = typeof row.total_cost === 'number' && Number.isFinite(row.total_cost) ? row.total_cost : undefined
+        const sourceCost = typeof row.total_cost === 'number' && Number.isFinite(row.total_cost) && row.total_cost >= 0 ? row.total_cost : undefined
         const costUSD = sourceCost ?? 0
         const inputTokens = row.input_tokens ?? 0
         const outputTokens = row.output_tokens ?? 0
@@ -102,6 +103,9 @@ function createParser(
         yield {
           provider: 'vercel-gateway',
           model,
+          pricingContext: { gateway: 'vercel-ai-gateway' },
+          costIsEstimated: sourceCost === undefined,
+          ...(sourceCost !== undefined ? { costAssignment: sourceMeteredCostAssignment(sourceCost, 'billing-export') } : {}),
           inputTokens,
           outputTokens,
           cacheCreationInputTokens: cacheWriteTokens,

--- a/src/providers/zed-model-provider.test.ts
+++ b/src/providers/zed-model-provider.test.ts
@@ -56,6 +56,7 @@ sqliteDescribe('Zed model provider provenance', () => {
     expect(calls[0]!.provider).toBe('zed')
     expect(calls[0]!.model).toBe('claude-sonnet-4-6')
     expect(calls[0]!.modelProvider).toBe('anthropic')
+    expect(calls[0]!.pricingContext).toEqual({ inferenceProvider: 'anthropic' })
   })
 
   it('omits malformed provider claims instead of inferring one from the model', async () => {

--- a/src/providers/zed.ts
+++ b/src/providers/zed.ts
@@ -87,6 +87,7 @@ function buildCall(opts: {
     provider: 'zed',
     model: opts.model,
     ...(opts.modelProvider ? { modelProvider: opts.modelProvider } : {}),
+    ...(opts.modelProvider ? { pricingContext: { inferenceProvider: opts.modelProvider } } : {}),
     inputTokens: input,
     outputTokens: output,
     cacheCreationInputTokens: cacheWrite,

--- a/src/session-cache.ts
+++ b/src/session-cache.ts
@@ -227,7 +227,7 @@ export const PROVIDER_PARSE_VERSIONS: Record<string, string> = {
   // the new optional fields.
   claude: 'advisor-usage-v1-skills-rich-capture-v1-cross-provider-pr-v1-native-id-reconciliation-v1',
   cline: 'worktree-project-grouping-v1-vscode-variants-v2-provider-zero-cost',
-  codewhale: 'aggregate-session-v2-provider-provenance',
+  codewhale: 'aggregate-session-v2-provider-provenance-pricing-evidence-v1',
   // Bump when the Codex parser changes attribution so unchanged, already-cached
   // session files re-parse (session-cache.json serves them without invoking the
   // provider parser otherwise). Covers native mcp_tool_call_end (#513) and
@@ -235,29 +235,29 @@ export const PROVIDER_PARSE_VERSIONS: Record<string, string> = {
   // rich-session-capture-v1: per-call LOC deltas + editFailed from
   // patch_apply_end. (The codex-results.json CODEX_CACHE_VERSION is bumped in
   // lockstep so the pre-session-cache layer re-parses too.)
-  codex: 'mcp-attribution-v5-est-cost-active-timing-mcp-wait-rich-capture-v1-cross-provider-pr-v1-reasoning-attribution-v1-pricing-context-tags-v1',
+  codex: 'mcp-attribution-v5-est-cost-active-timing-mcp-wait-rich-capture-v1-cross-provider-pr-v1-reasoning-attribution-v1-pricing-context-tags-v1-pricing-evidence-provider-routes-v1',
   cursor: 'composer-anchored-crediting-v1-est-cost',
   'cursor-agent': 'workspaceless-transcript-v2-estimated-cost',
   copilot: 'cli-shutdown-cost-v3-source-provenance',
   goose: 'sqlite-session-v1-provider-provenance',
   grok: 'estimated-cost-v1',
-  hermes: 'reasoning-output-accounting-v2-provider-provenance-cost-semantics-v2',
+  hermes: 'reasoning-output-accounting-v2-provider-provenance-cost-semantics-v2-pricing-evidence-v1',
   'lingtai-tui': 'token-ledger-registry-activity-v3',
   'ibm-bob': 'worktree-project-grouping-v1',
   kiro: 'ide-parsing-v3-provider-provenance',
   'mistral-vibe': 'session-cost-only-v1-provider-provenance-estimated-cost-v2',
-  quickdesk: 'emf-sqlite-v2-est-cost',
+  quickdesk: 'emf-sqlite-v2-est-cost-pricing-evidence-v1',
   kimicode: 'wire-usage-v1-est-cost',
   'kilo-code': 'worktree-project-grouping-v1',
   'roo-code': 'worktree-project-grouping-v1',
   zerostack: 'cumulative-session-v1-provider-provenance-estimated-cost-v2',
   warp: 'worktree-project-grouping-v1-est-cost',
-  antigravity: 'worktree-project-grouping-v6-provider-reasoning-filter-usage-accounting-v2-source-union-v1-durable-v1-output-reasoning-map-v2',
+  antigravity: 'worktree-project-grouping-v6-provider-reasoning-filter-usage-accounting-v2-source-union-v1-durable-v1-output-reasoning-map-v2-pricing-evidence-v1',
   // OpenCode keeps valid usage in archived root/child sessions. The parser
   // must scan the complete SQLite session tree, not only active sessions.
-  opencode: 'sqlite-session-tree-v2-provider-id-v1-free-route-v1-route-cost-v1',
+  opencode: 'sqlite-session-tree-v2-provider-id-v1-free-route-v1-route-cost-v1-pricing-context-v1',
   // Preserve the source-recorded thread.model.provider through the shared cache.
-  zed: 'sqlite-zstd-ledger-v1-model-provider-v1',
+  zed: 'sqlite-zstd-ledger-v1-model-provider-v1-pricing-context-v1',
 }
 // ── Cache Dir ──────────────────────────────────────────────────────────
 

--- a/tests/providers/antigravity.test.ts
+++ b/tests/providers/antigravity.test.ts
@@ -251,6 +251,7 @@ describe('antigravity provider helpers', () => {
 
     expect(calls).toHaveLength(1)
     expect(calls[0]!.modelProvider).toBe('google')
+    expect(calls[0]!.pricingContext).toEqual({ inferenceProvider: 'google' })
   })
 
   it('preserves cache reads and total output for legacy direct generator usage', () => {

--- a/tests/providers/codewhale.test.ts
+++ b/tests/providers/codewhale.test.ts
@@ -165,6 +165,7 @@ describe('codewhale provider', () => {
       provider: 'codewhale',
       model: 'anthropic/claude-sonnet-4-6',
       modelProvider: 'deepseek',
+      pricingContext: { inferenceProvider: 'deepseek' },
       inputTokens: 12_345,
       outputTokens: 0,
       cacheCreationInputTokens: 0,
@@ -173,6 +174,7 @@ describe('codewhale provider', () => {
       webSearchRequests: 1,
       costUSD: 0.95,
       costIsEstimated: false,
+      costAssignment: { kind: 'metered', source: 'client' },
       timestamp: '2026-07-15T12:34:56.000Z',
       userMessage: 'Implement the parser',
       sessionId: 'session-full',
@@ -209,14 +211,22 @@ describe('codewhale provider', () => {
       model: 'gpt-4o-mini',
       cost: { session_cost_usd: 0, subagent_cost_usd: 0 },
     })
+    const malformedPath = await writeSession(join(tmpDir, 'sessions'), 'malformed.json', {
+      totalTokens: 1_000_000,
+      model: 'gpt-4o-mini',
+      cost: { session_cost_usd: 'not-a-number' },
+    })
 
     const [estimated] = await parseOne(estimatedPath)
     const [exactZero] = await parseOne(exactZeroPath)
+    const [malformed] = await parseOne(malformedPath)
 
     expect(estimated!.costUSD).toBeGreaterThan(0)
     expect(estimated!.costIsEstimated).toBe(true)
     expect(exactZero!.costUSD).toBe(0)
     expect(exactZero!.costIsEstimated).toBe(false)
+    expect(malformed!.costIsEstimated).toBe(true)
+    expect(malformed!.costAssignment).toBeUndefined()
   })
 
   it('retains an explicit zero-cost record when aggregate tokens are absent', async () => {

--- a/tests/providers/hermes.test.ts
+++ b/tests/providers/hermes.test.ts
@@ -264,6 +264,7 @@ skipUnlessSqlite('hermes provider', () => {
       provider: 'hermes',
       model: 'gpt-5.5',
       modelProvider: 'openai-codex',
+      pricingContext: { inferenceProvider: 'openai-codex' },
       inputTokens: 1000,
       outputTokens: 200,
       cacheReadInputTokens: 300,
@@ -566,6 +567,7 @@ skipUnlessSqlite('hermes provider', () => {
 
     const actual = await collectCalls(tmpDir, `${dbPath}#hermes-session=actual-wins`)
     expect(actual[0]).toMatchObject({ costUSD: 1.23, costIsEstimated: false })
+    expect(actual[0]!.costAssignment).toMatchObject({ kind: 'metered', source: 'client' })
 
     const estimated = await collectCalls(tmpDir, `${dbPath}#hermes-session=estimated-cost`)
     expect(estimated[0]).toMatchObject({ costUSD: 0.75, costIsEstimated: true })

--- a/tests/providers/opencode.test.ts
+++ b/tests/providers/opencode.test.ts
@@ -323,6 +323,7 @@ skipUnlessSqlite('opencode provider - session parsing', () => {
     const call = calls[0]!
     expect(call.provider).toBe('opencode')
     expect(call.modelProvider).toBe('opencode-go')
+    expect(call.pricingContext).toEqual({ route: 'opencode-go' })
     expect(call.model).toBe('claude-opus-4-6')
     expect(call.inputTokens).toBe(100)
     expect(call.outputTokens).toBe(200)
@@ -583,6 +584,7 @@ skipUnlessSqlite('opencode provider - session parsing', () => {
     const calls = await collectCalls(createOpenCodeProvider(tmpDir), dbPath, 'sess-1')
     expect(calls).toHaveLength(1)
     expect(calls[0]!.modelProvider).toBe('opencode-go')
+    expect(calls[0]!.pricingContext).toEqual({ route: 'opencode-go' })
     expect(calls[0]!.costUSD).toBe(63.281744016)
   })
 

--- a/tests/providers/quickdesk.test.ts
+++ b/tests/providers/quickdesk.test.ts
@@ -206,6 +206,7 @@ skipUnlessSqlite('quickdesk provider', () => {
       outputTokens: 30,
       costUSD: 0.0042,
       costIsEstimated: false,
+      costAssignment: { kind: 'metered', source: 'client' },
       tools: ['Read'],
       timestamp: '2026-07-14T00:00:00.123Z',
       sessionId: 'session-alpha',

--- a/tests/providers/vercel-gateway.test.ts
+++ b/tests/providers/vercel-gateway.test.ts
@@ -64,6 +64,8 @@ describe('vercel-gateway provider', () => {
     }
     expect(calls).toHaveLength(1)
     expect(calls[0]?.costUSD).toBe(1.25)
+    expect(calls[0]?.pricingContext).toEqual({ gateway: 'vercel-ai-gateway' })
+    expect(calls[0]?.costAssignment).toMatchObject({ kind: 'metered', source: 'billing-export' })
     expect(calls[0]?.inputTokens).toBe(1000)
     expect(calls[0]?.outputTokens).toBe(200)
     expect(calls[0]?.deduplicationKey).toBe('vercel-gateway:2026-06-01:anthropic/claude-sonnet-4.6')
@@ -101,6 +103,8 @@ describe('vercel-gateway provider', () => {
     expect(calls[0]?.cacheReadInputTokens).toBe(120)
     expect(calls[0]?.cacheCreationInputTokens).toBe(8)
     expect(calls[0]?.reasoningTokens).toBe(4)
+    expect(calls[0]?.costIsEstimated).toBe(false)
+    expect(calls[0]?.costAssignment).toMatchObject({ kind: 'metered', amountMicrosUsd: 0 })
   })
 
   it('retains one bounded aggregate row for explicit free usage', async () => {
@@ -127,6 +131,30 @@ describe('vercel-gateway provider', () => {
 
     expect(calls).toHaveLength(1)
     expect(calls[0]!.costUSD).toBe(0)
+  })
+
+  it('does not invent metered cost when the report omits or rejects total_cost', async () => {
+    globalThis.fetch = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({
+        results: [
+          { day: '2026-06-04', model: 'openai/gpt-4o', input_tokens: 10, output_tokens: 5 },
+          { day: '2026-06-04', model: 'openai/gpt-4o-mini', total_cost: -1, input_tokens: 10, output_tokens: 5 },
+        ],
+      }),
+    })) as typeof fetch
+
+    const range = {
+      start: new Date('2026-06-04T00:00:00.000Z'),
+      end: new Date('2026-06-04T23:59:59.999Z'),
+    }
+    const calls = []
+    for await (const call of vercelGateway.createSessionParser({
+      path: 'vercel-ai-gateway:report', project: 'Vercel AI Gateway', provider: 'vercel-gateway',
+    }, new Set(), range).parse()) calls.push(call)
+
+    expect(calls).toHaveLength(2)
+    expect(calls.every(call => call.costUSD === 0 && call.costIsEstimated === true && call.costAssignment === undefined)).toBe(true)
   })
 })
 


### PR DESCRIPTION
## What changed

- Preserve explicit pricing evidence from Codex, OpenCode, Antigravity, Zed, CodeWhale, Hermes, Quick Desktop, and Vercel Gateway.
- Model names and collector branding no longer infer billing authority or provider identity.
- Route/provider/cost evidence is propagated through runtime assignment and session-cache round trips.
- Malformed or missing cost fields fail closed as estimated/unavailable; unknown is never treated as zero.
- Added focused regression coverage and minimal provider documentation.

## Why

Pricing evidence must remain attributable to the source route or provider when the source explicitly exposes it, while avoiding unsafe billing assumptions from model ownership, collector names, or gateway branding.

## Impact

- Existing assignments remain immutable.
- No pricing catalog expansion: schema v1 and all 82 catalog records are unchanged.
- No private-content expansion and no canonical cache rewrite.
- The Android worktree remains isolated under `android/**`.

## Root cause

The previous flow could lose source-level provider/route/cost evidence or allow heuristic identity signals to influence metered assignment. This change makes source evidence explicit and fail-closed.

## Checks

- 19 focused Vitest files: 311 tests passed.
- `npx tsc --noEmit` passed.
- `git diff --check` passed.
- Catalog validation passed: schema v1, 82 records.
- CI is expected to run on this draft PR.

No merge or release was performed.