### PR TITLE
Prepare Android 0.1.0-alpha.2 release candidate

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -142,11 +142,13 @@ Rollback preserves endpoint identity, OS-vault material, analytics, Workspace st
 
 ## Android direct distribution boundary
 
-Android's first intended direct channel is a Founder-gated GitHub Release with
-one production-signed `Metrora-Android-<versionName>.apk`, a public release
-manifest and `SHA256SUMS`. The source-bound workflow is manual-only, does not
-publish from pushes or tags, and can prepare only a draft release after an
-existing tag is independently bound to the reviewed source commit. See
+Android's direct channel is a Founder-gated GitHub Release with one
+production-signed `Metrora-Android-<versionName>.apk`, a public release manifest
+and `SHA256SUMS`. The immutable public release is `0.1.0-alpha.1`; the current
+`0.1.0-alpha.2` source candidate is not public. The source-bound workflow is
+manual-only, does not publish from pushes or tags, and can prepare only a draft
+release after an existing tag is independently bound to the reviewed source
+commit. See
 [`docs/ANDROID_PUBLIC_DISTRIBUTION_V1.md`](docs/ANDROID_PUBLIC_DISTRIBUTION_V1.md).
 
 The V1 production custody contract uses a JKS keystore. The keystore and
@@ -155,9 +157,9 @@ materializes them only for the protected signing step and does not persist
 them in `GITHUB_ENV` or release metadata.
 
 The QA physical-acceptance identity is not a production release identity.
-Google Play and F-Droid remain separate gates, and no public Android
-availability claim is made until the production key, physical acceptance and
-Founder publication decision exist.
+Google Play and F-Droid remain separate gates. The alpha.1 public availability
+claim is limited to its immutable GitHub release; alpha.2 remains blocked until
+the production key, physical acceptance and Founder publication decision exist.
 
 ## Prohibitions
 

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -30,8 +30,8 @@ fun requiredProductionSigningValue(environmentName: String, propertyName: String
         ?: error("Production signing is enabled but $environmentName/$propertyName is missing")
 
 val androidApplicationId = "eu.metrora.app"
-val androidVersionCode = 1
-val androidVersionName = "0.1.0-alpha.1"
+val androidVersionCode = 2
+val androidVersionName = "0.1.0-alpha.2"
 
 val productionKeystorePath = if (productionReleaseEnabled) {
     requiredProductionSigningValue(

--- a/docs/ANDROID_PUBLIC_DISTRIBUTION_V1.md
+++ b/docs/ANDROID_PUBLIC_DISTRIBUTION_V1.md
@@ -1,14 +1,17 @@
 # Android public distribution v1
 
-**Status:** release-readiness contract; no public Android release has been
-created by this document or its workflow.
+**Status:** direct-APK distribution contract; `0.1.0-alpha.1` is the
+immutable public Android release. The `0.1.0-alpha.2` / `versionCode = 2`
+source candidate on this release line is not public.
 
-**Base audit:** `maikolsiragusaa/metrora@69f0688fea5bb48f37b770e8de590ad20e490d74`
+**Historical base audit:** `maikolsiragusaa/metrora@69f0688fea5bb48f37b770e8de590ad20e490d74`
 
-This document moves the implemented Android companion from buildable and
-QA-accepted to ready for a Founder-gated, direct GitHub APK release. It does
-not authorize publication, Google Play submission, F-Droid submission, a tag,
-or a website/README promotion wave.
+This document records the Founder-gated, direct GitHub APK contract for the
+implemented Android companion. It does not authorize publication of the alpha.2
+candidate, Google Play submission, F-Droid submission, a tag, or a
+website/README promotion wave. The table below is historical evidence for the
+named audit base; its alpha.1 and no-public-release statements are not current
+alpha.2 authority.
 
 ## Current-state audit
 
@@ -37,7 +40,7 @@ evidence and Workspace semantics.
 
 ## Direct distribution contract
 
-The first public Android channel is a GitHub Release containing one canonical
+The public Android channel is a GitHub Release containing one canonical
 APK for ordinary direct installation:
 
 - repository: `maikolsiragusaa/metrora`;
@@ -48,7 +51,13 @@ APK for ordinary direct installation:
 - manifest asset: `Metrora-Android-<versionName>.manifest.json`;
 - integrity asset: `SHA256SUMS`.
 
-The release manifest is intentionally small and public:
+The immutable public release currently remains `0.1.0-alpha.1` with
+`versionCode = 1`. The source candidate prepared on this release line is
+`0.1.0-alpha.2` with `versionCode = 2`; it is not public and must not replace
+the alpha.1 download or Obtainium guidance.
+
+The following illustrative manifest uses the immutable alpha.1 public identity;
+it is a schema example, not alpha.2 release evidence:
 
 ```json
 {
@@ -80,17 +89,20 @@ Android has a platform-native version authority separate from the frozen
 Windows Store package version:
 
 - source authority: `android/app/build.gradle.kts`;
-- current `versionName`: `0.1.0-alpha.1`;
-- current `versionCode`: `1`;
+- latest public `versionName`: `0.1.0-alpha.1`;
+- latest public `versionCode`: `1`;
+- current source-candidate `versionName`: `0.1.0-alpha.2`;
+- current source-candidate `versionCode`: `2`;
 - GitHub identity: `android-v<versionName>`;
 - Play and direct APK upgrades use the same `eu.metrora.app` package line and
   the same strictly increasing `versionCode` sequence.
 
-The current value is retained because no production-signed Android artifact has
-been publicly installable. A first public alpha at `versionCode = 1` is valid;
-there is no need to spend a version number before the first public release.
-Every later publicly installable upgrade must use a strictly larger integer.
-`versionName` remains human-readable and may use the existing Metrora
+The immutable alpha.1 production-signed artifact consumed `versionCode = 1`.
+The alpha.2 source candidate advances the same application identity to
+`versionCode = 2`; it remains blocked from public distribution until the
+production-key, independent-review, Founder-authorization and merge gates are
+complete. Every later publicly installable upgrade must use a strictly larger
+integer. `versionName` remains human-readable and may use the existing Metrora
 pre-release convention.
 
 Android version identity is not coupled to the Windows Store package version.
@@ -338,5 +350,6 @@ confirm all of the following outside this pull request:
 - release notes, checksum and manifest are reviewed;
 - only then is the draft eligible for explicit public publication.
 
-Until those actions occur, the repository state is **public-distribution-ready
-for the production-key gate**, not a public Android release.
+Until those actions occur for alpha.2, the repository state is **a source
+candidate ready for the production-key gate**, not a public alpha.2 release.
+The immutable alpha.1 artifact remains the current public Android release.

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -150,7 +150,10 @@ See [Windows distribution](WINDOWS_DISTRIBUTION.md), [Versioning authority](VERS
 
 ## Build and validate the Android companion
 
-The Android companion is a source/build surface for the implemented local LAN contract. Its current scope is physically accepted, but it is not a public Android release. Ordinary contributors do not need private QA signing material.
+The Android companion is a source/build surface for the implemented local LAN
+contract. The current public GitHub pre-release is `0.1.0-alpha.1`; the
+`0.1.0-alpha.2` source candidate is not public. Ordinary contributors do not
+need private QA signing material.
 
 Use:
 

--- a/docs/VERSIONING.md
+++ b/docs/VERSIONING.md
@@ -47,15 +47,23 @@ package-version rules and pass their own acceptance and publication gates.
 ## Android version authority
 
 Android uses the native `versionName` and integer `versionCode` declared in
-`android/app/build.gradle.kts`. The current never-public source value is:
+`android/app/build.gradle.kts`. The immutable public Android release is:
 
 - `versionName = 0.1.0-alpha.1`;
 - `versionCode = 1`;
 - application ID `eu.metrora.app`.
 
-Because no production-signed Android artifact has been publicly installable,
-retaining `versionCode = 1` for the first direct APK is valid. Every later
-publicly installable Android upgrade must use a strictly larger `versionCode`.
+The current source candidate advances the same package line to:
+
+- `versionName = 0.1.0-alpha.2`;
+- `versionCode = 2`;
+- application ID `eu.metrora.app`.
+
+The alpha.2 source candidate is not a public release. Public download and
+release guidance must continue to point to the immutable alpha.1 artifact until
+a separately authorized production-signed alpha.2 release exists. The public
+alpha.1 artifact consumed `versionCode = 1`; every later publicly installable
+Android upgrade must use a strictly larger `versionCode`.
 The human-readable `versionName` is used in the deterministic GitHub identity
 `android-v<versionName>` and asset name
 `Metrora-Android-<versionName>.apk`. Android's version line is independent of

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -166,7 +166,7 @@ See [`WINDOWS_DISTRIBUTION.md`](WINDOWS_DISTRIBUTION.md), [`WINDOWS_FORMAT_DERIV
 src/       canonical collection, parsing, pricing, analytics, evidence and CLI
 app/       Electron desktop application
 dash/      local browser dashboard
-android/   implemented local companion; public Android distribution not released
+android/   implemented local companion; public alpha.1 release, alpha.2 source candidate
 mac/       native macOS menubar companion
 gnome/     GNOME Shell companion
 tests/     canonical core and integration tests


### PR DESCRIPTION
## Summary

- Advance the canonical Android version authority to `0.1.0-alpha.2` / `versionCode = 2` while preserving `eu.metrora.app`.
- Converge current Android version/distribution documentation so alpha.1 remains the immutable public release and alpha.2 is clearly a non-public source candidate.
- Leave the accepted QR image-import implementation and the source-bound production workflow unchanged.

## Validation

- `gradle -p android --no-daemon :app:testGithubDebugUnitTest :app:lint :app:assembleGithubDebug` — PASS under Gradle 9.6.1.
- `:app:assembleGithubRelease` — PASS as an unsigned, non-production release-variant build.
- `node --test scripts/verify-android-release.node-test.mjs` — 5/5 PASS.
- `npm run version:check` — PASS.
- `git diff --check` — PASS.
- Unsigned release APK metadata: `eu.metrora.app`, `0.1.0-alpha.2`, versionCode `2`.

## Release boundary

- No production signing or production credentials were used.
- No tag, GitHub Release, or public alpha.2 artifact was created.
- Production signing remains blocked until independent review, Founder merge authorization, and an exact source commit reachable from `main`.