### PR TITLE
fix(desktop): prevent blank Windows dev window

### DIFF
--- a/app/electron/main.test.ts
+++ b/app/electron/main.test.ts
@@ -14,7 +14,7 @@ vi.mock('electron', () => ({
   shell: { openExternal: vi.fn() },
 }))
 
-import { createApplicationMenuTemplate, createBeforeQuitHandler, createBridgeHandlers } from './main'
+import { createApplicationMenuTemplate, createBeforeQuitHandler, createBridgeHandlers, shouldInstallApplicationMenu } from './main'
 import { CliError } from './cli'
 import type { DesktopShareRuntime, DesktopShareStatus } from './share-runtime'
 import { Telemetry } from './telemetry'
@@ -316,6 +316,12 @@ describe('createApplicationMenuTemplate', () => {
     expect(roles).toContain('toggleDevTools')
     expect(roles).not.toContain('reload')
     expect(roles).not.toContain('forceReload')
+  })
+
+  it('installs the menu for development on Windows but keeps packaged Windows apps menu-free', () => {
+    expect(shouldInstallApplicationMenu(true, 'win32')).toBe(true)
+    expect(shouldInstallApplicationMenu(false, 'win32')).toBe(false)
+    expect(shouldInstallApplicationMenu(false, 'darwin')).toBe(true)
   })
 })
 

--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -403,6 +403,10 @@ export function ipcChannelAliases(channel: string): string[] {
   return [channel]
 }
 
+export function shouldInstallApplicationMenu(isDev: boolean, platform = process.platform): boolean {
+  return platform === 'darwin' || isDev
+}
+
 function registerHandlers(): void {
   const share = initializeDesktopShareRuntime({
     isPackaged: app.isPackaged,
@@ -439,7 +443,10 @@ function registerHandlers(): void {
 }
 
 function installApplicationMenu(): void {
-  Menu.setApplicationMenu(process.platform === 'darwin' ? Menu.buildFromTemplate(createApplicationMenuTemplate()) : null)
+  const isDev = !app.isPackaged && Boolean(process.env.VITE_DEV_SERVER_URL)
+  Menu.setApplicationMenu(shouldInstallApplicationMenu(isDev)
+    ? Menu.buildFromTemplate(createApplicationMenuTemplate(isDev))
+    : null)
 }
 
 function createWindow(): BrowserWindow {

--- a/app/package.json
+++ b/app/package.json
@@ -9,7 +9,7 @@
     "build:electron": "tsc -p tsconfig.electron.json",
     "build:renderer": "vite build",
     "build": "npm run brand:assets && npm run build:electron && npm run build:renderer",
-    "dev": "npm run stage-cli && npm run build:electron && concurrently -k -n vite,electron -c cyan,magenta \"vite\" \"wait-on tcp:127.0.0.1:5173 && cross-env VITE_DEV_SERVER_URL=http://127.0.0.1:5173 electron .\"",
+    "dev": "npm run stage-cli && npm run build:electron && concurrently -k -n vite,electron -c cyan,magenta \"vite\" \"wait-on http-get://127.0.0.1:5173/ && cross-env VITE_DEV_SERVER_URL=http://127.0.0.1:5173 electron .\"",
     "test": "vitest run",
     "test:safe-storage": "electron scripts/probe-safe-storage.cjs",
     "typecheck": "tsc --noEmit -p tsconfig.json",


### PR DESCRIPTION
## What changed

- Gate Electron startup on a successful renderer HTML GET instead of TCP listen readiness.
- Install the existing application menu in non-packaged development builds on Windows/Linux so the existing development-only Toggle Developer Tools role is available.
- Keep packaged Windows apps menu-free and add focused coverage for the platform/dev decision.

## Root cause

The dev launcher used `wait-on tcp:127.0.0.1:5173`. On this Windows checkout the TCP listener became available before Vite could serve HTML (about 420 ms vs. about 1.45 s for the first HTTP 200). Electron then performed its one-shot `loadURL` during that gap. A controlled delayed-listener reproduction produced `ERR_CONNECTION_RESET (-101)`; because the window is created with `show: false` and only shown on `ready-to-show`, the failed navigation leaves a blank/hidden renderer window with no retry.

The clean physical run also exposed an independent DevTools issue: Windows development previously called `Menu.setApplicationMenu(null)`, so the existing `toggleDevTools` role and Ctrl+Shift+I path were not installed.

## Validation

- App `npm ci`
- App `npm run typecheck`
- App `npm test`: 76 files, 572 tests passed
- App `npm run build`
- Root `npm run build:cli`
- Changed Electron tests: 89 passed
- Targeted retry of the unrelated root cache-lock test: 5 passed
- Root full test run: one unrelated flaky cache-lock test failure; 317 files passed, 2 skipped, 1 failed
- Clean Windows `npm run dev`: Vite 200/#root, responsive Metrora window, Home/Settings/Devices/Connect phone verified through the renderer, preload bridge present, and graceful quit removed the dev process tree and port 5173.
- No Android, signing, release, tag, or production environment changes.