### PR TITLE
Document the public Community/commercial boundary

### DIFF
--- a/docs/COMMERCIAL_BOUNDARY.md
+++ b/docs/COMMERCIAL_BOUNDARY.md
@@ -1,0 +1,51 @@
+# Community and commercial boundary
+
+Metrora is developed as one product with a permanently useful open-source Community core and optional commercial capabilities.
+
+This document describes repository and licensing boundaries only. It does not announce unavailable paid features, pricing, hosted services or release dates.
+
+## Metrora Community
+
+The source code in this repository is governed by the repository's MIT License unless a file explicitly states otherwise.
+
+Community owns the canonical local-first foundations, including the public measurement, pricing, provenance, evidence, local analytics, export and interoperability contracts that make Metrora independently useful without a commercial account.
+
+Community must not be deliberately degraded solely to force a paid upgrade.
+
+## Optional Metrora Pro
+
+Future Metrora Pro capabilities may be implemented as separately licensed proprietary software outside this repository.
+
+A Pro implementation may consume stable public contracts and extension points from Community. Its private source is not licensed under this repository's MIT License merely because it interoperates with Community.
+
+Examples of capability classes that may have optional commercial implementations include advanced intelligence, proprietary workflows/evaluations, advanced automation/orchestration, commercial governance and other differentiated software. A roadmap category is not a claim that a paid capability currently exists.
+
+## Optional managed services
+
+Future managed capabilities may provide services that intrinsically require Metrora-operated infrastructure or variable provider/compute spend, such as authorized remote synchronization, managed model execution or managed workers.
+
+Managed services are distinct from the MIT Community source and from proprietary software licensing. Local Community history, evidence and export must remain usable when an optional managed service is unavailable or not purchased.
+
+## Public/private authority rule
+
+The public repository remains authoritative for canonical measurement semantics and public compatibility contracts.
+
+Commercial or managed implementations must not create a secret second interpretation of local usage, historical pricing, provenance or evidence.
+
+Public interfaces may intentionally support optional commercial modules. Publishing an interface or schema under MIT does not publish an external proprietary implementation of that interface.
+
+## Contributions and licensing
+
+Contributions accepted into this repository are contributed to the MIT-licensed public project according to the repository contribution terms.
+
+Do not submit confidential commercial source, private evaluation assets, production credentials, entitlement secrets, customer data or other protected commercial material to this repository.
+
+## Distribution
+
+Metrora may be distributed through multiple channels, including source releases, operating-system stores and mobile stores. Distribution channel does not change the licence of this repository's source code.
+
+An official build may in the future combine compatible Community artifacts with separately licensed optional components where the applicable distribution channel permits it. Such components must identify their separate terms and must not imply that proprietary source is part of this MIT repository.
+
+## Current-state rule
+
+Only capabilities documented elsewhere as shipped are currently available. This boundary does not by itself authorize or announce Pro, billing, accounts, remote synchronization, managed inference, enterprise deployment or other future commercial infrastructure.


### PR DESCRIPTION
## Status

**READY FOR INTEGRATION**

The concurrent public-repository implementation workstreams have closed. This documentation branch has been rebased/recreated on current public `main` after PR #198 and PR #199 were merged.

## Purpose

Add one concise public document explaining that this repository remains MIT-licensed Community source while future optional Pro software and managed services may be separately licensed outside this repository.

## Boundary

- no runtime/code changes;
- no README claim that paid capabilities already exist;
- no pricing, billing or account authorization;
- no change to the repository MIT licence;
- no weakening of Community measurement, history, evidence or export;
- no private roadmap, tax or commercial-provider detail exposed.

## Companion work

Private commercial architecture is maintained separately in `maikolsiragusaa/metrora-commercial` and operational commerce boundaries in `maikolsiragusaa/metrora-infra`.

## Final merge gate

Revalidated against current public `main` `541496f6e83950a8c594bba64479cba3ef6f0201`. No newer public document duplicates this boundary. The PR contains one documentation file only: `docs/COMMERCIAL_BOUNDARY.md`.