### PR TITLE
Prepare RC11 Windows Store companion parity candidate

### DIFF
--- a/.github/workflows/windows-store-package.yml
+++ b/.github/workflows/windows-store-package.yml
@@ -9,15 +9,29 @@ on:
       - '.github/workflows/windows-physical-acceptance.yml'
       - 'app/package.json'
       - 'app/package-lock.json'
+      - 'app/electron/share-bridge.ts'
+      - 'app/electron/main.ts'
+      - 'app/electron/share-runtime.ts'
+      - 'app/scripts/appx-manifest-created.cjs'
       - 'app/scripts/stage-cli.mjs'
       - 'app/scripts/after-pack.cjs'
+      - 'package-lock.json'
+      - 'release/windows-store-package-version.v1.json'
+      - 'scripts/appx-manifest-created.node-test.mjs'
+      - 'scripts/check-version-consistency.mjs'
       - 'tsup.config.ts'
       - 'scripts/generate-brand-assets.mjs'
+      - 'scripts/probe-packaged-companion-runtime.mjs'
+      - 'scripts/version-authority-lib.mjs'
+      - 'scripts/version-authority.node-test.mjs'
       - 'scripts/windows-store-identity.node-test.mjs'
       - 'scripts/windows-store-local-test*'
       - 'scripts/verify-windows-store-local-test-report.mjs'
       - 'scripts/*Windows-Store-Local-Test*.ps1'
       - 'scripts/Test-Metrora-Windows-Release-Syntax.ps1'
+      - 'src/desktop-share-runtime-entry.ts'
+      - 'src/models.ts'
+      - 'src/sharing/**'
       - 'docs/WINDOWS_STORE_IDENTITY_V1.md'
       - 'docs/WINDOWS_STORE_LOCAL_TEST_GUIDED.md'
       - 'package.json'
@@ -28,15 +42,29 @@ on:
       - '.github/workflows/windows-physical-acceptance.yml'
       - 'app/package.json'
       - 'app/package-lock.json'
+      - 'app/electron/share-bridge.ts'
+      - 'app/electron/main.ts'
+      - 'app/electron/share-runtime.ts'
+      - 'app/scripts/appx-manifest-created.cjs'
       - 'app/scripts/stage-cli.mjs'
       - 'app/scripts/after-pack.cjs'
+      - 'package-lock.json'
+      - 'release/windows-store-package-version.v1.json'
+      - 'scripts/appx-manifest-created.node-test.mjs'
+      - 'scripts/check-version-consistency.mjs'
       - 'tsup.config.ts'
       - 'scripts/generate-brand-assets.mjs'
+      - 'scripts/probe-packaged-companion-runtime.mjs'
+      - 'scripts/version-authority-lib.mjs'
+      - 'scripts/version-authority.node-test.mjs'
       - 'scripts/windows-store-identity.node-test.mjs'
       - 'scripts/windows-store-local-test*'
       - 'scripts/verify-windows-store-local-test-report.mjs'
       - 'scripts/*Windows-Store-Local-Test*.ps1'
       - 'scripts/Test-Metrora-Windows-Release-Syntax.ps1'
+      - 'src/desktop-share-runtime-entry.ts'
+      - 'src/models.ts'
+      - 'src/sharing/**'
       - 'docs/WINDOWS_STORE_IDENTITY_V1.md'
       - 'docs/WINDOWS_STORE_LOCAL_TEST_GUIDED.md'
       - 'package.json'
@@ -56,8 +84,19 @@ jobs:
     timeout-minutes: 45
     env:
       CSC_IDENTITY_AUTO_DISCOVERY: 'false'
+      SOURCE_COMMIT: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+
+      - name: Verify exact source binding
+        shell: pwsh
+        run: |
+          $head = (git rev-parse HEAD).Trim()
+          if ($head -cne $env:SOURCE_COMMIT) {
+            throw "checked out source $head does not match the bound source $env:SOURCE_COMMIT"
+          }
 
       - uses: actions/setup-node@v4
         with:
@@ -67,11 +106,17 @@ jobs:
       - name: Validate Store identity and channel separation
         run: node scripts/windows-store-identity.node-test.mjs
 
+      - name: Validate version authority
+        run: npm run version:check
+
       - name: Install core dependencies
         run: npm ci --no-audit --no-fund
 
       - name: Install desktop dependencies
         run: npm --prefix app ci --no-audit --no-fund
+
+      - name: Validate AppX manifest version hook
+        run: node --test scripts/appx-manifest-created.node-test.mjs
 
       - name: Build unsigned AppX candidate without publication
         run: npm --prefix app run package:store
@@ -120,17 +165,33 @@ jobs:
             throw 'unexpected application identifier'
           }
 
-          $productVersion = [string](Get-Content -LiteralPath 'package.json' -Raw | ConvertFrom-Json).version
-          $productCore = $productVersion -replace '-rc\.\d+$', ''
-          if ($productCore -notmatch '^\d+\.\d+\.\d+$') {
-            throw 'product version cannot be mapped to the Store package version'
+          $productPackage = Get-Content -LiteralPath 'package.json' -Raw | ConvertFrom-Json
+          $desktopPackage = Get-Content -LiteralPath 'app\package.json' -Raw | ConvertFrom-Json
+          $productVersion = [string]$productPackage.version
+          $desktopBuildVersion = [string]$desktopPackage.build.buildVersion
+          if ($productVersion -cne '1.0.0-rc.11') {
+            throw "unexpected product source version: $productVersion"
           }
-          $expectedStoreVersion = "$productCore.0"
+          if ($desktopBuildVersion -cne '1.0.0.11') {
+            throw "unexpected Desktop build version: $desktopBuildVersion"
+          }
+
+          $storeVersionAuthority = Get-Content -LiteralPath 'release\windows-store-package-version.v1.json' -Raw | ConvertFrom-Json
+          if (
+            [int]$storeVersionAuthority.schemaVersion -ne 1 -or
+            [string]$storeVersionAuthority.publishedStorePackageVersion -cne '1.0.0.0' -or
+            [string]$storeVersionAuthority.candidateStorePackageVersion -cne '1.0.1.0'
+          ) {
+            throw 'Store package version authority is not the reviewed RC10 baseline -> RC11 candidate'
+          }
+          $expectedStoreVersion = [string]$storeVersionAuthority.candidateStorePackageVersion
           if ([string]$identity.Version -cne $expectedStoreVersion) {
             throw "unexpected Store package version: expected $expectedStoreVersion, got $($identity.Version)"
           }
 
-          $capabilities = @($manifest.Package.Capabilities.ChildNodes | ForEach-Object { $_.GetAttribute('Name') })
+          $capabilities = @($manifest.Package.Capabilities.ChildNodes |
+            Where-Object { $_.NodeType -eq 1 } |
+            ForEach-Object { $_.GetAttribute('Name') })
           if ($capabilities.Count -ne 1 -or $capabilities[0] -cne 'runFullTrust') {
             throw 'unexpected capability set'
           }
@@ -165,6 +226,7 @@ jobs:
           $cliRoot = Join-Path $unpacked 'app\resources\cli'
           $cliLauncher = Join-Path $cliRoot 'dist\launch.js'
           $cliArchive = Join-Path $unpacked 'app\resources\cli.asar'
+          $companionRuntime = Join-Path $cliArchive 'dist\desktop-share-runtime.js'
           $electron = Join-Path $unpacked 'app\Metrora.exe'
           foreach ($requiredPath in @($cliLauncher, $cliArchive, $electron)) {
             if (-not (Test-Path -LiteralPath $requiredPath -PathType Leaf)) {
@@ -204,6 +266,23 @@ jobs:
             if ($null -eq $status.today -or $null -eq $status.month) {
               throw 'packaged CLI status JSON is missing expected accounting fields'
             }
+
+            $companionProbe = Join-Path $PWD 'scripts\probe-packaged-companion-runtime.mjs'
+            $companionOutput = (& $electron $companionProbe $companionRuntime | Out-String).Trim()
+            if ($LASTEXITCODE -ne 0) {
+              throw "packaged companion runtime import failed: $companionOutput"
+            }
+            try {
+              $companion = $companionOutput | ConvertFrom-Json
+            } catch {
+              throw "packaged companion runtime probe did not return JSON: $companionOutput"
+            }
+            if (
+              [string]$companion.packagedCompanionRuntimeSmoke -cne 'pass' -or
+              [string]$companion.packagedCompanionRuntimeEntry -cne 'createDesktopShareRuntime'
+            ) {
+              throw 'packaged companion runtime probe returned an unexpected result'
+            }
           } finally {
             $env:ELECTRON_RUN_AS_NODE = $previousRunAsNode
           }
@@ -214,15 +293,27 @@ jobs:
 
           $hash = (Get-FileHash -LiteralPath $package.FullName -Algorithm SHA256).Hash.ToLowerInvariant()
           $summary = [ordered]@{
-            schemaVersion = 1
-            sourceCommit = $env:GITHUB_SHA
+            schemaVersion = 2
+            sourceCommit = $env:SOURCE_COMMIT
+            productVersion = $productVersion
+            desktopBuildVersion = $desktopBuildVersion
             artifactName = $package.Name
             sha256 = $hash
             packageVersion = [string]$identity.Version
             architecture = [string]$identity.ProcessorArchitecture
+            identityName = [string]$identity.Name
+            publisher = [string]$identity.Publisher
+            publisherDisplayName = [string]$properties.PublisherDisplayName
+            displayName = [string]$properties.DisplayName
+            applicationId = [string]$application.Id
+            capabilities = @($capabilities)
             packagedCliSmoke = 'pass'
             cliRuntimeContainer = 'asar'
             looseCliNodeModules = $false
+            packagedCompanionRuntimeSmoke = 'pass'
+            packagedCompanionRuntimePath = 'app/resources/cli.asar/dist/desktop-share-runtime.js'
+            packagedCompanionRuntimeEntry = 'createDesktopShareRuntime'
+            unsigned = $true
             signed = $false
             submitted = $false
             published = $false
@@ -235,7 +326,7 @@ jobs:
       - name: Upload short-lived Store candidate
         uses: actions/upload-artifact@v4
         with:
-          name: metrora-windows-store-${{ github.sha }}
+          name: metrora-windows-store-${{ env.SOURCE_COMMIT }}
           path: app/release/Metrora-Windows-Store-Candidate
           if-no-files-found: error
           include-hidden-files: true
@@ -250,6 +341,10 @@ jobs:
 
           - Artifact: `${{ steps.inspect.outputs.artifact_name }}`
           - SHA-256: `${{ steps.inspect.outputs.sha256 }}`
+          - Product source: `1.0.0-rc.11`
+          - Desktop build: `1.0.0.11`
+          - Store AppX version: `1.0.1.0`
           - Packaged CLI: sealed ASAR executed with bundled Electron runtime
+          - Packaged companion runtime: import smoke passed at `app/resources/cli.asar/dist/desktop-share-runtime.js`
           - State: unsigned, not submitted, not published
           "@ >> $env:GITHUB_STEP_SUMMARY

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -12,7 +12,8 @@ current public release boundary.
 - Repository: `maikolsiragusaa/metrora`
 - Canonical command: `metrora`
 - Published Store source line: `1.0.0-rc.10`
-- Current desktop build version: `1.0.0.10`
+- Published desktop build version: `1.0.0.10`
+- Current Store update candidate: `1.0.0-rc.11` / Desktop `1.0.0.11` / Store `1.0.1.0`
 - Latest published GitHub technical preview: `1.0.0-rc.7`
 
 The published command is `metrora`. Historical protocol and signed-data
@@ -32,6 +33,11 @@ boundary and the sealed packaged Store CLI runtime. Post-RC10 development is
 separate from the published package; any future Store update requires its own
 candidate, acceptance, submission and publication decision.
 
+The current post-RC10 engineering candidate is `1.0.0-rc.11`, with Desktop
+build version `1.0.0.11` and Store package identity version `1.0.1.0`. It is an
+unsigned, non-published candidate only. The published Store remains RC10 until
+Microsoft publishes a later package.
+
 `1.0.0-rc.7` remains the latest published GitHub Windows technical preview. That channel is unsigned, manually updated and not Microsoft Store certified. Its source, release assets, manifests and checksums remain immutable historical publication evidence.
 
 The Microsoft Store path is separate from source builds and GitHub technical
@@ -46,11 +52,16 @@ Exact source commits and artifact digests belong in the applicable workflow/rele
 
 Metrora deliberately separates three version forms:
 
-- product/source SemVer: `1.0.0-rc.10`;
-- desktop build version: `1.0.0.10`;
-- Microsoft Store AppX package identity version for the `1.0.0` line: `1.0.0.0`.
+- product/source SemVer: `1.0.0-rc.11` for the current candidate;
+- desktop build version: `1.0.0.11` for the current candidate;
+- Microsoft Store AppX package identity version: `1.0.1.0` for the current candidate;
+- published Store baseline: RC10 / `1.0.0.0`.
 
-The Store's four-component package identity is a platform contract and must not be confused with the desktop build counter or the SemVer pre-release label. See [`docs/VERSIONING.md`](docs/VERSIONING.md).
+The Store's four-component package identity is a platform contract and must not
+be confused with the desktop build counter or the SemVer pre-release label. The
+published baseline and candidate are maintained in
+`release/windows-store-package-version.v1.json`. See
+[`docs/VERSIONING.md`](docs/VERSIONING.md).
 
 ## Release responsibilities
 
@@ -99,16 +110,21 @@ An unsigned GitHub pre-release must state that its portable/installer assets are
 
 ## Microsoft Store candidate boundary
 
-The Store candidate must be built from the exact reviewed source commit using the non-publishing Store workflow. A submitted artifact remains bound to that source line:
+The RC11 Store candidate must be built from the exact reviewed source commit
+using the non-publishing Store workflow. The candidate carries the current
+Desktop companion runtime in `resources/cli.asar` and must pass an import-only
+smoke through the bundled Electron runtime before physical pairing is attempted.
+A submitted artifact remains bound to that source line:
 
 1. the exact AppX artifact and workflow manifest must verify;
 2. Store identity, publisher, architecture, capabilities and package version must match reviewed configuration;
 3. the packaged CLI must execute successfully from the AppX payload without a separately installed Node.js or a loose scoped `node_modules` runtime tree;
-4. the unsigned submission candidate must remain byte-identical to the workflow output;
-5. a separately test-signed copy may be used only for bounded local physical acceptance;
-6. local-test package/certificate/private-key material must be removed afterward;
-7. the sanitized local acceptance report must pass;
-8. submission requires an explicit stop/go after those checks.
+4. the packaged companion module must import from `app/resources/cli.asar/dist/desktop-share-runtime.js` and expose `createDesktopShareRuntime` without starting a listener;
+5. the unsigned submission candidate must remain byte-identical to the workflow output;
+6. a separately test-signed copy may be used only for bounded local physical acceptance;
+7. local-test package/certificate/private-key material must be removed afterward;
+8. the sanitized local acceptance report must pass;
+9. submission requires an explicit stop/go after those checks.
 
 A passing local test is not Microsoft certification and does not authorize publication or Store-availability claims. A future Store update requires a new reviewed candidate and its own acceptance/submission decision.
 

--- a/app/DISTRIBUTION.md
+++ b/app/DISTRIBUTION.md
@@ -11,6 +11,9 @@ This document defines the desktop packaging boundary. Platform-specific release 
 - Published Store source line: `1.0.0-rc.10`
 - Published desktop build version: `1.0.0.10`
 - Published Store AppX identity version: `1.0.0.0`
+- Current Store update candidate: `1.0.0-rc.11`
+- Current candidate desktop build version: `1.0.0.11`
+- Current candidate Store AppX identity version: `1.0.1.0`
 - Historical GitHub technical preview: `1.0.0-rc.7`
 
 Inherited names may remain only where required for compatibility or provenance. They are not Metrora distribution names.
@@ -22,6 +25,14 @@ Packaged desktop builds include the required Metrora command-line runtime and do
 The root CLI build keeps its normal production dependency closure external. `app/scripts/stage-cli.mjs` copies that exact production closure into a version-matched staging layout, and `app/scripts/after-pack.cjs` seals it into `cli.asar` inside Electron resources. A tiny stable launcher remains outside the archive and loads the runtime through Electron's ASAR-aware Node loader before any external PATH entry is considered.
 
 The Store payload must not expose a loose CLI `node_modules` tree. Keeping `@scope/package` paths inside `cli.asar` prevents AppX packaging from rewriting those path segments. The Store package workflow executes the CLI from the extracted AppX layout with packaged `Metrora.exe`, so module resolution is tested as shipped rather than inferred from file presence.
+
+The packaged companion runtime is the sealed module at
+`app/resources/cli.asar/dist/desktop-share-runtime.js`. The Store workflow
+imports that exact module through the bundled Electron runtime and requires the
+`createDesktopShareRuntime` entry point without starting a listener or creating
+pairing state. Store package versions are maintained in the canonical
+`../release/windows-store-package-version.v1.json` authority and are not derived
+from product SemVer.
 
 Persisted Workspace endpoint metadata is reconciled to the current packaged Metrora/collector version without replacing endpoint identity, Workspace membership or evidence history.
 
@@ -37,7 +48,7 @@ npm --prefix app run package:store    # Windows AppX x64, development packaging
 npm --prefix app run package:linux    # Linux AppImage, deb and rpm x64
 ```
 
-These commands create development or engineering artifacts. They do not by themselves create an official release or replace the Microsoft Store distribution.
+These commands create development or engineering artifacts. They do not by themselves create an official release or replace the Microsoft Store distribution. The RC11 Store output remains unsigned, non-submitted and non-published until separate Founder and Microsoft gates pass.
 
 ## Official distribution requirements
 

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "metrora-desktop",
-  "version": "1.0.0-rc.10",
+  "version": "1.0.0-rc.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "metrora-desktop",
-      "version": "1.0.0-rc.10",
+      "version": "1.0.0-rc.11",
       "dependencies": {
         "@gsap/react": "^2.1.2",
         "gsap": "^3.15.0",
@@ -23,6 +23,7 @@
         "@types/react": "^19.2.17",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^4.7.0",
+        "@xmldom/xmldom": "^0.8.13",
         "concurrently": "^10.0.3",
         "cross-env": "^10.1.0",
         "electron": "^43.1.0",

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "metrora-desktop",
   "private": true,
-  "version": "1.0.0-rc.10",
+  "version": "1.0.0-rc.11",
   "description": "Metrora Desktop — local-first AI usage intelligence",
   "main": "dist/electron/bootstrap.js",
   "scripts": {
@@ -37,6 +37,7 @@
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^4.7.0",
+    "@xmldom/xmldom": "^0.8.13",
     "concurrently": "^10.0.3",
     "cross-env": "^10.1.0",
     "electron": "^43.1.0",
@@ -60,6 +61,7 @@
       "package.json"
     ],
     "afterPack": "./scripts/after-pack.cjs",
+    "appxManifestCreated": "./scripts/appx-manifest-created.cjs",
     "mac": {
       "target": [
         {
@@ -143,7 +145,7 @@
       "maintainer": "Vensent (https://metrora.eu)",
       "executableName": "metrora"
     },
-    "buildVersion": "1.0.0.10"
+    "buildVersion": "1.0.0.11"
   },
   "homepage": "https://metrora.eu",
   "publisher": "Vensent",

--- a/app/scripts/appx-manifest-created.cjs
+++ b/app/scripts/appx-manifest-created.cjs
@@ -1,0 +1,121 @@
+const { readFileSync, writeFileSync } = require('node:fs')
+const { resolve } = require('node:path')
+const { pathToFileURL } = require('node:url')
+const { DOMParser } = require('@xmldom/xmldom')
+
+const FOUNDATION_NAMESPACE = 'http://schemas.microsoft.com/appx/manifest/foundation/windows10'
+const EXPECTED_IDENTITY_NAME = 'Vensent.Metrora'
+const EXPECTED_PUBLISHER = 'CN=BC955F81-5099-4C27-A7A6-FF611BAACC3F'
+const EXPECTED_ARCHITECTURE = 'x64'
+const AUTHORITY_PATH = resolve(__dirname, '..', '..', 'release', 'windows-store-package-version.v1.json')
+const VERSION_AUTHORITY_MODULE = pathToFileURL(resolve(__dirname, '..', '..', 'scripts', 'version-authority-lib.mjs')).href
+
+function parseManifest(xml) {
+  const errors = []
+  const document = new DOMParser({
+    errorHandler: {
+      warning: () => {},
+      error: message => errors.push(String(message)),
+      fatalError: message => errors.push(String(message)),
+    },
+  }).parseFromString(xml, 'application/xml')
+
+  if (errors.length > 0 || !document?.documentElement) {
+    throw new Error('AppX manifest XML is malformed')
+  }
+  if (
+    document.documentElement.localName !== 'Package' ||
+    document.documentElement.namespaceURI !== FOUNDATION_NAMESPACE
+  ) {
+    throw new Error('AppX manifest root must be the Windows foundation Package element')
+  }
+  return document
+}
+
+function getIdentity(document) {
+  const identities = []
+  for (let child = document.documentElement.firstChild; child; child = child.nextSibling) {
+    if (
+      child.nodeType === 1 &&
+      child.localName === 'Identity' &&
+      child.namespaceURI === FOUNDATION_NAMESPACE
+    ) identities.push(child)
+  }
+  if (identities.length !== 1 || document.getElementsByTagNameNS(FOUNDATION_NAMESPACE, 'Identity').length !== 1) {
+    throw new Error('AppX manifest must contain exactly one direct Package/Identity element')
+  }
+
+  const identity = identities[0]
+  for (const [attribute, expected] of [
+    ['Name', EXPECTED_IDENTITY_NAME],
+    ['Publisher', EXPECTED_PUBLISHER],
+    ['ProcessorArchitecture', EXPECTED_ARCHITECTURE],
+  ]) {
+    if (identity.getAttribute(attribute) !== expected) {
+      throw new Error(`AppX manifest Identity ${attribute} is not the reviewed Store value`)
+    }
+  }
+  const currentVersion = identity.getAttribute('Version')
+  if (!currentVersion) throw new Error('AppX manifest Identity Version is missing')
+  return { identity, currentVersion }
+}
+
+function replaceIdentityVersion(xml, currentVersion, candidateVersion) {
+  // The XML DOM above proves this is the one structural Identity element. The
+  // bounded text match below preserves every unrelated byte in the generated
+  // manifest and can only replace the exact Version attribute on that element.
+  const identityTags = [...xml.matchAll(/<(?:(?:[A-Za-z_][\w.-]*):)?Identity\b[^>]*\/?>/g)]
+  if (identityTags.length !== 1) throw new Error('AppX manifest Identity text shape is ambiguous')
+
+  const identityTag = identityTags[0][0]
+  const versionAttributes = [...identityTag.matchAll(/\bVersion\s*=\s*(['"])([^'"]*)\1/g)]
+  if (versionAttributes.length !== 1 || versionAttributes[0][2] !== currentVersion) {
+    throw new Error('AppX manifest Identity Version attribute shape is ambiguous')
+  }
+
+  const versionAttribute = versionAttributes[0]
+  const quoteOffset = versionAttribute[0].indexOf(versionAttribute[1])
+  const valueStart = identityTags[0].index + versionAttribute.index + quoteOffset + 1
+  return `${xml.slice(0, valueStart)}${candidateVersion}${xml.slice(valueStart + currentVersion.length)}`
+}
+
+function applyStorePackageVersion(xml, authority) {
+  if (typeof xml !== 'string') throw new Error('AppX manifest XML must be a string')
+  if (
+    !authority ||
+    typeof authority.publishedStorePackageVersion !== 'string' ||
+    typeof authority.candidateStorePackageVersion !== 'string'
+  ) {
+    throw new Error('Store package version authority is incomplete')
+  }
+
+  const document = parseManifest(xml)
+  const { currentVersion } = getIdentity(document)
+  if (currentVersion !== authority.publishedStorePackageVersion) {
+    throw new Error(
+      `generated AppX identity version must equal the published Store baseline ${authority.publishedStorePackageVersion}`,
+    )
+  }
+  if (authority.candidateStorePackageVersion === authority.publishedStorePackageVersion) {
+    throw new Error('candidate Store package version must differ from the published baseline')
+  }
+  return replaceIdentityVersion(xml, currentVersion, authority.candidateStorePackageVersion)
+}
+
+async function loadStorePackageVersionAuthority() {
+  const { validateStorePackageVersionAuthority } = await import(VERSION_AUTHORITY_MODULE)
+  return validateStorePackageVersionAuthority(JSON.parse(readFileSync(AUTHORITY_PATH, 'utf8')))
+}
+
+async function appxManifestCreated(manifestPath) {
+  if (typeof manifestPath !== 'string' || !manifestPath) {
+    throw new Error('appxManifestCreated requires the generated AppxManifest.xml path')
+  }
+  const authority = await loadStorePackageVersionAuthority()
+  const original = readFileSync(manifestPath, 'utf8')
+  const transformed = applyStorePackageVersion(original, authority)
+  writeFileSync(manifestPath, transformed, 'utf8')
+}
+
+exports.default = appxManifestCreated
+exports.applyStorePackageVersion = applyStorePackageVersion

--- a/docs/VERSIONING.md
+++ b/docs/VERSIONING.md
@@ -5,7 +5,10 @@ Metrora uses semantic versioning for public product identity and separate numeri
 ## Current line
 
 - Published Store source line: `1.0.0-rc.10`
-- Desktop build version: `1.0.0.10`
+- Published Desktop build version: `1.0.0.10`
+- Current Store update candidate source line: `1.0.0-rc.11`
+- Current candidate Desktop build version: `1.0.0.11`
+- Current candidate Store package version: `1.0.1.0`
 - Latest published GitHub technical preview: `1.0.0-rc.7`
 - First intended stable release: `1.0.0`
 
@@ -33,16 +36,22 @@ The Microsoft Store AppX/MSIX manifest has a separate four-component package ide
 
 The final component is `0` for the Store package contract. The SemVer pre-release suffix (`-rc.N`) is **not** encoded into the AppX identity version, and the desktop build counter (`MAJOR.MINOR.PATCH.N`) must not be presented as the Store package version.
 
-For the current `1.0.0` Store-associated source line:
+The published baseline and the next candidate are separate authorities:
 
-- source/product candidate: `1.0.0-rc.10`;
-- desktop build version: `1.0.0.10`;
-- published Store AppX identity version: `1.0.0.0`.
+- published RC10 source/product line: `1.0.0-rc.10`;
+- published RC10 Desktop build version: `1.0.0.10`;
+- published Store AppX identity version: `1.0.0.0`;
+- current RC11 source/product candidate: `1.0.0-rc.11`;
+- current RC11 Desktop build version: `1.0.0.11`;
+- current candidate Store AppX identity version: `1.0.1.0`.
 
-The published Store authority is the frozen RC10 line under Vensent. A local
-build with the same identity version is not, by itself, evidence of the live
-listing; later Store updates must advance according to the Store's
-package-version rules and pass their own acceptance and publication gates.
+The machine-readable Store package authority is
+`release/windows-store-package-version.v1.json`. It is the single source for
+the published baseline and candidate package versions. The AppX hook reads it
+after electron-builder creates the manifest; it does not derive a package
+version from product SemVer or the Desktop build counter. A local build with a
+known identity version is not, by itself, evidence of the live listing; later
+Store updates must pass their own acceptance and publication gates.
 
 ## Android version authority
 
@@ -96,7 +105,8 @@ The following values must agree where they represent the same authority:
 - root `package.json` and root `package-lock.json` — product SemVer;
 - desktop `app/package.json` and `app/package-lock.json` — product SemVer;
 - desktop `buildVersion` — desktop numeric build mapping;
-- Store AppX manifest — Store package-version mapping;
+- `release/windows-store-package-version.v1.json` — published and candidate Store package versions;
+- Store AppX manifest — candidate Store package-version mapping after the hook;
 - current-version declarations in `RELEASING.md`;
 - current desktop declarations in `app/DISTRIBUTION.md`;
 - current release-line declarations in this document and `docs/WINDOWS_DISTRIBUTION.md`.

--- a/docs/WINDOWS_DISTRIBUTION.md
+++ b/docs/WINDOWS_DISTRIBUTION.md
@@ -8,7 +8,7 @@ Metrora for Windows is available on the **Microsoft Store**, published by Vensen
 
 The Microsoft Store package is the supported public Windows distribution. Repository builds and historical GitHub pre-releases remain separate development or archival artifacts and are not the recommended install path.
 
-The currently published Store line is traceable to source candidate `1.0.0-rc.10`, desktop build version `1.0.0.10`, and Store AppX identity version `1.0.0.0`. Development on `main` may advance independently after that published line.
+The currently published Store line is traceable to source candidate `1.0.0-rc.10`, desktop build version `1.0.0.10`, and Store AppX identity version `1.0.0.0`. The current post-RC10 engineering candidate is `1.0.0-rc.11`, desktop build `1.0.0.11`, and Store AppX identity `1.0.1.0`; it is not published. Development on `main` may advance independently after that published line.
 
 Historical 0.9.19 and RC7 acceptance material remains immutable evidence for those source lines only.
 
@@ -23,8 +23,13 @@ Windows uses multiple version authorities deliberately:
 - published Store source line: `1.0.0-rc.10`;
 - published desktop build version: `1.0.0.10`;
 - published Microsoft Store AppX identity version: `1.0.0.0`.
+- current candidate source line: `1.0.0-rc.11`;
+- current candidate desktop build version: `1.0.0.11`;
+- current candidate Store AppX identity version: `1.0.1.0`.
 
-The Store AppX four-part identity is not the desktop build counter. See [Versioning authority](VERSIONING.md).
+The Store AppX four-part identity is not the desktop build counter. The
+published baseline and candidate are maintained in
+`release/windows-store-package-version.v1.json`. See [Versioning authority](VERSIONING.md).
 
 ## Package requirements
 
@@ -47,9 +52,9 @@ The existing RC7 release remains immutable as a historical technical preview. La
 
 ## Microsoft Store distribution
 
-The Store workflow derives an x64 AppX from reviewed source and validates its identity, architecture, capabilities and bundled runtime boundary. The Store manifest's four-part package identity remains separate from the desktop build counter.
+The Store workflow derives an x64 AppX from reviewed source and validates its identity, architecture, capabilities and bundled runtime boundary. It also imports `app/resources/cli.asar/dist/desktop-share-runtime.js` through the bundled Electron runtime and requires `createDesktopShareRuntime` without starting a listener. The Store manifest's four-part package identity remains separate from the desktop build counter.
 
-The published Store line passed its source-bound package and physical-runtime acceptance before publication. Later source work remains separate until a future Store update is explicitly prepared and accepted.
+The published Store line passed its source-bound package and physical-runtime acceptance before publication. RC11 is currently prepared only as a candidate; later source work remains separate until a future Store update is explicitly physically accepted, submitted and published.
 
 ## Accounting presentation boundary
 
@@ -64,13 +69,19 @@ For each future official Windows Store update, verify:
 1. product and publisher identity are exact;
 2. first launch works without an external Node.js installation;
 3. the bundled CLI starts from the packaged layout;
-4. supported local usage sources remain discoverable;
-5. existing endpoint and Workspace state are preserved safely;
-6. installation channels do not collide or silently migrate one another;
-7. update and rollback preserve user-owned local state;
-8. public version and channel information are truthful;
-9. no private data enters package metadata, reports or provenance;
-10. published artifacts remain bound to reviewed public source.
+4. the packaged companion runtime imports from the exact AppX ASAR path;
+5. supported local usage sources remain discoverable;
+6. existing endpoint and Workspace state are preserved safely;
+7. installation channels do not collide or silently migrate one another;
+8. update and rollback preserve user-owned local state;
+9. public version and channel information are truthful;
+10. no private data enters package metadata, reports or provenance;
+11. published artifacts remain bound to reviewed public source.
+
+The controlled RC10-to-RC11 update/profile-preservation test remains a deferred
+Founder-run acceptance step. The repository currently performs only the safe
+machine-verifiable package-version ordering check; it does not install over a
+real Store package or claim Microsoft Store-managed update certification.
 
 ## Responsibility boundary
 

--- a/docs/WINDOWS_STORE_IDENTITY_V1.md
+++ b/docs/WINDOWS_STORE_IDENTITY_V1.md
@@ -1,6 +1,6 @@
 # Windows Store package identity v1
 
-**Status:** identity assigned / separate Store candidate boundary
+**Status:** identity assigned / RC11 candidate boundary / not published
 
 ## Purpose
 
@@ -8,7 +8,13 @@ Define the separate Windows Store packaging boundary for Metrora.
 
 The exact manifest values are maintained in the reviewed desktop build configuration. They must match the Store authority byte-for-byte and must not be duplicated across public documentation.
 
-RC10 is the source line associated with the Store submission. This document does not claim certification, publication or availability, and post-RC10 development is separate from that submitted artifact. It also does not authorize a different submission or any change to the already published GitHub `1.0.0-rc.7` artifacts.
+RC10 is the frozen source line associated with the published Store package. The
+current engineering candidate is RC11 (`1.0.0-rc.11`) with Desktop build
+`1.0.0.11` and candidate Store package version `1.0.1.0`. This document does
+not claim certification, publication or availability for RC11, and post-RC10
+development is separate from the published artifact. It also does not
+authorize a different submission or any change to the already published
+GitHub `1.0.0-rc.7` artifacts.
 
 ## Build boundary
 
@@ -19,6 +25,14 @@ npm --prefix app run package:store
 ```
 
 The command produces one non-publishing x64 AppX candidate with the assigned Store identity and the required full-trust desktop capability.
+
+The Store package identity version is not derived from product SemVer or the
+Desktop build version. The single machine-readable authority is
+`release/windows-store-package-version.v1.json`, which records the published
+baseline `1.0.0.0` and the RC11 candidate `1.0.1.0`. The supported
+`appxManifestCreated` hook validates the generated `Package/Identity` shape and
+replaces only its Version value; it fails closed on an unexpected, missing or
+ambiguous identity.
 
 The existing technical-user installer remains separate:
 
@@ -38,6 +52,10 @@ A local PASS is not Store certification and does not authorize publication or av
 
 ## Current limitations
 
-The Store target has a separate package identity and local-acceptance path. It is not a signed Microsoft channel, an automatic update for existing installations, or a publication claim.
+The Store target has a separate package identity and local-acceptance path. The
+RC11 candidate is not a signed Microsoft channel, an automatic update for
+existing installations, or a publication claim.
 
-The RC10 source line is associated with the Store submission; certification and publication remain distinct gates. No post-RC10 code is part of that submitted artifact.
+The RC10 source line and `1.0.0.0` package remain the live Store authority;
+certification, publication and Store-managed update behavior remain distinct
+gates. No post-RC10 code is part of the published RC10 artifact.

--- a/docs/WINDOWS_STORE_LOCAL_TEST_GUIDED.md
+++ b/docs/WINDOWS_STORE_LOCAL_TEST_GUIDED.md
@@ -10,13 +10,18 @@ The local test verifies:
 
 - the downloaded artifact is bound to the expected source commit;
 - the AppX manifest matches the reviewed package configuration;
+- the candidate carries an importable companion runtime at `app/resources/cli.asar/dist/desktop-share-runtime.js`;
 - the package installs for the current Windows user;
 - Metrora launches with the expected product presentation;
+- the production Android `0.1.0-alpha.1` APK can complete the bounded companion flow;
 - local collection works without a separately installed Node.js runtime;
 - the package, trusted certificate and private key are removed afterward;
 - the final report contains no local paths, usernames, package identity values, keys or certificates.
 
-It does not verify Store signing, certification, publication, Store-managed updates or a package flight.
+It does not verify Store signing, certification, publication, Store-managed
+updates or a package flight. The automated workflow's companion smoke is
+import-only and never starts a listener, creates pairing state or claims a
+physical Android pairing.
 
 ## Prerequisites
 
@@ -59,14 +64,28 @@ Temporary PFX and CER files are deleted before the script exits. The trusted pub
 
 ## Manual observations
 
-In the launched app, confirm all four observations:
+In the launched app, confirm every observation below with the production
+Android APK already published as `android-v0.1.0-alpha.1`:
 
 1. Metrora launches normally.
 2. Windows and the app present the expected product identity.
-3. At least one supported local provider can be collected when test data exists.
-4. The packaged app works without a separately installed Node.js runtime.
+3. The Connect phone surface opens.
+4. The production Android APK scans the displayed QR.
+5. The SAS shown by both sides matches.
+6. Desktop explicit approval succeeds.
+7. Android Home receives real data.
+8. Activity receives real sessions.
+9. Analyze receives accepted factual data.
+10. Settings/device/security state remains coherent.
+11. Disconnect/offline followed by reconnect works.
+12. At least one supported local provider can be collected when test data exists.
+13. The packaged app works without a separately installed Node.js runtime.
 
-Do not enter prompts, keys, account data or other private material into the report.
+Record only `pass` or `fail`; do not enter prompts, responses, usernames,
+filesystem paths, local IP addresses, account data, pairing certificates,
+private keys, bearer tokens, SAS values, device secrets or other private
+material into the report. Omitting a companion observation defaults the report
+to FAIL, so a PASS cannot hide an unperformed step.
 
 ## Complete and clean up
 
@@ -77,6 +96,15 @@ From the same elevated PowerShell session, record each observation as `pass` or 
   -AcceptanceDirectory 'C:\Metrora-Store-Local-Test' `
   -Launch pass `
   -IdentityPresentation pass `
+  -ConnectPhoneSurface pass `
+  -ProductionAndroidQrScan pass `
+  -SasMatch pass `
+  -DesktopApproval pass `
+  -AndroidHomeData pass `
+  -AndroidActivitySessions pass `
+  -AndroidAnalyzeFacts pass `
+  -SettingsDeviceSecurity pass `
+  -DisconnectReconnect pass `
   -LocalCollection pass `
   -NoExternalNode pass
 ```
@@ -109,4 +137,43 @@ A passing local report is one submission input only. It does not authorize:
 - replacement of the existing portable or NSIS channels;
 - claims about Store-managed update behavior.
 
+The RC10-to-RC11 update/profile-preservation sequence is deliberately deferred
+to a separate Founder-run controlled test profile. No automation in this path
+installs over the real Store package or claims Microsoft Store-managed update
+certification. The machine-verifiable candidate ordering check is covered by
+the version authority and Store identity tests.
+
 Submission, certification, publication and availability remain separate gates; this guide does not authorize a publication action or a Store-availability claim.
+
+## Deferred controlled update acceptance
+
+**Status: STOPPED/DEFERRED — Founder-run physical step, not automated.**
+
+The safe update test must use a dedicated Windows test profile and never the
+real Store-installed Metrora package:
+
+1. Prepare a frozen RC10-equivalent baseline package with Store identity
+   version `1.0.0.0` and the same temporary local-test signing identity that
+   will be used for the candidate.
+2. Prepare the RC11 candidate with Store identity version `1.0.1.0`; verify
+   both packages are test-signed copies and neither is Microsoft Store-signed.
+3. Install the baseline, create only bounded user-owned test state, and record
+   sanitized pre-update status for endpoint identity, Workspace state, a
+   user-owned file, and companion-state coherence.
+4. Install the candidate as the version increase and verify endpoint identity,
+   Workspace state, the user-owned file, fail-safe/coherent companion state,
+   launch, and local collection.
+5. Exercise the candidate's disconnect/offline -> reconnect path, then remove
+   the candidate, baseline, temporary certificate, private key and all test
+   state.
+6. Preserve only a sanitized PASS/FAIL record containing package versions,
+   source/digest references and boolean observations. Do not record usernames,
+   paths, addresses, certificates, keys, tokens, SAS values or private data.
+
+This is deferred because the repository's current local Store tooling is
+designed for clean install/launch acceptance and does not provide a reliable,
+isolated same-certificate upgrade harness. Building a fragile updater or
+running a test-signed AppX over the real Store installation would risk the
+published package. The version authority and identity tests prove only that
+`1.0.1.0` is greater than the frozen `1.0.0.0` baseline; they do not claim
+Microsoft Store-managed update certification.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "metrora",
-  "version": "1.0.0-rc.10",
+  "version": "1.0.0-rc.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "metrora",
-      "version": "1.0.0-rc.10",
+      "version": "1.0.0-rc.11",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metrora",
-  "version": "1.0.0-rc.10",
+  "version": "1.0.0-rc.11",
   "private": true,
   "description": "Metrora — local-first AI usage intelligence for tools, models, projects and sessions",
   "type": "module",

--- a/release/windows-store-package-version.v1.json
+++ b/release/windows-store-package-version.v1.json
@@ -1,0 +1,5 @@
+{
+  "schemaVersion": 1,
+  "publishedStorePackageVersion": "1.0.0.0",
+  "candidateStorePackageVersion": "1.0.1.0"
+}

--- a/scripts/Complete-Metrora-Windows-Store-Local-Test.ps1
+++ b/scripts/Complete-Metrora-Windows-Store-Local-Test.ps1
@@ -18,6 +18,33 @@ param(
   [ValidateSet('pass', 'fail')]
   [string]$NoExternalNode,
 
+  [ValidateSet('pass', 'fail')]
+  [string]$ConnectPhoneSurface = 'fail',
+
+  [ValidateSet('pass', 'fail')]
+  [string]$ProductionAndroidQrScan = 'fail',
+
+  [ValidateSet('pass', 'fail')]
+  [string]$SasMatch = 'fail',
+
+  [ValidateSet('pass', 'fail')]
+  [string]$DesktopApproval = 'fail',
+
+  [ValidateSet('pass', 'fail')]
+  [string]$AndroidHomeData = 'fail',
+
+  [ValidateSet('pass', 'fail')]
+  [string]$AndroidActivitySessions = 'fail',
+
+  [ValidateSet('pass', 'fail')]
+  [string]$AndroidAnalyzeFacts = 'fail',
+
+  [ValidateSet('pass', 'fail')]
+  [string]$SettingsDeviceSecurity = 'fail',
+
+  [ValidateSet('pass', 'fail')]
+  [string]$DisconnectReconnect = 'fail',
+
   [string]$RepositoryRoot = (Get-Location).Path
 )
 
@@ -60,11 +87,20 @@ try {
   $cleanupErrors += 'certificate removal failed'
 }
 
-$observations = [ordered]@{
-  launch = $Launch
-  identityPresentation = $IdentityPresentation
-  localCollection = $LocalCollection
-  noExternalNode = $NoExternalNode
+  $observations = [ordered]@{
+    launch = $Launch
+    identityPresentation = $IdentityPresentation
+    connectPhoneSurface = $ConnectPhoneSurface
+    productionAndroidQrScan = $ProductionAndroidQrScan
+    sasMatch = $SasMatch
+    desktopApproval = $DesktopApproval
+    androidHomeData = $AndroidHomeData
+    androidActivitySessions = $AndroidActivitySessions
+    androidAnalyzeFacts = $AndroidAnalyzeFacts
+    settingsDeviceSecurity = $SettingsDeviceSecurity
+    disconnectReconnect = $DisconnectReconnect
+    localCollection = $LocalCollection
+    noExternalNode = $NoExternalNode
 }
 $allObservationsPass = @($observations.Values | Where-Object { $_ -ne 'pass' }).Count -eq 0
 $cleanupComplete = (
@@ -77,7 +113,7 @@ $status = if ($allObservationsPass -and $cleanupComplete) { 'pass' } else { 'fai
 
 $report = [ordered]@{
   kind = 'metrora.windows-store-local-test-report'
-  version = 1
+  version = 2
   status = $status
   generatedAt = [DateTime]::UtcNow.ToString('yyyy-MM-ddTHH:mm:ss.fffZ')
   source = [ordered]@{
@@ -88,6 +124,8 @@ $report = [ordered]@{
     artifactName = [string]$context.package.artifactName
     unsignedSha256 = [string]$context.package.unsignedSha256
     testSignedSha256 = [string]$context.package.testSignedSha256
+    productVersion = [string]$context.package.productVersion
+    desktopBuildVersion = [string]$context.package.desktopBuildVersion
     version = [string]$context.package.version
     architecture = [string]$context.package.architecture
   }

--- a/scripts/Prepare-Metrora-Windows-Store-Local-Test.ps1
+++ b/scripts/Prepare-Metrora-Windows-Store-Local-Test.ps1
@@ -48,21 +48,36 @@ if ($manifests.Count -ne 1) {
   throw "expected exactly one Store package manifest, found $($manifests.Count)"
 }
 
-$artifactManifest = Get-Content -LiteralPath $manifests[0].FullName -Raw | ConvertFrom-Json
-Assert-MetroraStoreLocalContextKeys $artifactManifest @(
-  'schemaVersion', 'sourceCommit', 'artifactName', 'sha256', 'packageVersion',
-  'architecture', 'signed', 'submitted', 'published'
-) 'Store artifact manifest'
-if (
-  [int]$artifactManifest.schemaVersion -ne 1 -or
-  [string]$artifactManifest.sourceCommit -ne $ExpectedCommit -or
-  [string]$artifactManifest.artifactName -ne $packages[0].Name -or
-  [string]$artifactManifest.sha256 -notmatch '^[a-f0-9]{64}$' -or
-  [string]$artifactManifest.packageVersion -notmatch '^\d+\.\d+\.\d+\.\d+$' -or
-  [string]$artifactManifest.architecture -ne 'x64' -or
-  [bool]$artifactManifest.signed -or
-  [bool]$artifactManifest.submitted -or
-  [bool]$artifactManifest.published
+  $artifactManifest = Get-Content -LiteralPath $manifests[0].FullName -Raw | ConvertFrom-Json
+  Assert-MetroraStoreLocalContextKeys $artifactManifest @(
+    'schemaVersion', 'sourceCommit', 'productVersion', 'desktopBuildVersion',
+    'artifactName', 'sha256', 'packageVersion', 'architecture',
+    'identityName', 'publisher', 'publisherDisplayName', 'displayName', 'applicationId', 'capabilities',
+    'packagedCliSmoke', 'cliRuntimeContainer', 'looseCliNodeModules',
+    'packagedCompanionRuntimeSmoke', 'packagedCompanionRuntimePath', 'packagedCompanionRuntimeEntry',
+    'unsigned', 'signed', 'submitted', 'published'
+  ) 'Store artifact manifest'
+  $artifactCapabilities = @($artifactManifest.capabilities | ForEach-Object { [string]$_ })
+  if (
+    [int]$artifactManifest.schemaVersion -ne 2 -or
+    [string]$artifactManifest.sourceCommit -ne $ExpectedCommit -or
+    [string]$artifactManifest.productVersion -notmatch '^\d+\.\d+\.\d+(?:-rc\.\d+)?$' -or
+    [string]$artifactManifest.desktopBuildVersion -notmatch '^\d+\.\d+\.\d+\.\d+$' -or
+    [string]$artifactManifest.artifactName -ne $packages[0].Name -or
+    [string]$artifactManifest.sha256 -notmatch '^[a-f0-9]{64}$' -or
+    [string]$artifactManifest.packageVersion -notmatch '^\d+\.\d+\.\d+\.\d+$' -or
+    [string]$artifactManifest.architecture -ne 'x64' -or
+    [string]$artifactManifest.identityName -ne 'Vensent.Metrora' -or
+    [string]$artifactManifest.publisher -ne 'CN=BC955F81-5099-4C27-A7A6-FF611BAACC3F' -or
+    [string]$artifactManifest.publisherDisplayName -ne 'Vensent' -or
+    [string]$artifactManifest.displayName -ne 'Metrora' -or
+    [string]$artifactManifest.applicationId -ne 'eu.metrora.desktop' -or
+    $artifactCapabilities.Count -ne 1 -or
+    $artifactCapabilities[0] -ne 'runFullTrust' -or
+    -not [bool]$artifactManifest.unsigned -or
+    [bool]$artifactManifest.signed -or
+    [bool]$artifactManifest.submitted -or
+    [bool]$artifactManifest.published
 ) {
   throw 'Store artifact manifest authority is invalid'
 }
@@ -81,10 +96,13 @@ if (Test-Path -LiteralPath (Join-Path $inspection 'AppxSignature.p7x')) {
 }
 $manifest = Get-MetroraStoreManifestInfo $inspection
 
-$desktopPackage = Get-Content -LiteralPath (Join-Path $repository 'app\package.json') -Raw | ConvertFrom-Json
-$appx = $desktopPackage.build.appx
-if (
-  $manifest.IdentityName -cne [string]$appx.identityName -or
+  $rootPackage = Get-Content -LiteralPath (Join-Path $repository 'package.json') -Raw | ConvertFrom-Json
+  $desktopPackage = Get-Content -LiteralPath (Join-Path $repository 'app\package.json') -Raw | ConvertFrom-Json
+  $appx = $desktopPackage.build.appx
+  if (
+    [string]$artifactManifest.productVersion -ne [string]$rootPackage.version -or
+    [string]$artifactManifest.desktopBuildVersion -ne [string]$desktopPackage.build.buildVersion -or
+    $manifest.IdentityName -cne [string]$appx.identityName -or
   $manifest.Publisher -cne [string]$appx.publisher -or
   $manifest.PublisherDisplayName -cne [string]$appx.publisherDisplayName -or
   $manifest.DisplayName -cne [string]$appx.displayName -or
@@ -178,6 +196,8 @@ try {
       unsignedSha256 = $unsignedSha256
       signedFile = 'local-test-signed.appx'
       testSignedSha256 = $signedSha256
+      productVersion = [string]$artifactManifest.productVersion
+      desktopBuildVersion = [string]$artifactManifest.desktopBuildVersion
       version = $manifest.Version
       architecture = $manifest.Architecture
       identityName = $manifest.IdentityName

--- a/scripts/Test-Metrora-Windows-Store-Local-Test-Runtime.ps1
+++ b/scripts/Test-Metrora-Windows-Store-Local-Test-Runtime.ps1
@@ -73,21 +73,37 @@ try {
   $artifactManifest = [pscustomobject]@{
     schemaVersion = 1
     sourceCommit = ('a' * 40)
-    artifactName = 'Metrora-1.0.0-rc.10-Windows-Store-x64.appx'
+    artifactName = 'Metrora-1.0.0-rc.11-Windows-Store-x64.appx'
     sha256 = ('b' * 64)
-    packageVersion = '1.0.0.0'
+    productVersion = '1.0.0-rc.11'
+    desktopBuildVersion = '1.0.0.11'
+    packageVersion = '1.0.1.0'
     architecture = 'x64'
+    identityName = 'Vensent.Metrora'
+    publisher = 'CN=BC955F81-5099-4C27-A7A6-FF611BAACC3F'
+    publisherDisplayName = 'Vensent'
+    displayName = 'Metrora'
+    applicationId = 'eu.metrora.desktop'
+    capabilities = @('runFullTrust')
     signed = $false
+    unsigned = $true
     submitted = $false
     published = $false
     packagedCliSmoke = 'pass'
     cliRuntimeContainer = 'asar'
     looseCliNodeModules = $false
+    packagedCompanionRuntimeSmoke = 'pass'
+    packagedCompanionRuntimePath = 'app/resources/cli.asar/dist/desktop-share-runtime.js'
+    packagedCompanionRuntimeEntry = 'createDesktopShareRuntime'
     futureAdditiveField = 'allowed'
   }
   Assert-MetroraStoreLocalContextKeys $artifactManifest @(
-    'schemaVersion', 'sourceCommit', 'artifactName', 'sha256', 'packageVersion',
-    'architecture', 'signed', 'submitted', 'published'
+    'schemaVersion', 'sourceCommit', 'productVersion', 'desktopBuildVersion',
+    'artifactName', 'sha256', 'packageVersion', 'architecture',
+    'identityName', 'publisher', 'publisherDisplayName', 'displayName', 'applicationId', 'capabilities',
+    'packagedCliSmoke', 'cliRuntimeContainer', 'looseCliNodeModules',
+    'packagedCompanionRuntimeSmoke', 'packagedCompanionRuntimePath', 'packagedCompanionRuntimeEntry',
+    'unsigned', 'signed', 'submitted', 'published'
   ) 'Store artifact manifest'
 
   $invalidArtifact = $artifactManifest | ConvertTo-Json -Depth 4 | ConvertFrom-Json
@@ -95,8 +111,12 @@ try {
   $rejectedArtifact = $false
   try {
     Assert-MetroraStoreLocalContextKeys $invalidArtifact @(
-      'schemaVersion', 'sourceCommit', 'artifactName', 'sha256', 'packageVersion',
-      'architecture', 'signed', 'submitted', 'published'
+      'schemaVersion', 'sourceCommit', 'productVersion', 'desktopBuildVersion',
+      'artifactName', 'sha256', 'packageVersion', 'architecture',
+      'identityName', 'publisher', 'publisherDisplayName', 'displayName', 'applicationId', 'capabilities',
+      'packagedCliSmoke', 'cliRuntimeContainer', 'looseCliNodeModules',
+      'packagedCompanionRuntimeSmoke', 'packagedCompanionRuntimePath', 'packagedCompanionRuntimeEntry',
+      'unsigned', 'signed', 'submitted', 'published'
     ) 'Store artifact manifest'
   } catch {
     $rejectedArtifact = $true

--- a/scripts/appx-manifest-created.node-test.mjs
+++ b/scripts/appx-manifest-created.node-test.mjs
@@ -1,0 +1,69 @@
+import assert from 'node:assert/strict'
+import { createRequire } from 'node:module'
+import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import test from 'node:test'
+
+const require = createRequire(import.meta.url)
+const hook = require(fileURLToPath(new URL('../app/scripts/appx-manifest-created.cjs', import.meta.url)))
+const applyStorePackageVersion = hook.applyStorePackageVersion
+const authority = {
+  schemaVersion: 1,
+  publishedStorePackageVersion: '1.0.0.0',
+  candidateStorePackageVersion: '1.0.1.0',
+}
+
+function manifest(overrides = '') {
+  return `<?xml version="1.0" encoding="utf-8"?>
+<Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10">
+  <Identity Name="Vensent.Metrora" Publisher="CN=BC955F81-5099-4C27-A7A6-FF611BAACC3F" Version="1.0.0.0" ProcessorArchitecture="x64"${overrides ? ` ${overrides}` : ''} />
+  <Properties><DisplayName>Metrora</DisplayName></Properties>
+</Package>
+`
+}
+
+test('applies only the candidate Store version to the structurally reviewed Identity', async () => {
+  const directory = mkdtempSync(join(tmpdir(), 'metrora-appx-hook-'))
+  const path = join(directory, 'AppxManifest.xml')
+  const original = manifest('ResourceGroup="unchanged"')
+  writeFileSync(path, original)
+
+  await hook.default(path)
+
+  const transformed = readFileSync(path, 'utf8')
+  assert.match(transformed, /Version="1\.0\.1\.0"/)
+  assert.match(transformed, /ResourceGroup="unchanged"/)
+  assert.equal(transformed, original.replace('Version="1.0.0.0"', 'Version="1.0.1.0"'))
+})
+
+test('rejects a generated manifest whose Store identity baseline is unexpected', () => {
+  assert.throws(
+    () => applyStorePackageVersion(manifest().replace('Version="1.0.0.0"', 'Version="1.0.0.9"'), authority),
+    /published Store baseline/,
+  )
+})
+
+test('rejects wrong identity, missing identity and ambiguous Identity shapes', () => {
+  assert.throws(
+    () => applyStorePackageVersion(manifest().replace('Name="Vensent.Metrora"', 'Name="Other.Package"'), authority),
+    /Identity Name/,
+  )
+  assert.throws(
+    () => applyStorePackageVersion(manifest().replace(/\n  <Identity[^\n]+\n/, '\n'), authority),
+    /exactly one direct Package\/Identity/,
+  )
+  assert.throws(
+    () => applyStorePackageVersion(manifest() + manifest().replace('<Package ', '<Package '), authority),
+    /malformed|exactly one direct Package\/Identity|AppX manifest root/,
+  )
+})
+
+test('rejects malformed XML and ambiguous Version attributes', () => {
+  assert.throws(() => applyStorePackageVersion('<Package>', authority), /malformed|root/)
+  assert.throws(
+    () => applyStorePackageVersion(manifest('Version="1.0.0.0"'), authority),
+    /malformed|Version attribute shape is ambiguous/,
+  )
+})

--- a/scripts/check-version-consistency.mjs
+++ b/scripts/check-version-consistency.mjs
@@ -1,6 +1,11 @@
 import { readFileSync } from 'node:fs'
 
-import { buildVersionFor, parseMetroraVersion } from './version-authority-lib.mjs'
+import {
+  STORE_PACKAGE_VERSION_AUTHORITY_PATH,
+  buildVersionFor,
+  parseMetroraVersion,
+  validateStorePackageVersionAuthority,
+} from './version-authority-lib.mjs'
 
 function readJson(path) { return JSON.parse(readFileSync(path, 'utf8')) }
 function fail(message) { throw new Error(`version authority: ${message}`) }
@@ -9,6 +14,7 @@ const rootPackage = readJson('package.json')
 const rootLock = readJson('package-lock.json')
 const appPackage = readJson('app/package.json')
 const appLock = readJson('app/package-lock.json')
+const storePackageVersionAuthority = validateStorePackageVersionAuthority(readJson(STORE_PACKAGE_VERSION_AUTHORITY_PATH))
 const version = rootPackage.version
 
 parseMetroraVersion(version)
@@ -21,4 +27,7 @@ if (appPackage.build?.buildVersion !== expectedBuildVersion) {
   fail(`desktop buildVersion is ${appPackage.build?.buildVersion}, expected ${expectedBuildVersion}`)
 }
 
-console.log(`Version authority verified: ${version} (${expectedBuildVersion})`)
+console.log(
+  `Version authority verified: ${version} (${expectedBuildVersion}); ` +
+  `Store package ${storePackageVersionAuthority.publishedStorePackageVersion} -> ${storePackageVersionAuthority.candidateStorePackageVersion}`,
+)

--- a/scripts/probe-packaged-companion-runtime.mjs
+++ b/scripts/probe-packaged-companion-runtime.mjs
@@ -1,0 +1,26 @@
+import { access } from 'node:fs/promises'
+import { constants } from 'node:fs'
+import { basename, resolve } from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+const runtimePathArg = process.argv[2]
+if (!runtimePathArg) throw new Error('packaged companion probe requires the exact runtime path')
+if (!process.versions.electron) throw new Error('packaged companion probe must run through the bundled Electron runtime')
+
+const runtimePath = resolve(runtimePathArg)
+if (basename(runtimePath) !== 'desktop-share-runtime.js' || !runtimePath.toLowerCase().includes('cli.asar')) {
+  throw new Error('packaged companion probe received a path outside cli.asar/dist/desktop-share-runtime.js')
+}
+await access(runtimePath, constants.R_OK)
+
+const runtimeModule = await import(pathToFileURL(runtimePath).href)
+if (typeof runtimeModule.createDesktopShareRuntime !== 'function') {
+  throw new Error('packaged companion runtime does not expose createDesktopShareRuntime')
+}
+
+// Import-only by design: this proves the shipped module is loadable without
+// starting its listener, creating pairing state or performing a physical pair.
+console.log(JSON.stringify({
+  packagedCompanionRuntimeSmoke: 'pass',
+  packagedCompanionRuntimeEntry: 'createDesktopShareRuntime',
+}))

--- a/scripts/verify-windows-store-local-test-report.mjs
+++ b/scripts/verify-windows-store-local-test-report.mjs
@@ -65,7 +65,7 @@ exactKeys(report, [
   'limitations',
 ], 'report')
 
-if (report.kind !== 'metrora.windows-store-local-test-report' || report.version !== 1) {
+if (report.kind !== 'metrora.windows-store-local-test-report' || report.version !== 2) {
   fail('report identity is invalid')
 }
 if (!['pass', 'fail'].includes(report.status)) fail('report status is invalid')
@@ -80,6 +80,8 @@ exactKeys(report.package, [
   'artifactName',
   'unsignedSha256',
   'testSignedSha256',
+  'productVersion',
+  'desktopBuildVersion',
   'version',
   'architecture',
 ], 'package')
@@ -90,6 +92,8 @@ if (report.package.unsignedSha256 === report.package.testSignedSha256) {
   fail('test-signed package must differ from the unsigned candidate')
 }
 requireString(report.package.version, /^\d+\.\d+\.\d+\.\d+$/, 'package version')
+requireString(report.package.productVersion, /^\d+\.\d+\.\d+(?:-rc\.\d+)?$/, 'package productVersion')
+requireString(report.package.desktopBuildVersion, /^\d+\.\d+\.\d+\.\d+$/, 'package desktopBuildVersion')
 if (report.package.architecture !== 'x64') fail('package architecture is invalid')
 
 exactKeys(report.platform, ['edition', 'version', 'build', 'architecture'], 'platform')
@@ -101,6 +105,15 @@ if (report.platform.architecture !== 'x64') fail('platform architecture is inval
 exactKeys(report.observations, [
   'launch',
   'identityPresentation',
+  'connectPhoneSurface',
+  'productionAndroidQrScan',
+  'sasMatch',
+  'desktopApproval',
+  'androidHomeData',
+  'androidActivitySessions',
+  'androidAnalyzeFacts',
+  'settingsDeviceSecurity',
+  'disconnectReconnect',
   'localCollection',
   'noExternalNode',
 ], 'observations')

--- a/scripts/version-authority-lib.mjs
+++ b/scripts/version-authority-lib.mjs
@@ -1,7 +1,9 @@
 const VERSION_PATTERN = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-rc\.(0|[1-9]\d*))?$/
+const STORE_PACKAGE_VERSION_PATTERN = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/
 const MAX_WINDOWS_COMPONENT = 65_535
 const STABLE_BUILD_COMPONENT = 10_000
 const MAX_RC_COMPONENT = STABLE_BUILD_COMPONENT - 1
+export const STORE_PACKAGE_VERSION_AUTHORITY_PATH = 'release/windows-store-package-version.v1.json'
 
 function parseComponent(raw, label, max = MAX_WINDOWS_COMPONENT) {
   const value = Number(raw)
@@ -43,4 +45,57 @@ export function buildVersionFor(version) {
   const parsed = parseMetroraVersion(version)
   const build = parsed.rc ?? STABLE_BUILD_COMPONENT
   return `${parsed.major}.${parsed.minor}.${parsed.patch}.${build}`
+}
+
+export function parseStorePackageVersion(version) {
+  if (typeof version !== 'string') throw new Error('Store package version must be a string')
+  const match = STORE_PACKAGE_VERSION_PATTERN.exec(version)
+  if (!match) {
+    throw new Error(`unsupported Store package version ${version}; expected four numeric components without leading zeroes`)
+  }
+
+  const major = parseComponent(match[1], 'Store package major version')
+  const minor = parseComponent(match[2], 'Store package minor version')
+  const patch = parseComponent(match[3], 'Store package patch version')
+  const revision = parseComponent(match[4], 'Store package revision')
+  if (revision !== 0) throw new Error('Store package revision must be 0 for the Windows Store contract')
+
+  return { version, major, minor, patch, revision }
+}
+
+export function compareStorePackageVersions(leftVersion, rightVersion) {
+  const left = parseStorePackageVersion(leftVersion)
+  const right = parseStorePackageVersion(rightVersion)
+
+  for (const key of ['major', 'minor', 'patch', 'revision']) {
+    if (left[key] !== right[key]) return left[key] < right[key] ? -1 : 1
+  }
+  return 0
+}
+
+export function validateStorePackageVersionAuthority(authority) {
+  if (!authority || typeof authority !== 'object' || Array.isArray(authority)) {
+    throw new Error('Store package version authority must be an object')
+  }
+
+  const actualKeys = Object.keys(authority).sort()
+  const expectedKeys = ['candidateStorePackageVersion', 'publishedStorePackageVersion', 'schemaVersion']
+  if (JSON.stringify(actualKeys) !== JSON.stringify(expectedKeys)) {
+    throw new Error('Store package version authority fields are invalid')
+  }
+  if (authority.schemaVersion !== 1) {
+    throw new Error('Store package version authority schemaVersion must be 1')
+  }
+
+  const publishedStorePackageVersion = parseStorePackageVersion(authority.publishedStorePackageVersion)
+  const candidateStorePackageVersion = parseStorePackageVersion(authority.candidateStorePackageVersion)
+  if (compareStorePackageVersions(candidateStorePackageVersion.version, publishedStorePackageVersion.version) <= 0) {
+    throw new Error('candidate Store package version must be greater than the published baseline')
+  }
+
+  return Object.freeze({
+    schemaVersion: 1,
+    publishedStorePackageVersion: publishedStorePackageVersion.version,
+    candidateStorePackageVersion: candidateStorePackageVersion.version,
+  })
 }

--- a/scripts/version-authority-lib.mjs
+++ b/scripts/version-authority-lib.mjs
@@ -58,6 +58,7 @@ export function parseStorePackageVersion(version) {
   const minor = parseComponent(match[2], 'Store package minor version')
   const patch = parseComponent(match[3], 'Store package patch version')
   const revision = parseComponent(match[4], 'Store package revision')
+  if (major === 0) throw new Error('Store package major version must be between 1 and 65535')
   if (revision !== 0) throw new Error('Store package revision must be 0 for the Windows Store contract')
 
   return { version, major, minor, patch, revision }

--- a/scripts/version-authority.node-test.mjs
+++ b/scripts/version-authority.node-test.mjs
@@ -1,12 +1,55 @@
 import assert from 'node:assert/strict'
 import { spawnSync } from 'node:child_process'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
 import test from 'node:test'
 
 import {
   buildVersionFor,
   compareMetroraVersions,
+  compareStorePackageVersions,
   parseMetroraVersion,
+  parseStorePackageVersion,
+  validateStorePackageVersionAuthority,
 } from './version-authority-lib.mjs'
+
+test('validates the dedicated Store package authority independently of product version', () => {
+  const authority = JSON.parse(readFileSync(resolve('release/windows-store-package-version.v1.json'), 'utf8'))
+  assert.deepEqual(validateStorePackageVersionAuthority(authority), {
+    schemaVersion: 1,
+    publishedStorePackageVersion: '1.0.0.0',
+    candidateStorePackageVersion: '1.0.1.0',
+  })
+  assert.equal(compareStorePackageVersions('1.0.0.0', '1.0.1.0'), -1)
+  assert.equal(parseStorePackageVersion('1.0.1.0').revision, 0)
+})
+
+test('rejects Store package versions outside the four-part Windows contract', () => {
+  for (const value of [
+    '1.0.0',
+    '1.0.0.1',
+    '1.0.0.00',
+    '1.0.0.0001',
+    '65536.0.0.0',
+    '1.65536.0.0',
+    '1.0.65536.0',
+    '1.0.0.65536',
+    '1.0.0.-1',
+  ]) {
+    assert.throws(() => parseStorePackageVersion(value), value)
+  }
+})
+
+test('rejects a Store authority that does not advance the published baseline', () => {
+  assert.throws(
+    () => validateStorePackageVersionAuthority({
+      schemaVersion: 1,
+      publishedStorePackageVersion: '1.0.1.0',
+      candidateStorePackageVersion: '1.0.1.0',
+    }),
+    /greater than the published baseline/,
+  )
+})
 
 test('orders the historical baseline before the first independent candidate', () => {
   assert.equal(compareMetroraVersions('0.9.19', '1.0.0-rc.1'), -1)

--- a/scripts/version-authority.node-test.mjs
+++ b/scripts/version-authority.node-test.mjs
@@ -26,6 +26,7 @@ test('validates the dedicated Store package authority independently of product v
 
 test('rejects Store package versions outside the four-part Windows contract', () => {
   for (const value of [
+    '0.1.0.0',
     '1.0.0',
     '1.0.0.1',
     '1.0.0.00',

--- a/scripts/windows-store-identity.node-test.mjs
+++ b/scripts/windows-store-identity.node-test.mjs
@@ -5,10 +5,19 @@ import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
+import {
+  STORE_PACKAGE_VERSION_AUTHORITY_PATH,
+  compareStorePackageVersions,
+  validateStorePackageVersionAuthority,
+} from './version-authority-lib.mjs'
+
 const repositoryRoot = resolve(fileURLToPath(new URL('..', import.meta.url)))
 const rootPackage = JSON.parse(readFileSync(resolve(repositoryRoot, 'package.json'), 'utf8'))
 const desktopPackage = JSON.parse(readFileSync(resolve(repositoryRoot, 'app/package.json'), 'utf8'))
 const brandGenerator = readFileSync(resolve(repositoryRoot, 'scripts/generate-brand-assets.mjs'), 'utf8')
+const storeVersionAuthority = validateStorePackageVersionAuthority(
+  JSON.parse(readFileSync(resolve(repositoryRoot, STORE_PACKAGE_VERSION_AUTHORITY_PATH), 'utf8')),
+)
 
 const expected = Object.freeze({
   applicationId: 'eu.metrora.desktop',
@@ -29,6 +38,12 @@ assert.equal(
   desktopPackage.scripts?.['package:win'],
   'npm run stage-cli && npm run build && electron-builder --win',
   'the existing Windows packaging command must remain unchanged',
+)
+
+assert.equal(
+  desktopPackage.build?.appxManifestCreated,
+  './scripts/appx-manifest-created.cjs',
+  'the Store identity version must be applied by the bounded AppX manifest hook',
 )
 
 assert.deepEqual(
@@ -69,19 +84,30 @@ assert.equal(
 )
 
 assert.equal(desktopPackage.version, rootPackage.version, 'desktop and root product SemVer must match')
-assert.equal(rootPackage.version, '1.0.0-rc.10', 'the current source candidate must remain 1.0.0-rc.10')
+assert.equal(rootPackage.version, '1.0.0-rc.11', 'the current source candidate must be 1.0.0-rc.11')
 assert.equal(
   desktopPackage.build?.buildVersion,
-  '1.0.0.10',
-  'the current desktop build version authority must remain 1.0.0.10',
+  '1.0.0.11',
+  'the current desktop build version authority must be 1.0.0.11',
 )
 
-const productCore = rootPackage.version.replace(/-rc\.\d+$/, '')
-assert.match(productCore, /^\d+\.\d+\.\d+$/)
 assert.equal(
-  `${productCore}.0`,
+  storeVersionAuthority.publishedStorePackageVersion,
   '1.0.0.0',
-  'the current Microsoft Store AppX identity version mapping must remain 1.0.0.0',
+  'the published Store baseline must remain the immutable RC10 package version',
+)
+assert.equal(
+  storeVersionAuthority.candidateStorePackageVersion,
+  '1.0.1.0',
+  'the current candidate Store package version must be 1.0.1.0',
+)
+assert.equal(
+  compareStorePackageVersions(
+    storeVersionAuthority.publishedStorePackageVersion,
+    storeVersionAuthority.candidateStorePackageVersion,
+  ),
+  -1,
+  'the candidate Store package version must advance the published baseline',
 )
 
 for (const asset of [

--- a/scripts/windows-store-local-test-lib.ps1
+++ b/scripts/windows-store-local-test-lib.ps1
@@ -77,7 +77,14 @@ function Assert-MetroraStoreLocalContextKeys($Value, [string[]]$Expected, [strin
       throw "$Label fields are invalid"
     }
 
-    $runtimeFields = @('packagedCliSmoke', 'cliRuntimeContainer', 'looseCliNodeModules')
+    $runtimeFields = @(
+      'packagedCliSmoke'
+      'cliRuntimeContainer'
+      'looseCliNodeModules'
+      'packagedCompanionRuntimeSmoke'
+      'packagedCompanionRuntimePath'
+      'packagedCompanionRuntimeEntry'
+    )
     $runtimePresent = @($runtimeFields | Where-Object { $actual -contains $_ })
     if ($runtimePresent.Count -ne 0 -and $runtimePresent.Count -ne $runtimeFields.Count) {
       throw "$Label fields are invalid"
@@ -86,9 +93,12 @@ function Assert-MetroraStoreLocalContextKeys($Value, [string[]]$Expected, [strin
       if (
         [string]$Value.packagedCliSmoke -ne 'pass' -or
         [string]$Value.cliRuntimeContainer -ne 'asar' -or
-        [bool]$Value.looseCliNodeModules
+        [bool]$Value.looseCliNodeModules -or
+        [string]$Value.packagedCompanionRuntimeSmoke -ne 'pass' -or
+        [string]$Value.packagedCompanionRuntimePath -ne 'app/resources/cli.asar/dist/desktop-share-runtime.js' -or
+        [string]$Value.packagedCompanionRuntimeEntry -ne 'createDesktopShareRuntime'
       ) {
-        throw 'Store artifact manifest packaged CLI authority is invalid'
+        throw 'Store artifact manifest packaged runtime authority is invalid'
       }
     }
     return
@@ -113,7 +123,7 @@ function Get-MetroraStoreLocalTestState([string]$AcceptanceDirectory, [string]$R
   Assert-MetroraStoreLocalContextKeys $context.source @('repository', 'commit') 'context.source'
   Assert-MetroraStoreLocalContextKeys $context.package @(
     'artifactName', 'unsignedFile', 'unsignedSha256', 'signedFile', 'testSignedSha256',
-    'version', 'architecture', 'identityName', 'publisher', 'applicationId'
+    'productVersion', 'desktopBuildVersion', 'version', 'architecture', 'identityName', 'publisher', 'applicationId'
   ) 'context.package'
   Assert-MetroraStoreLocalContextKeys $context.platform @(
     'edition', 'version', 'build', 'architecture'
@@ -132,6 +142,8 @@ function Get-MetroraStoreLocalTestState([string]$AcceptanceDirectory, [string]$R
     $context.package.unsignedSha256 -notmatch '^[a-f0-9]{64}$' -or
     $context.package.testSignedSha256 -notmatch '^[a-f0-9]{64}$' -or
     $context.package.unsignedSha256 -eq $context.package.testSignedSha256 -or
+    $context.package.productVersion -notmatch '^\d+\.\d+\.\d+(?:-rc\.\d+)?$' -or
+    $context.package.desktopBuildVersion -notmatch '^\d+\.\d+\.\d+\.\d+$' -or
     $context.package.version -notmatch '^\d+\.\d+\.\d+\.\d+$' -or
     $context.package.architecture -ne 'x64' -or
     $context.platform.architecture -ne 'x64' -or

--- a/scripts/windows-store-local-test-report.node-test.mjs
+++ b/scripts/windows-store-local-test-report.node-test.mjs
@@ -12,7 +12,7 @@ const commit = 'a'.repeat(40)
 function validReport() {
   return {
     kind: 'metrora.windows-store-local-test-report',
-    version: 1,
+    version: 2,
     status: 'pass',
     generatedAt: '2026-08-06T18:00:00.000Z',
     source: {
@@ -20,10 +20,12 @@ function validReport() {
       commit,
     },
     package: {
-      artifactName: 'Metrora-1.0.0-rc.7-Windows-Store-x64.appx',
+      artifactName: 'Metrora-1.0.0-rc.11-Windows-Store-x64.appx',
       unsignedSha256: '1'.repeat(64),
       testSignedSha256: '2'.repeat(64),
-      version: '1.0.0.7',
+      productVersion: '1.0.0-rc.11',
+      desktopBuildVersion: '1.0.0.11',
+      version: '1.0.1.0',
       architecture: 'x64',
     },
     platform: {
@@ -35,6 +37,15 @@ function validReport() {
     observations: {
       launch: 'pass',
       identityPresentation: 'pass',
+      connectPhoneSurface: 'pass',
+      productionAndroidQrScan: 'pass',
+      sasMatch: 'pass',
+      desktopApproval: 'pass',
+      androidHomeData: 'pass',
+      androidActivitySessions: 'pass',
+      androidAnalyzeFacts: 'pass',
+      settingsDeviceSecurity: 'pass',
+      disconnectReconnect: 'pass',
       localCollection: 'pass',
       noExternalNode: 'pass',
     },
@@ -78,6 +89,12 @@ test('accepts a complete passing report', () => {
   const result = verify(validReport(), ['--require-pass'])
   assert.equal(result.status, 0, result.stderr)
   assert.equal(JSON.parse(result.stdout).status, 'pass')
+})
+
+test('rejects a report that omits a mandatory companion observation', () => {
+  const report = validReport()
+  delete report.observations.androidHomeData
+  assert.notEqual(verify(report, ['--require-pass']).status, 0)
 })
 
 test('accepts a consistent failure unless pass is required', () => {


### PR DESCRIPTION
## Summary

- advances the current product candidate to `1.0.0-rc.11` and Desktop build `1.0.0.11`;
- introduces the canonical Store package authority `1.0.0.0 -> 1.0.1.0`;
- applies `1.0.1.0` through electron-builder's supported `appxManifestCreated` hook with structural fail-closed assertions;
- extends the existing Store workflow with exact source binding, AppX identity evidence, sealed CLI smoke, and an Electron/ASAR import smoke for `createDesktopShareRuntime`;
- makes the local Store acceptance report fail closed unless all required companion observations are recorded;
- documents the controlled update test as deferred Founder-run acceptance.

## Validation

- `npm run version:check`
- version-authority, Store identity, AppX hook, Store report, and physical candidate native tests
- Store PowerShell runtime tests under PowerShell 7 and Windows PowerShell 5.1
- Windows release-script syntax validation
- `npm ci --no-audit --no-fund`
- `npm run build:cli`
- `npm --prefix app ci --no-audit --no-fund`
- `npm --prefix app run typecheck`
- `npm --prefix app test` — 76 files / 572 tests
- `npm --prefix app run build`
- local `npm --prefix app run package:store` — exact AppX import probe passed

The candidate remains unsigned, non-submitted, and non-published. No Microsoft Store submission, production signing, Android artifact mutation, merge, tag, or release was performed.