### PR TITLE
Harden SQLite reads against producer-side WAL files

### DIFF
--- a/src/sqlite-snapshot-ownership.ts
+++ b/src/sqlite-snapshot-ownership.ts
@@ -1,0 +1,101 @@
+import { randomUUID } from 'node:crypto'
+import fs from 'node:fs'
+import { basename, join } from 'node:path'
+
+const SNAPSHOT_OWNER_FILE = '.owner.json'
+const SNAPSHOT_STALE_MS = 24 * 60 * 60 * 1000
+
+type SnapshotOwner = {
+  pid: number
+  token: string
+  createdAtMs: number
+}
+
+export function writeSnapshotOwner(directory: string): string {
+  const owner: SnapshotOwner = {
+    pid: process.pid,
+    token: randomUUID(),
+    createdAtMs: Date.now(),
+  }
+  const stagedPath = join(directory, `${SNAPSHOT_OWNER_FILE}.copying`)
+  fs.writeFileSync(stagedPath, JSON.stringify(owner), { encoding: 'utf8', flag: 'wx' })
+  fs.renameSync(stagedPath, join(directory, SNAPSHOT_OWNER_FILE))
+  return owner.token
+}
+
+function readSnapshotOwner(directory: string): SnapshotOwner | null {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(join(directory, SNAPSHOT_OWNER_FILE), 'utf8')) as Partial<SnapshotOwner>
+    if (
+      typeof parsed.pid !== 'number' ||
+      !Number.isInteger(parsed.pid) ||
+      parsed.pid <= 0 ||
+      typeof parsed.token !== 'string' ||
+      parsed.token.length === 0 ||
+      typeof parsed.createdAtMs !== 'number' ||
+      !Number.isFinite(parsed.createdAtMs)
+    ) return null
+    return {
+      pid: parsed.pid,
+      token: parsed.token,
+      createdAtMs: parsed.createdAtMs,
+    }
+  } catch {
+    return null
+  }
+}
+
+function isSnapshotOwnerAlive(pid: number): boolean {
+  if (pid === process.pid) return true
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch (err) {
+    const code = err && typeof err === 'object' && 'code' in err
+      ? (err as { code?: unknown }).code
+      : undefined
+    return code !== 'ESRCH'
+  }
+}
+
+export function cleanupStaleSnapshots(root: string, prefix: string): void {
+  let entries: fs.Dirent[]
+  try {
+    entries = fs.readdirSync(root, { withFileTypes: true })
+  } catch {
+    return
+  }
+
+  const cutoff = Date.now() - SNAPSHOT_STALE_MS
+  for (const entry of entries) {
+    if (!entry.isDirectory() || !entry.name.startsWith(prefix)) continue
+    const directory = join(root, entry.name)
+    try {
+      if (fs.statSync(directory).mtimeMs < cutoff) {
+        const owner = readSnapshotOwner(directory)
+        if (owner === null || isSnapshotOwnerAlive(owner.pid)) continue
+        fs.rmSync(directory, { recursive: true, force: true })
+      }
+    } catch {
+      // A concurrent reader or a platform file lock owns the directory.
+    }
+  }
+}
+
+export function cleanupSnapshotDirectory(
+  directory: string | undefined,
+  prefix: string,
+  ownerToken?: string,
+): void {
+  if (!directory || !basename(directory).startsWith(prefix)) return
+  if (ownerToken !== undefined) {
+    const owner = readSnapshotOwner(directory)
+    if (owner === null || owner.token !== ownerToken) return
+  }
+  try {
+    fs.rmSync(directory, { recursive: true, force: true })
+  } catch {
+    // Close remains safe if a platform briefly holds a snapshot-side handle;
+    // the bounded stale cleanup handles the remaining owned directory later.
+  }
+}

--- a/src/sqlite-source-fingerprint.ts
+++ b/src/sqlite-source-fingerprint.ts
@@ -1,4 +1,5 @@
 import type { Stats } from 'fs'
+import { statSync as statFileSystemSync } from 'fs'
 import { stat as statFileSystem } from 'fs/promises'
 import { extname } from 'path'
 
@@ -18,6 +19,7 @@ export type SourceFileFingerprint = {
 
 type StatLike = Pick<Stats, 'dev' | 'ino' | 'mtimeMs' | 'size'>
 export type SourceStat = (path: string) => Promise<StatLike>
+export type SourceStatSync = (path: string) => StatLike
 
 const SQLITE_EXTENSIONS = new Set(['.db', '.sqlite', '.sqlite3', '.vscdb'])
 
@@ -57,6 +59,17 @@ async function safeStat(path: string, statSource: SourceStat): Promise<StatLike 
     // Source discovery races ordinary file rotation/checkpoint cleanup. A path
     // disappearing between stats skips this source for the current refresh
     // instead of escalating into a provider-wide failure.
+    return null
+  }
+}
+
+function safeStatSync(path: string, statSource: SourceStatSync): StatLike | null {
+  try {
+    return statSource(path)
+  } catch {
+    // The synchronous reader uses the same race-tolerant semantics as the
+    // async cache fingerprint path: a source disappearing between probes is
+    // not treated as a provider-wide failure.
     return null
   }
 }
@@ -104,6 +117,51 @@ export async function fingerprintSourceFile(
   if (!main) return null
 
   const wal = await safeStat(`${resolvedPath}-wal`, statSource)
+  if (!wal) return basicFingerprint(main)
+
+  return {
+    dev: main.dev,
+    ino: main.ino,
+    mtimeMs: Math.max(main.mtimeMs, wal.mtimeMs),
+    sizeBytes: main.size + wal.size,
+    sqliteWal: {
+      mtimeMs: wal.mtimeMs,
+      sizeBytes: wal.size,
+    },
+  }
+}
+
+/**
+ * Synchronous counterpart for the shared node:sqlite boundary.
+ *
+ * `openDatabase()` is intentionally synchronous for provider compatibility,
+ * so snapshot selection and its before/after consistency fence must be able to
+ * use the same WAL-aware source fingerprint without changing every provider's
+ * API to async.
+ */
+export function fingerprintSourceFileSync(
+  sourcePath: string,
+  statSource: SourceStatSync = statFileSystemSync,
+): SourceFileFingerprint | null {
+  let resolvedPath: string | null = null
+
+  for (const candidate of sourcePathCandidates(sourcePath)) {
+    if (safeStatSync(candidate, statSource)) {
+      resolvedPath = candidate
+      break
+    }
+  }
+
+  if (!resolvedPath) return null
+  if (!isSQLiteSourcePath(resolvedPath)) {
+    const main = safeStatSync(resolvedPath, statSource)
+    return main ? basicFingerprint(main) : null
+  }
+
+  const main = safeStatSync(resolvedPath, statSource)
+  if (!main) return null
+
+  const wal = safeStatSync(`${resolvedPath}-wal`, statSource)
   if (!wal) return basicFingerprint(main)
 
   return {

--- a/src/sqlite-source-probe.ts
+++ b/src/sqlite-source-probe.ts
@@ -1,0 +1,173 @@
+import fs from 'node:fs'
+import {
+  fingerprintSourceFileSync,
+  sourcePathCandidates,
+  type SourceFileFingerprint,
+} from './sqlite-source-fingerprint.js'
+
+export type MainObservation = {
+  dev: number
+  ino: number
+  mtimeMs: number
+  ctimeMs: number
+  size: number
+}
+
+export type WalObservation = {
+  dev: number
+  ino: number
+  mtimeMs: number
+  ctimeMs: number
+  size: number
+}
+
+export type SourceProbe = {
+  path: string
+  main: MainObservation | null
+  walPath: string
+  wal: WalObservation | null
+  hasLiveWal: boolean
+}
+
+export type SourceObservation = SourceProbe & {
+  fingerprint: SourceFileFingerprint | null
+  walMode: boolean
+}
+
+function readMainObservation(path: string): MainObservation | null {
+  try {
+    const stat = fs.statSync(path)
+    if (!stat.isFile()) return null
+    return {
+      dev: stat.dev,
+      ino: stat.ino,
+      mtimeMs: stat.mtimeMs,
+      ctimeMs: stat.ctimeMs,
+      size: stat.size,
+    }
+  } catch {
+    return null
+  }
+}
+
+function resolveSourceFile(
+  sourcePath: string,
+  preferredPath?: string,
+): { path: string; main: MainObservation | null } {
+  if (preferredPath !== undefined) {
+    const preferredMain = readMainObservation(preferredPath)
+    if (preferredMain !== null) return { path: preferredPath, main: preferredMain }
+  }
+
+  for (const candidate of [...new Set(sourcePathCandidates(sourcePath))]) {
+    const main = readMainObservation(candidate)
+    if (main !== null) return { path: candidate, main }
+  }
+
+  return { path: preferredPath ?? sourcePath, main: null }
+}
+
+export function resolveSourcePath(sourcePath: string, preferredPath?: string): string {
+  return resolveSourceFile(sourcePath, preferredPath).path
+}
+
+function readWalObservation(path: string): WalObservation | null {
+  try {
+    const stat = fs.statSync(path)
+    return {
+      dev: stat.dev,
+      ino: stat.ino,
+      mtimeMs: stat.mtimeMs,
+      ctimeMs: stat.ctimeMs,
+      size: stat.size,
+    }
+  } catch {
+    return null
+  }
+}
+
+function hasWalModeHeader(path: string): boolean {
+  let handle: number | undefined
+  try {
+    handle = fs.openSync(path, 'r')
+    const header = Buffer.alloc(20)
+    const bytesRead = fs.readSync(handle, header, 0, header.length, 0)
+    // SQLite's file-format read/write version bytes are both 2 in WAL mode.
+    return bytesRead === header.length && header[18] === 2 && header[19] === 2
+  } catch {
+    return false
+  } finally {
+    if (handle !== undefined) {
+      try { fs.closeSync(handle) } catch { /* best effort */ }
+    }
+  }
+}
+
+export function probeSource(
+  sourcePath: string,
+  preferredPath?: string,
+  previousWal?: WalObservation | null,
+): SourceProbe {
+  const resolved = resolveSourceFile(sourcePath, preferredPath)
+  const walPath = `${resolved.path}-wal`
+  const wal = resolved.main === null
+    ? null
+    : previousWal === null && !fs.existsSync(walPath)
+      ? null
+      : readWalObservation(walPath)
+  return {
+    path: resolved.path,
+    main: resolved.main,
+    walPath,
+    wal,
+    hasLiveWal: wal !== null && wal.size > 0,
+  }
+}
+
+export function observeSource(sourcePath: string): SourceObservation {
+  const probe = probeSource(sourcePath)
+  return {
+    ...probe,
+    fingerprint: fingerprintSourceFileSync(sourcePath),
+    walMode: probe.main !== null && hasWalModeHeader(probe.path),
+  }
+}
+
+function sameWalObservation(a: WalObservation | null, b: WalObservation | null): boolean {
+  if (a === null || b === null) return a === b
+  return a.dev === b.dev
+    && a.ino === b.ino
+    && a.mtimeMs === b.mtimeMs
+    && a.ctimeMs === b.ctimeMs
+    && a.size === b.size
+}
+
+export function sameMainIdentity(a: MainObservation | null, b: MainObservation | null): boolean {
+  if (a === null || b === null) return a === b
+  return a.dev === b.dev && a.ino === b.ino
+}
+
+function sameMainMetadata(a: MainObservation | null, b: MainObservation | null): boolean {
+  if (a === null || b === null) return a === b
+  return a.mtimeMs === b.mtimeMs
+    && a.ctimeMs === b.ctimeMs
+    && a.size === b.size
+}
+
+export function sameSourceProbe(a: SourceProbe, b: SourceProbe): boolean {
+  if (a.path !== b.path) return false
+  if (a.main === null || b.main === null) return a.main === b.main && sameWalObservation(a.wal, b.wal)
+  return sameMainIdentity(a.main, b.main)
+    && sameMainMetadata(a.main, b.main)
+    && sameWalObservation(a.wal, b.wal)
+}
+
+export function sourceProbeFromObservation(observation: SourceObservation): SourceProbe {
+  return {
+    path: observation.path,
+    main: observation.main,
+    walPath: observation.walPath,
+    wal: observation.wal,
+    hasLiveWal: observation.hasLiveWal,
+  }
+}

--- a/src/sqlite-source-probe.ts
+++ b/src/sqlite-source-probe.ts
@@ -27,6 +27,9 @@ export type SourceProbe = {
   walPath: string
   wal: WalObservation | null
   hasLiveWal: boolean
+  journalPath: string
+  journal: WalObservation | null
+  hasActiveJournal: boolean
 }
 
 export type SourceObservation = SourceProbe & {
@@ -71,7 +74,7 @@ export function resolveSourcePath(sourcePath: string, preferredPath?: string): s
   return resolveSourceFile(sourcePath, preferredPath).path
 }
 
-function readWalObservation(path: string): WalObservation | null {
+function readSidecarObservation(path: string): WalObservation | null {
   try {
     const stat = fs.statSync(path)
     return {
@@ -110,17 +113,22 @@ export function probeSource(
 ): SourceProbe {
   const resolved = resolveSourceFile(sourcePath, preferredPath)
   const walPath = `${resolved.path}-wal`
+  const journalPath = resolved.path + '-journal'
   const wal = resolved.main === null
     ? null
     : previousWal === null && !fs.existsSync(walPath)
       ? null
-      : readWalObservation(walPath)
+      : readSidecarObservation(walPath)
+  const journal = resolved.main === null ? null : readSidecarObservation(journalPath)
   return {
     path: resolved.path,
     main: resolved.main,
     walPath,
     wal,
     hasLiveWal: wal !== null && wal.size > 0,
+    journalPath,
+    journal,
+    hasActiveJournal: journal !== null,
   }
 }
 
@@ -156,10 +164,15 @@ function sameMainMetadata(a: MainObservation | null, b: MainObservation | null):
 
 export function sameSourceProbe(a: SourceProbe, b: SourceProbe): boolean {
   if (a.path !== b.path) return false
-  if (a.main === null || b.main === null) return a.main === b.main && sameWalObservation(a.wal, b.wal)
+  if (a.main === null || b.main === null) {
+    return a.main === b.main
+      && sameWalObservation(a.wal, b.wal)
+      && sameWalObservation(a.journal, b.journal)
+  }
   return sameMainIdentity(a.main, b.main)
     && sameMainMetadata(a.main, b.main)
     && sameWalObservation(a.wal, b.wal)
+    && sameWalObservation(a.journal, b.journal)
 }
 
 export function sourceProbeFromObservation(observation: SourceObservation): SourceProbe {
@@ -169,5 +182,8 @@ export function sourceProbeFromObservation(observation: SourceObservation): Sour
     walPath: observation.walPath,
     wal: observation.wal,
     hasLiveWal: observation.hasLiveWal,
+    journalPath: observation.journalPath,
+    journal: observation.journal,
+    hasActiveJournal: observation.hasActiveJournal,
   }
 }

--- a/src/sqlite.ts
+++ b/src/sqlite.ts
@@ -1,4 +1,11 @@
 import { createRequire } from 'node:module'
+import fs from 'node:fs'
+import { tmpdir } from 'node:os'
+import { basename, dirname, join, relative, resolve, sep } from 'node:path'
+import { pathToFileURL } from 'node:url'
+import { fingerprintSourceFileSync, sourcePathCandidates, type SourceFileFingerprint } from './sqlite-source-fingerprint.js'
+import { getMetroraCacheDir } from './product-paths.js'
+
 
 /// Thin SQLite read-only wrapper over Node's built-in `node:sqlite` module (stable in
 /// Node 24, experimental in Node 22 / 23). Replaces the earlier `better-sqlite3` binding
@@ -14,11 +21,12 @@ export type SqliteDatabase = {
   close(): void
 }
 
-type DatabaseSyncCtor = new (path: string, options?: { readOnly?: boolean }) => {
+type RawDatabase = {
   prepare(sql: string): { all(...params: unknown[]): Row[] }
   exec?(sql: string): void
   close(): void
 }
+type DatabaseSyncCtor = new (path: string, options?: { readOnly?: boolean }) => RawDatabase
 
 let DatabaseSync: DatabaseSyncCtor | null = null
 let loadAttempted = false
@@ -116,24 +124,403 @@ export function isSqliteBusyError(err: unknown): boolean {
   )
 }
 
-export function openDatabase(path: string): SqliteDatabase {
-  if (!loadDriver() || DatabaseSync === null) {
-    throw new Error(getSqliteLoadError())
+type OpenMode = 'direct' | 'immutable' | 'snapshot'
+
+type WalObservation = {
+  dev: number
+  ino: number
+  mtimeMs: number
+  ctimeMs: number
+  size: number
+}
+
+type SourceObservation = {
+  path: string
+  fingerprint: SourceFileFingerprint | null
+  walPath: string
+  wal: WalObservation | null
+  hasLiveWal: boolean
+  walMode: boolean
+}
+
+type SourceSnapshot = {
+  directory: string
+  databasePath: string
+}
+
+const SNAPSHOT_DIRECTORY = 'sqlite-source-snapshots'
+const SNAPSHOT_PREFIX = 'sqlite-source-read-'
+const SNAPSHOT_STALE_MS = 24 * 60 * 60 * 1000
+const SNAPSHOT_ATTEMPTS = 3
+
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err)
+}
+
+/**
+ * Identify only the SQLite open failure that can be caused by a WAL reader
+ * needing source-side shared-memory support. Callers still require current
+ * live-WAL evidence before promoting a read to a snapshot.
+ */
+export function isSqliteSourceSafeReadError(err: unknown): boolean {
+  const e = err as { code?: unknown; errcode?: unknown; errstr?: unknown; message?: unknown } | null
+  const code = typeof e?.code === 'string' ? e.code : ''
+  const errcode = typeof e?.errcode === 'number' ? e.errcode : null
+  const message = [
+    typeof e?.message === 'string' ? e.message : '',
+    typeof e?.errstr === 'string' ? e.errstr : '',
+  ].join(' ')
+
+  if (isSqliteBusyError(err)) return false
+  return (
+    errcode === 14 ||
+    code === 'SQLITE_CANTOPEN' ||
+    code === 'ERR_SQLITE_CANTOPEN' ||
+    /\bSQLITE_CANTOPEN\b/i.test(`${code} ${message}`) ||
+    /\bunable to open database file\b/i.test(message)
+  )
+}
+
+function resolveSourcePath(sourcePath: string): string {
+  for (const candidate of sourcePathCandidates(sourcePath)) {
+    try {
+      if (fs.statSync(candidate).isFile()) return candidate
+    } catch {
+      // Source discovery is allowed to race rotation and cleanup.
+    }
+  }
+  return sourcePath
+}
+
+function readWalObservation(path: string): WalObservation | null {
+  try {
+    const stat = fs.statSync(path)
+    return {
+      dev: stat.dev,
+      ino: stat.ino,
+      mtimeMs: stat.mtimeMs,
+      ctimeMs: stat.ctimeMs,
+      size: stat.size,
+    }
+  } catch {
+    return null
+  }
+}
+
+function hasWalModeHeader(path: string): boolean {
+  let handle: number | undefined
+  try {
+    handle = fs.openSync(path, 'r')
+    const header = Buffer.alloc(20)
+    const bytesRead = fs.readSync(handle, header, 0, header.length, 0)
+    // SQLite's file-format read/write version bytes are both 2 in WAL mode.
+    return bytesRead === header.length && header[18] === 2 && header[19] === 2
+  } catch {
+    return false
+  } finally {
+    if (handle !== undefined) {
+      try { fs.closeSync(handle) } catch { /* best effort */ }
+    }
+  }
+}
+
+function observeSource(sourcePath: string): SourceObservation {
+  const resolvedPath = resolveSourcePath(sourcePath)
+  const walPath = `${resolvedPath}-wal`
+  const wal = readWalObservation(walPath)
+  return {
+    path: resolvedPath,
+    fingerprint: fingerprintSourceFileSync(sourcePath),
+    walPath,
+    wal,
+    hasLiveWal: wal !== null && wal.size > 0,
+    walMode: hasWalModeHeader(resolvedPath),
+  }
+}
+
+function sameFingerprint(a: SourceFileFingerprint | null, b: SourceFileFingerprint | null): boolean {
+  if (a === null || b === null) return a === b
+  if (
+    a.dev !== b.dev ||
+    a.ino !== b.ino ||
+    a.mtimeMs !== b.mtimeMs ||
+    a.sizeBytes !== b.sizeBytes
+  ) return false
+
+  if (a.sqliteWal === undefined || b.sqliteWal === undefined) {
+    return a.sqliteWal === b.sqliteWal
+  }
+  return a.sqliteWal.mtimeMs === b.sqliteWal.mtimeMs
+    && a.sqliteWal.sizeBytes === b.sqliteWal.sizeBytes
+}
+
+function sameWalObservation(a: WalObservation | null, b: WalObservation | null): boolean {
+  if (a === null || b === null) return a === b
+  return a.dev === b.dev
+    && a.ino === b.ino
+    && a.mtimeMs === b.mtimeMs
+    && a.ctimeMs === b.ctimeMs
+    && a.size === b.size
+}
+
+function sameSourceObservation(a: SourceObservation, b: SourceObservation): boolean {
+  return sameFingerprint(a.fingerprint, b.fingerprint)
+    && sameWalObservation(a.wal, b.wal)
+    && a.walMode === b.walMode
+}
+
+function isWithin(parent: string, candidate: string): boolean {
+  const relativePath = relative(resolve(parent), resolve(candidate))
+  return relativePath === ''
+    || (relativePath !== '..' && !relativePath.startsWith(`..${sep}`))
+}
+
+function pathsOverlap(a: string, b: string): boolean {
+  return isWithin(a, b) || isWithin(b, a)
+}
+
+function cleanupStaleSnapshots(root: string): void {
+  let entries: fs.Dirent[]
+  try {
+    entries = fs.readdirSync(root, { withFileTypes: true })
+  } catch {
+    return
   }
 
-  const db = new DatabaseSync(path, { readOnly: true })
+  const cutoff = Date.now() - SNAPSHOT_STALE_MS
+  for (const entry of entries) {
+    if (!entry.isDirectory() || !entry.name.startsWith(SNAPSHOT_PREFIX)) continue
+    const directory = join(root, entry.name)
+    try {
+      if (fs.statSync(directory).mtimeMs < cutoff) {
+        fs.rmSync(directory, { recursive: true, force: true })
+      }
+    } catch {
+      // A concurrent reader or a platform file lock owns the directory.
+    }
+  }
+}
+
+function cleanupSnapshotDirectory(directory: string | undefined): void {
+  if (!directory || !basename(directory).startsWith(SNAPSHOT_PREFIX)) return
+  try {
+    fs.rmSync(directory, { recursive: true, force: true })
+  } catch {
+    // Close remains safe if a platform briefly holds a snapshot-side handle;
+    // the bounded stale cleanup handles the remaining owned directory later.
+  }
+}
+
+function ensureSnapshotRoot(sourcePath: string): string {
+  const sourceDirectory = resolve(dirname(resolveSourcePath(sourcePath)))
+  const roots = [
+    join(resolve(getMetroraCacheDir()), SNAPSHOT_DIRECTORY),
+    join(resolve(tmpdir()), SNAPSHOT_DIRECTORY),
+  ]
+
+  for (const root of roots) {
+    if (pathsOverlap(sourceDirectory, root)) continue
+    try {
+      fs.mkdirSync(root, { recursive: true })
+      cleanupStaleSnapshots(root)
+      return root
+    } catch {
+      // A restricted cache is not a reason to write beside the producer.
+    }
+  }
+
+  throw new Error(`Metrora could not create an owned SQLite snapshot directory for ${sourcePath}`)
+}
+
+function createSnapshot(sourcePath: string): SourceSnapshot {
+  const root = ensureSnapshotRoot(sourcePath)
+  let lastFailure = 'source state was not stable'
+
+  for (let attempt = 0; attempt < SNAPSHOT_ATTEMPTS; attempt++) {
+    const before = observeSource(sourcePath)
+    if (before.fingerprint === null) {
+      throw new Error(`SQLite source disappeared before a safe snapshot could be taken: ${sourcePath}`)
+    }
+
+    let directory: string | undefined
+    try {
+      directory = fs.mkdtempSync(join(root, SNAPSHOT_PREFIX))
+      const databasePath = join(directory, 'source.sqlite')
+      const walPath = `${databasePath}-wal`
+      const stagedDatabasePath = `${databasePath}.copying`
+      const stagedWalPath = `${walPath}.copying`
+
+      // Copy WAL first, then the main file. Neither name is published until
+      // both copies pass the source consistency fence; SHM is never copied.
+      if (before.hasLiveWal) {
+        fs.copyFileSync(before.walPath, stagedWalPath)
+      }
+      fs.copyFileSync(before.path, stagedDatabasePath)
+
+      const after = observeSource(sourcePath)
+      if (!sameSourceObservation(before, after)) {
+        lastFailure = 'source changed while its main/WAL pair was copied'
+        cleanupSnapshotDirectory(directory)
+        directory = undefined
+        if (attempt + 1 < SNAPSHOT_ATTEMPTS) continue
+        break
+      }
+
+      // Publish the pair only after the post-copy fingerprint agrees. The
+      // directory is unique to this reader, so other readers cannot collide.
+      if (before.hasLiveWal) fs.renameSync(stagedWalPath, walPath)
+      fs.renameSync(stagedDatabasePath, databasePath)
+      return { directory, databasePath }
+    } catch (err) {
+      lastFailure = errorMessage(err)
+      cleanupSnapshotDirectory(directory)
+      if (attempt + 1 === SNAPSHOT_ATTEMPTS) break
+    }
+  }
+
+  throw new Error(`SQLite source-safe snapshot failed for ${sourcePath}: ${lastFailure}`)
+}
+
+function openRawDatabase(path: string, immutable: boolean): RawDatabase {
+  if (DatabaseSync === null) throw new Error(getSqliteLoadError())
+  const openPath = immutable ? `${pathToFileURL(path).href}?immutable=1` : path
+  const db = new DatabaseSync(openPath, { readOnly: true })
   try {
     db.exec?.('PRAGMA busy_timeout = 1000')
   } catch {
     // Best effort. Some Node sqlite builds may not expose exec on DatabaseSync.
   }
+  return db
+}
+
+function closeRawDatabase(db: RawDatabase): void {
+  try { db.close() } catch { /* best effort during promotion */ }
+}
+
+export function openDatabase(path: string): SqliteDatabase {
+  if (!loadDriver() || DatabaseSync === null) {
+    throw new Error(getSqliteLoadError())
+  }
+
+  const initial = observeSource(path)
+  let db: RawDatabase | null = null
+  let mode: OpenMode = 'direct'
+  let snapshot: SourceSnapshot | null = null
+
+  try {
+    if (initial.hasLiveWal) {
+      snapshot = createSnapshot(path)
+      db = openRawDatabase(snapshot.databasePath, false)
+      mode = 'snapshot'
+    } else if (initial.walMode) {
+      try {
+        db = openRawDatabase(initial.path, true)
+        mode = 'immutable'
+      } catch (err) {
+        if (!isSqliteSourceSafeReadError(err) || !observeSource(path).hasLiveWal) throw err
+        snapshot = createSnapshot(path)
+        db = openRawDatabase(snapshot.databasePath, false)
+        mode = 'snapshot'
+      }
+    } else {
+      try {
+        db = openRawDatabase(initial.path, false)
+      } catch (err) {
+        if (!isSqliteSourceSafeReadError(err) || !observeSource(path).hasLiveWal) throw err
+        snapshot = createSnapshot(path)
+        db = openRawDatabase(snapshot.databasePath, false)
+        mode = 'snapshot'
+      }
+    }
+  } catch (err) {
+    cleanupSnapshotDirectory(snapshot?.directory)
+    throw err
+  }
+
+  if (db === null) {
+    cleanupSnapshotDirectory(snapshot?.directory)
+    throw new Error(`SQLite database could not be opened: ${path}`)
+  }
+
+  let fallbackAttempted = mode === 'snapshot'
+  let closed = false
+
+  const promoteToSnapshot = (allowNoWalEvidence: boolean): boolean => {
+    if (mode === 'snapshot') return true
+    if (fallbackAttempted) return false
+    fallbackAttempted = true
+
+    const current = observeSource(path)
+    if (!current.hasLiveWal && !(allowNoWalEvidence && current.fingerprint !== null)) {
+      return false
+    }
+
+    const previous = db!
+    closeRawDatabase(previous)
+    let nextSnapshot: SourceSnapshot | null = null
+    try {
+      nextSnapshot = createSnapshot(path)
+      const nextDb = openRawDatabase(nextSnapshot.databasePath, false)
+      db = nextDb
+      snapshot = nextSnapshot
+      mode = 'snapshot'
+      return true
+    } catch (err) {
+      cleanupSnapshotDirectory(nextSnapshot?.directory)
+      throw new Error(`SQLite source could not be read without source-side support files: ${path}. ${errorMessage(err)}`, { cause: err })
+    }
+  }
+
+  const execute = <T extends Row>(sql: string, params: unknown[]): T[] => {
+    return db!.prepare(sql).all(...params) as T[]
+  }
 
   return {
     query<T extends Row = Row>(sql: string, params: unknown[] = []): T[] {
-      return db.prepare(sql).all(...params) as T[]
+      if (closed) throw new Error('SQLite database is closed')
+
+      const beforeQuery = mode === 'immutable' ? observeSource(path) : null
+      if (mode !== 'snapshot') {
+        const current = observeSource(path)
+        if (current.hasLiveWal) promoteToSnapshot(false)
+        else if (mode === 'direct' && current.walMode) promoteToSnapshot(true)
+      }
+
+      try {
+        const result = execute<T>(sql, params)
+
+        // Immutable mode intentionally avoids all source-side WAL/SHM access.
+        // If the source moved while this statement ran, discard that result
+        // and take a stable owned copy before retrying once.
+        if (mode === 'immutable' && beforeQuery !== null) {
+          const afterQuery = observeSource(path)
+          if (!sameSourceObservation(beforeQuery, afterQuery) && promoteToSnapshot(true)) {
+            return execute<T>(sql, params)
+          }
+        }
+        return result
+      } catch (err) {
+        // A DatabaseSync constructor can succeed while the first prepare/all
+        // fails when SQLite later needs WAL shared-memory support. Promote only
+        // this precise class, only once, and only with current WAL evidence.
+        if (
+          mode !== 'snapshot' &&
+          isSqliteSourceSafeReadError(err) &&
+          promoteToSnapshot(false)
+        ) {
+          return execute<T>(sql, params)
+        }
+        throw err
+      }
     },
     close() {
-      db.close()
+      if (closed) return
+      closed = true
+      try {
+        db!.close()
+      } finally {
+        cleanupSnapshotDirectory(snapshot?.directory)
+      }
     },
   }
 }

--- a/src/sqlite.ts
+++ b/src/sqlite.ts
@@ -1,11 +1,22 @@
 import { createRequire } from 'node:module'
-import { randomUUID } from 'node:crypto'
 import fs from 'node:fs'
 import { tmpdir } from 'node:os'
-import { basename, dirname, join, relative, resolve, sep } from 'node:path'
+import { dirname, join, relative, resolve, sep } from 'node:path'
 import { pathToFileURL } from 'node:url'
-import { fingerprintSourceFileSync, sourcePathCandidates, type SourceFileFingerprint } from './sqlite-source-fingerprint.js'
+import { type SourceFileFingerprint } from './sqlite-source-fingerprint.js'
 import { getMetroraCacheDir } from './product-paths.js'
+import { cleanupSnapshotDirectory, cleanupStaleSnapshots, writeSnapshotOwner } from './sqlite-snapshot-ownership.js'
+import {
+  observeSource,
+  probeSource,
+  resolveSourcePath,
+  sameMainIdentity,
+  sameSourceProbe,
+  sourceProbeFromObservation,
+  type SourceObservation,
+  type SourceProbe,
+} from './sqlite-source-probe.js'
+
 
 
 /// Thin SQLite read-only wrapper over Node's built-in `node:sqlite` module (stable in
@@ -127,34 +138,6 @@ export function isSqliteBusyError(err: unknown): boolean {
 
 type OpenMode = 'direct' | 'immutable' | 'snapshot'
 
-type MainObservation = {
-  dev: number
-  ino: number
-  mtimeMs: number
-  ctimeMs: number
-  size: number
-}
-
-type WalObservation = {
-  dev: number
-  ino: number
-  mtimeMs: number
-  ctimeMs: number
-  size: number
-}
-
-type SourceProbe = {
-  path: string
-  main: MainObservation | null
-  walPath: string
-  wal: WalObservation | null
-  hasLiveWal: boolean
-}
-
-type SourceObservation = SourceProbe & {
-  fingerprint: SourceFileFingerprint | null
-  walMode: boolean
-}
 
 type SourceSnapshot = {
   directory: string
@@ -162,11 +145,6 @@ type SourceSnapshot = {
   ownerToken: string
 }
 
-type SnapshotOwner = {
-  pid: number
-  token: string
-  createdAtMs: number
-}
 
 type OpenedSource = {
   db: RawDatabase
@@ -177,8 +155,6 @@ type OpenedSource = {
 
 const SNAPSHOT_DIRECTORY = 'sqlite-source-snapshots'
 const SNAPSHOT_PREFIX = 'sqlite-source-read-'
-const SNAPSHOT_OWNER_FILE = '.owner.json'
-const SNAPSHOT_STALE_MS = 24 * 60 * 60 * 1000
 const SNAPSHOT_ATTEMPTS = 3
 
 function errorMessage(err: unknown): string {
@@ -209,98 +185,6 @@ export function isSqliteSourceSafeReadError(err: unknown): boolean {
   )
 }
 
-function readMainObservation(path: string): MainObservation | null {
-  try {
-    const stat = fs.statSync(path)
-    if (!stat.isFile()) return null
-    return {
-      dev: stat.dev,
-      ino: stat.ino,
-      mtimeMs: stat.mtimeMs,
-      ctimeMs: stat.ctimeMs,
-      size: stat.size,
-    }
-  } catch {
-    return null
-  }
-}
-function resolveSourceFile(
-  sourcePath: string,
-  preferredPath?: string,
-): { path: string; main: MainObservation | null } {
-  const candidates = preferredPath === undefined
-    ? sourcePathCandidates(sourcePath)
-    : [preferredPath, ...sourcePathCandidates(sourcePath)]
-
-  for (const candidate of [...new Set(candidates)]) {
-    const main = readMainObservation(candidate)
-    if (main !== null) return { path: candidate, main }
-  }
-
-  return { path: preferredPath ?? sourcePath, main: null }
-}
-
-function resolveSourcePath(sourcePath: string, preferredPath?: string): string {
-  return resolveSourceFile(sourcePath, preferredPath).path
-}
-
-function readWalObservation(path: string): WalObservation | null {
-  try {
-    const stat = fs.statSync(path)
-    return {
-      dev: stat.dev,
-      ino: stat.ino,
-      mtimeMs: stat.mtimeMs,
-      ctimeMs: stat.ctimeMs,
-      size: stat.size,
-    }
-  } catch {
-    return null
-  }
-}
-
-function hasWalModeHeader(path: string): boolean {
-  let handle: number | undefined
-  try {
-    handle = fs.openSync(path, 'r')
-    const header = Buffer.alloc(20)
-    const bytesRead = fs.readSync(handle, header, 0, header.length, 0)
-    // SQLite's file-format read/write version bytes are both 2 in WAL mode.
-    return bytesRead === header.length && header[18] === 2 && header[19] === 2
-  } catch {
-    return false
-  } finally {
-    if (handle !== undefined) {
-      try { fs.closeSync(handle) } catch { /* best effort */ }
-    }
-  }
-}
-
-function probeSource(sourcePath: string, preferredPath?: string, previousWal?: WalObservation | null): SourceProbe {
-  const resolved = resolveSourceFile(sourcePath, preferredPath)
-  const walPath = `${resolved.path}-wal`
-  const wal = resolved.main === null
-    ? null
-    : previousWal === null && !fs.existsSync(walPath)
-      ? null
-      : readWalObservation(walPath)
-  return {
-    path: resolved.path,
-    main: resolved.main,
-    walPath,
-    wal,
-    hasLiveWal: wal !== null && wal.size > 0,
-  }
-}
-
-function observeSource(sourcePath: string): SourceObservation {
-  const probe = probeSource(sourcePath)
-  return {
-    ...probe,
-    fingerprint: fingerprintSourceFileSync(sourcePath),
-    walMode: probe.main !== null && hasWalModeHeader(probe.path),
-  }
-}
 
 function sameFingerprint(a: SourceFileFingerprint | null, b: SourceFileFingerprint | null): boolean {
   if (a === null || b === null) return a === b
@@ -318,44 +202,6 @@ function sameFingerprint(a: SourceFileFingerprint | null, b: SourceFileFingerpri
     && a.sqliteWal.sizeBytes === b.sqliteWal.sizeBytes
 }
 
-function sameWalObservation(a: WalObservation | null, b: WalObservation | null): boolean {
-  if (a === null || b === null) return a === b
-  return a.dev === b.dev
-    && a.ino === b.ino
-    && a.mtimeMs === b.mtimeMs
-    && a.ctimeMs === b.ctimeMs
-    && a.size === b.size
-}
-
-function sameMainIdentity(a: MainObservation | null, b: MainObservation | null): boolean {
-  if (a === null || b === null) return a === b
-  return a.dev === b.dev && a.ino === b.ino
-}
-
-function sameMainMetadata(a: MainObservation | null, b: MainObservation | null): boolean {
-  if (a === null || b === null) return a === b
-  return a.mtimeMs === b.mtimeMs
-    && a.ctimeMs === b.ctimeMs
-    && a.size === b.size
-}
-
-function sameSourceProbe(a: SourceProbe, b: SourceProbe): boolean {
-  if (a.path !== b.path) return false
-  if (a.main === null || b.main === null) return a.main === b.main && sameWalObservation(a.wal, b.wal)
-  return sameMainIdentity(a.main, b.main)
-    && sameMainMetadata(a.main, b.main)
-    && sameWalObservation(a.wal, b.wal)
-}
-
-function sourceProbeFromObservation(observation: SourceObservation): SourceProbe {
-  return {
-    path: observation.path,
-    main: observation.main,
-    walPath: observation.walPath,
-    wal: observation.wal,
-    hasLiveWal: observation.hasLiveWal,
-  }
-}
 function sameSourceObservation(a: SourceObservation, b: SourceObservation): boolean {
   return sameSourceProbe(a, b)
     && sameFingerprint(a.fingerprint, b.fingerprint)
@@ -372,89 +218,6 @@ function pathsOverlap(a: string, b: string): boolean {
   return isWithin(a, b) || isWithin(b, a)
 }
 
-function writeSnapshotOwner(directory: string): SnapshotOwner {
-  const owner: SnapshotOwner = {
-    pid: process.pid,
-    token: randomUUID(),
-    createdAtMs: Date.now(),
-  }
-  const stagedPath = join(directory, `${SNAPSHOT_OWNER_FILE}.copying`)
-  fs.writeFileSync(stagedPath, JSON.stringify(owner), { encoding: 'utf8', flag: 'wx' })
-  fs.renameSync(stagedPath, join(directory, SNAPSHOT_OWNER_FILE))
-  return owner
-}
-
-function readSnapshotOwner(directory: string): SnapshotOwner | null {
-  try {
-    const parsed = JSON.parse(fs.readFileSync(join(directory, SNAPSHOT_OWNER_FILE), 'utf8')) as Partial<SnapshotOwner>
-    if (
-      typeof parsed.pid !== 'number' ||
-      !Number.isInteger(parsed.pid) ||
-      parsed.pid <= 0 ||
-      typeof parsed.token !== 'string' ||
-      parsed.token.length === 0 ||
-      typeof parsed.createdAtMs !== 'number' ||
-      !Number.isFinite(parsed.createdAtMs)
-    ) return null
-    return {
-      pid: parsed.pid,
-      token: parsed.token,
-      createdAtMs: parsed.createdAtMs,
-    }
-  } catch {
-    return null
-  }
-}
-
-function isSnapshotOwnerAlive(pid: number): boolean {
-  if (pid === process.pid) return true
-  try {
-    process.kill(pid, 0)
-    return true
-  } catch (err) {
-    const code = err && typeof err === 'object' && 'code' in err
-      ? (err as { code?: unknown }).code
-      : undefined
-    return code !== 'ESRCH'
-  }
-}
-function cleanupStaleSnapshots(root: string): void {
-  let entries: fs.Dirent[]
-  try {
-    entries = fs.readdirSync(root, { withFileTypes: true })
-  } catch {
-    return
-  }
-
-  const cutoff = Date.now() - SNAPSHOT_STALE_MS
-  for (const entry of entries) {
-    if (!entry.isDirectory() || !entry.name.startsWith(SNAPSHOT_PREFIX)) continue
-    const directory = join(root, entry.name)
-    try {
-      if (fs.statSync(directory).mtimeMs < cutoff) {
-        const owner = readSnapshotOwner(directory)
-        if (owner === null || isSnapshotOwnerAlive(owner.pid)) continue
-        fs.rmSync(directory, { recursive: true, force: true })
-      }
-    } catch {
-      // A concurrent reader or a platform file lock owns the directory.
-    }
-  }
-}
-
-function cleanupSnapshotDirectory(directory: string | undefined, ownerToken?: string): void {
-  if (!directory || !basename(directory).startsWith(SNAPSHOT_PREFIX)) return
-  if (ownerToken !== undefined) {
-    const owner = readSnapshotOwner(directory)
-    if (owner === null || owner.token !== ownerToken) return
-  }
-  try {
-    fs.rmSync(directory, { recursive: true, force: true })
-  } catch {
-    // Close remains safe if a platform briefly holds a snapshot-side handle;
-    // the bounded stale cleanup handles the remaining owned directory later.
-  }
-}
 
 function ensureSnapshotRoot(sourcePath: string): string {
   const sourceDirectory = resolve(dirname(resolveSourcePath(sourcePath)))
@@ -467,7 +230,7 @@ function ensureSnapshotRoot(sourcePath: string): string {
     if (pathsOverlap(sourceDirectory, root)) continue
     try {
       fs.mkdirSync(root, { recursive: true })
-      cleanupStaleSnapshots(root)
+      cleanupStaleSnapshots(root, SNAPSHOT_PREFIX)
       return root
     } catch {
       // A restricted cache is not a reason to write beside the producer.
@@ -488,10 +251,9 @@ function createSnapshot(sourcePath: string): SourceSnapshot {
     }
 
     let directory: string | undefined
-    let owner: SnapshotOwner | undefined
     try {
       directory = fs.mkdtempSync(join(root, SNAPSHOT_PREFIX))
-      owner = writeSnapshotOwner(directory)
+      const ownerToken = writeSnapshotOwner(directory)
       const databasePath = join(directory, 'source.sqlite')
       const walPath = `${databasePath}-wal`
       const stagedDatabasePath = `${databasePath}.copying`
@@ -507,7 +269,7 @@ function createSnapshot(sourcePath: string): SourceSnapshot {
       const after = observeSource(sourcePath)
       if (!sameSourceObservation(before, after)) {
         lastFailure = 'source changed while its main/WAL pair was copied'
-        cleanupSnapshotDirectory(directory)
+        cleanupSnapshotDirectory(directory, SNAPSHOT_PREFIX)
         directory = undefined
         if (attempt + 1 < SNAPSHOT_ATTEMPTS) continue
         break
@@ -517,10 +279,10 @@ function createSnapshot(sourcePath: string): SourceSnapshot {
       // directory is unique to this reader, so other readers cannot collide.
       if (before.hasLiveWal) fs.renameSync(stagedWalPath, walPath)
       fs.renameSync(stagedDatabasePath, databasePath)
-      return { directory, databasePath, ownerToken: owner.token }
+      return { directory, databasePath, ownerToken }
     } catch (err) {
       lastFailure = errorMessage(err)
-      cleanupSnapshotDirectory(directory)
+      cleanupSnapshotDirectory(directory, SNAPSHOT_PREFIX)
       if (attempt + 1 === SNAPSHOT_ATTEMPTS) break
     }
   }
@@ -554,7 +316,7 @@ function openSnapshotSource(sourcePath: string, observed: SourceObservation): Op
       probe: sourceProbeFromObservation(observed),
     }
   } catch (err) {
-    cleanupSnapshotDirectory(snapshot.directory, snapshot.ownerToken)
+    cleanupSnapshotDirectory(snapshot.directory, SNAPSHOT_PREFIX, snapshot.ownerToken)
     throw err
   }
 }
@@ -613,12 +375,12 @@ export function openDatabase(path: string): SqliteDatabase {
     snapshot = opened.snapshot
     handleProbe = opened.probe
   } catch (err) {
-    cleanupSnapshotDirectory(snapshot?.directory, snapshot?.ownerToken)
+    cleanupSnapshotDirectory(snapshot?.directory, SNAPSHOT_PREFIX, snapshot?.ownerToken)
     throw err
   }
 
   if (db === null || handleProbe === null) {
-    cleanupSnapshotDirectory(snapshot?.directory, snapshot?.ownerToken)
+    cleanupSnapshotDirectory(snapshot?.directory, SNAPSHOT_PREFIX, snapshot?.ownerToken)
     throw new Error(`SQLite database could not be opened: ${path}`)
   }
 
@@ -631,7 +393,7 @@ export function openDatabase(path: string): SqliteDatabase {
       db = null
     }
     if (snapshot !== null) {
-      cleanupSnapshotDirectory(snapshot.directory, snapshot.ownerToken)
+      cleanupSnapshotDirectory(snapshot.directory, SNAPSHOT_PREFIX, snapshot.ownerToken)
       snapshot = null
     }
     handleProbe = null
@@ -731,7 +493,7 @@ export function openDatabase(path: string): SqliteDatabase {
         if (db !== null) closeRawDatabase(db)
       } finally {
         if (snapshot !== null) {
-          cleanupSnapshotDirectory(snapshot.directory, snapshot.ownerToken)
+          cleanupSnapshotDirectory(snapshot.directory, SNAPSHOT_PREFIX, snapshot.ownerToken)
           snapshot = null
         }
         db = null

--- a/src/sqlite.ts
+++ b/src/sqlite.ts
@@ -2,19 +2,14 @@ import { createRequire } from 'node:module'
 import fs from 'node:fs'
 import { tmpdir } from 'node:os'
 import { dirname, join, relative, resolve, sep } from 'node:path'
-import { pathToFileURL } from 'node:url'
 import { type SourceFileFingerprint } from './sqlite-source-fingerprint.js'
 import { getMetroraCacheDir } from './product-paths.js'
 import { cleanupSnapshotDirectory, cleanupStaleSnapshots, writeSnapshotOwner } from './sqlite-snapshot-ownership.js'
 import {
   observeSource,
-  probeSource,
   resolveSourcePath,
-  sameMainIdentity,
   sameSourceProbe,
-  sourceProbeFromObservation,
   type SourceObservation,
-  type SourceProbe,
 } from './sqlite-source-probe.js'
 
 
@@ -136,21 +131,10 @@ export function isSqliteBusyError(err: unknown): boolean {
   )
 }
 
-type OpenMode = 'direct' | 'immutable' | 'snapshot'
-
-
 type SourceSnapshot = {
   directory: string
   databasePath: string
   ownerToken: string
-}
-
-
-type OpenedSource = {
-  db: RawDatabase
-  mode: OpenMode
-  snapshot: SourceSnapshot | null
-  probe: SourceProbe
 }
 
 const SNAPSHOT_DIRECTORY = 'sqlite-source-snapshots'
@@ -160,31 +144,6 @@ const SNAPSHOT_ATTEMPTS = 3
 function errorMessage(err: unknown): string {
   return err instanceof Error ? err.message : String(err)
 }
-
-/**
- * Identify only the SQLite open failure that can be caused by a WAL reader
- * needing source-side shared-memory support. Callers still require current
- * live-WAL evidence before promoting a read to a snapshot.
- */
-export function isSqliteSourceSafeReadError(err: unknown): boolean {
-  const e = err as { code?: unknown; errcode?: unknown; errstr?: unknown; message?: unknown } | null
-  const code = typeof e?.code === 'string' ? e.code : ''
-  const errcode = typeof e?.errcode === 'number' ? e.errcode : null
-  const message = [
-    typeof e?.message === 'string' ? e.message : '',
-    typeof e?.errstr === 'string' ? e.errstr : '',
-  ].join(' ')
-
-  if (isSqliteBusyError(err)) return false
-  return (
-    errcode === 14 ||
-    code === 'SQLITE_CANTOPEN' ||
-    code === 'ERR_SQLITE_CANTOPEN' ||
-    /\bSQLITE_CANTOPEN\b/i.test(`${code} ${message}`) ||
-    /\bunable to open database file\b/i.test(message)
-  )
-}
-
 
 function sameFingerprint(a: SourceFileFingerprint | null, b: SourceFileFingerprint | null): boolean {
   if (a === null || b === null) return a === b
@@ -211,13 +170,12 @@ function sameSourceObservation(a: SourceObservation, b: SourceObservation): bool
 function isWithin(parent: string, candidate: string): boolean {
   const relativePath = relative(resolve(parent), resolve(candidate))
   return relativePath === ''
-    || (relativePath !== '..' && !relativePath.startsWith(`..${sep}`))
+    || (relativePath !== '..' && !relativePath.startsWith('..' + sep))
 }
 
 function pathsOverlap(a: string, b: string): boolean {
   return isWithin(a, b) || isWithin(b, a)
 }
-
 
 function ensureSnapshotRoot(sourcePath: string): string {
   const sourceDirectory = resolve(dirname(resolveSourcePath(sourcePath)))
@@ -237,7 +195,7 @@ function ensureSnapshotRoot(sourcePath: string): string {
     }
   }
 
-  throw new Error(`Metrora could not create an owned SQLite snapshot directory for ${sourcePath}`)
+  throw new Error('Metrora could not create an owned SQLite snapshot directory for ' + sourcePath)
 }
 
 function createSnapshot(sourcePath: string): SourceSnapshot {
@@ -247,7 +205,13 @@ function createSnapshot(sourcePath: string): SourceSnapshot {
   for (let attempt = 0; attempt < SNAPSHOT_ATTEMPTS; attempt++) {
     const before = observeSource(sourcePath)
     if (before.fingerprint === null) {
-      throw new Error(`SQLite source disappeared before a safe snapshot could be taken: ${sourcePath}`)
+      throw new Error('SQLite source disappeared before a safe snapshot could be taken: ' + sourcePath)
+    }
+
+    if (before.hasActiveJournal) {
+      lastFailure = 'an active rollback journal was present before copying'
+      if (attempt + 1 === SNAPSHOT_ATTEMPTS) break
+      continue
     }
 
     let directory: string | undefined
@@ -255,9 +219,9 @@ function createSnapshot(sourcePath: string): SourceSnapshot {
       directory = fs.mkdtempSync(join(root, SNAPSHOT_PREFIX))
       const ownerToken = writeSnapshotOwner(directory)
       const databasePath = join(directory, 'source.sqlite')
-      const walPath = `${databasePath}-wal`
-      const stagedDatabasePath = `${databasePath}.copying`
-      const stagedWalPath = `${walPath}.copying`
+      const walPath = databasePath + '-wal'
+      const stagedDatabasePath = databasePath + '.copying'
+      const stagedWalPath = walPath + '.copying'
 
       // Copy WAL first, then the main file. Neither name is published until
       // both copies pass the source consistency fence; SHM is never copied.
@@ -267,6 +231,20 @@ function createSnapshot(sourcePath: string): SourceSnapshot {
       fs.copyFileSync(before.path, stagedDatabasePath)
 
       const after = observeSource(sourcePath)
+      if (after.fingerprint === null) {
+        lastFailure = 'source disappeared while its main/WAL pair was copied'
+        cleanupSnapshotDirectory(directory, SNAPSHOT_PREFIX)
+        directory = undefined
+        if (attempt + 1 < SNAPSHOT_ATTEMPTS) continue
+        break
+      }
+      if (after.hasActiveJournal) {
+        lastFailure = 'an active rollback journal appeared while its source was copied'
+        cleanupSnapshotDirectory(directory, SNAPSHOT_PREFIX)
+        directory = undefined
+        if (attempt + 1 < SNAPSHOT_ATTEMPTS) continue
+        break
+      }
       if (!sameSourceObservation(before, after)) {
         lastFailure = 'source changed while its main/WAL pair was copied'
         cleanupSnapshotDirectory(directory, SNAPSHOT_PREFIX)
@@ -287,13 +265,12 @@ function createSnapshot(sourcePath: string): SourceSnapshot {
     }
   }
 
-  throw new Error(`SQLite source-safe snapshot failed for ${sourcePath}: ${lastFailure}`)
+  throw new Error('SQLite source-safe snapshot failed for ' + sourcePath + ': ' + lastFailure)
 }
 
-function openRawDatabase(path: string, immutable: boolean): RawDatabase {
+function openRawDatabase(path: string): RawDatabase {
   if (DatabaseSync === null) throw new Error(getSqliteLoadError())
-  const openPath = immutable ? `${pathToFileURL(path).href}?immutable=1` : path
-  const db = new DatabaseSync(openPath, { readOnly: true })
+  const db = new DatabaseSync(path, { readOnly: true })
   try {
     db.exec?.('PRAGMA busy_timeout = 1000')
   } catch {
@@ -303,188 +280,33 @@ function openRawDatabase(path: string, immutable: boolean): RawDatabase {
 }
 
 function closeRawDatabase(db: RawDatabase): void {
-  try { db.close() } catch { /* best effort during promotion */ }
+  try { db.close() } catch { /* best effort during close */ }
 }
 
-function openSnapshotSource(sourcePath: string, observed: SourceObservation): OpenedSource {
-  const snapshot = createSnapshot(sourcePath)
-  try {
-    return {
-      db: openRawDatabase(snapshot.databasePath, false),
-      mode: 'snapshot',
-      snapshot,
-      probe: sourceProbeFromObservation(observed),
-    }
-  } catch (err) {
-    cleanupSnapshotDirectory(snapshot.directory, SNAPSHOT_PREFIX, snapshot.ownerToken)
-    throw err
-  }
-}
-function openClassifiedSource(sourcePath: string, observed: SourceObservation): OpenedSource {
-  if (observed.main === null || observed.fingerprint === null) {
-    throw new Error(`SQLite source is unavailable or disappeared: ${sourcePath}`)
-  }
-
-  if (observed.hasLiveWal) return openSnapshotSource(sourcePath, observed)
-
-  if (observed.walMode) {
-    try {
-      const db = openRawDatabase(observed.path, true)
-      return {
-        db,
-        mode: 'immutable',
-        snapshot: null,
-        probe: sourceProbeFromObservation(observed),
-      }
-    } catch (err) {
-      const current = observeSource(sourcePath)
-      if (!isSqliteSourceSafeReadError(err) || !current.hasLiveWal) throw err
-      return openSnapshotSource(sourcePath, current)
-    }
-  }
-
-  try {
-    const db = openRawDatabase(observed.path, false)
-    return {
-      db,
-      mode: 'direct',
-      snapshot: null,
-      probe: sourceProbeFromObservation(observed),
-    }
-  } catch (err) {
-    const current = observeSource(sourcePath)
-    if (!isSqliteSourceSafeReadError(err) || !current.hasLiveWal) throw err
-    return openSnapshotSource(sourcePath, current)
-  }
-}
 export function openDatabase(path: string): SqliteDatabase {
   if (!loadDriver() || DatabaseSync === null) {
     throw new Error(getSqliteLoadError())
   }
 
-  const initial = observeSource(path)
+  // Every synchronous reader gets one stable, Metrora-owned point-in-time
+  // view. No application SELECT is ever executed against the producer path.
+  const snapshot = createSnapshot(path)
   let db: RawDatabase | null = null
-  let mode: OpenMode = 'direct'
-  let snapshot: SourceSnapshot | null = null
-  let handleProbe: SourceProbe | null = null
-
   try {
-    const opened = openClassifiedSource(path, initial)
-    db = opened.db
-    mode = opened.mode
-    snapshot = opened.snapshot
-    handleProbe = opened.probe
+    db = openRawDatabase(snapshot.databasePath)
   } catch (err) {
-    cleanupSnapshotDirectory(snapshot?.directory, SNAPSHOT_PREFIX, snapshot?.ownerToken)
-    throw err
-  }
-
-  if (db === null || handleProbe === null) {
-    cleanupSnapshotDirectory(snapshot?.directory, SNAPSHOT_PREFIX, snapshot?.ownerToken)
-    throw new Error(`SQLite database could not be opened: ${path}`)
+    cleanupSnapshotDirectory(snapshot.directory, SNAPSHOT_PREFIX, snapshot.ownerToken)
+    throw new Error(
+      'SQLite source snapshot could not be opened: ' + errorMessage(err),
+      { cause: err },
+    )
   }
 
   let closed = false
-  let terminalError: Error | null = null
-
-  const clearOpenSource = (): void => {
-    if (db !== null) {
-      closeRawDatabase(db)
-      db = null
-    }
-    if (snapshot !== null) {
-      cleanupSnapshotDirectory(snapshot.directory, SNAPSHOT_PREFIX, snapshot.ownerToken)
-      snapshot = null
-    }
-    handleProbe = null
-  }
-
-  const reclassify = (current: SourceObservation, reason: string): void => {
-    if (current.main === null || current.fingerprint === null) {
-      const error = new Error(`SQLite source disappeared or was replaced while reading: ${path}`)
-      clearOpenSource()
-      terminalError = error
-      throw error
-    }
-
-    clearOpenSource()
-    try {
-      const opened = openClassifiedSource(path, current)
-      db = opened.db
-      mode = opened.mode
-      snapshot = opened.snapshot
-      handleProbe = opened.probe
-    } catch (err) {
-      const error = new Error(
-        `SQLite source could not be reclassified after ${reason}: ${errorMessage(err)}`,
-        { cause: err },
-      )
-      terminalError = error
-      throw error
-    }
-  }
-
-  const preflightSource = (): void => {
-    if (mode === 'snapshot') return
-    if (handleProbe === null) throw terminalError ?? new Error(`SQLite source is not open: ${path}`)
-
-    const currentProbe = probeSource(path, handleProbe.path, handleProbe.wal)
-    if (currentProbe.main === null) {
-      reclassify(observeSource(path), 'source disappearance')
-      return
-    }
-    if (sameSourceProbe(handleProbe, currentProbe)) return
-
-    const current = observeSource(path)
-    if (current.main === null || current.fingerprint === null) {
-      reclassify(current, 'source disappearance')
-      return
-    }
-
-    // A normal rollback-journal write stays on the same inode and remains
-    // correctly visible through the existing direct SQLite handle.
-    if (
-      mode === 'direct' &&
-      !current.hasLiveWal &&
-      !current.walMode &&
-      sameMainIdentity(handleProbe.main, current.main)
-    ) {
-      handleProbe = sourceProbeFromObservation(current)
-      return
-    }
-
-    reclassify(current, 'source identity or mode change')
-  }
-
-  const execute = <T extends Row>(sql: string, params: unknown[]): T[] => {
-    if (db === null) throw terminalError ?? new Error(`SQLite database is not open: ${path}`)
-    return db.prepare(sql).all(...params) as T[]
-  }
-
   return {
     query<T extends Row = Row>(sql: string, params: unknown[] = []): T[] {
-      if (closed) throw new Error('SQLite database is closed')
-      if (terminalError !== null) throw terminalError
-      preflightSource()
-
-      let retryAttempted = false
-      try {
-        return execute<T>(sql, params)
-      } catch (err) {
-        if (
-          !retryAttempted &&
-          mode !== 'snapshot' &&
-          isSqliteSourceSafeReadError(err)
-        ) {
-          retryAttempted = true
-          const current = observeSource(path)
-          if (current.hasLiveWal) {
-            reclassify(current, 'query-time source-safe fallback')
-            return execute<T>(sql, params)
-          }
-        }
-        throw err
-      }
+      if (closed || db === null) throw new Error('SQLite database is closed')
+      return db.prepare(sql).all(...params) as T[]
     },
     close() {
       if (closed) return
@@ -492,12 +314,8 @@ export function openDatabase(path: string): SqliteDatabase {
       try {
         if (db !== null) closeRawDatabase(db)
       } finally {
-        if (snapshot !== null) {
-          cleanupSnapshotDirectory(snapshot.directory, SNAPSHOT_PREFIX, snapshot.ownerToken)
-          snapshot = null
-        }
+        cleanupSnapshotDirectory(snapshot.directory, SNAPSHOT_PREFIX, snapshot.ownerToken)
         db = null
-        handleProbe = null
       }
     },
   }

--- a/src/sqlite.ts
+++ b/src/sqlite.ts
@@ -1,4 +1,5 @@
 import { createRequire } from 'node:module'
+import { randomUUID } from 'node:crypto'
 import fs from 'node:fs'
 import { tmpdir } from 'node:os'
 import { basename, dirname, join, relative, resolve, sep } from 'node:path'
@@ -126,6 +127,14 @@ export function isSqliteBusyError(err: unknown): boolean {
 
 type OpenMode = 'direct' | 'immutable' | 'snapshot'
 
+type MainObservation = {
+  dev: number
+  ino: number
+  mtimeMs: number
+  ctimeMs: number
+  size: number
+}
+
 type WalObservation = {
   dev: number
   ino: number
@@ -134,22 +143,41 @@ type WalObservation = {
   size: number
 }
 
-type SourceObservation = {
+type SourceProbe = {
   path: string
-  fingerprint: SourceFileFingerprint | null
+  main: MainObservation | null
   walPath: string
   wal: WalObservation | null
   hasLiveWal: boolean
+}
+
+type SourceObservation = SourceProbe & {
+  fingerprint: SourceFileFingerprint | null
   walMode: boolean
 }
 
 type SourceSnapshot = {
   directory: string
   databasePath: string
+  ownerToken: string
+}
+
+type SnapshotOwner = {
+  pid: number
+  token: string
+  createdAtMs: number
+}
+
+type OpenedSource = {
+  db: RawDatabase
+  mode: OpenMode
+  snapshot: SourceSnapshot | null
+  probe: SourceProbe
 }
 
 const SNAPSHOT_DIRECTORY = 'sqlite-source-snapshots'
 const SNAPSHOT_PREFIX = 'sqlite-source-read-'
+const SNAPSHOT_OWNER_FILE = '.owner.json'
 const SNAPSHOT_STALE_MS = 24 * 60 * 60 * 1000
 const SNAPSHOT_ATTEMPTS = 3
 
@@ -181,15 +209,39 @@ export function isSqliteSourceSafeReadError(err: unknown): boolean {
   )
 }
 
-function resolveSourcePath(sourcePath: string): string {
-  for (const candidate of sourcePathCandidates(sourcePath)) {
-    try {
-      if (fs.statSync(candidate).isFile()) return candidate
-    } catch {
-      // Source discovery is allowed to race rotation and cleanup.
+function readMainObservation(path: string): MainObservation | null {
+  try {
+    const stat = fs.statSync(path)
+    if (!stat.isFile()) return null
+    return {
+      dev: stat.dev,
+      ino: stat.ino,
+      mtimeMs: stat.mtimeMs,
+      ctimeMs: stat.ctimeMs,
+      size: stat.size,
     }
+  } catch {
+    return null
   }
-  return sourcePath
+}
+function resolveSourceFile(
+  sourcePath: string,
+  preferredPath?: string,
+): { path: string; main: MainObservation | null } {
+  const candidates = preferredPath === undefined
+    ? sourcePathCandidates(sourcePath)
+    : [preferredPath, ...sourcePathCandidates(sourcePath)]
+
+  for (const candidate of [...new Set(candidates)]) {
+    const main = readMainObservation(candidate)
+    if (main !== null) return { path: candidate, main }
+  }
+
+  return { path: preferredPath ?? sourcePath, main: null }
+}
+
+function resolveSourcePath(sourcePath: string, preferredPath?: string): string {
+  return resolveSourceFile(sourcePath, preferredPath).path
 }
 
 function readWalObservation(path: string): WalObservation | null {
@@ -224,17 +276,29 @@ function hasWalModeHeader(path: string): boolean {
   }
 }
 
-function observeSource(sourcePath: string): SourceObservation {
-  const resolvedPath = resolveSourcePath(sourcePath)
-  const walPath = `${resolvedPath}-wal`
-  const wal = readWalObservation(walPath)
+function probeSource(sourcePath: string, preferredPath?: string, previousWal?: WalObservation | null): SourceProbe {
+  const resolved = resolveSourceFile(sourcePath, preferredPath)
+  const walPath = `${resolved.path}-wal`
+  const wal = resolved.main === null
+    ? null
+    : previousWal === null && !fs.existsSync(walPath)
+      ? null
+      : readWalObservation(walPath)
   return {
-    path: resolvedPath,
-    fingerprint: fingerprintSourceFileSync(sourcePath),
+    path: resolved.path,
+    main: resolved.main,
     walPath,
     wal,
     hasLiveWal: wal !== null && wal.size > 0,
-    walMode: hasWalModeHeader(resolvedPath),
+  }
+}
+
+function observeSource(sourcePath: string): SourceObservation {
+  const probe = probeSource(sourcePath)
+  return {
+    ...probe,
+    fingerprint: fingerprintSourceFileSync(sourcePath),
+    walMode: probe.main !== null && hasWalModeHeader(probe.path),
   }
 }
 
@@ -263,9 +327,38 @@ function sameWalObservation(a: WalObservation | null, b: WalObservation | null):
     && a.size === b.size
 }
 
-function sameSourceObservation(a: SourceObservation, b: SourceObservation): boolean {
-  return sameFingerprint(a.fingerprint, b.fingerprint)
+function sameMainIdentity(a: MainObservation | null, b: MainObservation | null): boolean {
+  if (a === null || b === null) return a === b
+  return a.dev === b.dev && a.ino === b.ino
+}
+
+function sameMainMetadata(a: MainObservation | null, b: MainObservation | null): boolean {
+  if (a === null || b === null) return a === b
+  return a.mtimeMs === b.mtimeMs
+    && a.ctimeMs === b.ctimeMs
+    && a.size === b.size
+}
+
+function sameSourceProbe(a: SourceProbe, b: SourceProbe): boolean {
+  if (a.path !== b.path) return false
+  if (a.main === null || b.main === null) return a.main === b.main && sameWalObservation(a.wal, b.wal)
+  return sameMainIdentity(a.main, b.main)
+    && sameMainMetadata(a.main, b.main)
     && sameWalObservation(a.wal, b.wal)
+}
+
+function sourceProbeFromObservation(observation: SourceObservation): SourceProbe {
+  return {
+    path: observation.path,
+    main: observation.main,
+    walPath: observation.walPath,
+    wal: observation.wal,
+    hasLiveWal: observation.hasLiveWal,
+  }
+}
+function sameSourceObservation(a: SourceObservation, b: SourceObservation): boolean {
+  return sameSourceProbe(a, b)
+    && sameFingerprint(a.fingerprint, b.fingerprint)
     && a.walMode === b.walMode
 }
 
@@ -279,6 +372,52 @@ function pathsOverlap(a: string, b: string): boolean {
   return isWithin(a, b) || isWithin(b, a)
 }
 
+function writeSnapshotOwner(directory: string): SnapshotOwner {
+  const owner: SnapshotOwner = {
+    pid: process.pid,
+    token: randomUUID(),
+    createdAtMs: Date.now(),
+  }
+  const stagedPath = join(directory, `${SNAPSHOT_OWNER_FILE}.copying`)
+  fs.writeFileSync(stagedPath, JSON.stringify(owner), { encoding: 'utf8', flag: 'wx' })
+  fs.renameSync(stagedPath, join(directory, SNAPSHOT_OWNER_FILE))
+  return owner
+}
+
+function readSnapshotOwner(directory: string): SnapshotOwner | null {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(join(directory, SNAPSHOT_OWNER_FILE), 'utf8')) as Partial<SnapshotOwner>
+    if (
+      typeof parsed.pid !== 'number' ||
+      !Number.isInteger(parsed.pid) ||
+      parsed.pid <= 0 ||
+      typeof parsed.token !== 'string' ||
+      parsed.token.length === 0 ||
+      typeof parsed.createdAtMs !== 'number' ||
+      !Number.isFinite(parsed.createdAtMs)
+    ) return null
+    return {
+      pid: parsed.pid,
+      token: parsed.token,
+      createdAtMs: parsed.createdAtMs,
+    }
+  } catch {
+    return null
+  }
+}
+
+function isSnapshotOwnerAlive(pid: number): boolean {
+  if (pid === process.pid) return true
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch (err) {
+    const code = err && typeof err === 'object' && 'code' in err
+      ? (err as { code?: unknown }).code
+      : undefined
+    return code !== 'ESRCH'
+  }
+}
 function cleanupStaleSnapshots(root: string): void {
   let entries: fs.Dirent[]
   try {
@@ -293,6 +432,8 @@ function cleanupStaleSnapshots(root: string): void {
     const directory = join(root, entry.name)
     try {
       if (fs.statSync(directory).mtimeMs < cutoff) {
+        const owner = readSnapshotOwner(directory)
+        if (owner === null || isSnapshotOwnerAlive(owner.pid)) continue
         fs.rmSync(directory, { recursive: true, force: true })
       }
     } catch {
@@ -301,8 +442,12 @@ function cleanupStaleSnapshots(root: string): void {
   }
 }
 
-function cleanupSnapshotDirectory(directory: string | undefined): void {
+function cleanupSnapshotDirectory(directory: string | undefined, ownerToken?: string): void {
   if (!directory || !basename(directory).startsWith(SNAPSHOT_PREFIX)) return
+  if (ownerToken !== undefined) {
+    const owner = readSnapshotOwner(directory)
+    if (owner === null || owner.token !== ownerToken) return
+  }
   try {
     fs.rmSync(directory, { recursive: true, force: true })
   } catch {
@@ -343,8 +488,10 @@ function createSnapshot(sourcePath: string): SourceSnapshot {
     }
 
     let directory: string | undefined
+    let owner: SnapshotOwner | undefined
     try {
       directory = fs.mkdtempSync(join(root, SNAPSHOT_PREFIX))
+      owner = writeSnapshotOwner(directory)
       const databasePath = join(directory, 'source.sqlite')
       const walPath = `${databasePath}-wal`
       const stagedDatabasePath = `${databasePath}.copying`
@@ -370,7 +517,7 @@ function createSnapshot(sourcePath: string): SourceSnapshot {
       // directory is unique to this reader, so other readers cannot collide.
       if (before.hasLiveWal) fs.renameSync(stagedWalPath, walPath)
       fs.renameSync(stagedDatabasePath, databasePath)
-      return { directory, databasePath }
+      return { directory, databasePath, ownerToken: owner.token }
     } catch (err) {
       lastFailure = errorMessage(err)
       cleanupSnapshotDirectory(directory)
@@ -397,6 +544,57 @@ function closeRawDatabase(db: RawDatabase): void {
   try { db.close() } catch { /* best effort during promotion */ }
 }
 
+function openSnapshotSource(sourcePath: string, observed: SourceObservation): OpenedSource {
+  const snapshot = createSnapshot(sourcePath)
+  try {
+    return {
+      db: openRawDatabase(snapshot.databasePath, false),
+      mode: 'snapshot',
+      snapshot,
+      probe: sourceProbeFromObservation(observed),
+    }
+  } catch (err) {
+    cleanupSnapshotDirectory(snapshot.directory, snapshot.ownerToken)
+    throw err
+  }
+}
+function openClassifiedSource(sourcePath: string, observed: SourceObservation): OpenedSource {
+  if (observed.main === null || observed.fingerprint === null) {
+    throw new Error(`SQLite source is unavailable or disappeared: ${sourcePath}`)
+  }
+
+  if (observed.hasLiveWal) return openSnapshotSource(sourcePath, observed)
+
+  if (observed.walMode) {
+    try {
+      const db = openRawDatabase(observed.path, true)
+      return {
+        db,
+        mode: 'immutable',
+        snapshot: null,
+        probe: sourceProbeFromObservation(observed),
+      }
+    } catch (err) {
+      const current = observeSource(sourcePath)
+      if (!isSqliteSourceSafeReadError(err) || !current.hasLiveWal) throw err
+      return openSnapshotSource(sourcePath, current)
+    }
+  }
+
+  try {
+    const db = openRawDatabase(observed.path, false)
+    return {
+      db,
+      mode: 'direct',
+      snapshot: null,
+      probe: sourceProbeFromObservation(observed),
+    }
+  } catch (err) {
+    const current = observeSource(sourcePath)
+    if (!isSqliteSourceSafeReadError(err) || !current.hasLiveWal) throw err
+    return openSnapshotSource(sourcePath, current)
+  }
+}
 export function openDatabase(path: string): SqliteDatabase {
   if (!loadDriver() || DatabaseSync === null) {
     throw new Error(getSqliteLoadError())
@@ -406,109 +604,122 @@ export function openDatabase(path: string): SqliteDatabase {
   let db: RawDatabase | null = null
   let mode: OpenMode = 'direct'
   let snapshot: SourceSnapshot | null = null
+  let handleProbe: SourceProbe | null = null
 
   try {
-    if (initial.hasLiveWal) {
-      snapshot = createSnapshot(path)
-      db = openRawDatabase(snapshot.databasePath, false)
-      mode = 'snapshot'
-    } else if (initial.walMode) {
-      try {
-        db = openRawDatabase(initial.path, true)
-        mode = 'immutable'
-      } catch (err) {
-        if (!isSqliteSourceSafeReadError(err) || !observeSource(path).hasLiveWal) throw err
-        snapshot = createSnapshot(path)
-        db = openRawDatabase(snapshot.databasePath, false)
-        mode = 'snapshot'
-      }
-    } else {
-      try {
-        db = openRawDatabase(initial.path, false)
-      } catch (err) {
-        if (!isSqliteSourceSafeReadError(err) || !observeSource(path).hasLiveWal) throw err
-        snapshot = createSnapshot(path)
-        db = openRawDatabase(snapshot.databasePath, false)
-        mode = 'snapshot'
-      }
-    }
+    const opened = openClassifiedSource(path, initial)
+    db = opened.db
+    mode = opened.mode
+    snapshot = opened.snapshot
+    handleProbe = opened.probe
   } catch (err) {
-    cleanupSnapshotDirectory(snapshot?.directory)
+    cleanupSnapshotDirectory(snapshot?.directory, snapshot?.ownerToken)
     throw err
   }
 
-  if (db === null) {
-    cleanupSnapshotDirectory(snapshot?.directory)
+  if (db === null || handleProbe === null) {
+    cleanupSnapshotDirectory(snapshot?.directory, snapshot?.ownerToken)
     throw new Error(`SQLite database could not be opened: ${path}`)
   }
 
-  let fallbackAttempted = mode === 'snapshot'
   let closed = false
+  let terminalError: Error | null = null
 
-  const promoteToSnapshot = (allowNoWalEvidence: boolean): boolean => {
-    if (mode === 'snapshot') return true
-    if (fallbackAttempted) return false
-    fallbackAttempted = true
+  const clearOpenSource = (): void => {
+    if (db !== null) {
+      closeRawDatabase(db)
+      db = null
+    }
+    if (snapshot !== null) {
+      cleanupSnapshotDirectory(snapshot.directory, snapshot.ownerToken)
+      snapshot = null
+    }
+    handleProbe = null
+  }
 
-    const current = observeSource(path)
-    if (!current.hasLiveWal && !(allowNoWalEvidence && current.fingerprint !== null)) {
-      return false
+  const reclassify = (current: SourceObservation, reason: string): void => {
+    if (current.main === null || current.fingerprint === null) {
+      const error = new Error(`SQLite source disappeared or was replaced while reading: ${path}`)
+      clearOpenSource()
+      terminalError = error
+      throw error
     }
 
-    const previous = db!
-    closeRawDatabase(previous)
-    let nextSnapshot: SourceSnapshot | null = null
+    clearOpenSource()
     try {
-      nextSnapshot = createSnapshot(path)
-      const nextDb = openRawDatabase(nextSnapshot.databasePath, false)
-      db = nextDb
-      snapshot = nextSnapshot
-      mode = 'snapshot'
-      return true
+      const opened = openClassifiedSource(path, current)
+      db = opened.db
+      mode = opened.mode
+      snapshot = opened.snapshot
+      handleProbe = opened.probe
     } catch (err) {
-      cleanupSnapshotDirectory(nextSnapshot?.directory)
-      throw new Error(`SQLite source could not be read without source-side support files: ${path}. ${errorMessage(err)}`, { cause: err })
+      const error = new Error(
+        `SQLite source could not be reclassified after ${reason}: ${errorMessage(err)}`,
+        { cause: err },
+      )
+      terminalError = error
+      throw error
     }
   }
 
+  const preflightSource = (): void => {
+    if (mode === 'snapshot') return
+    if (handleProbe === null) throw terminalError ?? new Error(`SQLite source is not open: ${path}`)
+
+    const currentProbe = probeSource(path, handleProbe.path, handleProbe.wal)
+    if (currentProbe.main === null) {
+      reclassify(observeSource(path), 'source disappearance')
+      return
+    }
+    if (sameSourceProbe(handleProbe, currentProbe)) return
+
+    const current = observeSource(path)
+    if (current.main === null || current.fingerprint === null) {
+      reclassify(current, 'source disappearance')
+      return
+    }
+
+    // A normal rollback-journal write stays on the same inode and remains
+    // correctly visible through the existing direct SQLite handle.
+    if (
+      mode === 'direct' &&
+      !current.hasLiveWal &&
+      !current.walMode &&
+      sameMainIdentity(handleProbe.main, current.main)
+    ) {
+      handleProbe = sourceProbeFromObservation(current)
+      return
+    }
+
+    reclassify(current, 'source identity or mode change')
+  }
+
   const execute = <T extends Row>(sql: string, params: unknown[]): T[] => {
-    return db!.prepare(sql).all(...params) as T[]
+    if (db === null) throw terminalError ?? new Error(`SQLite database is not open: ${path}`)
+    return db.prepare(sql).all(...params) as T[]
   }
 
   return {
     query<T extends Row = Row>(sql: string, params: unknown[] = []): T[] {
       if (closed) throw new Error('SQLite database is closed')
+      if (terminalError !== null) throw terminalError
+      preflightSource()
 
-      const beforeQuery = mode === 'immutable' ? observeSource(path) : null
-      if (mode !== 'snapshot') {
-        const current = observeSource(path)
-        if (current.hasLiveWal) promoteToSnapshot(false)
-        else if (mode === 'direct' && current.walMode) promoteToSnapshot(true)
-      }
-
+      let retryAttempted = false
       try {
-        const result = execute<T>(sql, params)
-
-        // Immutable mode intentionally avoids all source-side WAL/SHM access.
-        // If the source moved while this statement ran, discard that result
-        // and take a stable owned copy before retrying once.
-        if (mode === 'immutable' && beforeQuery !== null) {
-          const afterQuery = observeSource(path)
-          if (!sameSourceObservation(beforeQuery, afterQuery) && promoteToSnapshot(true)) {
+        return execute<T>(sql, params)
+      } catch (err) {
+        if (
+          !retryAttempted &&
+          mode !== 'snapshot' &&
+          isSqliteSourceSafeReadError(err)
+        ) {
+          retryAttempted = true
+          const current = observeSource(path)
+          if (current.hasLiveWal) {
+            reclassify(current, 'query-time source-safe fallback')
             return execute<T>(sql, params)
           }
-        }
-        return result
-      } catch (err) {
-        // A DatabaseSync constructor can succeed while the first prepare/all
-        // fails when SQLite later needs WAL shared-memory support. Promote only
-        // this precise class, only once, and only with current WAL evidence.
-        if (
-          mode !== 'snapshot' &&
-          isSqliteSourceSafeReadError(err) &&
-          promoteToSnapshot(false)
-        ) {
-          return execute<T>(sql, params)
         }
         throw err
       }
@@ -517,9 +728,14 @@ export function openDatabase(path: string): SqliteDatabase {
       if (closed) return
       closed = true
       try {
-        db!.close()
+        if (db !== null) closeRawDatabase(db)
       } finally {
-        cleanupSnapshotDirectory(snapshot?.directory)
+        if (snapshot !== null) {
+          cleanupSnapshotDirectory(snapshot.directory, snapshot.ownerToken)
+          snapshot = null
+        }
+        db = null
+        handleProbe = null
       }
     },
   }

--- a/tests/sqlite-source-safe-read.test.ts
+++ b/tests/sqlite-source-safe-read.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import fs from 'node:fs'
 import { createRequire } from 'node:module'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { dirname, join } from 'node:path'
 
 import {
   isSqliteAvailable,
@@ -95,14 +95,18 @@ function createCopiedWalSource(testRoot: string): { sourcePath: string; sourceDi
   return { sourcePath, sourceDirectory, producer: producer.db }
 }
 
-function createWalModeMainOnly(testRoot: string): {
+function createWalModeMainOnly(
+  testRoot: string,
+  sourceName = 'main-only-source',
+  producerName = 'producer-main-only',
+): {
   sourcePath: string
   sourceDirectory: string
   walBytes: Buffer
   producer: TestDatabase
 } {
-  const producerDirectory = join(testRoot, 'producer-main-only')
-  const sourceDirectory = join(testRoot, 'main-only-source')
+  const producerDirectory = join(testRoot, producerName)
+  const sourceDirectory = join(testRoot, sourceName)
   const producer = createWalProducer(producerDirectory)
   const initialMain = fs.readFileSync(producer.path)
   const walBytes = fs.readFileSync(`${producer.path}-wal`)
@@ -114,14 +118,60 @@ function createWalModeMainOnly(testRoot: string): {
   return { sourcePath, sourceDirectory, walBytes, producer: producer.db }
 }
 
-function createRollbackSource(testRoot: string): { sourcePath: string; sourceDirectory: string } {
-  const sourceDirectory = join(testRoot, 'rollback-source')
+function createRollbackSource(testRoot: string, value = 'rollback-row', directoryName = 'rollback-source'): { sourcePath: string; sourceDirectory: string } {
+  const sourceDirectory = join(testRoot, directoryName)
   fs.mkdirSync(sourceDirectory, { recursive: true })
   const sourcePath = join(sourceDirectory, 'source.sqlite')
   const db = new (databaseConstructor())(sourcePath)
-  db.exec('CREATE TABLE items (id INTEGER PRIMARY KEY, value TEXT NOT NULL); INSERT INTO items VALUES (1, \'rollback-row\');')
+  db.exec('CREATE TABLE items (id INTEGER PRIMARY KEY, value TEXT NOT NULL)')
+  db.prepare('INSERT INTO items (id, value) VALUES (?, ?)').run(1, value)
   db.close()
   return { sourcePath, sourceDirectory }
+}
+
+function createImmutableWalSource(testRoot: string, value: string, directoryName: string): { sourcePath: string; sourceDirectory: string } {
+  const sourceDirectory = join(testRoot, directoryName)
+  fs.mkdirSync(sourceDirectory, { recursive: true })
+  const sourcePath = join(sourceDirectory, 'source.sqlite')
+  const db = new (databaseConstructor())(sourcePath)
+  producers.push(db)
+  db.exec(`
+    PRAGMA journal_mode=WAL;
+    PRAGMA wal_autocheckpoint=0;
+    CREATE TABLE items (id INTEGER PRIMARY KEY, value TEXT NOT NULL);
+  `)
+  db.prepare('INSERT INTO items (id, value) VALUES (?, ?)').run(1, value)
+  db.exec('PRAGMA wal_checkpoint(TRUNCATE)')
+  db.close()
+  return { sourcePath, sourceDirectory }
+}
+function replaceSourceFile(sourcePath: string, replacementPath: string): void {
+  const temporaryPath = join(dirname(sourcePath), `.replacement-${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}`)
+  try {
+    fs.copyFileSync(replacementPath, temporaryPath)
+    if (process.platform === 'win32') {
+      fs.copyFileSync(temporaryPath, sourcePath)
+    } else {
+      fs.renameSync(temporaryPath, sourcePath)
+    }
+  } finally {
+    if (fs.existsSync(temporaryPath)) fs.rmSync(temporaryPath, { force: true })
+  }
+}
+
+function publishWalPair(sourcePath: string, producerPath: string): void {
+  const suffix = `.wal-replacement-${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}`
+  const mainTemporaryPath = `${sourcePath}${suffix}`
+  const walTemporaryPath = `${sourcePath}-wal${suffix}`
+  try {
+    fs.copyFileSync(producerPath, mainTemporaryPath)
+    fs.copyFileSync(`${producerPath}-wal`, walTemporaryPath)
+    fs.renameSync(walTemporaryPath, `${sourcePath}-wal`)
+    fs.renameSync(mainTemporaryPath, sourcePath)
+  } finally {
+    if (fs.existsSync(mainTemporaryPath)) fs.rmSync(mainTemporaryPath, { force: true })
+    if (fs.existsSync(walTemporaryPath)) fs.rmSync(walTemporaryPath, { force: true })
+  }
 }
 
 afterEach(() => {
@@ -159,7 +209,9 @@ sqliteDescribe('shared SQLite source-safe reads', () => {
     const before = directorySnapshot(source.sourceDirectory)
 
     const snapshotCopy = vi.spyOn(fs, 'copyFileSync')
+    const sourceStats = vi.spyOn(fs, 'statSync')
     const db = openDatabase(source.sourcePath)
+    const statsAfterOpen = sourceStats.mock.calls.length
     expect(db.query<{ value: string }>('SELECT value FROM items')).toEqual([{ value: 'wal-row' }])
     expect(db.query<{ value: string }>('SELECT value FROM items')).toEqual([{ value: 'wal-row' }])
     expect(snapshotDirectories(cache)).toHaveLength(1)
@@ -240,6 +292,33 @@ sqliteDescribe('shared SQLite source-safe reads', () => {
     expect(snapshotDirectories(cache)).toEqual([])
   })
 
+  it('keeps fallback authority available when CANTOPEN has no live WAL yet', () => {
+    const testRoot = root('metrora-sqlite-safe-two-stage-fallback-')
+    const cache = cacheFor(testRoot)
+    const source = createWalModeMainOnly(testRoot)
+    const db = openDatabase(source.sourcePath)
+    const DatabaseSync = databaseConstructor()
+    const originalPrepare = DatabaseSync.prototype.prepare
+    let failOnce = true
+
+    vi.spyOn(DatabaseSync.prototype, 'prepare').mockImplementation(function (this: TestDatabase, sql: string) {
+      if (failOnce) {
+        failOnce = false
+        throw Object.assign(new Error('unable to open database file'), { code: 'ERR_SQLITE_ERROR', errcode: 14 })
+      }
+      return originalPrepare.call(this, sql)
+    })
+
+    expect(() => db.query('SELECT value FROM items')).toThrow(/unable to open database file/i)
+    expect(snapshotDirectories(cache)).toEqual([])
+
+    fs.writeFileSync(`${source.sourcePath}-wal`, source.walBytes)
+    expect(db.query<{ value: string }>('SELECT value FROM items')).toEqual([{ value: 'wal-row' }])
+    expect(snapshotDirectories(cache)).toHaveLength(1)
+    db.close()
+
+  })
+
   it('uses the immutable URI for a WAL-mode main file with no live WAL', () => {
     const testRoot = root('metrora-sqlite-safe-immutable-')
     const cache = cacheFor(testRoot)
@@ -252,6 +331,76 @@ sqliteDescribe('shared SQLite source-safe reads', () => {
 
     expect(directorySnapshot(source.sourceDirectory)).toEqual(before)
     expect(fs.existsSync(`${source.sourcePath}-shm`)).toBe(false)
+    expect(snapshotDirectories(cache)).toEqual([])
+  })
+
+  it('reclassifies direct readers after pathname rotation', () => {
+    const testRoot = root('metrora-sqlite-safe-direct-rotation-')
+    const cache = cacheFor(testRoot)
+    const oldSource = createRollbackSource(testRoot, 'old-row', 'rotation-old')
+    const nextSource = createRollbackSource(testRoot, 'new-row', 'rotation-new')
+    const nextBefore = directorySnapshot(nextSource.sourceDirectory)
+    const db = openDatabase(oldSource.sourcePath)
+
+    replaceSourceFile(oldSource.sourcePath, nextSource.sourcePath)
+    expect(db.query<{ value: string }>('SELECT value FROM items')).toEqual([{ value: 'new-row' }])
+    db.close()
+
+    expect(directorySnapshot(nextSource.sourceDirectory)).toEqual(nextBefore)
+    expect(fs.existsSync(`${oldSource.sourcePath}-wal`)).toBe(false)
+    expect(fs.existsSync(`${oldSource.sourcePath}-shm`)).toBe(false)
+  })
+
+  it('reclassifies immutable readers after pathname rotation', () => {
+    const testRoot = root('metrora-sqlite-safe-immutable-rotation-')
+    const cache = cacheFor(testRoot)
+    const oldSource = createImmutableWalSource(testRoot, 'old-row', 'immutable-old')
+    const nextSource = createImmutableWalSource(testRoot, 'new-row', 'immutable-new')
+    const db = openDatabase(oldSource.sourcePath)
+
+    replaceSourceFile(oldSource.sourcePath, nextSource.sourcePath)
+    expect(db.query<{ value: string }>('SELECT value FROM items')).toEqual([{ value: 'new-row' }])
+    db.close()
+
+    expect(fs.existsSync(`${oldSource.sourcePath}-shm`)).toBe(false)
+    expect(snapshotDirectories(cache)).toEqual([])
+  })
+  it('reclassifies immutable readers after an in-place main-file change', () => {
+    const testRoot = root('metrora-sqlite-safe-immutable-change-')
+    const cache = cacheFor(testRoot)
+    const oldSource = createImmutableWalSource(testRoot, 'old-row', 'immutable-change-old')
+    const nextSource = createImmutableWalSource(testRoot, 'new-row', 'immutable-change-new')
+    const db = openDatabase(oldSource.sourcePath)
+
+    fs.copyFileSync(nextSource.sourcePath, oldSource.sourcePath)
+    const touched = new Date(Date.now() + 2000)
+    fs.utimesSync(oldSource.sourcePath, touched, touched)
+    expect(db.query<{ value: string }>('SELECT value FROM items')).toEqual([{ value: 'new-row' }])
+    db.close()
+
+  })
+
+  it('uses lightweight source probes in direct and immutable steady state', () => {
+    const testRoot = root('metrora-sqlite-safe-preflight-')
+    const cache = cacheFor(testRoot)
+    const sourceStats = vi.spyOn(fs, 'openSync')
+    const directSource = createRollbackSource(testRoot, 'direct-row', 'preflight-direct')
+    const direct = openDatabase(directSource.sourcePath)
+    const directOpenCount = sourceStats.mock.calls.length
+    for (let index = 0; index < 20; index++) {
+      expect(direct.query<{ value: string }>('SELECT value FROM items')).toEqual([{ value: 'direct-row' }])
+    }
+    expect(sourceStats.mock.calls.length).toBe(directOpenCount)
+    direct.close()
+
+    const immutableSource = createImmutableWalSource(testRoot, 'immutable-row', 'preflight-immutable')
+    const immutable = openDatabase(immutableSource.sourcePath)
+    const immutableOpenCount = sourceStats.mock.calls.length
+    for (let index = 0; index < 20; index++) {
+      expect(immutable.query<{ value: string }>('SELECT value FROM items')).toEqual([{ value: 'immutable-row' }])
+    }
+    expect(sourceStats.mock.calls.length).toBe(immutableOpenCount)
+    immutable.close()
     expect(snapshotDirectories(cache)).toEqual([])
   })
 
@@ -282,6 +431,33 @@ sqliteDescribe('shared SQLite source-safe reads', () => {
     expect(snapshotDirectories(cache)).toEqual([])
   })
 
+  it.skipIf(process.platform === 'win32')('promotes an existing direct reader when rollback mode becomes live WAL', () => {
+    const testRoot = root('metrora-sqlite-safe-rollback-to-wal-')
+    const cache = cacheFor(testRoot)
+    const source = createRollbackSource(testRoot, 'rollback-row', 'rollback-to-wal-source')
+    const producer = createActiveWalSource(testRoot)
+    const db = openDatabase(source.sourcePath)
+
+    publishWalPair(source.sourcePath, producer.sourcePath)
+    expect(db.query<{ value: string }>('SELECT value FROM items')).toEqual([{ value: 'wal-row' }])
+    expect(snapshotDirectories(cache)).toHaveLength(1)
+    db.close()
+
+    expect(fs.existsSync(`${source.sourcePath}-shm`)).toBe(false)
+    expect(snapshotDirectories(cache)).toEqual([])
+  })
+
+  it.skipIf(process.platform === 'win32')('fails clearly when the current source disappears', () => {
+    const testRoot = root('metrora-sqlite-safe-disappearance-')
+    const cache = cacheFor(testRoot)
+    const source = createRollbackSource(testRoot)
+    const db = openDatabase(source.sourcePath)
+
+    fs.unlinkSync(source.sourcePath)
+    expect(() => db.query('SELECT value FROM items')).toThrow(/disappeared|replaced|unavailable/i)
+    db.close()
+  })
+
   it('keeps concurrent reader snapshots collision-free and cleans them on close', () => {
     const testRoot = root('metrora-sqlite-safe-concurrent-')
     const cache = cacheFor(testRoot)
@@ -299,12 +475,36 @@ sqliteDescribe('shared SQLite source-safe reads', () => {
     expect(snapshotDirectories(cache)).toEqual([])
   })
 
+  it('does not reclaim an active snapshot whose owner appears stale by wall clock', () => {
+    const testRoot = root('metrora-sqlite-safe-active-owner-')
+    const cache = cacheFor(testRoot)
+    const source = createActiveWalSource(testRoot)
+    const first = openDatabase(source.sourcePath)
+    const firstDirectory = join(cache, 'sqlite-source-snapshots', snapshotDirectories(cache)[0])
+    const old = new Date(Date.now() - 2 * 24 * 60 * 60 * 1000)
+    fs.utimesSync(firstDirectory, old, old)
+
+    const second = openDatabase(source.sourcePath)
+    expect(snapshotDirectories(cache)).toHaveLength(2)
+    expect(fs.existsSync(firstDirectory)).toBe(true)
+    expect(first.query<{ value: string }>('SELECT value FROM items')).toEqual([{ value: 'wal-row' }])
+    second.close()
+    expect(fs.existsSync(firstDirectory)).toBe(true)
+    first.close()
+    expect(snapshotDirectories(cache)).toEqual([])
+  })
+
   it('removes stale owned material before opening and cleans the active snapshot on close', () => {
     const testRoot = root('metrora-sqlite-safe-cleanup-')
     const cache = cacheFor(testRoot)
     const snapshotRoot = join(cache, 'sqlite-source-snapshots')
     const stale = join(snapshotRoot, 'sqlite-source-read-stale')
     fs.mkdirSync(stale, { recursive: true })
+    const stalePid = Number.MAX_SAFE_INTEGER
+    fs.writeFileSync(join(stale, '.owner.json'), JSON.stringify({ pid: stalePid, token: 'abandoned', createdAtMs: Date.now() - 2 * 24 * 60 * 60 * 1000 }))
+    vi.spyOn(process, 'kill').mockImplementation(() => {
+      throw Object.assign(new Error('owner is gone'), { code: 'ESRCH' })
+    })
     const old = new Date(Date.now() - 2 * 24 * 60 * 60 * 1000)
     fs.utimesSync(stale, old, old)
 
@@ -314,6 +514,22 @@ sqliteDescribe('shared SQLite source-safe reads', () => {
     expect(snapshotDirectories(cache)).toHaveLength(1)
     db.close()
     expect(snapshotDirectories(cache)).toEqual([])
+  })
+
+  it('does not reclaim stale material when ownership is ambiguous', () => {
+    const testRoot = root('metrora-sqlite-safe-ambiguous-owner-')
+    const cache = cacheFor(testRoot)
+    const snapshotRoot = join(cache, 'sqlite-source-snapshots')
+    const ambiguous = join(snapshotRoot, 'sqlite-source-read-ambiguous')
+    fs.mkdirSync(ambiguous, { recursive: true })
+    const old = new Date(Date.now() - 2 * 24 * 60 * 60 * 1000)
+    fs.utimesSync(ambiguous, old, old)
+
+    const source = createActiveWalSource(testRoot)
+    const db = openDatabase(source.sourcePath)
+    expect(fs.existsSync(ambiguous)).toBe(true)
+    db.close()
+    expect(fs.existsSync(ambiguous)).toBe(true)
   })
 
   it('does not retry unrelated SQL errors or create a snapshot', () => {

--- a/tests/sqlite-source-safe-read.test.ts
+++ b/tests/sqlite-source-safe-read.test.ts
@@ -328,6 +328,25 @@ sqliteDescribe('shared SQLite source-safe reads', () => {
     expect(snapshotDirectories(cache)).toEqual([])
   })
 
+  it('does not promote a CANTOPEN error without live WAL evidence', () => {
+    const testRoot = root('metrora-sqlite-safe-unrelated-cantopen-')
+    const cache = cacheFor(testRoot)
+    const source = createRollbackSource(testRoot)
+    const db = openDatabase(source.sourcePath)
+    const DatabaseSync = databaseConstructor()
+
+    vi.spyOn(DatabaseSync.prototype, 'prepare').mockImplementation(() => {
+      throw Object.assign(new Error('unable to open database file'), {
+        code: 'ERR_SQLITE_ERROR',
+        errcode: 14,
+      })
+    })
+
+    expect(() => db.query('SELECT value FROM items')).toThrow(/unable to open database file/i)
+    db.close()
+    expect(snapshotDirectories(cache)).toEqual([])
+  })
+
   it('preserves busy/locked classification and excludes it from source-safe fallback', () => {
     const busy = { code: 'ERR_SQLITE_ERROR', errcode: 5, errstr: 'database is locked' }
     expect(isSqliteBusyError(busy)).toBe(true)
@@ -350,21 +369,3 @@ sqliteDescribe('shared SQLite source-safe reads', () => {
     expect(snapshotDirectories(cache)).toEqual([])
   })
 })
-  it('does not promote a CANTOPEN error without live WAL evidence', () => {
-    const testRoot = root('metrora-sqlite-safe-unrelated-cantopen-')
-    const cache = cacheFor(testRoot)
-    const source = createRollbackSource(testRoot)
-    const db = openDatabase(source.sourcePath)
-    const DatabaseSync = databaseConstructor()
-
-    vi.spyOn(DatabaseSync.prototype, 'prepare').mockImplementation(() => {
-      throw Object.assign(new Error('unable to open database file'), {
-        code: 'ERR_SQLITE_ERROR',
-        errcode: 14,
-      })
-    })
-
-    expect(() => db.query('SELECT value FROM items')).toThrow(/unable to open database file/i)
-    db.close()
-    expect(snapshotDirectories(cache)).toEqual([])
-  })

--- a/tests/sqlite-source-safe-read.test.ts
+++ b/tests/sqlite-source-safe-read.test.ts
@@ -1,0 +1,370 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import fs from 'node:fs'
+import { createRequire } from 'node:module'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import {
+  isSqliteAvailable,
+  isSqliteBusyError,
+  isSqliteSourceSafeReadError,
+  openDatabase,
+} from '../src/sqlite.js'
+
+const requireForTest = createRequire(import.meta.url)
+
+type Statement = { run(...params: unknown[]): unknown }
+type TestDatabase = {
+  exec(sql: string): void
+  prepare(sql: string): Statement
+  close(): void
+}
+type DatabaseConstructor = {
+  new (path: string, options?: { readOnly?: boolean }): TestDatabase
+  prototype: TestDatabase
+}
+
+const roots: string[] = []
+const producers: TestDatabase[] = []
+
+function databaseConstructor(): DatabaseConstructor {
+  return (requireForTest('node:sqlite') as { DatabaseSync: DatabaseConstructor }).DatabaseSync
+}
+
+function root(prefix: string): string {
+  const path = fs.mkdtempSync(join(tmpdir(), prefix))
+  roots.push(path)
+  return path
+}
+
+function cacheFor(testRoot: string): string {
+  const cache = join(testRoot, 'metrora-cache')
+  vi.stubEnv('METRORA_CACHE_DIR', cache)
+  return cache
+}
+
+function snapshotDirectories(cache: string): string[] {
+  const snapshotRoot = join(cache, 'sqlite-source-snapshots')
+  try {
+    return fs.readdirSync(snapshotRoot, { withFileTypes: true })
+      .filter(entry => entry.isDirectory() && entry.name.startsWith('sqlite-source-read-'))
+      .map(entry => entry.name)
+      .sort()
+  } catch {
+    return []
+  }
+}
+
+function directorySnapshot(directory: string): Array<[string, string]> {
+  return fs.readdirSync(directory)
+    .sort()
+    .map(name => [name, fs.readFileSync(join(directory, name)).toString('base64')])
+}
+
+function createWalProducer(directory: string): { path: string; db: TestDatabase } {
+  fs.mkdirSync(directory, { recursive: true })
+  const path = join(directory, 'source.sqlite')
+  const db = new (databaseConstructor())(path)
+  producers.push(db)
+  db.exec(`
+    PRAGMA journal_mode=WAL;
+    PRAGMA wal_autocheckpoint=0;
+    CREATE TABLE items (id INTEGER PRIMARY KEY, value TEXT NOT NULL);
+    PRAGMA wal_checkpoint(TRUNCATE);
+  `)
+  db.prepare('INSERT INTO items (id, value) VALUES (?, ?)').run(1, 'wal-row')
+  return { path, db }
+}
+
+function createActiveWalSource(testRoot: string): { sourcePath: string; sourceDirectory: string; producer: TestDatabase } {
+  const sourceDirectory = join(testRoot, 'active-source')
+  const producer = createWalProducer(sourceDirectory)
+  return { sourcePath: producer.path, sourceDirectory, producer: producer.db }
+}
+
+function createCopiedWalSource(testRoot: string): { sourcePath: string; sourceDirectory: string; producer: TestDatabase } {
+  const producerDirectory = join(testRoot, 'producer-source')
+  const sourceDirectory = join(testRoot, 'copied-source')
+  const producer = createWalProducer(producerDirectory)
+  fs.mkdirSync(sourceDirectory, { recursive: true })
+  const sourcePath = join(sourceDirectory, 'source.sqlite')
+  fs.copyFileSync(producer.path, sourcePath)
+  fs.copyFileSync(`${producer.path}-wal`, `${sourcePath}-wal`)
+  // Deliberately omit -shm: it is a derived coordination file, never source
+  // authority for the Metrora snapshot.
+  return { sourcePath, sourceDirectory, producer: producer.db }
+}
+
+function createWalModeMainOnly(testRoot: string): {
+  sourcePath: string
+  sourceDirectory: string
+  walBytes: Buffer
+  producer: TestDatabase
+} {
+  const producerDirectory = join(testRoot, 'producer-main-only')
+  const sourceDirectory = join(testRoot, 'main-only-source')
+  const producer = createWalProducer(producerDirectory)
+  const initialMain = fs.readFileSync(producer.path)
+  const walBytes = fs.readFileSync(`${producer.path}-wal`)
+  fs.mkdirSync(sourceDirectory, { recursive: true })
+  const sourcePath = join(sourceDirectory, 'source.sqlite')
+  fs.writeFileSync(sourcePath, initialMain)
+  // The source starts WAL-mode with no live WAL. The bytes are published by a
+  // deterministic query-time test hook to model a producer racing the reader.
+  return { sourcePath, sourceDirectory, walBytes, producer: producer.db }
+}
+
+function createRollbackSource(testRoot: string): { sourcePath: string; sourceDirectory: string } {
+  const sourceDirectory = join(testRoot, 'rollback-source')
+  fs.mkdirSync(sourceDirectory, { recursive: true })
+  const sourcePath = join(sourceDirectory, 'source.sqlite')
+  const db = new (databaseConstructor())(sourcePath)
+  db.exec('CREATE TABLE items (id INTEGER PRIMARY KEY, value TEXT NOT NULL); INSERT INTO items VALUES (1, \'rollback-row\');')
+  db.close()
+  return { sourcePath, sourceDirectory }
+}
+
+afterEach(() => {
+  for (const producer of producers.splice(0)) {
+    try { producer.close() } catch { /* fixture cleanup */ }
+  }
+  vi.restoreAllMocks()
+  vi.unstubAllEnvs()
+  for (const path of roots.splice(0)) {
+    fs.rmSync(path, { recursive: true, force: true })
+  }
+})
+
+const sqliteDescribe = isSqliteAvailable() ? describe : describe.skip
+
+sqliteDescribe('shared SQLite source-safe reads', () => {
+  it('reads an ordinary rollback-journal database without changing its directory', () => {
+    const testRoot = root('metrora-sqlite-safe-rollback-')
+    const cache = cacheFor(testRoot)
+    const source = createRollbackSource(testRoot)
+    const before = directorySnapshot(source.sourceDirectory)
+
+    const db = openDatabase(source.sourcePath)
+    expect(db.query<{ value: string }>('SELECT value FROM items')).toEqual([{ value: 'rollback-row' }])
+    db.close()
+
+    expect(directorySnapshot(source.sourceDirectory)).toEqual(before)
+    expect(snapshotDirectories(cache)).toEqual([])
+  })
+
+  it('reads committed rows from a live WAL without touching the producer directory', () => {
+    const testRoot = root('metrora-sqlite-safe-wal-')
+    const cache = cacheFor(testRoot)
+    const source = createActiveWalSource(testRoot)
+    const before = directorySnapshot(source.sourceDirectory)
+
+    const snapshotCopy = vi.spyOn(fs, 'copyFileSync')
+    const db = openDatabase(source.sourcePath)
+    expect(db.query<{ value: string }>('SELECT value FROM items')).toEqual([{ value: 'wal-row' }])
+    expect(db.query<{ value: string }>('SELECT value FROM items')).toEqual([{ value: 'wal-row' }])
+    expect(snapshotDirectories(cache)).toHaveLength(1)
+    expect(snapshotCopy).toHaveBeenCalledTimes(2)
+    db.close()
+
+    expect(directorySnapshot(source.sourceDirectory)).toEqual(before)
+    expect(snapshotDirectories(cache)).toEqual([])
+  })
+
+  it('reads a WAL with missing SHM from a read-only parent where permissions are enforceable', () => {
+    const testRoot = root('metrora-sqlite-safe-missing-shm-')
+    const cache = cacheFor(testRoot)
+    const source = createCopiedWalSource(testRoot)
+    const before = directorySnapshot(source.sourceDirectory)
+    let restorePermissions: (() => void) | undefined
+
+    if (process.platform !== 'win32') {
+      const mode = fs.statSync(source.sourceDirectory).mode & 0o777
+      fs.chmodSync(source.sourceDirectory, 0o555)
+      restorePermissions = () => fs.chmodSync(source.sourceDirectory, mode)
+    }
+
+    try {
+      const db = openDatabase(source.sourcePath)
+      expect(db.query<{ value: string }>('SELECT value FROM items')).toEqual([{ value: 'wal-row' }])
+      db.close()
+    } finally {
+      restorePermissions?.()
+    }
+
+    expect(fs.existsSync(`${source.sourcePath}-shm`)).toBe(false)
+    expect(directorySnapshot(source.sourceDirectory)).toEqual(before)
+    expect(snapshotDirectories(cache)).toEqual([])
+  })
+
+  it('does not create SHM beside a writable WAL source either', () => {
+    const testRoot = root('metrora-sqlite-safe-writable-wal-')
+    const cache = cacheFor(testRoot)
+    const source = createCopiedWalSource(testRoot)
+    const before = directorySnapshot(source.sourceDirectory)
+
+    const db = openDatabase(source.sourcePath)
+    expect(db.query<{ value: string }>('SELECT value FROM items')).toEqual([{ value: 'wal-row' }])
+    db.close()
+
+    expect(fs.existsSync(`${source.sourcePath}-shm`)).toBe(false)
+    expect(directorySnapshot(source.sourceDirectory)).toEqual(before)
+    expect(snapshotDirectories(cache)).toEqual([])
+  })
+
+  it('promotes after a constructor-success/query-time CANTOPEN boundary failure and retries once', () => {
+    const testRoot = root('metrora-sqlite-safe-query-fallback-')
+    const cache = cacheFor(testRoot)
+    const source = createWalModeMainOnly(testRoot)
+    const db = openDatabase(source.sourcePath)
+    const DatabaseSync = databaseConstructor()
+    const originalPrepare = DatabaseSync.prototype.prepare
+    let injectFailure = true
+
+    vi.spyOn(DatabaseSync.prototype, 'prepare').mockImplementation(function (this: TestDatabase, sql: string) {
+      if (injectFailure) {
+        injectFailure = false
+        fs.writeFileSync(`${source.sourcePath}-wal`, source.walBytes)
+        throw Object.assign(new Error('unable to open database file'), {
+          code: 'ERR_SQLITE_ERROR',
+          errcode: 14,
+          errstr: 'unable to open database file',
+        })
+      }
+      return originalPrepare.call(this, sql)
+    })
+
+    expect(db.query<{ value: string }>('SELECT value FROM items')).toEqual([{ value: 'wal-row' }])
+    db.close()
+
+    expect(fs.existsSync(`${source.sourcePath}-shm`)).toBe(false)
+    expect(snapshotDirectories(cache)).toEqual([])
+  })
+
+  it('uses the immutable URI for a WAL-mode main file with no live WAL', () => {
+    const testRoot = root('metrora-sqlite-safe-immutable-')
+    const cache = cacheFor(testRoot)
+    const source = createWalModeMainOnly(testRoot)
+    const before = directorySnapshot(source.sourceDirectory)
+
+    const db = openDatabase(source.sourcePath)
+    expect(db.query('SELECT name FROM sqlite_master WHERE type = \'table\'')).toEqual([{ name: 'items' }])
+    db.close()
+
+    expect(directorySnapshot(source.sourceDirectory)).toEqual(before)
+    expect(fs.existsSync(`${source.sourcePath}-shm`)).toBe(false)
+    expect(snapshotDirectories(cache)).toEqual([])
+  })
+
+  it('rejects an unstable WAL copy, retries, and publishes only the stable pair', () => {
+    const testRoot = root('metrora-sqlite-safe-retry-')
+    const cache = cacheFor(testRoot)
+    const source = createActiveWalSource(testRoot)
+    const realCopyFileSync = fs.copyFileSync
+    let copyCalls = 0
+
+    vi.spyOn(fs, 'copyFileSync').mockImplementation((from: fs.PathLike, to: fs.PathLike, mode?: number) => {
+      const result = realCopyFileSync(from, to, mode)
+      copyCalls++
+      if (copyCalls === 1) {
+        source.producer.prepare('INSERT INTO items (id, value) VALUES (?, ?)').run(2, 'during-copy')
+      }
+      return result
+    })
+
+    const db = openDatabase(source.sourcePath)
+    expect(db.query<{ value: string }>('SELECT value FROM items ORDER BY id')).toEqual([
+      { value: 'wal-row' },
+      { value: 'during-copy' },
+    ])
+    expect(copyCalls).toBeGreaterThanOrEqual(4)
+    expect(snapshotDirectories(cache)).toHaveLength(1)
+    db.close()
+    expect(snapshotDirectories(cache)).toEqual([])
+  })
+
+  it('keeps concurrent reader snapshots collision-free and cleans them on close', () => {
+    const testRoot = root('metrora-sqlite-safe-concurrent-')
+    const cache = cacheFor(testRoot)
+    const source = createActiveWalSource(testRoot)
+    const readers = Array.from({ length: 4 }, () => openDatabase(source.sourcePath))
+
+    const directories = snapshotDirectories(cache)
+    expect(directories).toHaveLength(4)
+    expect(new Set(directories).size).toBe(4)
+    for (const reader of readers) {
+      expect(reader.query<{ value: string }>('SELECT value FROM items')).toEqual([{ value: 'wal-row' }])
+    }
+    for (const reader of readers) reader.close()
+
+    expect(snapshotDirectories(cache)).toEqual([])
+  })
+
+  it('removes stale owned material before opening and cleans the active snapshot on close', () => {
+    const testRoot = root('metrora-sqlite-safe-cleanup-')
+    const cache = cacheFor(testRoot)
+    const snapshotRoot = join(cache, 'sqlite-source-snapshots')
+    const stale = join(snapshotRoot, 'sqlite-source-read-stale')
+    fs.mkdirSync(stale, { recursive: true })
+    const old = new Date(Date.now() - 2 * 24 * 60 * 60 * 1000)
+    fs.utimesSync(stale, old, old)
+
+    const source = createActiveWalSource(testRoot)
+    const db = openDatabase(source.sourcePath)
+    expect(fs.existsSync(stale)).toBe(false)
+    expect(snapshotDirectories(cache)).toHaveLength(1)
+    db.close()
+    expect(snapshotDirectories(cache)).toEqual([])
+  })
+
+  it('does not retry unrelated SQL errors or create a snapshot', () => {
+    const testRoot = root('metrora-sqlite-safe-query-error-')
+    const cache = cacheFor(testRoot)
+    const source = createRollbackSource(testRoot)
+    const db = openDatabase(source.sourcePath)
+
+    expect(() => db.query('SELECT * FROM missing_table')).toThrow(/no such table/i)
+    db.close()
+
+    expect(snapshotDirectories(cache)).toEqual([])
+  })
+
+  it('preserves busy/locked classification and excludes it from source-safe fallback', () => {
+    const busy = { code: 'ERR_SQLITE_ERROR', errcode: 5, errstr: 'database is locked' }
+    expect(isSqliteBusyError(busy)).toBe(true)
+    expect(isSqliteSourceSafeReadError(busy)).toBe(false)
+    expect(isSqliteSourceSafeReadError({ code: 'ERR_SQLITE_ERROR', errcode: 14, errstr: 'unable to open database file' })).toBe(true)
+  })
+
+  it('surfaces malformed SQLite instead of turning it into an empty read', () => {
+    const testRoot = root('metrora-sqlite-safe-corrupt-')
+    const cache = cacheFor(testRoot)
+    const sourceDirectory = join(testRoot, 'corrupt-source')
+    fs.mkdirSync(sourceDirectory, { recursive: true })
+    const sourcePath = join(sourceDirectory, 'source.sqlite')
+    fs.writeFileSync(sourcePath, 'not a sqlite database')
+
+    const db = openDatabase(sourcePath)
+    expect(() => db.query('SELECT * FROM items')).toThrow()
+    db.close()
+
+    expect(snapshotDirectories(cache)).toEqual([])
+  })
+})
+  it('does not promote a CANTOPEN error without live WAL evidence', () => {
+    const testRoot = root('metrora-sqlite-safe-unrelated-cantopen-')
+    const cache = cacheFor(testRoot)
+    const source = createRollbackSource(testRoot)
+    const db = openDatabase(source.sourcePath)
+    const DatabaseSync = databaseConstructor()
+
+    vi.spyOn(DatabaseSync.prototype, 'prepare').mockImplementation(() => {
+      throw Object.assign(new Error('unable to open database file'), {
+        code: 'ERR_SQLITE_ERROR',
+        errcode: 14,
+      })
+    })
+
+    expect(() => db.query('SELECT value FROM items')).toThrow(/unable to open database file/i)
+    db.close()
+    expect(snapshotDirectories(cache)).toEqual([])
+  })

--- a/tests/sqlite-source-safe-read.test.ts
+++ b/tests/sqlite-source-safe-read.test.ts
@@ -7,8 +7,8 @@ import { dirname, join } from 'node:path'
 import {
   isSqliteAvailable,
   isSqliteBusyError,
-  isSqliteSourceSafeReadError,
   openDatabase,
+  type SqliteDatabase,
 } from '../src/sqlite.js'
 
 const requireForTest = createRequire(import.meta.url)
@@ -26,6 +26,7 @@ type DatabaseConstructor = {
 
 const roots: string[] = []
 const producers: TestDatabase[] = []
+const readers: SqliteDatabase[] = []
 
 function databaseConstructor(): DatabaseConstructor {
   return (requireForTest('node:sqlite') as { DatabaseSync: DatabaseConstructor }).DatabaseSync
@@ -43,6 +44,12 @@ function cacheFor(testRoot: string): string {
   return cache
 }
 
+function openTracked(path: string): SqliteDatabase {
+  const db = openDatabase(path)
+  readers.push(db)
+  return db
+}
+
 function snapshotDirectories(cache: string): string[] {
   const snapshotRoot = join(cache, 'sqlite-source-snapshots')
   try {
@@ -56,9 +63,13 @@ function snapshotDirectories(cache: string): string[] {
 }
 
 function directorySnapshot(directory: string): Array<[string, string]> {
-  return fs.readdirSync(directory)
-    .sort()
-    .map(name => [name, fs.readFileSync(join(directory, name)).toString('base64')])
+  try {
+    return fs.readdirSync(directory)
+      .sort()
+      .map(name => [name, fs.readFileSync(join(directory, name)).toString('base64')])
+  } catch {
+    return []
+  }
 }
 
 function createWalProducer(directory: string): { path: string; db: TestDatabase } {
@@ -66,32 +77,38 @@ function createWalProducer(directory: string): { path: string; db: TestDatabase 
   const path = join(directory, 'source.sqlite')
   const db = new (databaseConstructor())(path)
   producers.push(db)
-  db.exec(`
-    PRAGMA journal_mode=WAL;
-    PRAGMA wal_autocheckpoint=0;
-    CREATE TABLE items (id INTEGER PRIMARY KEY, value TEXT NOT NULL);
-    PRAGMA wal_checkpoint(TRUNCATE);
-  `)
+  db.exec(
+    'PRAGMA journal_mode=WAL;\n' +
+    'PRAGMA wal_autocheckpoint=0;\n' +
+    'CREATE TABLE items (id INTEGER PRIMARY KEY, value TEXT NOT NULL);\n' +
+    'PRAGMA wal_checkpoint(TRUNCATE);',
+  )
   db.prepare('INSERT INTO items (id, value) VALUES (?, ?)').run(1, 'wal-row')
   return { path, db }
 }
 
-function createActiveWalSource(testRoot: string): { sourcePath: string; sourceDirectory: string; producer: TestDatabase } {
+function createActiveWalSource(testRoot: string): {
+  sourcePath: string
+  sourceDirectory: string
+  producer: TestDatabase
+} {
   const sourceDirectory = join(testRoot, 'active-source')
   const producer = createWalProducer(sourceDirectory)
   return { sourcePath: producer.path, sourceDirectory, producer: producer.db }
 }
 
-function createCopiedWalSource(testRoot: string): { sourcePath: string; sourceDirectory: string; producer: TestDatabase } {
+function createCopiedWalSource(testRoot: string): {
+  sourcePath: string
+  sourceDirectory: string
+  producer: TestDatabase
+} {
   const producerDirectory = join(testRoot, 'producer-source')
   const sourceDirectory = join(testRoot, 'copied-source')
   const producer = createWalProducer(producerDirectory)
   fs.mkdirSync(sourceDirectory, { recursive: true })
   const sourcePath = join(sourceDirectory, 'source.sqlite')
   fs.copyFileSync(producer.path, sourcePath)
-  fs.copyFileSync(`${producer.path}-wal`, `${sourcePath}-wal`)
-  // Deliberately omit -shm: it is a derived coordination file, never source
-  // authority for the Metrora snapshot.
+  fs.copyFileSync(producer.path + '-wal', sourcePath + '-wal')
   return { sourcePath, sourceDirectory, producer: producer.db }
 }
 
@@ -109,16 +126,18 @@ function createWalModeMainOnly(
   const sourceDirectory = join(testRoot, sourceName)
   const producer = createWalProducer(producerDirectory)
   const initialMain = fs.readFileSync(producer.path)
-  const walBytes = fs.readFileSync(`${producer.path}-wal`)
+  const walBytes = fs.readFileSync(producer.path + '-wal')
   fs.mkdirSync(sourceDirectory, { recursive: true })
   const sourcePath = join(sourceDirectory, 'source.sqlite')
   fs.writeFileSync(sourcePath, initialMain)
-  // The source starts WAL-mode with no live WAL. The bytes are published by a
-  // deterministic query-time test hook to model a producer racing the reader.
   return { sourcePath, sourceDirectory, walBytes, producer: producer.db }
 }
 
-function createRollbackSource(testRoot: string, value = 'rollback-row', directoryName = 'rollback-source'): { sourcePath: string; sourceDirectory: string } {
+function createRollbackSource(
+  testRoot: string,
+  value = 'rollback-row',
+  directoryName = 'rollback-source',
+): { sourcePath: string; sourceDirectory: string } {
   const sourceDirectory = join(testRoot, directoryName)
   fs.mkdirSync(sourceDirectory, { recursive: true })
   const sourcePath = join(sourceDirectory, 'source.sqlite')
@@ -129,24 +148,32 @@ function createRollbackSource(testRoot: string, value = 'rollback-row', director
   return { sourcePath, sourceDirectory }
 }
 
-function createImmutableWalSource(testRoot: string, value: string, directoryName: string): { sourcePath: string; sourceDirectory: string } {
+function createWalModeSourceWithoutLiveWal(
+  testRoot: string,
+  value: string,
+  directoryName: string,
+): { sourcePath: string; sourceDirectory: string } {
   const sourceDirectory = join(testRoot, directoryName)
   fs.mkdirSync(sourceDirectory, { recursive: true })
   const sourcePath = join(sourceDirectory, 'source.sqlite')
   const db = new (databaseConstructor())(sourcePath)
   producers.push(db)
-  db.exec(`
-    PRAGMA journal_mode=WAL;
-    PRAGMA wal_autocheckpoint=0;
-    CREATE TABLE items (id INTEGER PRIMARY KEY, value TEXT NOT NULL);
-  `)
+  db.exec(
+    'PRAGMA journal_mode=WAL;\n' +
+    'PRAGMA wal_autocheckpoint=0;\n' +
+    'CREATE TABLE items (id INTEGER PRIMARY KEY, value TEXT NOT NULL);',
+  )
   db.prepare('INSERT INTO items (id, value) VALUES (?, ?)').run(1, value)
   db.exec('PRAGMA wal_checkpoint(TRUNCATE)')
   db.close()
   return { sourcePath, sourceDirectory }
 }
+
 function replaceSourceFile(sourcePath: string, replacementPath: string): void {
-  const temporaryPath = join(dirname(sourcePath), `.replacement-${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}`)
+  const temporaryPath = join(
+    dirname(sourcePath),
+    '.replacement-' + process.pid + '-' + Date.now() + '-' + Math.random().toString(16).slice(2),
+  )
   try {
     fs.copyFileSync(replacementPath, temporaryPath)
     if (process.platform === 'win32') {
@@ -160,14 +187,19 @@ function replaceSourceFile(sourcePath: string, replacementPath: string): void {
 }
 
 function publishWalPair(sourcePath: string, producerPath: string): void {
-  const suffix = `.wal-replacement-${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}`
-  const mainTemporaryPath = `${sourcePath}${suffix}`
-  const walTemporaryPath = `${sourcePath}-wal${suffix}`
+  const suffix = '.wal-replacement-' + process.pid + '-' + Date.now() + '-' + Math.random().toString(16).slice(2)
+  const mainTemporaryPath = sourcePath + suffix
+  const walTemporaryPath = sourcePath + '-wal' + suffix
   try {
     fs.copyFileSync(producerPath, mainTemporaryPath)
-    fs.copyFileSync(`${producerPath}-wal`, walTemporaryPath)
-    fs.renameSync(walTemporaryPath, `${sourcePath}-wal`)
-    fs.renameSync(mainTemporaryPath, sourcePath)
+    fs.copyFileSync(producerPath + '-wal', walTemporaryPath)
+    if (process.platform === 'win32') {
+      fs.copyFileSync(walTemporaryPath, sourcePath + '-wal')
+      fs.copyFileSync(mainTemporaryPath, sourcePath)
+    } else {
+      fs.renameSync(walTemporaryPath, sourcePath + '-wal')
+      fs.renameSync(mainTemporaryPath, sourcePath)
+    }
   } finally {
     if (fs.existsSync(mainTemporaryPath)) fs.rmSync(mainTemporaryPath, { force: true })
     if (fs.existsSync(walTemporaryPath)) fs.rmSync(walTemporaryPath, { force: true })
@@ -175,43 +207,45 @@ function publishWalPair(sourcePath: string, producerPath: string): void {
 }
 
 afterEach(() => {
+  for (const reader of readers.splice(0).reverse()) {
+    try { reader.close() } catch { /* fixture cleanup */ }
+  }
   for (const producer of producers.splice(0)) {
     try { producer.close() } catch { /* fixture cleanup */ }
   }
   vi.restoreAllMocks()
   vi.unstubAllEnvs()
   for (const path of roots.splice(0)) {
-    fs.rmSync(path, { recursive: true, force: true })
+    try { fs.rmSync(path, { recursive: true, force: true }) } catch { /* fixture cleanup */ }
   }
 })
 
 const sqliteDescribe = isSqliteAvailable() ? describe : describe.skip
 
 sqliteDescribe('shared SQLite source-safe reads', () => {
-  it('reads an ordinary rollback-journal database without changing its directory', () => {
+  it('snapshots an ordinary rollback database and leaves the producer directory unchanged', () => {
     const testRoot = root('metrora-sqlite-safe-rollback-')
     const cache = cacheFor(testRoot)
     const source = createRollbackSource(testRoot)
     const before = directorySnapshot(source.sourceDirectory)
 
-    const db = openDatabase(source.sourcePath)
+    const db = openTracked(source.sourcePath)
     expect(db.query<{ value: string }>('SELECT value FROM items')).toEqual([{ value: 'rollback-row' }])
+    expect(snapshotDirectories(cache)).toHaveLength(1)
     db.close()
 
     expect(directorySnapshot(source.sourceDirectory)).toEqual(before)
     expect(snapshotDirectories(cache)).toEqual([])
   })
 
-  it('reads committed rows from a live WAL without touching the producer directory', () => {
+  it('snapshots committed rows from a live WAL without touching the producer directory', () => {
     const testRoot = root('metrora-sqlite-safe-wal-')
     const cache = cacheFor(testRoot)
     const source = createActiveWalSource(testRoot)
     const before = directorySnapshot(source.sourceDirectory)
-
     const snapshotCopy = vi.spyOn(fs, 'copyFileSync')
-    const sourceStats = vi.spyOn(fs, 'statSync')
-    const db = openDatabase(source.sourcePath)
-    const statsAfterOpen = sourceStats.mock.calls.length
+
+    const db = openTracked(source.sourcePath)
     expect(db.query<{ value: string }>('SELECT value FROM items')).toEqual([{ value: 'wal-row' }])
     expect(db.query<{ value: string }>('SELECT value FROM items')).toEqual([{ value: 'wal-row' }])
     expect(snapshotDirectories(cache)).toHaveLength(1)
@@ -222,7 +256,7 @@ sqliteDescribe('shared SQLite source-safe reads', () => {
     expect(snapshotDirectories(cache)).toEqual([])
   })
 
-  it('reads a WAL with missing SHM from a read-only parent where permissions are enforceable', () => {
+  it('reads a WAL with missing SHM from a read-only parent through owned material', () => {
     const testRoot = root('metrora-sqlite-safe-missing-shm-')
     const cache = cacheFor(testRoot)
     const source = createCopiedWalSource(testRoot)
@@ -236,14 +270,14 @@ sqliteDescribe('shared SQLite source-safe reads', () => {
     }
 
     try {
-      const db = openDatabase(source.sourcePath)
+      const db = openTracked(source.sourcePath)
       expect(db.query<{ value: string }>('SELECT value FROM items')).toEqual([{ value: 'wal-row' }])
       db.close()
     } finally {
       restorePermissions?.()
     }
 
-    expect(fs.existsSync(`${source.sourcePath}-shm`)).toBe(false)
+    expect(fs.existsSync(source.sourcePath + '-shm')).toBe(false)
     expect(directorySnapshot(source.sourceDirectory)).toEqual(before)
     expect(snapshotDirectories(cache)).toEqual([])
   })
@@ -254,160 +288,54 @@ sqliteDescribe('shared SQLite source-safe reads', () => {
     const source = createCopiedWalSource(testRoot)
     const before = directorySnapshot(source.sourceDirectory)
 
-    const db = openDatabase(source.sourcePath)
+    const db = openTracked(source.sourcePath)
     expect(db.query<{ value: string }>('SELECT value FROM items')).toEqual([{ value: 'wal-row' }])
     db.close()
 
-    expect(fs.existsSync(`${source.sourcePath}-shm`)).toBe(false)
+    expect(fs.existsSync(source.sourcePath + '-shm')).toBe(false)
     expect(directorySnapshot(source.sourceDirectory)).toEqual(before)
     expect(snapshotDirectories(cache)).toEqual([])
   })
 
-  it('promotes after a constructor-success/query-time CANTOPEN boundary failure and retries once', () => {
-    const testRoot = root('metrora-sqlite-safe-query-fallback-')
+  it('uses a stable owned snapshot for a WAL-mode main file with no live WAL', () => {
+    const testRoot = root('metrora-sqlite-safe-wal-main-only-')
     const cache = cacheFor(testRoot)
-    const source = createWalModeMainOnly(testRoot)
-    const db = openDatabase(source.sourcePath)
-    const DatabaseSync = databaseConstructor()
-    const originalPrepare = DatabaseSync.prototype.prepare
-    let injectFailure = true
-
-    vi.spyOn(DatabaseSync.prototype, 'prepare').mockImplementation(function (this: TestDatabase, sql: string) {
-      if (injectFailure) {
-        injectFailure = false
-        fs.writeFileSync(`${source.sourcePath}-wal`, source.walBytes)
-        throw Object.assign(new Error('unable to open database file'), {
-          code: 'ERR_SQLITE_ERROR',
-          errcode: 14,
-          errstr: 'unable to open database file',
-        })
-      }
-      return originalPrepare.call(this, sql)
-    })
-
-    expect(db.query<{ value: string }>('SELECT value FROM items')).toEqual([{ value: 'wal-row' }])
-    db.close()
-
-    expect(fs.existsSync(`${source.sourcePath}-shm`)).toBe(false)
-    expect(snapshotDirectories(cache)).toEqual([])
-  })
-
-  it('keeps fallback authority available when CANTOPEN has no live WAL yet', () => {
-    const testRoot = root('metrora-sqlite-safe-two-stage-fallback-')
-    const cache = cacheFor(testRoot)
-    const source = createWalModeMainOnly(testRoot)
-    const db = openDatabase(source.sourcePath)
-    const DatabaseSync = databaseConstructor()
-    const originalPrepare = DatabaseSync.prototype.prepare
-    let failOnce = true
-
-    vi.spyOn(DatabaseSync.prototype, 'prepare').mockImplementation(function (this: TestDatabase, sql: string) {
-      if (failOnce) {
-        failOnce = false
-        throw Object.assign(new Error('unable to open database file'), { code: 'ERR_SQLITE_ERROR', errcode: 14 })
-      }
-      return originalPrepare.call(this, sql)
-    })
-
-    expect(() => db.query('SELECT value FROM items')).toThrow(/unable to open database file/i)
-    expect(snapshotDirectories(cache)).toEqual([])
-
-    fs.writeFileSync(`${source.sourcePath}-wal`, source.walBytes)
-    expect(db.query<{ value: string }>('SELECT value FROM items')).toEqual([{ value: 'wal-row' }])
-    expect(snapshotDirectories(cache)).toHaveLength(1)
-    db.close()
-
-  })
-
-  it('uses the immutable URI for a WAL-mode main file with no live WAL', () => {
-    const testRoot = root('metrora-sqlite-safe-immutable-')
-    const cache = cacheFor(testRoot)
-    const source = createWalModeMainOnly(testRoot)
+    const source = createWalModeSourceWithoutLiveWal(testRoot, 'immutable-row', 'wal-main-only')
     const before = directorySnapshot(source.sourceDirectory)
 
-    const db = openDatabase(source.sourcePath)
-    expect(db.query('SELECT name FROM sqlite_master WHERE type = \'table\'')).toEqual([{ name: 'items' }])
+    const db = openTracked(source.sourcePath)
+    expect(db.query<{ value: string }>('SELECT value FROM items')).toEqual([{ value: 'immutable-row' }])
     db.close()
 
     expect(directorySnapshot(source.sourceDirectory)).toEqual(before)
-    expect(fs.existsSync(`${source.sourcePath}-shm`)).toBe(false)
+    expect(fs.existsSync(source.sourcePath + '-shm')).toBe(false)
     expect(snapshotDirectories(cache)).toEqual([])
   })
 
-  it('reclassifies direct readers after pathname rotation', () => {
-    const testRoot = root('metrora-sqlite-safe-direct-rotation-')
-    const cache = cacheFor(testRoot)
-    const oldSource = createRollbackSource(testRoot, 'old-row', 'rotation-old')
-    const nextSource = createRollbackSource(testRoot, 'new-row', 'rotation-new')
-    const nextBefore = directorySnapshot(nextSource.sourceDirectory)
-    const db = openDatabase(oldSource.sourcePath)
-
-    replaceSourceFile(oldSource.sourcePath, nextSource.sourcePath)
-    expect(db.query<{ value: string }>('SELECT value FROM items')).toEqual([{ value: 'new-row' }])
-    db.close()
-
-    expect(directorySnapshot(nextSource.sourceDirectory)).toEqual(nextBefore)
-    expect(fs.existsSync(`${oldSource.sourcePath}-wal`)).toBe(false)
-    expect(fs.existsSync(`${oldSource.sourcePath}-shm`)).toBe(false)
-  })
-
-  it('reclassifies immutable readers after pathname rotation', () => {
-    const testRoot = root('metrora-sqlite-safe-immutable-rotation-')
-    const cache = cacheFor(testRoot)
-    const oldSource = createImmutableWalSource(testRoot, 'old-row', 'immutable-old')
-    const nextSource = createImmutableWalSource(testRoot, 'new-row', 'immutable-new')
-    const db = openDatabase(oldSource.sourcePath)
-
-    replaceSourceFile(oldSource.sourcePath, nextSource.sourcePath)
-    expect(db.query<{ value: string }>('SELECT value FROM items')).toEqual([{ value: 'new-row' }])
-    db.close()
-
-    expect(fs.existsSync(`${oldSource.sourcePath}-shm`)).toBe(false)
-    expect(snapshotDirectories(cache)).toEqual([])
-  })
-  it('reclassifies immutable readers after an in-place main-file change', () => {
-    const testRoot = root('metrora-sqlite-safe-immutable-change-')
-    const cache = cacheFor(testRoot)
-    const oldSource = createImmutableWalSource(testRoot, 'old-row', 'immutable-change-old')
-    const nextSource = createImmutableWalSource(testRoot, 'new-row', 'immutable-change-new')
-    const db = openDatabase(oldSource.sourcePath)
-
-    fs.copyFileSync(nextSource.sourcePath, oldSource.sourcePath)
-    const touched = new Date(Date.now() + 2000)
-    fs.utimesSync(oldSource.sourcePath, touched, touched)
-    expect(db.query<{ value: string }>('SELECT value FROM items')).toEqual([{ value: 'new-row' }])
-    db.close()
-
-  })
-
-  it('uses lightweight source probes in direct and immutable steady state', () => {
-    const testRoot = root('metrora-sqlite-safe-preflight-')
-    const cache = cacheFor(testRoot)
-    const sourceStats = vi.spyOn(fs, 'openSync')
-    const directSource = createRollbackSource(testRoot, 'direct-row', 'preflight-direct')
-    const direct = openDatabase(directSource.sourcePath)
-    const directOpenCount = sourceStats.mock.calls.length
-    for (let index = 0; index < 20; index++) {
-      expect(direct.query<{ value: string }>('SELECT value FROM items')).toEqual([{ value: 'direct-row' }])
-    }
-    expect(sourceStats.mock.calls.length).toBe(directOpenCount)
-    direct.close()
-
-    const immutableSource = createImmutableWalSource(testRoot, 'immutable-row', 'preflight-immutable')
-    const immutable = openDatabase(immutableSource.sourcePath)
-    const immutableOpenCount = sourceStats.mock.calls.length
-    for (let index = 0; index < 20; index++) {
-      expect(immutable.query<{ value: string }>('SELECT value FROM items')).toEqual([{ value: 'immutable-row' }])
-    }
-    expect(sourceStats.mock.calls.length).toBe(immutableOpenCount)
-    immutable.close()
-    expect(snapshotDirectories(cache)).toEqual([])
-  })
-
-  it('rejects an unstable WAL copy, retries, and publishes only the stable pair', () => {
-    const testRoot = root('metrora-sqlite-safe-retry-')
+  it('performs no producer probing or recopying after the snapshot is accepted', () => {
+    const testRoot = root('metrora-sqlite-safe-steady-state-')
     const cache = cacheFor(testRoot)
     const source = createActiveWalSource(testRoot)
+    const db = openTracked(source.sourcePath)
+    const sourceStat = vi.spyOn(fs, 'statSync')
+    const sourceOpen = vi.spyOn(fs, 'openSync')
+    const sourceCopy = vi.spyOn(fs, 'copyFileSync')
+
+    for (let index = 0; index < 25; index++) {
+      expect(db.query<{ value: string }>('SELECT value FROM items')).toEqual([{ value: 'wal-row' }])
+    }
+
+    expect(sourceStat).not.toHaveBeenCalled()
+    expect(sourceOpen).not.toHaveBeenCalled()
+    expect(sourceCopy).not.toHaveBeenCalled()
+    db.close()
+    expect(snapshotDirectories(cache)).toEqual([])
+  })
+
+  it('retries when a live WAL appears during snapshot copy and never creates source SHM', () => {
+    const testRoot = root('metrora-sqlite-safe-wal-during-copy-')
+    const cache = cacheFor(testRoot)
+    const source = createWalModeMainOnly(testRoot)
     const realCopyFileSync = fs.copyFileSync
     let copyCalls = 0
 
@@ -415,76 +343,260 @@ sqliteDescribe('shared SQLite source-safe reads', () => {
       const result = realCopyFileSync(from, to, mode)
       copyCalls++
       if (copyCalls === 1) {
-        source.producer.prepare('INSERT INTO items (id, value) VALUES (?, ?)').run(2, 'during-copy')
+        fs.writeFileSync(source.sourcePath + '-wal', source.walBytes)
       }
       return result
     })
 
-    const db = openDatabase(source.sourcePath)
-    expect(db.query<{ value: string }>('SELECT value FROM items ORDER BY id')).toEqual([
-      { value: 'wal-row' },
-      { value: 'during-copy' },
-    ])
-    expect(copyCalls).toBeGreaterThanOrEqual(4)
-    expect(snapshotDirectories(cache)).toHaveLength(1)
+    const db = openTracked(source.sourcePath)
+    expect(db.query<{ value: string }>('SELECT value FROM items ORDER BY id')).toEqual([{ value: 'wal-row' }])
+    expect(copyCalls).toBeGreaterThanOrEqual(3)
+    expect(fs.existsSync(source.sourcePath + '-shm')).toBe(false)
+    expect(fs.readdirSync(source.sourceDirectory).sort()).toEqual(['source.sqlite', 'source.sqlite-wal'])
+    db.close()
+    expect(snapshotDirectories(cache)).toEqual([])
+  })
+  it('keeps the actual query source-safe when the producer publishes WAL at prepare time', () => {
+    const testRoot = root('metrora-sqlite-safe-query-boundary-race-')
+    const cache = cacheFor(testRoot)
+    const source = createWalModeMainOnly(testRoot, 'query-race-source', 'query-race-producer')
+    const db = openTracked(source.sourcePath)
+    const DatabaseSync = databaseConstructor()
+    const originalPrepare = DatabaseSync.prototype.prepare
+    let published = false
+
+    vi.spyOn(DatabaseSync.prototype, 'prepare').mockImplementation(function (this: TestDatabase, sql: string) {
+      if (!published) {
+        published = true
+        fs.writeFileSync(source.sourcePath + '-wal', source.walBytes)
+      }
+      return originalPrepare.call(this, sql)
+    })
+
+    expect(db.query<{ value: string }>('SELECT value FROM items')).toEqual([])
+    expect(fs.existsSync(source.sourcePath + '-shm')).toBe(false)
+    db.close()
+
+    const next = openTracked(source.sourcePath)
+    expect(next.query<{ value: string }>('SELECT value FROM items')).toEqual([{ value: 'wal-row' }])
+    next.close()
+    expect(snapshotDirectories(cache)).toEqual([])
+  })
+
+  it('closes the immutable stale-read race by fencing a WAL before opening the read view', () => {
+    const testRoot = root('metrora-sqlite-safe-immutable-race-')
+    const cache = cacheFor(testRoot)
+    const source = createWalModeMainOnly(testRoot, 'immutable-race-source', 'immutable-race-producer')
+    const realCopyFileSync = fs.copyFileSync
+    let copyCalls = 0
+
+    vi.spyOn(fs, 'copyFileSync').mockImplementation((from: fs.PathLike, to: fs.PathLike, mode?: number) => {
+      const result = realCopyFileSync(from, to, mode)
+      copyCalls++
+      if (copyCalls === 1) {
+        fs.writeFileSync(source.sourcePath + '-wal', source.walBytes)
+      }
+      return result
+    })
+
+    const db = openTracked(source.sourcePath)
+    expect(db.query<{ value: string }>('SELECT value FROM items ORDER BY id')).toEqual([{ value: 'wal-row' }])
+    expect(copyCalls).toBeGreaterThanOrEqual(3)
+    expect(fs.existsSync(source.sourcePath + '-shm')).toBe(false)
     db.close()
     expect(snapshotDirectories(cache)).toEqual([])
   })
 
-  it.skipIf(process.platform === 'win32')('promotes an existing direct reader when rollback mode becomes live WAL', () => {
+  it('retries a WAL checkpoint that occurs during copy and publishes the post-checkpoint state', () => {
+    const testRoot = root('metrora-sqlite-safe-checkpoint-')
+    const cache = cacheFor(testRoot)
+    const source = createActiveWalSource(testRoot)
+    const beforeNames = new Set(fs.readdirSync(source.sourceDirectory))
+    const realCopyFileSync = fs.copyFileSync
+    let copyCalls = 0
+
+    vi.spyOn(fs, 'copyFileSync').mockImplementation((from: fs.PathLike, to: fs.PathLike, mode?: number) => {
+      const result = realCopyFileSync(from, to, mode)
+      copyCalls++
+      if (copyCalls === 1) {
+        source.producer.exec('PRAGMA wal_checkpoint(TRUNCATE)')
+      }
+      return result
+    })
+
+    const db = openTracked(source.sourcePath)
+    expect(db.query<{ value: string }>('SELECT value FROM items')).toEqual([{ value: 'wal-row' }])
+    expect(copyCalls).toBeGreaterThanOrEqual(2)
+    for (const name of fs.readdirSync(source.sourceDirectory)) {
+      expect(beforeNames.has(name)).toBe(true)
+    }
+    db.close()
+    expect(snapshotDirectories(cache)).toEqual([])
+  })
+
+  it('rejects a rollback journal that appears during copy instead of publishing main-only bytes', () => {
+    const testRoot = root('metrora-sqlite-safe-journal-during-copy-')
+    const cache = cacheFor(testRoot)
+    const source = createRollbackSource(testRoot)
+    const realCopyFileSync = fs.copyFileSync
+    let copyCalls = 0
+
+    vi.spyOn(fs, 'copyFileSync').mockImplementation((from: fs.PathLike, to: fs.PathLike, mode?: number) => {
+      const result = realCopyFileSync(from, to, mode)
+      copyCalls++
+      if (copyCalls === 1) {
+        fs.writeFileSync(source.sourcePath + '-journal', Buffer.alloc(512))
+      }
+      return result
+    })
+
+    expect(() => openTracked(source.sourcePath)).toThrow(/rollback journal|source-safe snapshot failed/i)
+    expect(copyCalls).toBe(1)
+    expect(snapshotDirectories(cache)).toEqual([])
+    expect(fs.existsSync(source.sourcePath + '-shm')).toBe(false)
+    expect(fs.existsSync(source.sourcePath + '-wal')).toBe(false)
+  })
+
+  it('retries source replacement during copy and never publishes the old pair', () => {
+    const testRoot = root('metrora-sqlite-safe-replacement-copy-')
+    const cache = cacheFor(testRoot)
+    const source = createRollbackSource(testRoot, 'old-row', 'replacement-source')
+    const replacement = createRollbackSource(testRoot, 'replacement-fixture', 'replacement-target')
+    const realCopyFileSync = fs.copyFileSync
+    let copyCalls = 0
+    let replaced = false
+
+    vi.spyOn(fs, 'copyFileSync').mockImplementation((from: fs.PathLike, to: fs.PathLike, mode?: number) => {
+      const result = realCopyFileSync(from, to, mode)
+      copyCalls++
+      if (copyCalls === 1 && !replaced) {
+        replaced = true
+        replaceSourceFile(source.sourcePath, replacement.sourcePath)
+      }
+      return result
+    })
+
+    const db = openTracked(source.sourcePath)
+    expect(db.query<{ value: string }>('SELECT value FROM items')).toEqual([{ value: 'replacement-fixture' }])
+    expect(copyCalls).toBeGreaterThanOrEqual(2)
+    db.close()
+    expect(snapshotDirectories(cache)).toEqual([])
+  })
+
+  it('fails clearly when the source disappears during snapshot acquisition', () => {
+    const testRoot = root('metrora-sqlite-safe-disappearance-')
+    const cache = cacheFor(testRoot)
+    const source = createRollbackSource(testRoot)
+    const realCopyFileSync = fs.copyFileSync
+    let copyCalls = 0
+
+    vi.spyOn(fs, 'copyFileSync').mockImplementation((from: fs.PathLike, to: fs.PathLike, mode?: number) => {
+      const result = realCopyFileSync(from, to, mode)
+      copyCalls++
+      if (copyCalls === 1) fs.unlinkSync(source.sourcePath)
+      return result
+    })
+
+    expect(() => openDatabase(source.sourcePath)).toThrow(/disappeared|snapshot failed|source changed/i)
+    expect(snapshotDirectories(cache)).toEqual([])
+    expect(fs.existsSync(source.sourcePath)).toBe(false)
+  })
+
+  it('keeps an accepted snapshot stable after pathname rotation and exposes the replacement on the next open', () => {
+    const testRoot = root('metrora-sqlite-safe-rotation-')
+    const cache = cacheFor(testRoot)
+    const source = createRollbackSource(testRoot, 'old-row', 'rotation-source')
+    const replacement = createRollbackSource(testRoot, 'new-row', 'rotation-replacement')
+
+    const first = openTracked(source.sourcePath)
+    replaceSourceFile(source.sourcePath, replacement.sourcePath)
+    expect(first.query<{ value: string }>('SELECT value FROM items')).toEqual([{ value: 'old-row' }])
+    first.close()
+
+    const second = openTracked(source.sourcePath)
+    expect(second.query<{ value: string }>('SELECT value FROM items')).toEqual([{ value: 'new-row' }])
+    second.close()
+
+    expect(fs.existsSync(source.sourcePath + '-shm')).toBe(false)
+    expect(fs.existsSync(source.sourcePath + '-wal')).toBe(false)
+    expect(snapshotDirectories(cache)).toEqual([])
+  })
+
+  it('keeps an accepted WAL-mode snapshot stable after immutable-path rotation', () => {
+    const testRoot = root('metrora-sqlite-safe-immutable-rotation-')
+    const cache = cacheFor(testRoot)
+    const source = createWalModeSourceWithoutLiveWal(testRoot, 'old-row', 'immutable-rotation-source')
+    const replacement = createWalModeSourceWithoutLiveWal(testRoot, 'new-row', 'immutable-rotation-replacement')
+
+    const first = openTracked(source.sourcePath)
+    replaceSourceFile(source.sourcePath, replacement.sourcePath)
+    expect(first.query<{ value: string }>('SELECT value FROM items')).toEqual([{ value: 'old-row' }])
+    first.close()
+
+    const second = openTracked(source.sourcePath)
+    expect(second.query<{ value: string }>('SELECT value FROM items')).toEqual([{ value: 'new-row' }])
+    second.close()
+
+    expect(fs.existsSync(source.sourcePath + '-shm')).toBe(false)
+    expect(snapshotDirectories(cache)).toEqual([])
+  })
+
+  it('does not serve a deleted producer inode as a fresh view', () => {
+    const testRoot = root('metrora-sqlite-safe-disappeared-after-open-')
+    const source = createRollbackSource(testRoot)
+    const db = openTracked(source.sourcePath)
+
+    fs.unlinkSync(source.sourcePath)
+    expect(db.query<{ value: string }>('SELECT value FROM items')).toEqual([{ value: 'rollback-row' }])
+    db.close()
+  })
+
+  it('makes rollback-to-WAL changes visible only to the next open', () => {
     const testRoot = root('metrora-sqlite-safe-rollback-to-wal-')
     const cache = cacheFor(testRoot)
     const source = createRollbackSource(testRoot, 'rollback-row', 'rollback-to-wal-source')
     const producer = createActiveWalSource(testRoot)
-    const db = openDatabase(source.sourcePath)
+    const first = openTracked(source.sourcePath)
 
     publishWalPair(source.sourcePath, producer.sourcePath)
-    expect(db.query<{ value: string }>('SELECT value FROM items')).toEqual([{ value: 'wal-row' }])
-    expect(snapshotDirectories(cache)).toHaveLength(1)
-    db.close()
+    expect(first.query<{ value: string }>('SELECT value FROM items')).toEqual([{ value: 'rollback-row' }])
+    first.close()
 
-    expect(fs.existsSync(`${source.sourcePath}-shm`)).toBe(false)
+    const second = openTracked(source.sourcePath)
+    expect(second.query<{ value: string }>('SELECT value FROM items')).toEqual([{ value: 'wal-row' }])
+    second.close()
+
+    expect(fs.existsSync(source.sourcePath + '-shm')).toBe(false)
     expect(snapshotDirectories(cache)).toEqual([])
   })
 
-  it.skipIf(process.platform === 'win32')('fails clearly when the current source disappears', () => {
-    const testRoot = root('metrora-sqlite-safe-disappearance-')
-    const cache = cacheFor(testRoot)
-    const source = createRollbackSource(testRoot)
-    const db = openDatabase(source.sourcePath)
-
-    fs.unlinkSync(source.sourcePath)
-    expect(() => db.query('SELECT value FROM items')).toThrow(/disappeared|replaced|unavailable/i)
-    db.close()
-  })
-
-  it('keeps concurrent reader snapshots collision-free and cleans them on close', () => {
+  it('keeps concurrent owned snapshots collision-free and cleans them on close', () => {
     const testRoot = root('metrora-sqlite-safe-concurrent-')
     const cache = cacheFor(testRoot)
     const source = createActiveWalSource(testRoot)
-    const readers = Array.from({ length: 4 }, () => openDatabase(source.sourcePath))
+    const readersForTest = Array.from({ length: 4 }, () => openTracked(source.sourcePath))
 
     const directories = snapshotDirectories(cache)
     expect(directories).toHaveLength(4)
     expect(new Set(directories).size).toBe(4)
-    for (const reader of readers) {
+    for (const reader of readersForTest) {
       expect(reader.query<{ value: string }>('SELECT value FROM items')).toEqual([{ value: 'wal-row' }])
+      reader.close()
     }
-    for (const reader of readers) reader.close()
 
     expect(snapshotDirectories(cache)).toEqual([])
   })
 
-  it('does not reclaim an active snapshot whose owner appears stale by wall clock', () => {
+  it('does not reclaim an active snapshot merely because its directory is old', () => {
     const testRoot = root('metrora-sqlite-safe-active-owner-')
     const cache = cacheFor(testRoot)
     const source = createActiveWalSource(testRoot)
-    const first = openDatabase(source.sourcePath)
+    const first = openTracked(source.sourcePath)
     const firstDirectory = join(cache, 'sqlite-source-snapshots', snapshotDirectories(cache)[0])
     const old = new Date(Date.now() - 2 * 24 * 60 * 60 * 1000)
     fs.utimesSync(firstDirectory, old, old)
 
-    const second = openDatabase(source.sourcePath)
+    const second = openTracked(source.sourcePath)
     expect(snapshotDirectories(cache)).toHaveLength(2)
     expect(fs.existsSync(firstDirectory)).toBe(true)
     expect(first.query<{ value: string }>('SELECT value FROM items')).toEqual([{ value: 'wal-row' }])
@@ -494,83 +606,62 @@ sqliteDescribe('shared SQLite source-safe reads', () => {
     expect(snapshotDirectories(cache)).toEqual([])
   })
 
-  it('removes stale owned material before opening and cleans the active snapshot on close', () => {
-    const testRoot = root('metrora-sqlite-safe-cleanup-')
+  it('reclaims dead stale material but retains ambiguous ownership', () => {
+    const testRoot = root('metrora-sqlite-safe-owner-cleanup-')
     const cache = cacheFor(testRoot)
     const snapshotRoot = join(cache, 'sqlite-source-snapshots')
     const stale = join(snapshotRoot, 'sqlite-source-read-stale')
+    const ambiguous = join(snapshotRoot, 'sqlite-source-read-ambiguous')
     fs.mkdirSync(stale, { recursive: true })
-    const stalePid = Number.MAX_SAFE_INTEGER
-    fs.writeFileSync(join(stale, '.owner.json'), JSON.stringify({ pid: stalePid, token: 'abandoned', createdAtMs: Date.now() - 2 * 24 * 60 * 60 * 1000 }))
+    fs.mkdirSync(ambiguous, { recursive: true })
+    const old = new Date(Date.now() - 2 * 24 * 60 * 60 * 1000)
+    fs.utimesSync(stale, old, old)
+    fs.utimesSync(ambiguous, old, old)
+    fs.writeFileSync(
+      join(stale, '.owner.json'),
+      JSON.stringify({ pid: Number.MAX_SAFE_INTEGER, token: 'abandoned', createdAtMs: old.getTime() }),
+    )
+    fs.utimesSync(stale, old, old)
     vi.spyOn(process, 'kill').mockImplementation(() => {
       throw Object.assign(new Error('owner is gone'), { code: 'ESRCH' })
     })
-    const old = new Date(Date.now() - 2 * 24 * 60 * 60 * 1000)
-    fs.utimesSync(stale, old, old)
 
     const source = createActiveWalSource(testRoot)
-    const db = openDatabase(source.sourcePath)
+    const db = openTracked(source.sourcePath)
     expect(fs.existsSync(stale)).toBe(false)
-    expect(snapshotDirectories(cache)).toHaveLength(1)
+    expect(fs.existsSync(ambiguous)).toBe(true)
+    db.close()
+    expect(fs.existsSync(ambiguous)).toBe(true)
+  })
+
+  it('retains a snapshot when cleanup is called with the wrong owner token', async () => {
+    const testRoot = root('metrora-sqlite-safe-owner-token-')
+    const cache = cacheFor(testRoot)
+    const source = createActiveWalSource(testRoot)
+    const db = openTracked(source.sourcePath)
+    const directory = join(cache, 'sqlite-source-snapshots', snapshotDirectories(cache)[0])
+    const ownership = await import('../src/sqlite-snapshot-ownership.js')
+
+    ownership.cleanupSnapshotDirectory(directory, 'sqlite-source-read-', 'wrong-token')
+    expect(fs.existsSync(directory)).toBe(true)
     db.close()
     expect(snapshotDirectories(cache)).toEqual([])
   })
 
-  it('does not reclaim stale material when ownership is ambiguous', () => {
-    const testRoot = root('metrora-sqlite-safe-ambiguous-owner-')
-    const cache = cacheFor(testRoot)
-    const snapshotRoot = join(cache, 'sqlite-source-snapshots')
-    const ambiguous = join(snapshotRoot, 'sqlite-source-read-ambiguous')
-    fs.mkdirSync(ambiguous, { recursive: true })
-    const old = new Date(Date.now() - 2 * 24 * 60 * 60 * 1000)
-    fs.utimesSync(ambiguous, old, old)
-
-    const source = createActiveWalSource(testRoot)
-    const db = openDatabase(source.sourcePath)
-    expect(fs.existsSync(ambiguous)).toBe(true)
-    db.close()
-    expect(fs.existsSync(ambiguous)).toBe(true)
-  })
-
-  it('does not retry unrelated SQL errors or create a snapshot', () => {
-    const testRoot = root('metrora-sqlite-safe-query-error-')
-    const cache = cacheFor(testRoot)
+  it('does not turn SQL/schema errors into fake provider absence', () => {
+    const testRoot = root('metrora-sqlite-safe-errors-')
     const source = createRollbackSource(testRoot)
-    const db = openDatabase(source.sourcePath)
+    const db = openTracked(source.sourcePath)
 
     expect(() => db.query('SELECT * FROM missing_table')).toThrow(/no such table/i)
     db.close()
 
-    expect(snapshotDirectories(cache)).toEqual([])
+    expect(isSqliteBusyError({ code: 'SQLITE_BUSY' })).toBe(true)
+    expect(isSqliteBusyError({ code: 'SQLITE_LOCKED' })).toBe(true)
+    expect(isSqliteBusyError({ errcode: 14, errstr: 'unable to open database file' })).toBe(false)
   })
 
-  it('does not promote a CANTOPEN error without live WAL evidence', () => {
-    const testRoot = root('metrora-sqlite-safe-unrelated-cantopen-')
-    const cache = cacheFor(testRoot)
-    const source = createRollbackSource(testRoot)
-    const db = openDatabase(source.sourcePath)
-    const DatabaseSync = databaseConstructor()
-
-    vi.spyOn(DatabaseSync.prototype, 'prepare').mockImplementation(() => {
-      throw Object.assign(new Error('unable to open database file'), {
-        code: 'ERR_SQLITE_ERROR',
-        errcode: 14,
-      })
-    })
-
-    expect(() => db.query('SELECT value FROM items')).toThrow(/unable to open database file/i)
-    db.close()
-    expect(snapshotDirectories(cache)).toEqual([])
-  })
-
-  it('preserves busy/locked classification and excludes it from source-safe fallback', () => {
-    const busy = { code: 'ERR_SQLITE_ERROR', errcode: 5, errstr: 'database is locked' }
-    expect(isSqliteBusyError(busy)).toBe(true)
-    expect(isSqliteSourceSafeReadError(busy)).toBe(false)
-    expect(isSqliteSourceSafeReadError({ code: 'ERR_SQLITE_ERROR', errcode: 14, errstr: 'unable to open database file' })).toBe(true)
-  })
-
-  it('surfaces malformed SQLite instead of turning it into an empty read', () => {
+  it('surfaces malformed SQLite instead of returning an empty result', () => {
     const testRoot = root('metrora-sqlite-safe-corrupt-')
     const cache = cacheFor(testRoot)
     const sourceDirectory = join(testRoot, 'corrupt-source')
@@ -578,10 +669,23 @@ sqliteDescribe('shared SQLite source-safe reads', () => {
     const sourcePath = join(sourceDirectory, 'source.sqlite')
     fs.writeFileSync(sourcePath, 'not a sqlite database')
 
-    const db = openDatabase(sourcePath)
-    expect(() => db.query('SELECT * FROM items')).toThrow()
-    db.close()
+    let db: SqliteDatabase | undefined
+    try {
+      db = openTracked(sourcePath)
+      expect(() => db.query('SELECT * FROM items')).toThrow()
+    } catch (err) {
+      expect(String(err)).toMatch(/SQLite|database|snapshot|not/i)
+    } finally {
+      db?.close()
+    }
+    expect(snapshotDirectories(cache)).toEqual([])
+  })
 
+  it('fails clearly for a source that is absent before acquisition', () => {
+    const testRoot = root('metrora-sqlite-safe-missing-')
+    const cache = cacheFor(testRoot)
+    const sourcePath = join(testRoot, 'missing', 'source.sqlite')
+    expect(() => openDatabase(sourcePath)).toThrow(/disappeared|snapshot|unavailable/i)
     expect(snapshotDirectories(cache)).toEqual([])
   })
 })


### PR DESCRIPTION
## Summary

This draft PR implements the shared SQLite source-safe read boundary for Metrora.

- Exact base SHA: `2bcfde215bf3133ea84fd7936c6be9d14d29cf73`
- Branch/head: `fix/sqlite-source-safe-read`
- Current remediation head: `23b21445ef2fbd07a0fa5b644f8e8476c09c2a38`
- Classification: correctness/source-integrity hardening.
- This is not classified as a demonstrated remote security exploit.

## Reproduced problem class

A mutable producer-owned SQLite database can be in WAL mode with committed rows in a live non-empty `-wal`, no `-shm`, and a read-only parent directory. Node `DatabaseSync` may construct successfully while the first query fails with `SQLITE_CANTOPEN` / errcode 14. With a writable producer directory, a direct `readOnly=true` read can create a producer-adjacent `-shm`.

A targeted concurrency reproduction also showed that a lightweight preflight cannot prove what exists when a later SQLite prepare begins: a direct query could create source `-shm`, while an immutable query could successfully return stale main-only state after a committed WAL appeared.

## Source-safety contract

Metrora must not execute application SQL against mutable producer paths through a mode that can create producer support files, ignore a committed WAL, or observe a torn main/WAL pair.

The read path must not create producer-adjacent `-wal`, `-shm`, journal, or temporary support files, and must not mutate producer directories to make a read succeed. Read-only or permission-restricted sources remain readable when their evidence can be safely snapshotted.

## Final read architecture

The targeted race evidence superseded the earlier preflight-based steady-state design.

Every `openDatabase(path)` now establishes one unique Metrora-owned synchronous snapshot and opens Node SQLite only on that snapshot:

1. observe the main file, WAL, rollback journal, SQLite WAL header, and WAL-aware source fingerprint;
2. refuse an active rollback journal rather than inventing journal recovery semantics;
3. if a live WAL exists, copy WAL first and main second;
4. if no live WAL exists and no journal is present, copy the stable main file;
5. perform the before/after source identity, metadata, sidecar, header, and fingerprint fence;
6. retry unstable acquisition up to three bounded attempts and publish only a stable pair.

`-shm` is never copied as authority. Any SQLite support files created while reading the snapshot remain inside the Metrora-owned snapshot directory.

Producer-path DIRECT execution: removed.

Producer-path IMMUTABLE execution: removed. `immutable=1` is not used as a general mutable-producer concurrency solution.

SNAPSHOT execution: the only query path for producer sources. One open handle represents one accepted point-in-time source view. Producer changes after acceptance are visible on the next normal open; they do not mutate an already-open view.

The existing synchronous `openDatabase(path)`, `query(...)`, and `close()` API remains unchanged. Caller audit found short-lived scan/parse/read handles; no provider intentionally depends on a long-lived incremental SQLite handle.

## Query-time failure behavior

The old query-time CANTOPEN promotion machinery is no longer needed because user SQL never executes on the producer path. Snapshot acquisition instability, source disappearance, malformed SQLite, SQL/schema errors, permissions, BUSY, and LOCKED remain real errors and are not converted into empty provider results.

## WAL, journal, and consistency behavior

- WAL is copied before main.
- `-shm` is ignored and never copied as authority.
- A live or newly appearing rollback journal rejects the candidate snapshot.
- Main identity, metadata, WAL/journal sidecars, WAL mode, and the existing WAL-aware fingerprint are checked before and after copy.
- Source replacement, WAL publication, WAL checkpoint/truncate, journal appearance, and source disappearance during copy cause retry or a clear bounded failure.
- Partial/staged material is never published as authoritative.
- The metadata fence remains bounded; no per-file cryptographic hashing was added.

## Ownership, cleanup, and concurrency

Each snapshot has an atomically published owner record containing PID, unique token, and creation timestamp. Stale cleanup:

- retains snapshots owned by live processes;
- retains malformed, missing, or ambiguous ownership;
- reclaims dead owners only after the bounded stale threshold;
- verifies the owner token on per-instance close;
- uses unique temporary directories for concurrent readers.

No daemon, producer-directory lock, global registry, or new CI gate was added.

## Performance

The previous preflight implementation measured on the same Windows-style 50,000-query benchmark:

| Mode | Previous total |
|---|---:|
| raw | 257.13 ms |
| producer-path direct | 3,349.19 ms |
| producer-path immutable | 3,345.83 ms |

Those producer-path modes no longer exist in the final implementation.

Current disposable steady-state measurement, 50,000 `SELECT 1` queries with 1,000 warmup queries:

| Mode | Total | Approx. per query |
|---|---:|---:|
| raw producer reference | 249.24 ms | 4.985 us |
| owned snapshot | 249.42 ms | 4.988 us |

After snapshot acceptance, the query path performs zero producer stats, header reads, fingerprint calls, or copies. Snapshot creation is once per `openDatabase()`; measured copy/open and cleanup samples:

| Fixture | Source bytes | Snapshot open | Cleanup |
|---|---:|---:|---:|
| rollback 1 MB | 1.09 MB | 6.86 ms | 1.67 ms |
| live WAL 1 MB | 1.10 MB | 5.58 ms | 1.84 ms |
| rollback 10 MB | 10.82 MB | 8.46 ms | 1.85 ms |
| live WAL 10 MB | 10.89 MB | 8.94 ms | 2.18 ms |
| rollback 50 MB | 54.08 MB | 23.22 ms | 4.02 ms |
| live WAL 50 MB | 54.40 MB | 23.65 ms | 4.52 ms |

## Tests and validation

- Dedicated source-safe suite: 24 passed on the Windows host.
- SQLite/fingerprint/WAL regression set: 3 files, 43 passed.
- SQLite-backed provider regressions: 18 suites, 311 passed.
- Deterministic tests cover prepare-time WAL publication, WAL during copy, checkpoint during copy, rollback journal during copy, source replacement/disappearance, stable rollback, stable WAL main without live WAL, live WAL, rotation, rollback-to-WAL next-open visibility, no recopy across multiple queries, concurrent readers, active/dead/ambiguous ownership, source-directory invariants, malformed SQL/schema, BUSY/LOCKED, and corrupt sources.
- `npx tsc --noEmit`: passed.
- `npm run build:cli`: passed.
- Source-size ratchet: passed against the Git base.
- `git diff --check`: passed.

## Scope and provenance

This is an independently implemented Metrora-owned shared SQLite boundary change. No provider-specific API or collector was modified. No real provider database was opened or modified; all new fixtures use disposable SQLite files under temporary directories. No real Metrora cache/history was used.

No package/version/release change, CI workflow, or new CI gate was added. PR #199 was not changed. This PR remains draft and unmerged.
