### PR TITLE
docs: surface Android alpha.3 public release

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,14 +10,14 @@ Understand where AI time, tokens and money go across tools, models, projects and
 
 [![Metrora CI](https://github.com/maikolsiragusaa/metrora/actions/workflows/ci.yml/badge.svg)](https://github.com/maikolsiragusaa/metrora/actions/workflows/ci.yml)
 [![Microsoft Store](https://img.shields.io/badge/Microsoft%20Store-Download-0078D4?logo=microsoft&logoColor=white)](https://apps.microsoft.com/detail/9NXSZFQSBBDX)
-[![Android](https://img.shields.io/badge/Android-0.1.0--alpha.1-3DDC84?logo=android&logoColor=white)](https://github.com/maikolsiragusaa/metrora/releases/tag/android-v0.1.0-alpha.1)
+[![Android](https://img.shields.io/badge/Android-0.1.0--alpha.3-3DDC84?logo=android&logoColor=white)](https://github.com/maikolsiragusaa/metrora/releases/tag/android-v0.1.0-alpha.3)
 [![Fluxer Community](https://img.shields.io/badge/Fluxer-Community-4641D9?logo=fluxer&logoColor=white)](https://metrora.eu/community)
 [![License: MIT](https://img.shields.io/badge/License-MIT-0F1115.svg)](LICENSE)
 
 </div>
 
 > [!IMPORTANT]
-> Metrora for Windows is available on the **Microsoft Store**, published by Vensent. The **Android companion is now publicly available as an early GitHub pre-release**. The current Store package remains the frozen RC10 Windows distribution and does not yet include the latest companion runtime used by the Android alpha, so Android pairing currently requires a current Desktop source build. Repository builds and historical GitHub Windows pre-releases remain separate development or archival artifacts.
+> Metrora for Windows is available on the **Microsoft Store**, published by Vensent. The **Android companion is publicly available as the production-signed `0.1.0-alpha.3` GitHub pre-release**. The live Store package remains the frozen RC10 Windows distribution while the RC11 update is in Microsoft certification; until Microsoft publishes RC11, Android pairing requires a current Desktop source build with the companion runtime. Repository builds and historical GitHub Windows pre-releases remain separate development or archival artifacts.
 
 ## Install Metrora
 
@@ -29,13 +29,13 @@ The Store package installs the bundled Metrora desktop and CLI runtime without r
 
 ### Android companion
 
-The first public Android alpha is [`0.1.0-alpha.1`](https://github.com/maikolsiragusaa/metrora/releases/tag/android-v0.1.0-alpha.1), distributed as a production-signed direct APK from GitHub Releases:
+The current public Android alpha is [`0.1.0-alpha.3`](https://github.com/maikolsiragusaa/metrora/releases/tag/android-v0.1.0-alpha.3), distributed as a production-signed direct APK from GitHub Releases:
 
-- [Download `Metrora-Android-0.1.0-alpha.1.apk`](https://github.com/maikolsiragusaa/metrora/releases/download/android-v0.1.0-alpha.1/Metrora-Android-0.1.0-alpha.1.apk)
+- [Download `Metrora-Android-0.1.0-alpha.3.apk`](https://github.com/maikolsiragusaa/metrora/releases/download/android-v0.1.0-alpha.3/Metrora-Android-0.1.0-alpha.3.apk)
 - verify the public manifest and `SHA256SUMS` attached to the release;
 - for Obtainium, add `https://github.com/maikolsiragusaa/metrora` and track the `android-v*` releases.
 
-This is an early direct-install channel, not a Google Play or F-Droid release. The companion pairs locally with Metrora Desktop and does not become a second collection or accounting authority. Until the next Windows Store update includes the current companion runtime, use a current Desktop source build for Android pairing.
+`0.1.0-alpha.1` remains an immutable historical release and `0.1.0-alpha.2` was never published. This is an early direct-install channel, not a Google Play or F-Droid release. The companion pairs locally with Metrora Desktop and does not become a second collection or accounting authority. Until the live Windows Store package includes the current companion runtime, use a current Desktop source build for Android pairing.
 
 ## What Metrora helps you understand
 
@@ -164,13 +164,13 @@ Historical API-equivalent pricing is date-effective and non-retroactive by defau
 | Desktop | Primary local analysis and configuration | **Available on Microsoft Store for Windows** |
 | CLI | Automation, inspection, export and keyboard-first analysis | Bundled with the Windows Store app; also available from source for development |
 | Local web dashboard | Browser view served from the local machine | Available locally |
-| Android companion | Read-focused local-network companion for a paired Desktop | **Public GitHub pre-release `0.1.0-alpha.1`; production-signed direct APK** |
+| Android companion | Read-focused local-network companion for a paired Desktop | **Public GitHub pre-release `0.1.0-alpha.3`; production-signed direct APK** |
 | macOS menubar | Compact local usage view | Development source retained; not an official Metrora distribution |
 | GNOME extension | Compact Linux panel view | Development source retained; not an official Metrora distribution |
 
 Windows is the first supported public desktop distribution. Source support for other desktop platforms does not imply that an accepted public package exists for those platforms.
 
-The Android companion is now publicly distributed through the [`android-v0.1.0-alpha.1`](https://github.com/maikolsiragusaa/metrora/releases/tag/android-v0.1.0-alpha.1) GitHub pre-release. It pairs with Metrora Desktop on the same LAN, can show a fresh Desktop-generated usage overview or an encrypted offline snapshot, and consumes bounded Project-aware Home, Activity Sessions/Pull Requests, Analyze/Models, Analyze/Spend and capability-driven Workspace projections. Activity uses additive cursor-paged metadata contracts and does not expose prompt/response content. QR pairing, SAS/Desktop approval and mutual-TLS device trust remain the local security boundary. The Android app does not duplicate collection, parsing, pricing, history or evidence authority. The live Microsoft Store package is still the frozen RC10 line; until a Store update carries the current companion runtime, Android-alpha pairing requires a current Desktop source build.
+The Android companion is publicly distributed through the [`android-v0.1.0-alpha.3`](https://github.com/maikolsiragusaa/metrora/releases/tag/android-v0.1.0-alpha.3) GitHub pre-release. It pairs with Metrora Desktop on the same LAN, can show a fresh Desktop-generated usage overview or an encrypted offline snapshot, and consumes bounded Project-aware Home, Activity Sessions/Pull Requests, Analyze/Models, Analyze/Spend and capability-driven Workspace projections. Activity uses additive cursor-paged metadata contracts and does not expose prompt/response content. QR pairing, image import, SAS/Desktop approval and mutual-TLS device trust remain the local security boundary. The Android app does not duplicate collection, parsing, pricing, history or evidence authority. The live Microsoft Store package is still the frozen RC10 line while RC11 is in Microsoft certification; until that Store update is published with the current companion runtime, Android pairing requires a current Desktop source build.
 
 ## Privacy model
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -144,19 +144,23 @@ npm --prefix app run typecheck
 npm --prefix app run build
 ```
 
-Development builds are not official Store-signed releases. Windows is the first supported public desktop distribution, and the Microsoft Store package is the recommended Windows install path. Repository packaging commands remain development and verification tools rather than alternate public distribution channels.
+Development builds are not official Store-signed releases. Windows is the first supported public desktop distribution, and the Microsoft Store package is the recommended Windows install path. The live Store line remains RC10 while RC11 is in Microsoft certification. Repository packaging commands remain development and verification tools rather than alternate public distribution channels.
 
 See [Windows distribution](WINDOWS_DISTRIBUTION.md), [Versioning authority](VERSIONING.md) and [`RELEASING.md`](../RELEASING.md).
 
-## Build and validate the Android companion
+## Android companion
 
-The Android companion is a source/build surface for the implemented local LAN
-contract. The current public GitHub pre-release is `0.1.0-alpha.1`; the
-`0.1.0-alpha.3` source candidate is not public. The prior `0.1.0-alpha.2`
-candidate is historical failed evidence and was never public. Ordinary
-contributors do not need private QA signing material.
+The current public GitHub pre-release is [`0.1.0-alpha.3`](https://github.com/maikolsiragusaa/metrora/releases/tag/android-v0.1.0-alpha.3), distributed as a production-signed direct APK for `eu.metrora.app` with `versionCode = 3`. `0.1.0-alpha.1` remains immutable historical release evidence; `0.1.0-alpha.2` was never published.
 
-Use:
+Until Microsoft publishes the RC11 Store update with the current companion runtime, pair alpha.3 with a current Metrora Desktop source build. The Android companion remains read-focused and does not become a second collection, pricing, accounting or history authority.
+
+For direct installation:
+
+- download `Metrora-Android-0.1.0-alpha.3.apk` from the alpha.3 GitHub Release;
+- verify the attached manifest and `SHA256SUMS` if desired;
+- Obtainium users can track the repository's `android-v*` releases.
+
+For repository Android development use:
 
 - Java 17;
 - Gradle 9.6.1, or the project-supported equivalent;
@@ -174,9 +178,9 @@ To validate the unsigned distribution channels used by the repository workflow:
 gradle -p android --no-daemon :app:assembleGithubRelease :app:assembleFdroidRelease :app:bundlePlayRelease
 ```
 
-The dedicated non-production QA identity is used only for trusted same-repository physical-acceptance CI and is not required for these commands. Fork pull requests do not receive QA secrets. Release, F-Droid and Play signing remain separate; no private signing material belongs in Git.
+The dedicated non-production QA identity is used only for trusted same-repository physical-acceptance CI and is not required for these commands. Production, QA, F-Droid and Play signing remain separate; no private signing material belongs in Git.
 
-See [Android companion foundation](ANDROID_COMPANION_FOUNDATION.md) for the accepted Windows↔Samsung matrix and [Local companion API v1](LOCAL_COMPANION_API.md) for the protocol boundary.
+See [Android public distribution v1](ANDROID_PUBLIC_DISTRIBUTION_V1.md), [Android companion foundation](ANDROID_COMPANION_FOUNDATION.md) and [Local companion API v1](LOCAL_COMPANION_API.md).
 
 ## Local files and compatibility
 


### PR DESCRIPTION
## Summary

- updates the public README Android badge, download links and product-surface status from alpha.1 to the published production-signed `0.1.0-alpha.3` release;
- keeps alpha.1 as immutable historical release evidence and alpha.2 as never-published failed evidence;
- records the current Windows boundary accurately: RC10 remains live while RC11 is in Microsoft certification, so Android pairing still requires a current Desktop source build until RC11 is published;
- updates Getting Started with the current alpha.3 direct-install and Obtainium guidance.

## Scope

Documentation/install-surface only. No runtime, packaging, release asset, tag, Store submission, Android artifact or version mutation.

This PR deliberately does not rewrite the deeper release-governance/history documents; those are preserved for the dedicated post-release documentation/roadmap resync rather than being collapsed into this small public-surface update.