### PR TITLE
Add Android QR image import

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -231,6 +231,7 @@ dependencies {
     implementation(libs.camera.lifecycle)
     implementation(libs.camera.view)
     implementation(libs.mlkit.barcode)
+    implementation(libs.exifinterface)
     implementation(libs.lifecycle.runtime.compose)
     implementation(libs.datastore.preferences)
     implementation(libs.coroutines.android)

--- a/android/app/src/main/kotlin/eu/metrora/app/ui/QrImageDecoder.kt
+++ b/android/app/src/main/kotlin/eu/metrora/app/ui/QrImageDecoder.kt
@@ -44,6 +44,14 @@ internal sealed interface QrImageImportHandling {
     data class Failed(val error: QrImageImportError) : QrImageImportHandling
 }
 
+internal enum class QrImageBitmapSource {
+    SYSTEM_THUMBNAIL,
+    DIRECT_DECODE,
+}
+
+internal fun shouldApplySourceExifOrientation(source: QrImageBitmapSource): Boolean =
+    source == QrImageBitmapSource.DIRECT_DECODE
+
 /**
  * Converts the bounded ML Kit result into a single image-import outcome.
  * Payload parsing intentionally remains outside this boundary.
@@ -191,7 +199,12 @@ internal class QrImageDecoder(context: Context) : Closeable {
         }
         if (thumbnail != null) {
             val bounded = enforceBitmapBounds(thumbnail)
-            return enforceBitmapBounds(applyExifOrientation(contentResolver, uri, bounded))
+            return orientBitmapForSource(
+                contentResolver = contentResolver,
+                uri = uri,
+                bitmap = bounded,
+                source = QrImageBitmapSource.SYSTEM_THUMBNAIL,
+            )
         }
 
         val bounds = BitmapFactory.Options().apply { inJustDecodeBounds = true }
@@ -207,8 +220,23 @@ internal class QrImageDecoder(context: Context) : Closeable {
         val decoded = decodeBitmap(contentResolver, uri, options)
             ?: throw IllegalArgumentException("Image content is unavailable or unreadable")
         val bounded = enforceBitmapBounds(decoded)
-        val oriented = applyExifOrientation(contentResolver, uri, bounded)
+        val oriented = orientBitmapForSource(
+            contentResolver = contentResolver,
+            uri = uri,
+            bitmap = bounded,
+            source = QrImageBitmapSource.DIRECT_DECODE,
+        )
         return enforceBitmapBounds(oriented)
+    }
+
+    private fun orientBitmapForSource(
+        contentResolver: ContentResolver,
+        uri: Uri,
+        bitmap: Bitmap,
+        source: QrImageBitmapSource,
+    ): Bitmap {
+        if (!shouldApplySourceExifOrientation(source)) return bitmap
+        return applyExifOrientation(contentResolver, uri, bitmap)
     }
 
     private fun applyExifOrientation(

--- a/android/app/src/main/kotlin/eu/metrora/app/ui/QrImageDecoder.kt
+++ b/android/app/src/main/kotlin/eu/metrora/app/ui/QrImageDecoder.kt
@@ -1,0 +1,326 @@
+package eu.metrora.app.ui
+
+import android.content.ContentResolver
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.graphics.Matrix
+import android.net.Uri
+import android.os.Build
+import android.util.Size
+import androidx.core.content.ContextCompat
+import androidx.exifinterface.media.ExifInterface
+import com.google.android.gms.tasks.Tasks
+import com.google.mlkit.vision.barcode.BarcodeScannerOptions
+import com.google.mlkit.vision.barcode.BarcodeScanning
+import com.google.mlkit.vision.barcode.common.Barcode
+import com.google.mlkit.vision.common.InputImage
+import java.io.Closeable
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+import java.util.concurrent.RejectedExecutionException
+import java.util.concurrent.atomic.AtomicBoolean
+
+internal sealed interface QrImageImportResult {
+    data object Cancelled : QrImageImportResult
+    data object NoQrCode : QrImageImportResult
+    data object MultipleQrCodes : QrImageImportResult
+    data object BlankRawValue : QrImageImportResult
+    data object ImageDecodeFailure : QrImageImportResult
+    data class Payload(val rawValue: String) : QrImageImportResult
+}
+
+internal enum class QrImageImportError {
+    NO_QR_CODE,
+    MULTIPLE_QR_CODES,
+    BLANK_RAW_VALUE,
+    IMAGE_DECODE_FAILURE,
+    INVALID_PAYLOAD,
+}
+
+internal sealed interface QrImageImportHandling {
+    data object Cancelled : QrImageImportHandling
+    data object Accepted : QrImageImportHandling
+    data class Failed(val error: QrImageImportError) : QrImageImportHandling
+}
+
+/**
+ * Converts the bounded ML Kit result into a single image-import outcome.
+ * Payload parsing intentionally remains outside this boundary.
+ */
+internal fun classifyQrImageResults(rawValues: List<String?>): QrImageImportResult = when {
+    rawValues.isEmpty() -> QrImageImportResult.NoQrCode
+    rawValues.size > 1 -> QrImageImportResult.MultipleQrCodes
+    else -> rawValues.single()?.takeIf(String::isNotBlank)?.let(QrImageImportResult::Payload)
+        ?: QrImageImportResult.BlankRawValue
+}
+
+/**
+ * Hands the one extracted raw value to the existing pairing callback exactly
+ * as camera acquisition does. No Metrora payload validation belongs here.
+ */
+internal fun handoffQrImageResult(
+    result: QrImageImportResult,
+    onPayload: (String) -> Boolean,
+): QrImageImportHandling = when (result) {
+    QrImageImportResult.Cancelled -> QrImageImportHandling.Cancelled
+    QrImageImportResult.NoQrCode -> QrImageImportHandling.Failed(QrImageImportError.NO_QR_CODE)
+    QrImageImportResult.MultipleQrCodes -> QrImageImportHandling.Failed(QrImageImportError.MULTIPLE_QR_CODES)
+    QrImageImportResult.BlankRawValue -> QrImageImportHandling.Failed(QrImageImportError.BLANK_RAW_VALUE)
+    QrImageImportResult.ImageDecodeFailure -> QrImageImportHandling.Failed(QrImageImportError.IMAGE_DECODE_FAILURE)
+    is QrImageImportResult.Payload -> if (onPayload(result.rawValue)) {
+        QrImageImportHandling.Accepted
+    } else {
+        QrImageImportHandling.Failed(QrImageImportError.INVALID_PAYLOAD)
+    }
+}
+
+/**
+ * A single decode operation owns its callback delivery. Cancelling it also
+ * invalidates any result already queued on the main executor.
+ */
+internal class QrImageDecodeOperation internal constructor() {
+    private val active = AtomicBoolean(true)
+
+    internal fun cancel() {
+        active.set(false)
+    }
+
+    internal fun isActive(): Boolean = active.get()
+
+    internal fun tryDeliver(): Boolean = active.compareAndSet(true, false)
+}
+
+/**
+ * Local, QR-only static-image decoder. The source bitmap is downsampled and
+ * released after ML Kit finishes; the selected Uri is never copied or stored.
+ */
+internal class QrImageDecoder(context: Context) : Closeable {
+    private val applicationContext = context.applicationContext
+    private val worker: ExecutorService = Executors.newSingleThreadExecutor()
+    private val callbackExecutor = ContextCompat.getMainExecutor(applicationContext)
+    private val scanner = BarcodeScanning.getClient(
+        BarcodeScannerOptions.Builder()
+            .setBarcodeFormats(Barcode.FORMAT_QR_CODE)
+            .build(),
+    )
+    private val closed = AtomicBoolean(false)
+
+    internal fun decode(
+        uri: Uri,
+        onResult: (QrImageImportResult) -> Unit,
+    ): QrImageDecodeOperation {
+        val operation = QrImageDecodeOperation()
+        if (closed.get()) {
+            operation.cancel()
+            return operation
+        }
+
+        try {
+            worker.execute {
+                decodeOnWorker(uri, operation, onResult)
+            }
+        } catch (_: RejectedExecutionException) {
+            operation.cancel()
+        }
+        return operation
+    }
+
+    override fun close() {
+        if (!closed.compareAndSet(false, true)) return
+        worker.shutdownNow()
+        scanner.close()
+    }
+
+    private fun decodeOnWorker(
+        uri: Uri,
+        operation: QrImageDecodeOperation,
+        onResult: (QrImageImportResult) -> Unit,
+    ) {
+        var bitmap: Bitmap? = null
+        try {
+            if (!operation.isActive()) return
+            val decodedBitmap = readBoundedBitmap(applicationContext.contentResolver, uri)
+            bitmap = decodedBitmap
+            if (!operation.isActive()) return
+
+            val barcodes = Tasks.await(scanner.process(InputImage.fromBitmap(decodedBitmap, 0)))
+            deliver(
+                operation = operation,
+                result = classifyQrImageResults(barcodes.map { it.rawValue }),
+                onResult = onResult,
+            )
+        } catch (_: InterruptedException) {
+            Thread.currentThread().interrupt()
+        } catch (_: Exception) {
+            deliver(operation, QrImageImportResult.ImageDecodeFailure, onResult)
+        } catch (_: OutOfMemoryError) {
+            deliver(operation, QrImageImportResult.ImageDecodeFailure, onResult)
+        } finally {
+            bitmap?.let { decoded ->
+                if (!decoded.isRecycled) decoded.recycle()
+            }
+        }
+    }
+
+    private fun deliver(
+        operation: QrImageDecodeOperation,
+        result: QrImageImportResult,
+        onResult: (QrImageImportResult) -> Unit,
+    ) {
+        try {
+            callbackExecutor.execute {
+                if (operation.tryDeliver()) onResult(result)
+            }
+        } catch (_: RejectedExecutionException) {
+            operation.cancel()
+        }
+    }
+
+    private fun readBoundedBitmap(contentResolver: ContentResolver, uri: Uri): Bitmap {
+        val thumbnail = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            runCatching {
+                contentResolver.loadThumbnail(
+                    uri,
+                    Size(MAX_IMAGE_DIMENSION.toInt(), MAX_IMAGE_DIMENSION.toInt()),
+                    null,
+                )
+            }.getOrNull()
+        } else {
+            null
+        }
+        if (thumbnail != null) {
+            val bounded = enforceBitmapBounds(thumbnail)
+            return enforceBitmapBounds(applyExifOrientation(contentResolver, uri, bounded))
+        }
+
+        val bounds = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+        decodeBitmap(contentResolver, uri, bounds)
+
+        require(bounds.outWidth > 0 && bounds.outHeight > 0) { "Image content is unreadable" }
+
+        val options = BitmapFactory.Options().apply {
+            inSampleSize = calculateSampleSize(bounds.outWidth, bounds.outHeight)
+            inPreferredConfig = Bitmap.Config.ARGB_8888
+            inScaled = false
+        }
+        val decoded = decodeBitmap(contentResolver, uri, options)
+            ?: throw IllegalArgumentException("Image content is unavailable or unreadable")
+        val bounded = enforceBitmapBounds(decoded)
+        val oriented = applyExifOrientation(contentResolver, uri, bounded)
+        return enforceBitmapBounds(oriented)
+    }
+
+    private fun applyExifOrientation(
+        contentResolver: ContentResolver,
+        uri: Uri,
+        bitmap: Bitmap,
+    ): Bitmap {
+        val orientation = readExifOrientation(contentResolver, uri)
+            ?: ExifInterface.ORIENTATION_NORMAL
+
+        val matrix = Matrix()
+        when (orientation) {
+            ExifInterface.ORIENTATION_FLIP_HORIZONTAL -> matrix.setScale(-1f, 1f)
+            ExifInterface.ORIENTATION_ROTATE_180 -> matrix.setRotate(180f)
+            ExifInterface.ORIENTATION_FLIP_VERTICAL -> matrix.setScale(1f, -1f)
+            ExifInterface.ORIENTATION_TRANSPOSE -> {
+                matrix.setRotate(90f)
+                matrix.postScale(-1f, 1f)
+            }
+            ExifInterface.ORIENTATION_ROTATE_90 -> matrix.setRotate(90f)
+            ExifInterface.ORIENTATION_TRANSVERSE -> {
+                matrix.setRotate(270f)
+                matrix.postScale(-1f, 1f)
+            }
+            ExifInterface.ORIENTATION_ROTATE_270 -> matrix.setRotate(270f)
+            else -> return bitmap
+        }
+
+        val transformed = Bitmap.createBitmap(
+            bitmap,
+            0,
+            0,
+            bitmap.width,
+            bitmap.height,
+            matrix,
+            true,
+        )
+        if (transformed !== bitmap) bitmap.recycle()
+        return transformed
+    }
+
+    private fun decodeBitmap(
+        contentResolver: ContentResolver,
+        uri: Uri,
+        options: BitmapFactory.Options,
+    ): Bitmap? {
+        val descriptorBitmap = runCatching {
+            contentResolver.openFileDescriptor(uri, "r")?.use { descriptor ->
+                BitmapFactory.decodeFileDescriptor(descriptor.fileDescriptor, null, options)
+            }
+        }.getOrNull()
+        if (descriptorBitmap != null) return descriptorBitmap
+
+        return runCatching {
+            contentResolver.openInputStream(uri)?.use { input ->
+                BitmapFactory.decodeStream(input, null, options)
+            }
+        }.getOrNull()
+    }
+
+    private fun readExifOrientation(
+        contentResolver: ContentResolver,
+        uri: Uri,
+    ): Int? {
+        val descriptorOrientation = runCatching {
+            contentResolver.openFileDescriptor(uri, "r")?.use { descriptor ->
+                ExifInterface(descriptor.fileDescriptor).getAttributeInt(
+                    ExifInterface.TAG_ORIENTATION,
+                    ExifInterface.ORIENTATION_NORMAL,
+                )
+            }
+        }.getOrNull()
+        if (descriptorOrientation != null) return descriptorOrientation
+
+        return runCatching {
+            contentResolver.openInputStream(uri)?.use { input ->
+                ExifInterface(input).getAttributeInt(
+                    ExifInterface.TAG_ORIENTATION,
+                    ExifInterface.ORIENTATION_NORMAL,
+                )
+            }
+        }.getOrNull()
+    }
+
+    private fun enforceBitmapBounds(bitmap: Bitmap): Bitmap {
+        val pixels = bitmap.width.toLong() * bitmap.height.toLong()
+        if (bitmap.width > MAX_IMAGE_DIMENSION ||
+            bitmap.height > MAX_IMAGE_DIMENSION ||
+            pixels > MAX_IMAGE_PIXELS
+        ) {
+            bitmap.recycle()
+            throw IllegalArgumentException("Image content exceeds the bounded decode size")
+        }
+        return bitmap
+    }
+
+    private fun calculateSampleSize(width: Int, height: Int): Int {
+        var sample = 1
+        while (scaledDimension(width, sample) > MAX_IMAGE_DIMENSION ||
+            scaledDimension(height, sample) > MAX_IMAGE_DIMENSION ||
+            scaledDimension(width, sample) * scaledDimension(height, sample) > MAX_IMAGE_PIXELS
+        ) {
+            sample *= 2
+        }
+        return sample
+    }
+
+    private fun scaledDimension(dimension: Int, sample: Int): Long =
+        (dimension.toLong() + sample.toLong() - 1L) / sample.toLong()
+
+    private companion object {
+        const val MAX_IMAGE_DIMENSION = 2_048L
+        const val MAX_IMAGE_PIXELS = 4_000_000L
+    }
+}

--- a/android/app/src/main/kotlin/eu/metrora/app/ui/QrScanner.kt
+++ b/android/app/src/main/kotlin/eu/metrora/app/ui/QrScanner.kt
@@ -1,9 +1,12 @@
 package eu.metrora.app.ui
 
 import android.Manifest
+import android.app.Activity
 import android.content.pm.PackageManager
+import android.net.Uri
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.activity.result.PickVisualMediaRequest
 import androidx.camera.core.CameraSelector
 import androidx.camera.core.ExperimentalGetImage
 import androidx.camera.core.ImageAnalysis
@@ -32,12 +35,14 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.CameraAlt
 import androidx.compose.material.icons.outlined.ErrorOutline
+import androidx.compose.material.icons.outlined.PhotoLibrary
 import androidx.compose.material.icons.outlined.QrCodeScanner
 import androidx.compose.material.icons.outlined.Security
 import androidx.compose.material.icons.outlined.Shield
 import androidx.compose.material3.Button
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -79,19 +84,59 @@ internal fun QrScannerScreen(
     onPayload: (String) -> Boolean,
 ) {
     val context = LocalContext.current
+    val activity = context as? Activity
     var hasPermission by remember {
         mutableStateOf(
             ContextCompat.checkSelfPermission(context, Manifest.permission.CAMERA) ==
                 PackageManager.PERMISSION_GRANTED,
         )
     }
-    var invalidPayload by remember { mutableStateOf(false) }
+    var scannerError by remember { mutableStateOf<QrScannerError?>(null) }
+    var imageDecodeOperation by remember { mutableStateOf<QrImageDecodeOperation?>(null) }
     val requestPermission = rememberLauncherForActivityResult(
         ActivityResultContracts.RequestPermission(),
     ) { granted -> hasPermission = granted }
+    val latestOnPayload = rememberUpdatedState(onPayload)
+    val imageDecoder = remember(context) { QrImageDecoder(context) }
+    val latestImageDecodeOperation = rememberUpdatedState(imageDecodeOperation)
+    val pickImage = rememberLauncherForActivityResult(
+        ActivityResultContracts.PickVisualMedia(),
+    ) { uri: Uri? ->
+        if (uri != null) {
+            imageDecodeOperation?.cancel()
+            scannerError = null
+            val operation = imageDecoder.decode(uri) { result ->
+                imageDecodeOperation = null
+                when (val handling = handoffQrImageResult(result, latestOnPayload.value)) {
+                    QrImageImportHandling.Cancelled -> Unit
+                    QrImageImportHandling.Accepted -> scannerError = null
+                    is QrImageImportHandling.Failed -> {
+                        scannerError = when (handling.error) {
+                            QrImageImportError.INVALID_PAYLOAD -> QrScannerError.INVALID_PAYLOAD
+                            QrImageImportError.NO_QR_CODE -> QrScannerError.NO_QR_CODE
+                            QrImageImportError.MULTIPLE_QR_CODES -> QrScannerError.MULTIPLE_QR_CODES
+                            QrImageImportError.BLANK_RAW_VALUE,
+                            QrImageImportError.IMAGE_DECODE_FAILURE,
+                            -> QrScannerError.IMAGE_READ_FAILURE
+                        }
+                    }
+                }
+            }
+            imageDecodeOperation = operation
+        }
+    }
 
     LaunchedEffect(Unit) {
-        if (!hasPermission) requestPermission.launch(Manifest.permission.CAMERA)
+        if (!hasPermission && activity?.shouldShowRequestPermissionRationale(Manifest.permission.CAMERA) == false) {
+            requestPermission.launch(Manifest.permission.CAMERA)
+        }
+    }
+
+    DisposableEffect(imageDecoder) {
+        onDispose {
+            latestImageDecodeOperation.value?.cancel()
+            imageDecoder.close()
+        }
     }
 
     Column(
@@ -131,7 +176,7 @@ internal fun QrScannerScreen(
                 if (hasPermission) {
                     QrCameraPreview(
                         onDetected = { raw ->
-                            invalidPayload = !onPayload(raw)
+                            scannerError = if (onPayload(raw)) null else QrScannerError.INVALID_PAYLOAD
                         },
                     )
                     ScannerAmbientGlow(Modifier.fillMaxSize())
@@ -144,7 +189,28 @@ internal fun QrScannerScreen(
             }
         }
 
-        if (invalidPayload) {
+        OutlinedButton(
+            onClick = {
+                imageDecodeOperation?.cancel()
+                imageDecodeOperation = null
+                scannerError = null
+                pickImage.launch(PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly))
+            },
+            modifier = Modifier.fillMaxWidth().heightIn(min = 48.dp),
+        ) {
+            Icon(imageVector = Icons.Outlined.PhotoLibrary, contentDescription = null)
+            Spacer(Modifier.width(8.dp))
+            Text(androidx.compose.ui.res.stringResource(R.string.import_qr_from_image))
+        }
+
+        val errorMessage = when (scannerError) {
+            null -> null
+            QrScannerError.INVALID_PAYLOAD -> R.string.qr_invalid_payload
+            QrScannerError.NO_QR_CODE -> R.string.qr_no_code_in_image
+            QrScannerError.MULTIPLE_QR_CODES -> R.string.qr_multiple_codes_in_image
+            QrScannerError.IMAGE_READ_FAILURE -> R.string.qr_image_read_failed
+        }
+        if (errorMessage != null) {
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
@@ -158,7 +224,7 @@ internal fun QrScannerScreen(
                     tint = MaterialTheme.colorScheme.error,
                 )
                 Text(
-                    text = androidx.compose.ui.res.stringResource(R.string.qr_invalid_payload),
+                    text = androidx.compose.ui.res.stringResource(errorMessage),
                     color = MaterialTheme.colorScheme.error,
                     style = MaterialTheme.typography.bodyMedium,
                 )
@@ -233,6 +299,13 @@ internal fun QrScannerScreen(
             Text(androidx.compose.ui.res.stringResource(R.string.manual_address_action))
         }
     }
+}
+
+private enum class QrScannerError {
+    INVALID_PAYLOAD,
+    NO_QR_CODE,
+    MULTIPLE_QR_CODES,
+    IMAGE_READ_FAILURE,
 }
 
 @Composable

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -212,7 +212,11 @@
     <string name="about_body">Local-first usage companion. No account or cloud relay is required.</string>
 
     <string name="scan_qr_body">Point your camera at the QR code shown in Metrora on your computer.</string>
+    <string name="import_qr_from_image">Import from image</string>
     <string name="qr_invalid_payload">That QR code is not a Metrora Desktop connection.</string>
+    <string name="qr_no_code_in_image">No Metrora QR code found in this image.</string>
+    <string name="qr_multiple_codes_in_image">More than one QR code was found. Choose an image with a single Metrora QR code.</string>
+    <string name="qr_image_read_failed">Could not read this image. Choose another image and try again.</string>
     <string name="qr_scanner_local_only">Metrora will verify the computer and show a six-digit code before Desktop access is approved.</string>
     <string name="qr_same_network_title">Keep both devices on the same network.</string>
     <string name="qr_same_network_body">Metrora connects directly to Desktop. No account or cloud relay is used.</string>

--- a/android/app/src/test/kotlin/eu/metrora/app/ui/QrImageDecoderTest.kt
+++ b/android/app/src/test/kotlin/eu/metrora/app/ui/QrImageDecoderTest.kt
@@ -1,0 +1,155 @@
+package eu.metrora.app.ui
+
+import eu.metrora.app.network.PairingBootstrap
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class QrImageDecoderTest {
+    @Test
+    fun no_qr_result_maps_to_no_qr_failure() {
+        var callbackCount = 0
+
+        val handling = handoffQrImageResult(classifyQrImageResults(emptyList())) {
+            callbackCount++
+            true
+        }
+
+        assertEquals(
+            QrImageImportHandling.Failed(QrImageImportError.NO_QR_CODE),
+            handling,
+        )
+        assertEquals(0, callbackCount)
+    }
+
+    @Test
+    fun exactly_one_qr_with_raw_value_is_accepted_for_callback_handoff() {
+        val raw = "metrora://connect?host=desktop.local&port=7777"
+        var handedOff: String? = null
+
+        val handling = handoffQrImageResult(classifyQrImageResults(listOf(raw))) {
+            handedOff = it
+            true
+        }
+
+        assertEquals(QrImageImportHandling.Accepted, handling)
+        assertEquals(raw, handedOff)
+    }
+
+    @Test
+    fun null_or_blank_raw_value_fails_closed() {
+        val nullHandling = handoffQrImageResult(classifyQrImageResults(listOf(null))) { true }
+        val blankHandling = handoffQrImageResult(classifyQrImageResults(listOf("  \n\t"))) { true }
+
+        assertEquals(
+            QrImageImportHandling.Failed(QrImageImportError.BLANK_RAW_VALUE),
+            nullHandling,
+        )
+        assertEquals(
+            QrImageImportHandling.Failed(QrImageImportError.BLANK_RAW_VALUE),
+            blankHandling,
+        )
+    }
+
+    @Test
+    fun multiple_qr_results_fail_closed_without_selecting_one() {
+        var handedOff: String? = null
+
+        val handling = handoffQrImageResult(classifyQrImageResults(listOf("first", "second"))) {
+            handedOff = it
+            true
+        }
+
+        assertEquals(
+            QrImageImportHandling.Failed(QrImageImportError.MULTIPLE_QR_CODES),
+            handling,
+        )
+        assertNull(handedOff)
+    }
+
+    @Test
+    fun image_decode_exception_maps_to_readable_failure() {
+        val handling = handoffQrImageResult(QrImageImportResult.ImageDecodeFailure) { true }
+
+        assertEquals(
+            QrImageImportHandling.Failed(QrImageImportError.IMAGE_DECODE_FAILURE),
+            handling,
+        )
+    }
+
+    @Test
+    fun picker_cancellation_is_ignored_without_callback_or_error() {
+        var callbackCount = 0
+
+        val handling = handoffQrImageResult(QrImageImportResult.Cancelled) {
+            callbackCount++
+            true
+        }
+
+        assertEquals(QrImageImportHandling.Cancelled, handling)
+        assertEquals(0, callbackCount)
+    }
+
+    @Test
+    fun invalid_metrora_payload_reaches_existing_pairing_authority() {
+        val raw = "https://example.com/account"
+        var handedOff: String? = null
+
+        val handling = handoffQrImageResult(QrImageImportResult.Payload(raw)) {
+            handedOff = it
+            runCatching { PairingBootstrap.parse(it) }.isSuccess
+        }
+
+        assertEquals(QrImageImportHandling.Failed(QrImageImportError.INVALID_PAYLOAD), handling)
+        assertEquals(raw, handedOff)
+    }
+
+    @Test
+    fun successful_import_calls_on_payload_exactly_once() {
+        val operation = QrImageDecodeOperation()
+        var callbackCount = 0
+
+        if (operation.tryDeliver()) {
+            handoffQrImageResult(QrImageImportResult.Payload("metrora://connect?host=desktop.local")) {
+                callbackCount++
+                true
+            }
+        }
+        if (operation.tryDeliver()) {
+            callbackCount++
+        }
+
+        assertEquals(1, callbackCount)
+    }
+
+    @Test
+    fun stale_or_repeated_import_cannot_deliver_a_second_pairing_result() {
+        val staleOperation = QrImageDecodeOperation()
+        val currentOperation = QrImageDecodeOperation()
+        var callbackCount = 0
+
+        staleOperation.cancel()
+        if (staleOperation.tryDeliver()) callbackCount++
+        if (currentOperation.tryDeliver()) callbackCount++
+        if (currentOperation.tryDeliver()) callbackCount++
+
+        assertFalse(staleOperation.isActive())
+        assertEquals(1, callbackCount)
+    }
+
+    @Test
+    fun valid_raw_payload_remains_accepted_by_existing_camera_callback_contract() {
+        val raw = "metrora://connect?host=desktop.local&port=7777"
+        var handedOff: String? = null
+
+        val handling = handoffQrImageResult(QrImageImportResult.Payload(raw)) {
+            handedOff = it
+            PairingBootstrap.parse(it).host == "desktop.local"
+        }
+
+        assertTrue(handling == QrImageImportHandling.Accepted)
+        assertEquals(raw, handedOff)
+    }
+}

--- a/android/app/src/test/kotlin/eu/metrora/app/ui/QrImageDecoderTest.kt
+++ b/android/app/src/test/kotlin/eu/metrora/app/ui/QrImageDecoderTest.kt
@@ -152,4 +152,18 @@ class QrImageDecoderTest {
         assertTrue(handling == QrImageImportHandling.Accepted)
         assertEquals(raw, handedOff)
     }
+
+    @Test
+    fun system_thumbnail_does_not_reapply_source_exif_orientation() {
+        assertFalse(
+            shouldApplySourceExifOrientation(QrImageBitmapSource.SYSTEM_THUMBNAIL),
+        )
+    }
+
+    @Test
+    fun direct_decode_still_applies_source_exif_orientation() {
+        assertTrue(
+            shouldApplySourceExifOrientation(QrImageBitmapSource.DIRECT_DECODE),
+        )
+    }
 }

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -5,6 +5,7 @@ camera = "1.4.2"
 datastore = "1.2.1"
 coroutines = "1.11.0"
 mlkitBarcode = "17.3.0"
+exifinterface = "1.4.2"
 lifecycle = "2.9.4"
 junit = "4.13.2"
 orgJson = "20250517"
@@ -21,6 +22,7 @@ camera-camera2 = { module = "androidx.camera:camera-camera2", version.ref = "cam
 camera-lifecycle = { module = "androidx.camera:camera-lifecycle", version.ref = "camera" }
 camera-view = { module = "androidx.camera:camera-view", version.ref = "camera" }
 mlkit-barcode = { module = "com.google.mlkit:barcode-scanning", version.ref = "mlkitBarcode" }
+exifinterface = { module = "androidx.exifinterface:exifinterface", version.ref = "exifinterface" }
 lifecycle-runtime-compose = { module = "androidx.lifecycle:lifecycle-runtime-compose", version.ref = "lifecycle" }
 datastore-preferences = { module = "androidx.datastore:datastore-preferences", version.ref = "datastore" }
 coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "coroutines" }


### PR DESCRIPTION
## Summary

Implements ANDROID_QR_IMAGE_IMPORT_V1 on the existing Android QR scanner screen.

- Adds the normal Android image-only Photo Picker action: “Import from image”.
- Reuses the existing ML Kit barcode dependency with QR-only static-image decoding.
- Uses a bounded, local decoder with Photo Picker thumbnail support, lifecycle cancellation, and fail-closed zero/blank/multiple-result handling.
- Hands exactly one non-blank raw value to the existing `onPayload(raw)` callback; PairingBootstrap/coordinator/SAS/approval/mTLS remain unchanged.
- Camera denial no longer blocks image import or manual address entry.
- Preserves correct image orientation: API 29+ system thumbnails are not EXIF-rotated twice; direct source decoding still applies source EXIF orientation.

## Validation

- `gradle -p android --no-daemon :app:testGithubDebugUnitTest :app:lint :app:assembleGithubDebug`
- 108 JVM tests across 15 suites, 0 failures/errors/skips; focused QR image suite: 12 tests.
- `node --test scripts/verify-android-release.node-test.mjs`: 5/5 passed.
- Dedicated Android API 34 AVD smoke through the real Photo Picker: normal QR, EXIF 90° QR and EXIF 270° QR all decoded and reached the existing pairing handoff; no-QR/multiple-QR/cancellation/camera-denied behavior also validated.

## Release boundary

- `versionName` remains `0.1.0-alpha.1`; `versionCode` remains `1`.
- No production signing, release, tag, or public artifact mutation.
- This PR does not modify Desktop/core, Windows Store, site, or private repositories.