### PR TITLE
Fix minified release crash after camera denial

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -145,8 +145,9 @@ Rollback preserves endpoint identity, OS-vault material, analytics, Workspace st
 Android's direct channel is a Founder-gated GitHub Release with one
 production-signed `Metrora-Android-<versionName>.apk`, a public release manifest
 and `SHA256SUMS`. The immutable public release is `0.1.0-alpha.1`; the current
-`0.1.0-alpha.2` source candidate is not public. The source-bound workflow is
-manual-only, does not publish from pushes or tags, and can prepare only a draft
+`0.1.0-alpha.3` source candidate is not public. The prior `0.1.0-alpha.2`
+candidate is historical failed evidence and was never public. The source-bound
+workflow is manual-only, does not publish from pushes or tags, and can prepare only a draft
 release after an existing tag is independently bound to the reviewed source
 commit. See
 [`docs/ANDROID_PUBLIC_DISTRIBUTION_V1.md`](docs/ANDROID_PUBLIC_DISTRIBUTION_V1.md).
@@ -158,7 +159,7 @@ them in `GITHUB_ENV` or release metadata.
 
 The QA physical-acceptance identity is not a production release identity.
 Google Play and F-Droid remain separate gates. The alpha.1 public availability
-claim is limited to its immutable GitHub release; alpha.2 remains blocked until
+claim is limited to its immutable GitHub release; alpha.3 remains blocked until
 the production key, physical acceptance and Founder publication decision exist.
 
 ## Prohibitions

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -30,8 +30,8 @@ fun requiredProductionSigningValue(environmentName: String, propertyName: String
         ?: error("Production signing is enabled but $environmentName/$propertyName is missing")
 
 val androidApplicationId = "eu.metrora.app"
-val androidVersionCode = 2
-val androidVersionName = "0.1.0-alpha.2"
+val androidVersionCode = 3
+val androidVersionName = "0.1.0-alpha.3"
 
 val productionKeystorePath = if (productionReleaseEnabled) {
     requiredProductionSigningValue(

--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -1,1 +1,15 @@
 # Metrora uses no reflection-based network model in the Android companion.
+
+# ML Kit discovers these barcode/common/vision components from manifest metadata
+# and constructs each registrar through its no-argument constructor. Keep only
+# those reflective entry points; the rest of the ML Kit implementation remains
+# minified.
+-keep class com.google.mlkit.vision.barcode.internal.BarcodeRegistrar {
+    public <init>();
+}
+-keep class com.google.mlkit.vision.common.internal.VisionCommonRegistrar {
+    public <init>();
+}
+-keep class com.google.mlkit.common.internal.CommonComponentRegistrar {
+    public <init>();
+}

--- a/docs/ANDROID_PUBLIC_DISTRIBUTION_V1.md
+++ b/docs/ANDROID_PUBLIC_DISTRIBUTION_V1.md
@@ -1,17 +1,19 @@
 # Android public distribution v1
 
 **Status:** direct-APK distribution contract; `0.1.0-alpha.1` is the
-immutable public Android release. The `0.1.0-alpha.2` / `versionCode = 2`
-source candidate on this release line is not public.
+immutable public Android release. The `0.1.0-alpha.3` / `versionCode = 3`
+source candidate on this release line is not public. The `0.1.0-alpha.2` /
+`versionCode = 2` candidate remains historical failed evidence and was never
+public.
 
 **Historical base audit:** `maikolsiragusaa/metrora@69f0688fea5bb48f37b770e8de590ad20e490d74`
 
 This document records the Founder-gated, direct GitHub APK contract for the
-implemented Android companion. It does not authorize publication of the alpha.2
+implemented Android companion. It does not authorize publication of the alpha.3
 candidate, Google Play submission, F-Droid submission, a tag, or a
 website/README promotion wave. The table below is historical evidence for the
 named audit base; its alpha.1 and no-public-release statements are not current
-alpha.2 authority.
+alpha.3 authority.
 
 ## Current-state audit
 
@@ -52,12 +54,14 @@ APK for ordinary direct installation:
 - integrity asset: `SHA256SUMS`.
 
 The immutable public release currently remains `0.1.0-alpha.1` with
-`versionCode = 1`. The source candidate prepared on this release line is
-`0.1.0-alpha.2` with `versionCode = 2`; it is not public and must not replace
-the alpha.1 download or Obtainium guidance.
+`versionCode = 1`. The current source candidate prepared on this release line
+is `0.1.0-alpha.3` with `versionCode = 3`; it is not public and must not replace
+the alpha.1 download or Obtainium guidance. The prior `0.1.0-alpha.2` /
+`versionCode = 2` candidate is retained as historical failed, unpublished
+evidence and must not be overwritten or reissued.
 
 The following illustrative manifest uses the immutable alpha.1 public identity;
-it is a schema example, not alpha.2 release evidence:
+it is a schema example, not alpha.3 release evidence:
 
 ```json
 {
@@ -91,18 +95,20 @@ Windows Store package version:
 - source authority: `android/app/build.gradle.kts`;
 - latest public `versionName`: `0.1.0-alpha.1`;
 - latest public `versionCode`: `1`;
-- current source-candidate `versionName`: `0.1.0-alpha.2`;
-- current source-candidate `versionCode`: `2`;
+- current source-candidate `versionName`: `0.1.0-alpha.3`;
+- current source-candidate `versionCode`: `3`;
 - GitHub identity: `android-v<versionName>`;
 - Play and direct APK upgrades use the same `eu.metrora.app` package line and
   the same strictly increasing `versionCode` sequence.
 
 The immutable alpha.1 production-signed artifact consumed `versionCode = 1`.
-The alpha.2 source candidate advances the same application identity to
-`versionCode = 2`; it remains blocked from public distribution until the
-production-key, independent-review, Founder-authorization and merge gates are
-complete. Every later publicly installable upgrade must use a strictly larger
-integer. `versionName` remains human-readable and may use the existing Metrora
+The historical alpha.2 candidate advanced the same application identity to
+`versionCode = 2` but failed scanner acceptance and remains unpublished. The
+alpha.3 source candidate advances the same identity to `versionCode = 3`; it
+remains blocked from public distribution until the production-key,
+independent-review, Founder-authorization and merge gates are complete. Every
+later publicly installable upgrade must use a strictly larger integer.
+`versionName` remains human-readable and may use the existing Metrora
 pre-release convention.
 
 Android version identity is not coupled to the Windows Store package version.
@@ -350,6 +356,7 @@ confirm all of the following outside this pull request:
 - release notes, checksum and manifest are reviewed;
 - only then is the draft eligible for explicit public publication.
 
-Until those actions occur for alpha.2, the repository state is **a source
-candidate ready for the production-key gate**, not a public alpha.2 release.
+Until those actions occur for alpha.3, the repository state is **a source
+candidate ready for the production-key gate**, not a public alpha.3 release.
+The historical alpha.2 candidate remains failed and unpublished.
 The immutable alpha.1 artifact remains the current public Android release.

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -152,8 +152,9 @@ See [Windows distribution](WINDOWS_DISTRIBUTION.md), [Versioning authority](VERS
 
 The Android companion is a source/build surface for the implemented local LAN
 contract. The current public GitHub pre-release is `0.1.0-alpha.1`; the
-`0.1.0-alpha.2` source candidate is not public. Ordinary contributors do not
-need private QA signing material.
+`0.1.0-alpha.3` source candidate is not public. The prior `0.1.0-alpha.2`
+candidate is historical failed evidence and was never public. Ordinary
+contributors do not need private QA signing material.
 
 Use:
 

--- a/docs/VERSIONING.md
+++ b/docs/VERSIONING.md
@@ -55,15 +55,16 @@ Android uses the native `versionName` and integer `versionCode` declared in
 
 The current source candidate advances the same package line to:
 
-- `versionName = 0.1.0-alpha.2`;
-- `versionCode = 2`;
+- `versionName = 0.1.0-alpha.3`;
+- `versionCode = 3`;
 - application ID `eu.metrora.app`.
 
-The alpha.2 source candidate is not a public release. Public download and
-release guidance must continue to point to the immutable alpha.1 artifact until
-a separately authorized production-signed alpha.2 release exists. The public
-alpha.1 artifact consumed `versionCode = 1`; every later publicly installable
-Android upgrade must use a strictly larger `versionCode`.
+The alpha.2 source candidate is historical failed evidence and was never
+public. The alpha.3 source candidate is also not a public release. Public
+download and release guidance must continue to point to the immutable alpha.1
+artifact until a separately authorized production-signed alpha.3 release
+exists. The public alpha.1 artifact consumed `versionCode = 1`; every later
+publicly installable Android upgrade must use a strictly larger `versionCode`.
 The human-readable `versionName` is used in the deterministic GitHub identity
 `android-v<versionName>` and asset name
 `Metrora-Android-<versionName>.apk`. Android's version line is independent of

--- a/scripts/verify-android-release.node-test.mjs
+++ b/scripts/verify-android-release.node-test.mjs
@@ -1,5 +1,8 @@
+import fs from 'node:fs'
 import test from 'node:test'
 import assert from 'node:assert/strict'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
 
 import {
   artifactFilenameForVersion,
@@ -11,6 +14,10 @@ import {
   parseSha256Sums,
   validateReleaseManifest,
 } from './verify-android-release.mjs'
+
+const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+const readRepositoryFile = relativePath =>
+  fs.readFileSync(path.join(repositoryRoot, relativePath), 'utf8')
 
 const sourceCommit = 'a'.repeat(40)
 const certificate = 'b'.repeat(64)
@@ -91,4 +98,32 @@ test('SHA256SUMS parsing rejects malformed or duplicate entries', () => {
   )
   assert.throws(() => parseSha256Sums(`${apk}  artifact.apk\n${apk}  artifact.apk\n`))
   assert.throws(() => parseSha256Sums(`${apk} *artifact.apk\n`))
+})
+
+test('release scanner keeps ML Kit registrars and camera-independent image import', () => {
+  const proguardRules = readRepositoryFile('android/app/proguard-rules.pro')
+  for (const registrar of [
+    'com.google.mlkit.vision.barcode.internal.BarcodeRegistrar',
+    'com.google.mlkit.vision.common.internal.VisionCommonRegistrar',
+    'com.google.mlkit.common.internal.CommonComponentRegistrar',
+  ]) {
+    const escapedRegistrar = registrar.replaceAll('.', '\\.')
+    assert.match(
+      proguardRules,
+      new RegExp(`-keep class ${escapedRegistrar}\\s*\\{\\s*public <init>\\(\\);\\s*\\}`),
+    )
+  }
+
+  const scannerSource = readRepositoryFile(
+    'android/app/src/main/kotlin/eu/metrora/app/ui/QrScanner.kt',
+  )
+  const cameraBranch = scannerSource.indexOf('if (hasPermission)')
+  const cameraBranchEnd = scannerSource.indexOf('\n        OutlinedButton(', cameraBranch)
+  const imageImport = scannerSource.indexOf('R.string.import_qr_from_image')
+
+  assert.notEqual(cameraBranch, -1)
+  assert.notEqual(cameraBranchEnd, -1)
+  assert.notEqual(imageImport, -1)
+  assert.ok(imageImport > cameraBranchEnd)
+  assert.match(scannerSource.slice(cameraBranch, cameraBranchEnd), /CameraPermissionPrompt/)
 })


### PR DESCRIPTION
## Summary

- retain the no-argument constructors for ML Kit's manifest-discovered barcode, vision-common, and common component registrars;
- advance the unpublished Android source candidate to 0.1.0-alpha.3 / versionCode 3;
- add a release-boundary regression for the registrar keep rules and camera-independent image import;
- keep alpha.1 as the public download authority and retain alpha.2 as historical failed, unpublished evidence.

The alpha.2 release stack deobfuscated to ML Kit BarcodeScanning.getClient, reached through Metrora's QrImageDecoder construction. Release-only R8 removal of reflective registrar constructors caused ComponentDiscovery failures and a null component dereference. The fix is targeted; minification, resource shrinking, camera permission semantics, QR import, pairing, and security behavior remain enabled.

## Validation

- required Gradle debug unit tests, lint, githubDebug, and minified githubRelease: PASS;
- Android release verifier Node tests: 6/6 PASS;
- npm version check and git diff check: PASS;
- API 34 minified githubRelease QA runtime: cold launch, camera granted, 10/10 camera-denied scanner cycles, Photo Picker import with camera denied, decoder hand-off, force-stop/relaunch, clear-data first run: PASS; zero fatal exceptions and zero registrar reflection warnings.

QA runtime used only the local debug keystore. No production signing or publication was performed.