### PR TITLE
docs: converge post-Android RC11 release state

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,7 +46,7 @@ npm --prefix app run build
 
 ### Android companion contributions
 
-The Android companion is implemented and physically accepted for the bounded local LAN scope, but it is not a public Android distribution. Follow [Getting started](docs/GETTING_STARTED.md#build-and-validate-the-android-companion) for the Java 17, Gradle 9.6.1/API 36 build path and [the Android foundation](docs/ANDROID_COMPANION_FOUNDATION.md) plus [local API contract](docs/LOCAL_COMPANION_API.md) for boundaries. Ordinary contributors do not need QA signing secrets; physical-acceptance signing is a trusted same-repository CI concern, and release/F-Droid/Play signing is separate.
+The Android companion is implemented and physically accepted for the bounded local LAN scope. The current public direct APK is alpha.3; Google Play and F-Droid remain separate channels. Follow [Getting started](docs/GETTING_STARTED.md#build-and-validate-the-android-companion) for the Java 17, Gradle 9.6.1/API 36 build path and [the Android foundation](docs/ANDROID_COMPANION_FOUNDATION.md) plus [local API contract](docs/LOCAL_COMPANION_API.md) for boundaries. Ordinary contributors do not need QA signing secrets; physical-acceptance signing is a trusted same-repository CI concern, and release/F-Droid/Play signing is separate.
 
 ## Contribution principles
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -34,9 +34,10 @@ separate from the published package; any future Store update requires its own
 candidate, acceptance, submission and publication decision.
 
 The current post-RC10 engineering candidate is `1.0.0-rc.11`, with Desktop
-build version `1.0.0.11` and Store package identity version `1.0.1.0`. It is an
-unsigned, non-published candidate only. The published Store remains RC10 until
-Microsoft publishes a later package.
+build version `1.0.0.11` and Store package identity version `1.0.1.0`. It has
+been submitted to Microsoft Partner Center and is undergoing certification; it
+is not publicly live. The published Store remains RC10 until Microsoft
+publishes a later package.
 
 `1.0.0-rc.7` remains the latest published GitHub Windows technical preview. That channel is unsigned, manually updated and not Microsoft Store certified. Its source, release assets, manifests and checksums remain immutable historical publication evidence.
 
@@ -160,12 +161,12 @@ Rollback preserves endpoint identity, OS-vault material, analytics, Workspace st
 
 Android's direct channel is a Founder-gated GitHub Release with one
 production-signed `Metrora-Android-<versionName>.apk`, a public release manifest
-and `SHA256SUMS`. The immutable public release is `0.1.0-alpha.1`; the current
-`0.1.0-alpha.3` source candidate is not public. The prior `0.1.0-alpha.2`
-candidate is historical failed evidence and was never public. The source-bound
-workflow is manual-only, does not publish from pushes or tags, and can prepare only a draft
-release after an existing tag is independently bound to the reviewed source
-commit. See
+and `SHA256SUMS`. The current public release is `0.1.0-alpha.3` under
+`android-v0.1.0-alpha.3`; `0.1.0-alpha.1` remains historical public-release
+evidence, and `0.1.0-alpha.2` is historical failed evidence that was never
+public. The source-bound workflow is manual-only, does not publish from pushes
+or tags, and can prepare only a draft release after an existing tag is
+independently bound to the reviewed source commit. See
 [`docs/ANDROID_PUBLIC_DISTRIBUTION_V1.md`](docs/ANDROID_PUBLIC_DISTRIBUTION_V1.md).
 
 The V1 production custody contract uses a JKS keystore. The keystore and
@@ -174,9 +175,9 @@ materializes them only for the protected signing step and does not persist
 them in `GITHUB_ENV` or release metadata.
 
 The QA physical-acceptance identity is not a production release identity.
-Google Play and F-Droid remain separate gates. The alpha.1 public availability
-claim is limited to its immutable GitHub release; alpha.3 remains blocked until
-the production key, physical acceptance and Founder publication decision exist.
+Google Play and F-Droid remain separate gates. The alpha.3 public-availability
+claim is limited to its immutable GitHub prerelease and direct APK; it does not
+imply Play or F-Droid distribution.
 
 ## Prohibitions
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -35,7 +35,7 @@ Security reports are welcome for:
 
 The latest public Windows technical preview is the **unsigned** GitHub pre-release `v1.0.0-rc.7`. Its release assets are bound to the published release evidence and checksums; it is not a signed stable channel, a Microsoft Store package, or an automatic update channel.
 
-Metrora also has an assigned Microsoft Store package identity and a reviewed non-publishing AppX build/local-acceptance path. RC10 is the source line associated with the Store submission. Submission is not certification or publication, and this repository makes no Store-availability claim.
+Metrora also has an assigned Microsoft Store package identity and a reviewed AppX build/local-acceptance path. RC10 remains the published Store authority; RC11 is the current submitted candidate undergoing Microsoft certification. Submission is not certification or publication, and RC11 is not a Store-availability claim.
 
 Stable signing, Store publication, and any future update-channel claims must remain explicit and channel-specific. Upstream Metrora artifacts are not Metrora releases.
 

--- a/app/DISTRIBUTION.md
+++ b/app/DISTRIBUTION.md
@@ -48,7 +48,7 @@ npm --prefix app run package:store    # Windows AppX x64, development packaging
 npm --prefix app run package:linux    # Linux AppImage, deb and rpm x64
 ```
 
-These commands create development or engineering artifacts. They do not by themselves create an official release or replace the Microsoft Store distribution. The RC11 Store output remains unsigned, non-submitted and non-published until separate Founder and Microsoft gates pass.
+These commands create development or engineering artifacts. They do not by themselves create an official release or replace the Microsoft Store distribution. The RC11 Store output is an unsigned submitted candidate undergoing Microsoft certification; it is not publicly published until the remaining release gates pass.
 
 ## Official distribution requirements
 

--- a/docs/ANDROID_PUBLIC_DISTRIBUTION_V1.md
+++ b/docs/ANDROID_PUBLIC_DISTRIBUTION_V1.md
@@ -1,21 +1,23 @@
 # Android public distribution v1
 
-**Status:** direct-APK distribution contract; `0.1.0-alpha.1` is the
-immutable public Android release. The `0.1.0-alpha.3` / `versionCode = 3`
-source candidate on this release line is not public. The `0.1.0-alpha.2` /
-`versionCode = 2` candidate remains historical failed evidence and was never
-public.
+**Status:** direct-APK distribution contract; the current public Android
+release is `0.1.0-alpha.3` / `versionCode = 3`. Its GitHub prerelease tag is
+`android-v0.1.0-alpha.3`, with accepted artifact
+`Metrora-Android-0.1.0-alpha.3.apk` and SHA-256
+`e9868958d26b58ffefa3aaa51a687cd64abc5e73219cd2e9cc8f8d0c8561f305`.
+`0.1.0-alpha.1` remains historical public-release evidence. The
+`0.1.0-alpha.2` / `versionCode = 2` candidate failed production release
+acceptance and was never public.
 
 **Historical base audit:** `maikolsiragusaa/metrora@69f0688fea5bb48f37b770e8de590ad20e490d74`
 
 This document records the Founder-gated, direct GitHub APK contract for the
-implemented Android companion. It does not authorize publication of the alpha.3
-candidate, Google Play submission, F-Droid submission, a tag, or a
-website/README promotion wave. The table below is historical evidence for the
-named audit base; its alpha.1 and no-public-release statements are not current
-alpha.3 authority.
+implemented Android companion. The table below preserves historical evidence
+for the named audit base; its alpha.1 and no-public-release statements are not
+current alpha.3 authority. Google Play and F-Droid remain separate channels
+with their own gates.
 
-## Current-state audit
+## Historical audit at the named base
 
 The audit covered the Android Gradle project and source tree, the existing
 Android companion workflow, repository release/version authorities, public
@@ -36,6 +38,14 @@ read-only infra release/custody conventions.
 | F-Droid | The flavor builds, but dependency/license/compliance status is not a release claim | CameraX/ML Kit and reproducible metadata need a separate review | Characterize only | Separate F-Droid gate |
 | Google Play | The Play AAB builds | Listing, Play signing and publication gates are not complete | Preserve buildability only | Separate Play gate |
 
+## Current accepted authority
+
+The direct Android release gate has completed for alpha.3. The public channel is
+the GitHub prerelease identified above; it is not a Google Play or F-Droid
+publication. The accepted production APK is the canonical direct-install
+artifact, and its public manifest and `SHA256SUMS` remain the integrity
+references for users.
+
 The Android product remains local-first and read-focused. Desktop/core remains
 authoritative for collection, parsing, pricing, accounting, canonical history,
 evidence and Workspace semantics.
@@ -53,27 +63,26 @@ APK for ordinary direct installation:
 - manifest asset: `Metrora-Android-<versionName>.manifest.json`;
 - integrity asset: `SHA256SUMS`.
 
-The immutable public release currently remains `0.1.0-alpha.1` with
-`versionCode = 1`. The current source candidate prepared on this release line
-is `0.1.0-alpha.3` with `versionCode = 3`; it is not public and must not replace
-the alpha.1 download or Obtainium guidance. The prior `0.1.0-alpha.2` /
-`versionCode = 2` candidate is retained as historical failed, unpublished
-evidence and must not be overwritten or reissued.
+The current public release is `0.1.0-alpha.3` with `versionCode = 3` and tag
+`android-v0.1.0-alpha.3`. The immutable `0.1.0-alpha.1` release remains
+historical evidence. The prior `0.1.0-alpha.2` / `versionCode = 2` candidate is
+retained as historical failed, unpublished evidence and must not be
+overwritten, reissued or described as a public release.
 
-The following illustrative manifest uses the immutable alpha.1 public identity;
-it is a schema example, not alpha.3 release evidence:
+The following illustrative manifest uses the current alpha.3 public identity;
+the certificate value remains a schema placeholder and is not release evidence:
 
 ```json
 {
   "schemaVersion": 1,
   "product": "Metrora",
-  "versionName": "0.1.0-alpha.1",
-  "versionCode": 1,
+  "versionName": "0.1.0-alpha.3",
+  "versionCode": 3,
   "distributionChannel": "github",
   "applicationId": "eu.metrora.app",
-  "sourceCommit": "<40-character source commit>",
-  "artifactFilename": "Metrora-Android-0.1.0-alpha.1.apk",
-  "artifactSha256": "<64-character SHA-256>",
+  "sourceCommit": "<reviewed source commit>",
+  "artifactFilename": "Metrora-Android-0.1.0-alpha.3.apk",
+  "artifactSha256": "e9868958d26b58ffefa3aaa51a687cd64abc5e73219cd2e9cc8f8d0c8561f305",
   "signingCertificateSha256": "<64-character certificate SHA-256>"
 }
 ```
@@ -93,21 +102,20 @@ Android has a platform-native version authority separate from the frozen
 Windows Store package version:
 
 - source authority: `android/app/build.gradle.kts`;
-- latest public `versionName`: `0.1.0-alpha.1`;
-- latest public `versionCode`: `1`;
-- current source-candidate `versionName`: `0.1.0-alpha.3`;
-- current source-candidate `versionCode`: `3`;
+- latest public `versionName`: `0.1.0-alpha.3`;
+- latest public `versionCode`: `3`;
+- current accepted source `versionName`: `0.1.0-alpha.3`;
+- current accepted source `versionCode`: `3`;
 - GitHub identity: `android-v<versionName>`;
 - Play and direct APK upgrades use the same `eu.metrora.app` package line and
   the same strictly increasing `versionCode` sequence.
 
 The immutable alpha.1 production-signed artifact consumed `versionCode = 1`.
 The historical alpha.2 candidate advanced the same application identity to
-`versionCode = 2` but failed scanner acceptance and remains unpublished. The
-alpha.3 source candidate advances the same identity to `versionCode = 3`; it
-remains blocked from public distribution until the production-key,
-independent-review, Founder-authorization and merge gates are complete. Every
-later publicly installable upgrade must use a strictly larger integer.
+`versionCode = 2` but failed production release acceptance and remains
+unpublished. The accepted alpha.3 release advances the same identity to
+`versionCode = 3`. Every later publicly installable upgrade must use a
+strictly larger integer.
 `versionName` remains human-readable and may use the existing Metrora
 pre-release convention.
 
@@ -342,8 +350,9 @@ infrastructure.
 
 ## Founder release checklist
 
-Before changing the state from candidate to public release, the Founder must
-confirm all of the following outside this pull request:
+The alpha.3 release completed the following Founder-owned gates. The same
+controls remain required before any future direct release changes from
+candidate to public:
 
 - production key exists in protected custody and recovery has been checked;
 - the protected workflow environment contains the required signing values;
@@ -354,9 +363,8 @@ confirm all of the following outside this pull request:
 - the GitHub Release tag is created intentionally and points to the approved
   source commit;
 - release notes, checksum and manifest are reviewed;
-- only then is the draft eligible for explicit public publication.
+- only then is a future draft eligible for explicit public publication.
 
-Until those actions occur for alpha.3, the repository state is **a source
-candidate ready for the production-key gate**, not a public alpha.3 release.
-The historical alpha.2 candidate remains failed and unpublished.
-The immutable alpha.1 artifact remains the current public Android release.
+The accepted alpha.3 artifact is the current public Android release.
+The historical alpha.2 candidate remains failed and unpublished, and the
+immutable alpha.1 artifact remains historical public-release evidence.

--- a/docs/MOBILE_PRODUCT_PARITY_V1.md
+++ b/docs/MOBILE_PRODUCT_PARITY_V1.md
@@ -416,7 +416,8 @@ Mobile Product Parity V1 until their authority and UX are separately defined:
 - specialized context, throughput, guard, hook, diagnostics and action
   workflows;
 - sync, remote relay, accounts, billing, subscription systems and provisioning;
-- public Android distribution/signing and release work;
+- Google Play/F-Droid distribution and later Android release-channel work beyond
+  the current direct alpha.3 channel;
 - historical backfill or mobile-side repair of incomplete model/category
   identity.
 

--- a/docs/VERSIONING.md
+++ b/docs/VERSIONING.md
@@ -62,18 +62,18 @@ Android uses the native `versionName` and integer `versionCode` declared in
 - `versionCode = 1`;
 - application ID `eu.metrora.app`.
 
-The current source candidate advances the same package line to:
+The current public direct APK advances the same package line to:
 
 - `versionName = 0.1.0-alpha.3`;
 - `versionCode = 3`;
 - application ID `eu.metrora.app`.
 
 The alpha.2 source candidate is historical failed evidence and was never
-public. The alpha.3 source candidate is also not a public release. Public
-download and release guidance must continue to point to the immutable alpha.1
-artifact until a separately authorized production-signed alpha.3 release
-exists. The public alpha.1 artifact consumed `versionCode = 1`; every later
-publicly installable Android upgrade must use a strictly larger `versionCode`.
+public. Alpha.3 is the current public GitHub prerelease under tag
+`android-v0.1.0-alpha.3`, with the canonical direct-install APK named
+`Metrora-Android-0.1.0-alpha.3.apk`. The public alpha.1 artifact consumed
+`versionCode = 1`; every later publicly installable Android upgrade must use a
+strictly larger `versionCode`.
 The human-readable `versionName` is used in the deterministic GitHub identity
 `android-v<versionName>` and asset name
 `Metrora-Android-<versionName>.apk`. Android's version line is independent of

--- a/docs/WINDOWS_DISTRIBUTION.md
+++ b/docs/WINDOWS_DISTRIBUTION.md
@@ -8,7 +8,7 @@ Metrora for Windows is available on the **Microsoft Store**, published by Vensen
 
 The Microsoft Store package is the supported public Windows distribution. Repository builds and historical GitHub pre-releases remain separate development or archival artifacts and are not the recommended install path.
 
-The currently published Store line is traceable to source candidate `1.0.0-rc.10`, desktop build version `1.0.0.10`, and Store AppX identity version `1.0.0.0`. The current post-RC10 engineering candidate is `1.0.0-rc.11`, desktop build `1.0.0.11`, and Store AppX identity `1.0.1.0`; it is not published. Development on `main` may advance independently after that published line.
+The currently published Store line is traceable to source candidate `1.0.0-rc.10`, desktop build version `1.0.0.10`, and Store AppX identity version `1.0.0.0`. The current post-RC10 engineering candidate is `1.0.0-rc.11`, desktop build `1.0.0.11`, and Store AppX identity `1.0.1.0`; it has been submitted to Microsoft Partner Center and is undergoing certification, but is not publicly live. Development on `main` may advance independently after that published line.
 
 Historical 0.9.19 and RC7 acceptance material remains immutable evidence for those source lines only.
 
@@ -54,7 +54,7 @@ The existing RC7 release remains immutable as a historical technical preview. La
 
 The Store workflow derives an x64 AppX from reviewed source and validates its identity, architecture, capabilities and bundled runtime boundary. It also imports `app/resources/cli.asar/dist/desktop-share-runtime.js` through the bundled Electron runtime and requires `createDesktopShareRuntime` without starting a listener. The Store manifest's four-part package identity remains separate from the desktop build counter.
 
-The published Store line passed its source-bound package and physical-runtime acceptance before publication. RC11 is currently prepared only as a candidate; later source work remains separate until a future Store update is explicitly physically accepted, submitted and published.
+The published Store line passed its source-bound package and physical-runtime acceptance before publication. RC11 is the submitted, in-certification candidate; later source work remains separate until a future Store update is explicitly certified, published and made available.
 
 ## Accounting presentation boundary
 

--- a/docs/WINDOWS_STORE_IDENTITY_V1.md
+++ b/docs/WINDOWS_STORE_IDENTITY_V1.md
@@ -1,6 +1,6 @@
 # Windows Store package identity v1
 
-**Status:** identity assigned / RC11 candidate boundary / not published
+**Status:** identity assigned / RC11 submitted and in certification / not published
 
 ## Purpose
 
@@ -10,9 +10,10 @@ The exact manifest values are maintained in the reviewed desktop build configura
 
 RC10 is the frozen source line associated with the published Store package. The
 current engineering candidate is RC11 (`1.0.0-rc.11`) with Desktop build
-`1.0.0.11` and candidate Store package version `1.0.1.0`. This document does
-not claim certification, publication or availability for RC11, and post-RC10
-development is separate from the published artifact. It also does not
+`1.0.0.11` and candidate Store package version `1.0.1.0`. RC11 has been
+submitted to Microsoft Partner Center and is undergoing certification; this
+document does not claim certification acceptance, publication or availability
+for RC11. Post-RC10 development is separate from the published artifact. It also does not
 authorize a different submission or any change to the already published
 GitHub `1.0.0-rc.7` artifacts.
 
@@ -46,15 +47,16 @@ Neither channel inherits the signature, certification or publication status of t
 
 The guided local path is documented in [`WINDOWS_STORE_LOCAL_TEST_GUIDED.md`](WINDOWS_STORE_LOCAL_TEST_GUIDED.md).
 
-It signs only a temporary copy. The public test certificate is trusted at machine level while its private key remains in the current-user personal store; both are removed with the installed package after validation. The unsigned candidate intended for Store submission is not modified.
+It signs only a temporary copy. The public test certificate is trusted at machine level while its private key remains in the current-user personal store; both are removed with the installed package after validation. The unsigned submitted candidate is not modified.
 
 A local PASS is not Store certification and does not authorize publication or availability claims.
 
 ## Current limitations
 
 The Store target has a separate package identity and local-acceptance path. The
-RC11 candidate is not a signed Microsoft channel, an automatic update for
-existing installations, or a publication claim.
+RC11 candidate is not yet a publicly available Microsoft channel or an
+automatic update for existing installations. Submission and certification in
+progress do not constitute publication.
 
 The RC10 source line and `1.0.0.0` package remain the live Store authority;
 certification, publication and Store-managed update behavior remain distinct

--- a/docs/WINDOWS_STORE_LOCAL_TEST_GUIDED.md
+++ b/docs/WINDOWS_STORE_LOCAL_TEST_GUIDED.md
@@ -13,7 +13,7 @@ The local test verifies:
 - the candidate carries an importable companion runtime at `app/resources/cli.asar/dist/desktop-share-runtime.js`;
 - the package installs for the current Windows user;
 - Metrora launches with the expected product presentation;
-- the production Android `0.1.0-alpha.1` APK can complete the bounded companion flow;
+- the production Android `0.1.0-alpha.3` APK can complete the bounded companion flow;
 - local collection works without a separately installed Node.js runtime;
 - the package, trusted certificate and private key are removed afterward;
 - the final report contains no local paths, usernames, package identity values, keys or certificates.
@@ -64,8 +64,8 @@ Temporary PFX and CER files are deleted before the script exits. The trusted pub
 
 ## Manual observations
 
-In the launched app, confirm every observation below with the production
-Android APK already published as `android-v0.1.0-alpha.1`:
+In the launched app, confirm every observation below with the current production
+Android APK published as `android-v0.1.0-alpha.3`:
 
 1. Metrora launches normally.
 2. Windows and the app present the expected product identity.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -166,7 +166,7 @@ See [`WINDOWS_DISTRIBUTION.md`](WINDOWS_DISTRIBUTION.md), [`WINDOWS_FORMAT_DERIV
 src/       canonical collection, parsing, pricing, analytics, evidence and CLI
 app/       Electron desktop application
 dash/      local browser dashboard
-android/   implemented local companion; public alpha.1 release, alpha.2 source candidate
+android/   implemented local companion; public alpha.3 release, alpha.1 historical, alpha.2 failed candidate
 mac/       native macOS menubar companion
 gnome/     GNOME Shell companion
 tests/     canonical core and integration tests


### PR DESCRIPTION
## Summary

- align public Android documentation on the current production-signed `0.1.0-alpha.3` GitHub prerelease;
- preserve alpha.1 as historical evidence and alpha.2 as failed/unpublished history;
- distinguish the published RC10 Store authority from submitted/in-certification, not-live RC11;
- keep Google Play/F-Droid as separate future gates.

Documentation/state records only. No runtime, release artifact, workflow, package identity, signing material, or Store submission changed.

Validation: targeted stale-state scans, `git diff --check`, changed-path scope audit. No product suites or rebuilds run.