### PR TITLE
fix: normalize Copilot OTel token semantics

### DIFF
--- a/app/renderer/lib/model-projection-types.ts
+++ b/app/renderer/lib/model-projection-types.ts
@@ -8,6 +8,7 @@ export type DurableModelAccountingRow = {
   inputTokens: number
   outputTokens: number
   reasoningTokens?: number
+  additiveReasoningTokens?: number
   cacheReadTokens: number
   cacheWriteTokens: number
   tokenDetail: boolean

--- a/app/renderer/lib/model-report-types.ts
+++ b/app/renderer/lib/model-report-types.ts
@@ -10,6 +10,7 @@ export type ModelReportRow = {
   inputTokens: number
   outputTokens: number
   reasoningTokens?: number
+  additiveReasoningTokens?: number
   reasoningSemantics?: ReasoningTokenSemantics
   cacheWriteTokens: number
   cacheReadTokens: number

--- a/app/renderer/lib/types.ts
+++ b/app/renderer/lib/types.ts
@@ -4,9 +4,10 @@
 
 // ————— Period + IPC error contract —————
 
-import type { ModelAccounting, ModelPresentation, ReasoningTokenSemantics } from './model-projection-types'
+import type { ModelAccounting, ModelPresentation } from './model-projection-types'
 import type { ModelReportRow } from './model-report-types'
 import type { ProjectScopePayload } from './project-bridge-types'
+import type { ModelStats, SessionRow } from './usage-projection-types'
 export type { ProjectScopePayload } from './project-bridge-types'
 
 export type {
@@ -18,6 +19,7 @@ export type {
 } from './model-projection-types'
 
 export type { ModelReportRow } from './model-report-types'
+export type { ModelStats, SessionRow } from './usage-projection-types'
 
 export type Period = 'today' | 'week' | '30days' | 'month' | 'all' | 'lifetime'
 
@@ -473,54 +475,7 @@ export type ReasoningMix = {
   }>
 }
 
-export type SessionRow = {
-  sessionId: string
-  /** Provider + exact id + project/source authority; never raw id alone. */
-  sessionKey?: string
-  // Captured human title (src/sessions-report.ts). Empty string when the
-  // transcript produced none; optional so older CLIs that predate the field
-  // render unchanged (the row falls back to the project as its primary label).
-  title?: string
-  project: string
-  provider: string
-  models: string[]
-  cost: number
-  savingsUSD: number
-  calls: number
-  turns: number
-  inputTokens: number
-  outputTokens: number
-  cacheReadTokens: number
-  cacheWriteTokens: number
-  reasoningTokens?: number
-  reasoningSemantics?: ReasoningTokenSemantics
-  reasoningMix?: ReasoningMix
-  startedAt: string
-  endedAt: string
-  durationMs: number
-}
-
 // ————— src/compare-stats.ts —————
-export type ModelStats = {
-  model: string
-  presentationIdentity?: string
-  calls: number
-  cost: number
-  outputTokens: number
-  reasoningTokens?: number
-  reasoningSemantics?: ReasoningTokenSemantics
-  inputTokens: number
-  cacheReadTokens: number
-  cacheWriteTokens: number
-  totalTurns: number
-  editTurns: number
-  oneShotTurns: number
-  retries: number
-  selfCorrections: number
-  editCost: number
-  firstSeen: string
-  lastSeen: string
-}
 export type ComparisonRow = {
   section: string
   label: string

--- a/app/renderer/lib/usage-projection-types.ts
+++ b/app/renderer/lib/usage-projection-types.ts
@@ -1,0 +1,52 @@
+import type { ReasoningTokenSemantics } from './model-projection-types'
+import type { ReasoningMix } from './types'
+
+export type SessionRow = {
+  sessionId: string
+  /** Provider + exact id + project/source authority; never raw id alone. */
+  sessionKey?: string
+  // Captured human title (src/sessions-report.ts). Empty string when the
+  // transcript produced none; optional so older CLIs that predate the field
+  // render unchanged (the row falls back to the project as its primary label).
+  title?: string
+  project: string
+  provider: string
+  models: string[]
+  cost: number
+  savingsUSD: number
+  calls: number
+  turns: number
+  inputTokens: number
+  outputTokens: number
+  cacheReadTokens: number
+  cacheWriteTokens: number
+  reasoningTokens?: number
+  additiveReasoningTokens?: number
+  reasoningSemantics?: ReasoningTokenSemantics
+  reasoningMix?: ReasoningMix
+  startedAt: string
+  endedAt: string
+  durationMs: number
+}
+
+export type ModelStats = {
+  model: string
+  presentationIdentity?: string
+  calls: number
+  cost: number
+  outputTokens: number
+  reasoningTokens?: number
+  additiveReasoningTokens?: number
+  reasoningSemantics?: ReasoningTokenSemantics
+  inputTokens: number
+  cacheReadTokens: number
+  cacheWriteTokens: number
+  totalTurns: number
+  editTurns: number
+  oneShotTurns: number
+  retries: number
+  selfCorrections: number
+  editCost: number
+  firstSeen: string
+  lastSeen: string
+}

--- a/app/renderer/lib/usageMetrics.test.ts
+++ b/app/renderer/lib/usageMetrics.test.ts
@@ -1,11 +1,13 @@
 import { describe, expect, it } from 'vitest'
 
 import {
+  additiveReasoningTokenCount,
   cacheReuseMultiple,
   cacheShare,
   costPerMillionObserved,
   costPerMillionTotal,
   formatReuseMultiple,
+  generatedTokenCount,
   observedTokenTotal,
   totalTokenCount,
 } from './usageMetrics'
@@ -33,33 +35,92 @@ describe('shared usage metrics', () => {
     expect(costPerMillionObserved(3.54, 24_579_000)).toBeCloseTo(0.1440, 3)
   })
 
-  it('adds separately reported reasoning exactly once and never guesses unavailable reasoning', () => {
+  it('keeps aggregate-output reasoning observed but not additive', () => {
     const usage = {
-      inputTokens: 100,
-      outputTokens: 200,
-      reasoningTokens: 50,
-      cacheReadTokens: 300,
-      cacheWriteTokens: 10,
-      reasoningSemantics: 'separate' as const,
+      inputTokens: 0,
+      outputTokens: 100,
+      reasoningTokens: 20,
+      additiveReasoningTokens: 0,
+      cacheReadTokens: 0,
+      cacheWriteTokens: 0,
+      reasoningSemantics: 'aggregate-output' as const,
     }
-    expect(totalTokenCount(usage)).toBe(660)
-    expect(costPerMillionTotal(6.6, usage)).toBe(10_000)
-    expect(totalTokenCount({ ...usage, reasoningSemantics: 'unavailable' })).toBe(610)
-    expect(totalTokenCount({ ...usage, reasoningSemantics: 'aggregate-output' })).toBe(610)
+    expect(additiveReasoningTokenCount(usage)).toBe(0)
+    expect(generatedTokenCount(usage)).toBe(100)
+    expect(totalTokenCount(usage)).toBe(100)
   })
 
-  it('keeps the observed mixed subtotal in Total and Cost / 1M without estimating the missing part', () => {
+  it('uses explicit additive reasoning for separate rows', () => {
     const usage = {
-      inputTokens: 100,
+      inputTokens: 0,
+      outputTokens: 100,
+      reasoningTokens: 30,
+      additiveReasoningTokens: 30,
+      cacheReadTokens: 0,
+      cacheWriteTokens: 0,
+      reasoningSemantics: 'separate' as const,
+    }
+    expect(additiveReasoningTokenCount(usage)).toBe(30)
+    expect(generatedTokenCount(usage)).toBe(130)
+    expect(totalTokenCount(usage)).toBe(130)
+  })
+
+  it('keeps the legacy separate fallback when additive reasoning is absent', () => {
+    const usage = {
+      inputTokens: 0,
+      outputTokens: 100,
+      reasoningTokens: 30,
+      cacheReadTokens: 0,
+      cacheWriteTokens: 0,
+      reasoningSemantics: 'separate' as const,
+    }
+    expect(additiveReasoningTokenCount(usage)).toBe(30)
+    expect(generatedTokenCount(usage)).toBe(130)
+    expect(totalTokenCount(usage)).toBe(130)
+  })
+
+  it('uses explicit additive reasoning for mixed rows without hiding observed reasoning', () => {
+    const usage = {
+      inputTokens: 0,
       outputTokens: 200,
       reasoningTokens: 50,
-      cacheReadTokens: 300,
-      cacheWriteTokens: 10,
+      additiveReasoningTokens: 30,
+      cacheReadTokens: 0,
+      cacheWriteTokens: 0,
       reasoningSemantics: 'mixed' as const,
     }
-    expect(totalTokenCount(usage)).toBe(660)
-    expect(costPerMillionTotal(6.6, usage)).toBe(10_000)
-    expect(totalTokenCount({ ...usage, reasoningTokens: undefined })).toBe(610)
+    expect(additiveReasoningTokenCount(usage)).toBe(30)
+    expect(generatedTokenCount(usage)).toBe(230)
+    expect(totalTokenCount(usage)).toBe(230)
+    expect(costPerMillionTotal(2.3, usage)).toBeCloseTo(10_000, 8)
+  })
+
+  it('does not infer additive reasoning for legacy mixed rows', () => {
+    const usage = {
+      inputTokens: 0,
+      outputTokens: 200,
+      reasoningTokens: 50,
+      cacheReadTokens: 0,
+      cacheWriteTokens: 0,
+      reasoningSemantics: 'mixed' as const,
+    }
+    expect(additiveReasoningTokenCount(usage)).toBe(0)
+    expect(generatedTokenCount(usage)).toBe(200)
+    expect(totalTokenCount(usage)).toBe(200)
+  })
+
+  it('keeps unavailable reasoning non-additive', () => {
+    const usage = {
+      inputTokens: 0,
+      outputTokens: 200,
+      reasoningTokens: 50,
+      cacheReadTokens: 0,
+      cacheWriteTokens: 0,
+      reasoningSemantics: 'unavailable' as const,
+    }
+    expect(additiveReasoningTokenCount(usage)).toBe(0)
+    expect(generatedTokenCount(usage)).toBeNull()
+    expect(totalTokenCount(usage)).toBe(200)
   })
 
   it('returns unavailable instead of infinity when cache reuse has no uncached input denominator', () => {

--- a/app/renderer/lib/usageMetrics.ts
+++ b/app/renderer/lib/usageMetrics.ts
@@ -4,7 +4,29 @@ export type UsageTokenTotals = {
   cacheReadTokens: number
   cacheWriteTokens: number
   reasoningTokens?: number
+  additiveReasoningTokens?: number
   reasoningSemantics?: 'separate' | 'aggregate-output' | 'unavailable' | 'mixed'
+}
+
+/**
+ * The only reasoning contribution that may be added to output totals.
+ *
+ * Explicit additive evidence is authoritative. The legacy fallback is limited
+ * to separate rows, where the old numeric reasoning field had that meaning.
+ * Mixed rows without the optional field cannot safely infer which observed
+ * reasoning was additive, so they contribute zero.
+ */
+export function additiveReasoningTokenCount(usage: UsageTokenTotals): number {
+  switch (usage.reasoningSemantics) {
+    case 'separate':
+      return usage.additiveReasoningTokens ?? usage.reasoningTokens ?? 0
+    case 'mixed':
+      return usage.additiveReasoningTokens ?? 0
+    case 'aggregate-output':
+    case 'unavailable':
+    default:
+      return 0
+  }
 }
 
 /**
@@ -17,21 +39,15 @@ export function observedTokenTotal(usage: UsageTokenTotals): number {
   return usage.inputTokens + usage.outputTokens + usage.cacheReadTokens + usage.cacheWriteTokens
 }
 
-/**
- * Safe user-facing total. Reasoning is added only from separately reported
- * evidence. For mixed sources this is a known subtotal; unavailable or
- * aggregate-output portions are not guessed.
- */
+/** Safe user-facing total. Observed reasoning remains a breakdown; only the
+ * additive subtotal contributes separately to the total. */
 export function totalTokenCount(usage: UsageTokenTotals): number {
-  const reasoning = usage.reasoningSemantics === 'separate' || usage.reasoningSemantics === 'mixed'
-    ? usage.reasoningTokens ?? 0
-    : 0
-  return observedTokenTotal(usage) + reasoning
+  return observedTokenTotal(usage) + additiveReasoningTokenCount(usage)
 }
 
 export function generatedTokenCount(usage: UsageTokenTotals): number | null {
   if (usage.reasoningSemantics === 'unavailable') return null
-  return usage.outputTokens + ((usage.reasoningSemantics === 'separate' || usage.reasoningSemantics === 'mixed') ? usage.reasoningTokens ?? 0 : 0)
+  return usage.outputTokens + additiveReasoningTokenCount(usage)
 }
 
 /**

--- a/app/renderer/sections/Compare.test.tsx
+++ b/app/renderer/sections/Compare.test.tsx
@@ -89,6 +89,28 @@ describe('Compare', () => {
     expect(mocks.getCompare).toHaveBeenCalledWith('30days', 'all', 'Sonnet 5', 'Opus 4.8')
   })
 
+  it('preserves observed mixed reasoning and uses the additive subtotal for totals and Cost / 1M', async () => {
+    const mixedA: ModelStats = {
+      ...modelA,
+      inputTokens: 0,
+      outputTokens: 200,
+      reasoningTokens: 50,
+      additiveReasoningTokens: 30,
+      reasoningSemantics: 'mixed',
+      cacheReadTokens: 0,
+      cacheWriteTokens: 0,
+      cost: 2.3,
+    }
+    mocks.getCompareModels.mockResolvedValue([mixedA, modelB])
+    mocks.getCompare.mockResolvedValue({ ...report, modelA: mixedA })
+    render(<Compare period="30days" provider="all" />)
+
+    const usage = await screen.findByRole('table', { name: 'Observed usage comparison' })
+    expect(within(usage).getByLabelText('Opus 4.8, Reasoning: 50')).toBeInTheDocument()
+    expect(within(usage).getByLabelText('Opus 4.8, Total tokens: 230')).toBeInTheDocument()
+    expect(within(usage).getByLabelText('Opus 4.8, Cost / 1M: $10,000.00')).toBeInTheDocument()
+  })
+
   it('keeps workflow heuristics collapsed and explicitly experimental', async () => {
     const user = userEvent.setup()
     mocks.getCompareModels.mockResolvedValue([modelA, modelB])

--- a/app/renderer/sections/Compare.tsx
+++ b/app/renderer/sections/Compare.tsx
@@ -214,7 +214,7 @@ function ObservedUsageCard({ modelA, modelB }: { modelA: ModelStats; modelB: Mod
     { label: 'Calls', valueA: modelA.calls.toLocaleString('en-US'), valueB: modelB.calls.toLocaleString('en-US') },
     { label: 'Input', valueA: formatCompact(modelA.inputTokens), valueB: formatCompact(modelB.inputTokens) },
     { label: 'Output', valueA: formatCompact(modelA.outputTokens), valueB: formatCompact(modelB.outputTokens) },
-    { label: 'Reasoning', valueA: modelA.reasoningSemantics === 'separate' || modelA.reasoningSemantics === 'mixed' ? formatCompact(modelA.reasoningTokens ?? 0) : '—', valueB: modelB.reasoningSemantics === 'separate' || modelB.reasoningSemantics === 'mixed' ? formatCompact(modelB.reasoningTokens ?? 0) : '—' },
+    { label: 'Reasoning', valueA: modelA.reasoningSemantics !== 'unavailable' && modelA.reasoningTokens !== undefined ? formatCompact(modelA.reasoningTokens) : '—', valueB: modelB.reasoningSemantics !== 'unavailable' && modelB.reasoningTokens !== undefined ? formatCompact(modelB.reasoningTokens) : '—' },
     { label: 'Cache R', valueA: formatCompact(modelA.cacheReadTokens), valueB: formatCompact(modelB.cacheReadTokens) },
     { label: 'Cache W', valueA: formatCompact(modelA.cacheWriteTokens), valueB: formatCompact(modelB.cacheWriteTokens) },
     { label: 'Cache ×', valueA: formatReuseMultiple(reuseA), valueB: formatReuseMultiple(reuseB), note: `Cache share: ${shareA == null ? '—' : `${Math.round(shareA * 1000) / 10}%`} / ${shareB == null ? '—' : `${Math.round(shareB * 1000) / 10}%`}` },

--- a/app/renderer/sections/Models.test.tsx
+++ b/app/renderer/sections/Models.test.tsx
@@ -66,6 +66,19 @@ const taskRows: ModelReportRow[] = [
   },
 ]
 
+const mixedTaskRow: ModelReportRow = {
+  ...taskRows[0]!,
+  inputTokens: 0,
+  outputTokens: 200,
+  reasoningTokens: 50,
+  additiveReasoningTokens: 30,
+  reasoningSemantics: 'mixed',
+  cacheReadTokens: 0,
+  cacheWriteTokens: 0,
+  totalTokens: 230,
+  costUSD: 2.3,
+}
+
 const auditRows: AuditRow[] = [{
   provider: 'anthropic',
   providerDisplayName: 'Anthropic',
@@ -238,6 +251,17 @@ describe('Models', () => {
     expect(screen.getByText(/Task attribution needs the original session records/i)).toBeInTheDocument()
     expect(screen.getByRole('columnheader', { name: 'Cache ×' })).toBeInTheDocument()
     expect(screen.getByRole('columnheader', { name: 'Cost / 1M' })).toBeInTheDocument()
+  })
+
+  it('carries observed and additive reasoning into task totals', async () => {
+    getModels.mockResolvedValue([mixedTaskRow])
+    render(<Models period="week" provider="anthropic" overview={loadedOverview()} />)
+
+    fireEvent.click(screen.getByRole('tab', { name: 'By task' }))
+
+    expect(await screen.findByText('coding')).toBeInTheDocument()
+    expect(screen.getAllByText('50').length).toBeGreaterThan(0)
+    expect(screen.getAllByText('230').length).toBeGreaterThan(0)
   })
 
   it('keeps Audit as an explicit on-demand diagnostic lens', async () => {

--- a/app/renderer/sections/Models.tsx
+++ b/app/renderer/sections/Models.tsx
@@ -11,7 +11,7 @@ import type { Section } from '../components/Sidebar'
 import { usePolled, type Polled } from '../hooks/usePolled'
 import { formatCompact, formatUsd } from '../lib/format'
 import { metrora } from '../lib/ipc'
-import { cacheReuseMultiple, costPerMillionTotal, formatReuseMultiple, totalTokenCount } from '../lib/usageMetrics'
+import { additiveReasoningTokenCount, cacheReuseMultiple, costPerMillionTotal, formatReuseMultiple, totalTokenCount } from '../lib/usageMetrics'
 import type { AuditRow, DateRange, DurableModelAccountingRow, DurableModelPresentationRow, MenubarPayload, ModelAccounting, ModelPresentation, ModelReportRow, Period, ReasoningTokenSemantics } from '../lib/types'
 import type { SettingsPane } from './Settings'
 import { combineModelPricing, modelPricingPresentation } from './modelPricingPresentation'
@@ -225,7 +225,7 @@ function ModelsUsage({
             <strong>Model usage</strong>
             <div style={authorityNoteStyle}>Historical cost, calls and retained token detail from Metrora&apos;s durable local ledger.</div>
             <div style={authorityNoteStyle}>Generated tok/s uses retained active-generation evidence only. Observed active-generation timing is shown where the source provides it; Active ms / 1K is the inverse secondary view and unavailable routes remain —.</div>
-            <div style={authorityNoteStyle}>Total = Input + Output + separately reported Reasoning + Cache R + Cache W. Reasoning is never guessed.</div>
+            <div style={authorityNoteStyle}>Total includes Input, Output, Cache R, Cache W, and only reasoning reported as additive. Reasoning shows observed evidence; mixed rows can include reasoning already inside Output.</div>
           {incomplete ? <div style={authorityNoteStyle}>Some older usage no longer has a reliable model identity; that remainder is shown as Other models.</div> : null}
           {tokenIncomplete ? <div style={authorityNoteStyle}>Legacy rows without a durable token split show — for token-derived metrics instead of guessing.</div> : null}
         </div>
@@ -370,10 +370,19 @@ function reportRowTotal(row: ModelReportRow): number {
     inputTokens: row.inputTokens,
     outputTokens: row.outputTokens,
     reasoningTokens: row.reasoningTokens,
+    additiveReasoningTokens: row.additiveReasoningTokens,
     reasoningSemantics: row.reasoningSemantics,
     cacheReadTokens: row.cacheReadTokens,
     cacheWriteTokens: row.cacheWriteTokens,
   })
+}
+
+function groupReasoningSemantics(rows: ModelReportRow[]): ReasoningTokenSemantics {
+  const semantics = new Set(rows.map(row => row.reasoningSemantics ?? 'unavailable'))
+  if (semantics.has('mixed') || (semantics.has('separate') && semantics.has('aggregate-output'))) return 'mixed'
+  if (semantics.has('separate')) return 'separate'
+  if (semantics.has('aggregate-output')) return 'aggregate-output'
+  return 'unavailable'
 }
 
 function ModelGroupRow({ rows, onAddAlias }: { rows: ModelReportRow[]; onAddAlias: () => void }) {
@@ -383,16 +392,15 @@ function ModelGroupRow({ rows, onAddAlias }: { rows: ModelReportRow[]; onAddAlia
   const input = rows.reduce((sum, row) => sum + row.inputTokens, 0)
   const output = rows.reduce((sum, row) => sum + row.outputTokens, 0)
   const reasoning = rows.reduce((sum, row) => sum + (row.reasoningTokens ?? 0), 0)
-  const reasoningSemantics: ReasoningTokenSemantics = rows.some(row => row.reasoningSemantics === 'separate' || row.reasoningSemantics === 'mixed')
-    ? 'separate'
-    : 'unavailable'
+  const additiveReasoning = rows.reduce((sum, row) => sum + additiveReasoningTokenCount(row), 0)
+  const reasoningSemantics = groupReasoningSemantics(rows)
   const cacheRead = rows.reduce((sum, row) => sum + row.cacheReadTokens, 0)
   const cacheWrite = rows.reduce((sum, row) => sum + row.cacheWriteTokens, 0)
-  const total = totalTokenCount({ inputTokens: input, outputTokens: output, reasoningTokens: reasoning, reasoningSemantics, cacheReadTokens: cacheRead, cacheWriteTokens: cacheWrite })
+  const total = totalTokenCount({ inputTokens: input, outputTokens: output, reasoningTokens: reasoning, additiveReasoningTokens: additiveReasoning, reasoningSemantics, cacheReadTokens: cacheRead, cacheWriteTokens: cacheWrite })
   const pricing = modelPricingPresentation(combineModelPricing(rows), calls)
   const costValue = pricing.costMode === 'unavailable' ? '—' : formatUsd(costUSD)
   const reuse = cacheReuseMultiple(input, cacheRead)
-  const unitCost = costPerMillionTotal(costUSD, { inputTokens: input, outputTokens: output, reasoningTokens: reasoning, reasoningSemantics, cacheReadTokens: cacheRead, cacheWriteTokens: cacheWrite })
+  const unitCost = costPerMillionTotal(costUSD, { inputTokens: input, outputTokens: output, reasoningTokens: reasoning, additiveReasoningTokens: additiveReasoning, reasoningSemantics, cacheReadTokens: cacheRead, cacheWriteTokens: cacheWrite })
 
   return (
     <tr className="model-group-row">
@@ -407,7 +415,7 @@ function ModelGroupRow({ rows, onAddAlias }: { rows: ModelReportRow[]; onAddAlia
         </span>
       </td>
       <td>{fmtInt(calls)}</td>
-      <td>{reasoningSemantics === 'separate' ? formatCompact(reasoning) : '—'}</td>
+      <td>{reasoningSemantics !== 'unavailable' ? formatCompact(reasoning) : '—'}</td>
       <td>{formatCompact(input)}</td>
       <td>{formatCompact(output)}</td>
       <td>{formatCompact(cacheRead)}</td>
@@ -429,6 +437,7 @@ function ModelTaskRow({ row }: { row: ModelReportRow }) {
     inputTokens: row.inputTokens,
     outputTokens: row.outputTokens,
     reasoningTokens: row.reasoningTokens,
+    additiveReasoningTokens: row.additiveReasoningTokens,
     reasoningSemantics: row.reasoningSemantics,
     cacheReadTokens: row.cacheReadTokens,
     cacheWriteTokens: row.cacheWriteTokens,
@@ -438,7 +447,7 @@ function ModelTaskRow({ row }: { row: ModelReportRow }) {
     <tr className="model-task-row">
       <td>{row.category ?? 'general'}</td>
       <td>{fmtInt(row.calls)}</td>
-      <td>{row.reasoningSemantics === 'separate' || row.reasoningSemantics === 'mixed' ? formatCompact(row.reasoningTokens ?? 0) : '—'}</td>
+      <td>{row.reasoningSemantics !== 'unavailable' && row.reasoningTokens !== undefined ? formatCompact(row.reasoningTokens) : '—'}</td>
       <td>{formatCompact(row.inputTokens)}</td>
       <td>{formatCompact(row.outputTokens)}</td>
       <td>{formatCompact(row.cacheReadTokens)}</td>

--- a/app/renderer/sections/ModelsDurableTable.test.tsx
+++ b/app/renderer/sections/ModelsDurableTable.test.tsx
@@ -11,9 +11,10 @@ function delivery(): DurableModelAccountingRow {
     cost: 1,
     savingsUSD: 0,
     calls: 2,
-    inputTokens: 100,
+    inputTokens: 0,
     outputTokens: 200,
     reasoningTokens: 50,
+    additiveReasoningTokens: 30,
     cacheReadTokens: 0,
     cacheWriteTokens: 0,
     tokenDetail: true,
@@ -40,7 +41,7 @@ function presentationRow(row: DurableModelAccountingRow): DurableModelPresentati
 }
 
 describe('durable Models table reasoning presentation', () => {
-  it('shows the observed mixed subtotal and includes it in Total', () => {
+  it('shows observed mixed reasoning and adds only the explicit subtotal to Total', () => {
     const row = delivery()
     const accounting: ModelAccounting = {
       rows: [row],
@@ -73,8 +74,8 @@ describe('durable Models table reasoning presentation', () => {
       />,
     )
 
-    expect(screen.getByText('≥50')).toBeInTheDocument()
-    expect(screen.getByText('350')).toBeInTheDocument()
-    expect(screen.getByTitle(/At least the shown reasoning tokens/)).toBeInTheDocument()
+    expect(screen.getByText('50')).toBeInTheDocument()
+    expect(screen.getByText('230')).toBeInTheDocument()
+    expect(screen.getByTitle(/only the additive subset/)).toBeInTheDocument()
   })
 })

--- a/app/renderer/sections/ModelsDurableTable.tsx
+++ b/app/renderer/sections/ModelsDurableTable.tsx
@@ -54,23 +54,15 @@ function tokenTotal(row: DurableModelRow): number {
 }
 
 function reasoningDisplay(row: Pick<DurableModelAccountingRow, 'reasoningSemantics' | 'reasoningTokens'>): string {
-  if (row.reasoningSemantics === 'separate') return formatCompact(row.reasoningTokens ?? 0)
-  if (row.reasoningSemantics === 'mixed' && (row.reasoningTokens ?? 0) > 0) {
-    return `≥${formatCompact(row.reasoningTokens!)}`
-  }
-  return '—'
+  if (row.reasoningSemantics === 'unavailable' || row.reasoningTokens === undefined) return '—'
+  return formatCompact(row.reasoningTokens)
 }
 
 function reasoningTitle(row: Pick<DurableModelAccountingRow, 'reasoningSemantics' | 'reasoningTokens'>): string {
-  if (row.reasoningSemantics === 'separate') return 'Separately reported reasoning tokens included in Total.'
-  if (row.reasoningSemantics === 'aggregate-output') return 'Reasoning is already included in Output; it is not added separately.'
-  if (row.reasoningSemantics === 'mixed' && (row.reasoningTokens ?? 0) > 0) {
-    return 'At least the shown reasoning tokens were separately observed and included in Total; other delivery reasoning is unavailable or already aggregated.'
-  }
-  if (row.reasoningSemantics === 'mixed') {
-    return 'Some delivery reasoning is unavailable or already aggregated; no separately reported reasoning evidence was retained.'
-  }
-  return 'Separate reasoning evidence is unavailable; it is not guessed.'
+  if (row.reasoningSemantics === 'separate') return 'Observed reasoning evidence; reasoning reported separately is included in Total.'
+  if (row.reasoningSemantics === 'aggregate-output') return 'Observed reasoning is already included in Output; it is not added separately to Total.'
+  if (row.reasoningSemantics === 'mixed') return 'Observed reasoning may include both output-included and separately additive tokens; only the additive subset is included separately in Total.'
+  return 'Observed reasoning evidence is unavailable; it is not guessed.'
 }
 
 function modelCacheReuse(row: DurableModelRow): number | null {

--- a/app/renderer/sections/Sessions.test.tsx
+++ b/app/renderer/sections/Sessions.test.tsx
@@ -128,6 +128,29 @@ describe('Sessions', () => {
     expect(within(table).getByRole('columnheader', { name: 'Cost / 1M' })).toBeInTheDocument()
   })
 
+  it('preserves observed mixed reasoning while adding only the explicit subtotal', async () => {
+    getSessions.mockResolvedValue([session({
+      sessionId: 'mixed',
+      title: 'Mixed reasoning',
+      project: 'metrora',
+      provider: 'copilot',
+      inputTokens: 0,
+      outputTokens: 200,
+      reasoningTokens: 50,
+      additiveReasoningTokens: 30,
+      reasoningSemantics: 'mixed',
+      cacheReadTokens: 0,
+      cacheWriteTokens: 0,
+      cost: 2.3,
+    })])
+    render(<Sessions period="lifetime" provider="all" />)
+
+    const table = await screen.findByRole('table', { name: 'Detailed sessions' })
+    const row = within(table).getAllByRole('row')[1]!
+    expect(row).toHaveTextContent('50')
+    expect(row).toHaveTextContent('230')
+  })
+
   it('keeps provider grouping as an explicit optional lens', async () => {
     const user = userEvent.setup()
     render(<Sessions period="lifetime" provider="all" />)

--- a/app/renderer/sections/Sessions.tsx
+++ b/app/renderer/sections/Sessions.tsx
@@ -96,6 +96,18 @@ function sessionUnitCost(row: SessionRow): number | null {
   return costPerMillionTotal(row.cost, row)
 }
 
+function hasObservedReasoning(row: Pick<SessionRow, 'reasoningSemantics' | 'reasoningTokens'>): boolean {
+  return row.reasoningSemantics !== 'unavailable' && row.reasoningTokens !== undefined
+}
+
+function sessionReasoningTitle(row: Pick<SessionRow, 'reasoningSemantics' | 'reasoningTokens'>): string {
+  if (!hasObservedReasoning(row)) return 'Observed reasoning evidence is unavailable; it is not guessed.'
+  if (row.reasoningSemantics === 'aggregate-output') return 'Observed reasoning is already included in Output; it is not added separately to Total.'
+  if (row.reasoningSemantics === 'mixed') return 'Observed reasoning may include both output-included and separately additive tokens; only the additive subset is included separately in Total.'
+  if (row.reasoningSemantics === 'separate') return 'Observed reasoning evidence; reasoning reported separately is included in Total.'
+  return 'Observed reasoning evidence; only reasoning reported as additive contributes separately to Total.'
+}
+
 function compareNullableDescending(a: number | null, b: number | null): number {
   if (a == null && b == null) return 0
   if (a == null) return 1
@@ -436,7 +448,7 @@ export function Sessions({
                       <td>{entry.row.calls.toLocaleString('en-US')}</td>
                       <td>{formatCompact(entry.row.inputTokens)}</td>
                       <td>{formatCompact(entry.row.outputTokens)}</td>
-                      <td title={entry.row.reasoningSemantics === 'unavailable' ? 'Separate reasoning evidence is unavailable; it is not guessed.' : 'Separately reported reasoning tokens included in Total.'}>{entry.row.reasoningSemantics === 'separate' || entry.row.reasoningSemantics === 'mixed' ? formatCompact(entry.row.reasoningTokens ?? 0) : '\u2014'}</td>
+                      <td title={sessionReasoningTitle(entry.row)}>{hasObservedReasoning(entry.row) ? formatCompact(entry.row.reasoningTokens!) : '\u2014'}</td>
                       <td>{formatCompact(entry.row.cacheReadTokens)}</td>
                       <td>{formatCompact(entry.row.cacheWriteTokens)}</td>
                       <td title={cacheShare(entry.row.inputTokens, entry.row.cacheReadTokens) == null ? undefined : `${Math.round((cacheShare(entry.row.inputTokens, entry.row.cacheReadTokens) ?? 0) * 1000) / 10}% of input served from cache`}>{formatReuseMultiple(sessionCacheReuse(entry.row))}</td>
@@ -475,10 +487,10 @@ function SessionDetail({ session, onCollapse }: { session: SessionRow; onCollaps
   const reuse = sessionCacheReuse(session)
   const share = cacheShare(session.inputTokens, session.cacheReadTokens)
   const unitCost = sessionUnitCost(session)
-  const hasSeparateReasoning = session.reasoningSemantics === 'separate' || session.reasoningSemantics === 'mixed'
-  const reasoningTokenSummary = !hasSeparateReasoning
+  const hasReasoning = hasObservedReasoning(session)
+  const reasoningTokenSummary = !hasReasoning
     ? 'Reasoning-token count unavailable'
-    : `${formatCompact(session.reasoningTokens ?? 0)} dedicated reasoning tokens`
+    : `${formatCompact(session.reasoningTokens!)} observed reasoning tokens`
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
@@ -505,11 +517,11 @@ function SessionDetail({ session, onCollapse }: { session: SessionRow; onCollaps
         <Stat label="Turns" value={session.turns.toLocaleString()} delta="assistant turns" />
         <Stat label="Input" value={formatCompact(session.inputTokens)} delta="uncached input" />
         <Stat label="Output" value={formatCompact(session.outputTokens)} delta="generated" />
-        <Stat label="Reasoning" value={hasSeparateReasoning ? formatCompact(session.reasoningTokens ?? 0) : '—'} delta={hasSeparateReasoning ? 'separately reported' : 'separate evidence unavailable'} />
+        <Stat label="Reasoning" value={hasReasoning ? formatCompact(session.reasoningTokens!) : '—'} delta={hasReasoning ? 'observed evidence' : 'evidence unavailable'} />
         <Stat label="Cache read" value={formatCompact(session.cacheReadTokens)} delta="reused input" />
         <Stat label="Cache write" value={formatCompact(session.cacheWriteTokens)} delta="written to cache" />
         <Stat label="Cache reuse" value={formatReuseMultiple(reuse)} delta={share == null ? 'No comparable input' : `${Math.round(share * 1000) / 10}% cache share`} />
-        <Stat label="Total" value={formatCompact(totalTokens)} delta="input + output + reasoning + cache" />
+        <Stat label="Total" value={formatCompact(totalTokens)} delta="input + output + additive reasoning + cache" />
         {session.savingsUSD > 0 ? <Stat label="Saved" value={formatUsd(session.savingsUSD)} delta="configured baseline" /> : null}
       </div>
       {session.reasoningMix && session.reasoningMix.rows.length > 0 && (

--- a/src/audit-report.ts
+++ b/src/audit-report.ts
@@ -2,7 +2,7 @@ import { getModelCosts, type ModelCosts } from './models.js'
 import { getProvider } from './providers/index.js'
 import { formatCost, formatTokens } from './format.js'
 import { renderTable, type TableColumn } from './text-table.js'
-import { reasoningSemanticsForProviders, separatelyReportedReasoningTokens } from './token-semantics.js'
+import { reasoningSemanticsForProviders, reasoningTokenTotals } from './token-semantics.js'
 import type { ProjectSummary } from './types.js'
 
 // One (provider, model) bucket, exposing both the raw token fields as recorded
@@ -24,11 +24,14 @@ export type AuditRow = {
     cachedInputTokens: number // OpenAI vocab
     webSearchRequests: number
   }
-  // What the reports display: separate reasoning folds into output, and the two
-  // cache-read vocabularies collapse to their max (providers fill one or both).
+  // What the reports display: raw reasoning remains a factual breakdown, while
+  // only additive reasoning folds into generated output. The two cache-read
+  // vocabularies collapse to their max (providers fill one or both).
   displayed: {
     inputTokens: number
     outputTokens: number
+    reasoningTokens: number
+    additiveReasoningTokens: number
     cacheWriteTokens: number
     cacheReadTokens: number
   }
@@ -56,7 +59,8 @@ export async function aggregateAudit(projects: ProjectSummary[]): Promise<AuditR
     calls: number
     attributedCostUSD: number
     cacheReadDisplayed: number
-    displayedReasoningTokens: number
+    observedReasoningTokens: number
+    additiveReasoningTokens: number
     raw: AuditRow['raw']
   }
   const buckets = new Map<string, Bucket>()
@@ -74,7 +78,8 @@ export async function aggregateAudit(projects: ProjectSummary[]): Promise<AuditR
               provider,
               model,
               calls: 0,
-              displayedReasoningTokens: 0,
+              observedReasoningTokens: 0,
+              additiveReasoningTokens: 0,
               attributedCostUSD: 0,
               cacheReadDisplayed: 0,
               raw: {
@@ -91,9 +96,12 @@ export async function aggregateAudit(projects: ProjectSummary[]): Promise<AuditR
           }
           const u = call.usage
           const callSemantics = call.reasoningSemantics ?? reasoningSemanticsForProviders([call.provider])
-          bucket.displayedReasoningTokens += call.reasoningSemantics === undefined
-            ? u.reasoningTokens
-            : separatelyReportedReasoningTokens(u.reasoningTokens, callSemantics)
+          const callReasoning = reasoningTokenTotals(
+            u.reasoningTokens,
+            call.reasoningSemantics === undefined ? undefined : callSemantics,
+          )
+          bucket.observedReasoningTokens += callReasoning.observedReasoningTokens
+          bucket.additiveReasoningTokens += callReasoning.additiveReasoningTokens
           bucket.raw.inputTokens += u.inputTokens
           bucket.raw.outputTokens += u.outputTokens
           bucket.raw.reasoningTokens += u.reasoningTokens
@@ -129,7 +137,9 @@ export async function aggregateAudit(projects: ProjectSummary[]): Promise<AuditR
     const meta = await resolveProvider(bucket.provider)
     const displayed = {
       inputTokens: bucket.raw.inputTokens,
-      outputTokens: bucket.raw.outputTokens + bucket.displayedReasoningTokens,
+      outputTokens: bucket.raw.outputTokens + bucket.additiveReasoningTokens,
+      reasoningTokens: bucket.observedReasoningTokens,
+      additiveReasoningTokens: bucket.additiveReasoningTokens,
       cacheWriteTokens: bucket.raw.cacheCreationInputTokens,
       cacheReadTokens: bucket.cacheReadDisplayed,
     }
@@ -214,7 +224,7 @@ export function renderAuditTable(rows: AuditRow[]): string {
   const legend = [
     '',
     'Columns are the raw token fields each provider records. metrora then normalizes for pricing:',
-    '  - Reason folds into Output (priced output = output + reasoning)',
+    '  - Reason is an observed breakdown; only additive reasoning folds into generated Output',
     '  - Cache rd = max(Anthropic cacheReadInput, OpenAI cached), since providers fill one or both',
     '  - Cache wr is priced at 1.25x the input rate, Cache rd at 0.1x, when a model omits explicit cache rates',
     'Use --format json for per-component cost, the rates applied, and both raw cache-read fields.',

--- a/src/audit-report.ts
+++ b/src/audit-report.ts
@@ -2,6 +2,7 @@ import { getModelCosts, type ModelCosts } from './models.js'
 import { getProvider } from './providers/index.js'
 import { formatCost, formatTokens } from './format.js'
 import { renderTable, type TableColumn } from './text-table.js'
+import { reasoningSemanticsForProviders, separatelyReportedReasoningTokens } from './token-semantics.js'
 import type { ProjectSummary } from './types.js'
 
 // One (provider, model) bucket, exposing both the raw token fields as recorded
@@ -23,7 +24,7 @@ export type AuditRow = {
     cachedInputTokens: number // OpenAI vocab
     webSearchRequests: number
   }
-  // What the reports display: reasoning folds into output, and the two
+  // What the reports display: separate reasoning folds into output, and the two
   // cache-read vocabularies collapse to their max (providers fill one or both).
   displayed: {
     inputTokens: number
@@ -55,6 +56,7 @@ export async function aggregateAudit(projects: ProjectSummary[]): Promise<AuditR
     calls: number
     attributedCostUSD: number
     cacheReadDisplayed: number
+    displayedReasoningTokens: number
     raw: AuditRow['raw']
   }
   const buckets = new Map<string, Bucket>()
@@ -72,6 +74,7 @@ export async function aggregateAudit(projects: ProjectSummary[]): Promise<AuditR
               provider,
               model,
               calls: 0,
+              displayedReasoningTokens: 0,
               attributedCostUSD: 0,
               cacheReadDisplayed: 0,
               raw: {
@@ -87,6 +90,10 @@ export async function aggregateAudit(projects: ProjectSummary[]): Promise<AuditR
             buckets.set(key, bucket)
           }
           const u = call.usage
+          const callSemantics = call.reasoningSemantics ?? reasoningSemanticsForProviders([call.provider])
+          bucket.displayedReasoningTokens += call.reasoningSemantics === undefined
+            ? u.reasoningTokens
+            : separatelyReportedReasoningTokens(u.reasoningTokens, callSemantics)
           bucket.raw.inputTokens += u.inputTokens
           bucket.raw.outputTokens += u.outputTokens
           bucket.raw.reasoningTokens += u.reasoningTokens
@@ -122,7 +129,7 @@ export async function aggregateAudit(projects: ProjectSummary[]): Promise<AuditR
     const meta = await resolveProvider(bucket.provider)
     const displayed = {
       inputTokens: bucket.raw.inputTokens,
-      outputTokens: bucket.raw.outputTokens + bucket.raw.reasoningTokens,
+      outputTokens: bucket.raw.outputTokens + bucket.displayedReasoningTokens,
       cacheWriteTokens: bucket.raw.cacheCreationInputTokens,
       cacheReadTokens: bucket.cacheReadDisplayed,
     }

--- a/src/compare-stats.ts
+++ b/src/compare-stats.ts
@@ -3,7 +3,7 @@ import { join } from 'path'
 
 import { presentationIdentityForModelName } from './model-presentation.js'
 import type { ProjectSummary } from './types.js'
-import { combineReasoningSemantics, reasoningSemanticsForProviders, type ReasoningTokenSemantics } from './token-semantics.js'
+import { combineReasoningSemantics, reasoningSemanticsForProviders, separatelyReportedReasoningTokens, type ReasoningTokenSemantics } from './token-semantics.js'
 
 const PLANNING_TOOLS = new Set(['TaskCreate', 'TaskUpdate', 'TodoWrite', 'EnterPlanMode', 'ExitPlanMode'])
 
@@ -93,13 +93,11 @@ export function aggregateModelStats(projects: ProjectSummary[]): ModelStats[] {
           cs.calls++
           cs.cost += call.costUSD
           cs.outputTokens += call.usage.outputTokens
-          const callReasoningSemantics = reasoningSemanticsForProviders([call.provider])
+          const callReasoningSemantics = call.reasoningSemantics ?? reasoningSemanticsForProviders([call.provider])
           cs.reasoningSemantics = cs.calls === 1
             ? callReasoningSemantics
             : combineReasoningSemantics([cs.reasoningSemantics, callReasoningSemantics])
-          if (callReasoningSemantics === 'separate') {
-            cs.reasoningTokens += call.usage.reasoningTokens
-          }
+          cs.reasoningTokens += separatelyReportedReasoningTokens(call.usage.reasoningTokens, callReasoningSemantics)
           cs.inputTokens += call.usage.inputTokens
           cs.cacheReadTokens += call.usage.cacheReadInputTokens
           cs.cacheWriteTokens += call.usage.cacheCreationInputTokens

--- a/src/compare-stats.ts
+++ b/src/compare-stats.ts
@@ -3,7 +3,7 @@ import { join } from 'path'
 
 import { presentationIdentityForModelName } from './model-presentation.js'
 import type { ProjectSummary } from './types.js'
-import { combineReasoningSemantics, reasoningSemanticsForProviders, separatelyReportedReasoningTokens, type ReasoningTokenSemantics } from './token-semantics.js'
+import { combineReasoningSemantics, reasoningSemanticsForProviders, reasoningTokenTotals, type ReasoningTokenSemantics } from './token-semantics.js'
 
 const PLANNING_TOOLS = new Set(['TaskCreate', 'TaskUpdate', 'TodoWrite', 'EnterPlanMode', 'ExitPlanMode'])
 
@@ -15,6 +15,7 @@ export type ModelStats = {
   cost: number
   outputTokens: number
   reasoningTokens: number
+  additiveReasoningTokens: number
   reasoningSemantics: ReasoningTokenSemantics
   inputTokens: number
   cacheReadTokens: number
@@ -38,6 +39,7 @@ function emptyModelStats(model: string): ModelStats {
     cost: 0,
     outputTokens: 0,
     reasoningTokens: 0,
+    additiveReasoningTokens: 0,
     reasoningSemantics: 'unavailable',
     inputTokens: 0,
     cacheReadTokens: 0,
@@ -94,10 +96,12 @@ export function aggregateModelStats(projects: ProjectSummary[]): ModelStats[] {
           cs.cost += call.costUSD
           cs.outputTokens += call.usage.outputTokens
           const callReasoningSemantics = call.reasoningSemantics ?? reasoningSemanticsForProviders([call.provider])
+          const callReasoning = reasoningTokenTotals(call.usage.reasoningTokens, callReasoningSemantics)
           cs.reasoningSemantics = cs.calls === 1
             ? callReasoningSemantics
             : combineReasoningSemantics([cs.reasoningSemantics, callReasoningSemantics])
-          cs.reasoningTokens += separatelyReportedReasoningTokens(call.usage.reasoningTokens, callReasoningSemantics)
+          cs.reasoningTokens += callReasoning.observedReasoningTokens
+          cs.additiveReasoningTokens += callReasoning.additiveReasoningTokens
           cs.inputTokens += call.usage.inputTokens
           cs.cacheReadTokens += call.usage.cacheReadInputTokens
           cs.cacheWriteTokens += call.usage.cacheCreationInputTokens
@@ -131,6 +135,7 @@ export function aggregatePresentationModelStats(projects: ProjectSummary[]): Mod
     existing.cost += raw.cost
     existing.outputTokens += raw.outputTokens
     existing.reasoningTokens += raw.reasoningTokens
+    existing.additiveReasoningTokens += raw.additiveReasoningTokens
     existing.reasoningSemantics = combineReasoningSemantics([existing.reasoningSemantics, raw.reasoningSemantics])
     existing.inputTokens += raw.inputTokens
     existing.cacheReadTokens += raw.cacheReadTokens

--- a/src/contracts/v1/provenance-mapper.ts
+++ b/src/contracts/v1/provenance-mapper.ts
@@ -113,7 +113,9 @@ function reasoningAttributionIsAllowed(
 }
 
 function positiveUsageHasPricingCoverage(call: ParsedApiCall, costs: ModelCosts): boolean {
-  const outputAndReasoning = call.usage.outputTokens + call.usage.reasoningTokens
+  const outputAndReasoning = call.reasoningSemantics === 'aggregate-output'
+    ? call.usage.outputTokens
+    : call.usage.outputTokens + call.usage.reasoningTokens
   if (!Number.isSafeInteger(outputAndReasoning)) return false
 
   let sawBillableFact = false
@@ -136,7 +138,9 @@ function locallyCalculatedCostMatches(
   call: ParsedApiCall,
   calculator: typeof calculateCost,
 ): boolean {
-  const outputAndReasoning = call.usage.outputTokens + call.usage.reasoningTokens
+  const outputAndReasoning = call.reasoningSemantics === 'aggregate-output'
+    ? call.usage.outputTokens
+    : call.usage.outputTokens + call.usage.reasoningTokens
   if (!Number.isSafeInteger(outputAndReasoning)) return false
 
   const expected = calculator(

--- a/src/contracts/v1/provenance-mapper.ts
+++ b/src/contracts/v1/provenance-mapper.ts
@@ -1,5 +1,6 @@
 import type { ModelCosts } from '../../models.js'
 import { calculateCost, getModelCosts } from '../../models.js'
+import { billableOutputTokens } from '../../token-semantics.js'
 import {
   CostAssignmentV1Schema,
   costAssignmentMatchesUsdV1,
@@ -113,9 +114,7 @@ function reasoningAttributionIsAllowed(
 }
 
 function positiveUsageHasPricingCoverage(call: ParsedApiCall, costs: ModelCosts): boolean {
-  const outputAndReasoning = call.reasoningSemantics === 'aggregate-output'
-    ? call.usage.outputTokens
-    : call.usage.outputTokens + call.usage.reasoningTokens
+  const outputAndReasoning = billableOutputTokens(call.provider, call.usage.outputTokens, call.usage.reasoningTokens, call.reasoningSemantics)
   if (!Number.isSafeInteger(outputAndReasoning)) return false
 
   let sawBillableFact = false
@@ -138,9 +137,7 @@ function locallyCalculatedCostMatches(
   call: ParsedApiCall,
   calculator: typeof calculateCost,
 ): boolean {
-  const outputAndReasoning = call.reasoningSemantics === 'aggregate-output'
-    ? call.usage.outputTokens
-    : call.usage.outputTokens + call.usage.reasoningTokens
+  const outputAndReasoning = billableOutputTokens(call.provider, call.usage.outputTokens, call.usage.reasoningTokens, call.reasoningSemantics)
   if (!Number.isSafeInteger(outputAndReasoning)) return false
 
   const expected = calculator(

--- a/src/daily-cache-core.ts
+++ b/src/daily-cache-core.ts
@@ -148,7 +148,7 @@ function sanitizeCategories(raw: unknown): DailyEntry['categories'] {
   return out
 }
 
-const OPTIONAL_SLICE_NUMERICS = ['sessions', 'inputTokens', 'outputTokens', 'reasoningTokens', 'cacheReadTokens', 'cacheWriteTokens', 'editTurns', 'oneShotTurns'] as const
+const OPTIONAL_SLICE_NUMERICS = ['sessions', 'inputTokens', 'outputTokens', 'reasoningTokens', 'additiveReasoningTokens', 'cacheReadTokens', 'cacheWriteTokens', 'editTurns', 'oneShotTurns'] as const
 
 /// Same junk-tolerance as sanitizeProjects, one level up: a foreign cache can
 /// hold anything under a provider slice, and structuredClone in the merge
@@ -188,7 +188,7 @@ function sanitizeProjects(raw: unknown): { projects?: DailyEntry['projects'] } {
       sessions: num(p.sessions),
       ...(typeof p.path === 'string' && p.path.length > 0 ? { path: p.path } : {}),
     }
-    for (const field of ['inputTokens', 'outputTokens', 'reasoningTokens', 'cacheReadTokens', 'cacheWriteTokens'] as const) {
+    for (const field of ['inputTokens', 'outputTokens', 'reasoningTokens', 'additiveReasoningTokens', 'cacheReadTokens', 'cacheWriteTokens'] as const) {
       if (typeof p[field] === 'number' && Number.isFinite(p[field])) clean[field] = Math.max(0, p[field])
     }
     setOwn(out, name, clean)
@@ -211,6 +211,9 @@ export function migrateDays(days: Record<string, unknown>[]): DailyEntry[] {
       outputTokens: num(d.outputTokens),
       ...(typeof d.reasoningTokens === 'number' && Number.isFinite(d.reasoningTokens)
         ? { reasoningTokens: Math.max(0, d.reasoningTokens) }
+        : {}),
+      ...(typeof d.additiveReasoningTokens === 'number' && Number.isFinite(d.additiveReasoningTokens)
+        ? { additiveReasoningTokens: Math.max(0, d.additiveReasoningTokens) }
         : {}),
       cacheReadTokens: num(d.cacheReadTokens),
       cacheWriteTokens: num(d.cacheWriteTokens),

--- a/src/daily-cache-merge.ts
+++ b/src/daily-cache-merge.ts
@@ -1,7 +1,7 @@
 import { emptyModelStats, mergeModelStats } from './daily-cache-model-detail.js'
 import type { DailyEntry, ProjectDayStats, ProviderDaySlice } from './daily-cache-types.js'
 
-const PROJECT_TOKEN_FIELDS = ['inputTokens', 'outputTokens', 'reasoningTokens', 'cacheReadTokens', 'cacheWriteTokens'] as const
+const PROJECT_TOKEN_FIELDS = ['inputTokens', 'outputTokens', 'reasoningTokens', 'additiveReasoningTokens', 'cacheReadTokens', 'cacheWriteTokens'] as const
 
 function num(v: unknown): number {
   return typeof v === 'number' && Number.isFinite(v) ? v : 0
@@ -11,6 +11,7 @@ function hasSliceData(slice: ProviderDaySlice): boolean {
   return slice.cost > 0 || slice.calls > 0 || (slice.savingsUSD ?? 0) > 0
     || (slice.inputTokens ?? 0) > 0 || (slice.outputTokens ?? 0) > 0
     || (slice.reasoningTokens ?? 0) > 0 || (slice.cacheReadTokens ?? 0) > 0
+    || (slice.additiveReasoningTokens ?? 0) > 0
     || (slice.cacheWriteTokens ?? 0) > 0
 }
 
@@ -58,6 +59,7 @@ function addSliceIntoDay(day: DailyEntry, provider: string, slice: ProviderDaySl
   day.inputTokens += slice.inputTokens ?? 0
   day.outputTokens += slice.outputTokens ?? 0
   if (slice.reasoningTokens !== undefined) day.reasoningTokens = (day.reasoningTokens ?? 0) + slice.reasoningTokens
+  if (slice.additiveReasoningTokens !== undefined) day.additiveReasoningTokens = (day.additiveReasoningTokens ?? 0) + slice.additiveReasoningTokens
   day.cacheReadTokens += slice.cacheReadTokens ?? 0
   day.cacheWriteTokens += slice.cacheWriteTokens ?? 0
   day.editTurns += slice.editTurns ?? 0

--- a/src/daily-cache-model-detail.ts
+++ b/src/daily-cache-model-detail.ts
@@ -34,6 +34,9 @@ export function sanitizeModels(raw: unknown): DailyEntry['models'] {
       ...(typeof m.reasoningTokens === 'number' && Number.isFinite(m.reasoningTokens)
         ? { reasoningTokens: Math.max(0, m.reasoningTokens) }
         : {}),
+      ...(typeof m.additiveReasoningTokens === 'number' && Number.isFinite(m.additiveReasoningTokens)
+        ? { additiveReasoningTokens: Math.max(0, m.additiveReasoningTokens) }
+        : {}),
       cacheReadTokens: finiteNumber(m.cacheReadTokens),
       cacheWriteTokens: finiteNumber(m.cacheWriteTokens),
       ...(isReasoningTokenSemantics(m.reasoningSemantics) ? { reasoningSemantics: m.reasoningSemantics } : {}),
@@ -61,6 +64,7 @@ export function mergeModelStats(target: ModelDayStats, source: ModelDayStats): v
   target.inputTokens += source.inputTokens
   target.outputTokens += source.outputTokens
   if (source.reasoningTokens !== undefined) target.reasoningTokens = (target.reasoningTokens ?? 0) + source.reasoningTokens
+  if (source.additiveReasoningTokens !== undefined) target.additiveReasoningTokens = (target.additiveReasoningTokens ?? 0) + source.additiveReasoningTokens
   target.cacheReadTokens += source.cacheReadTokens
   target.cacheWriteTokens += source.cacheWriteTokens
   if (!target.modelProvider && source.modelProvider) target.modelProvider = source.modelProvider

--- a/src/daily-cache-model-detail.ts
+++ b/src/daily-cache-model-detail.ts
@@ -1,7 +1,15 @@
 import type { DailyEntry, ModelDayStats } from './daily-cache-core.js'
+import { combineReasoningSemantics, type ReasoningTokenSemantics } from './token-semantics.js'
 
 function finiteNumber(value: unknown): number {
   return typeof value === 'number' && Number.isFinite(value) ? value : 0
+}
+
+function isReasoningTokenSemantics(value: unknown): value is ReasoningTokenSemantics {
+  return value === 'separate'
+    || value === 'aggregate-output'
+    || value === 'unavailable'
+    || value === 'mixed'
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -28,6 +36,7 @@ export function sanitizeModels(raw: unknown): DailyEntry['models'] {
         : {}),
       cacheReadTokens: finiteNumber(m.cacheReadTokens),
       cacheWriteTokens: finiteNumber(m.cacheWriteTokens),
+      ...(isReasoningTokenSemantics(m.reasoningSemantics) ? { reasoningSemantics: m.reasoningSemantics } : {}),
       ...(typeof m.modelProvider === 'string' && m.modelProvider.trim().length > 0
         ? { modelProvider: m.modelProvider.trim() }
         : {}),
@@ -57,5 +66,10 @@ export function mergeModelStats(target: ModelDayStats, source: ModelDayStats): v
   if (!target.modelProvider && source.modelProvider) target.modelProvider = source.modelProvider
   if (source.sourceProviders && source.sourceProviders.length > 0) {
     target.sourceProviders = [...new Set([...(target.sourceProviders ?? []), ...source.sourceProviders])].sort()
+  }
+  if (source.reasoningSemantics) {
+    target.reasoningSemantics = target.reasoningSemantics === undefined
+      ? source.reasoningSemantics
+      : combineReasoningSemantics([target.reasoningSemantics, source.reasoningSemantics])
   }
 }

--- a/src/daily-cache-types.ts
+++ b/src/daily-cache-types.ts
@@ -1,3 +1,4 @@
+import type { ReasoningTokenSemantics } from './token-semantics.js'
 export type ModelDayStats = {
   calls: number
   cost: number
@@ -6,6 +7,9 @@ export type ModelDayStats = {
   outputTokens: number
   /// Separately observed reasoning/thinking tokens. Optional for legacy days.
   reasoningTokens?: number
+  /// Explicit source semantics when a model row contains a source with
+  /// independently classified reasoning tokens.
+  reasoningSemantics?: ReasoningTokenSemantics
   cacheReadTokens: number
   cacheWriteTokens: number
   /// Source-recorded model/API provider when the collector exposes it.

--- a/src/daily-cache-types.ts
+++ b/src/daily-cache-types.ts
@@ -7,6 +7,8 @@ export type ModelDayStats = {
   outputTokens: number
   /// Separately observed reasoning/thinking tokens. Optional for legacy days.
   reasoningTokens?: number
+  /// Only the observed reasoning subtotal that is additive to output.
+  additiveReasoningTokens?: number
   /// Explicit source semantics when a model row contains a source with
   /// independently classified reasoning tokens.
   reasoningSemantics?: ReasoningTokenSemantics
@@ -34,6 +36,8 @@ export type ProjectDayStats = {
   outputTokens?: number
   /// Separately observed reasoning/thinking tokens. Optional for legacy days.
   reasoningTokens?: number
+  /// Only the observed reasoning subtotal that is additive to output.
+  additiveReasoningTokens?: number
   cacheReadTokens?: number
   cacheWriteTokens?: number
   path?: string
@@ -51,6 +55,7 @@ export type ProviderDaySlice = {
   inputTokens?: number
   outputTokens?: number
   reasoningTokens?: number
+  additiveReasoningTokens?: number
   cacheReadTokens?: number
   cacheWriteTokens?: number
   editTurns?: number
@@ -70,6 +75,8 @@ export type DailyEntry = {
   outputTokens: number
   /// Separately observed reasoning/thinking tokens. Optional for legacy days.
   reasoningTokens?: number
+  /// Only the observed reasoning subtotal that is additive to output.
+  additiveReasoningTokens?: number
   cacheReadTokens: number
   cacheWriteTokens: number
   editTurns: number

--- a/src/daily-cache-tz-reconcile.ts
+++ b/src/daily-cache-tz-reconcile.ts
@@ -66,6 +66,7 @@ function subtractModelStats(base: ModelDayStats, sub: ModelDayStats): ModelDaySt
     cacheWriteTokens,
     ...(base.modelProvider ? { modelProvider: base.modelProvider } : {}),
     ...(base.sourceProviders?.length ? { sourceProviders: [...base.sourceProviders] } : {}),
+    ...(base.reasoningSemantics ? { reasoningSemantics: base.reasoningSemantics } : {}),
   }
 }
 
@@ -189,6 +190,7 @@ function modelDelta(base: ModelDayStats, reduced: ModelDayStats | undefined): Mo
       : {}),
     cacheReadTokens: Math.max(0, base.cacheReadTokens - num(reduced?.cacheReadTokens)),
     cacheWriteTokens: Math.max(0, base.cacheWriteTokens - num(reduced?.cacheWriteTokens)),
+    ...(base.reasoningSemantics ? { reasoningSemantics: base.reasoningSemantics } : {}),
   }
 }
 

--- a/src/daily-cache-tz-reconcile.ts
+++ b/src/daily-cache-tz-reconcile.ts
@@ -22,6 +22,7 @@ function hasSliceData(slice: ProviderDaySlice): boolean {
     || num(slice.inputTokens) > 0
     || num(slice.outputTokens) > 0
     || num(slice.reasoningTokens) > 0
+    || num(slice.additiveReasoningTokens) > 0
     || num(slice.cacheReadTokens) > 0
     || num(slice.cacheWriteTokens) > 0
     || num(slice.editTurns) > 0
@@ -35,6 +36,7 @@ function hasModelData(model: ModelDayStats): boolean {
     || model.inputTokens > 0
     || model.outputTokens > 0
     || num(model.reasoningTokens) > 0
+    || num(model.additiveReasoningTokens) > 0
     || model.cacheReadTokens > 0
     || model.cacheWriteTokens > 0
 }
@@ -46,12 +48,14 @@ function subtractModelStats(base: ModelDayStats, sub: ModelDayStats): ModelDaySt
   const inputTokens = Math.max(0, base.inputTokens - num(sub.inputTokens))
   const outputTokens = Math.max(0, base.outputTokens - num(sub.outputTokens))
   const reasoningTokens = Math.max(0, num(base.reasoningTokens) - num(sub.reasoningTokens))
+  const additiveReasoningTokens = Math.max(0, num(base.additiveReasoningTokens) - num(sub.additiveReasoningTokens))
   const cacheReadTokens = Math.max(0, base.cacheReadTokens - num(sub.cacheReadTokens))
   const cacheWriteTokens = Math.max(0, base.cacheWriteTokens - num(sub.cacheWriteTokens))
 
   if (
     calls === 0 && cost === 0 && savingsUSD === 0
     && inputTokens === 0 && outputTokens === 0 && reasoningTokens === 0
+    && additiveReasoningTokens === 0
     && cacheReadTokens === 0 && cacheWriteTokens === 0
   ) return null
 
@@ -62,6 +66,8 @@ function subtractModelStats(base: ModelDayStats, sub: ModelDayStats): ModelDaySt
     inputTokens,
     outputTokens,
     ...(base.reasoningTokens !== undefined || sub.reasoningTokens !== undefined ? { reasoningTokens } : {}),
+    ...(base.additiveReasoningTokens !== undefined || sub.additiveReasoningTokens !== undefined
+      ? { additiveReasoningTokens } : {}),
     cacheReadTokens,
     cacheWriteTokens,
     ...(base.modelProvider ? { modelProvider: base.modelProvider } : {}),
@@ -113,7 +119,7 @@ function subtractProjectStats(base: ProjectDayStats, sub: ProjectDayStats): Proj
   const sessions = Math.max(0, num(base.sessions) - num(sub.sessions))
   const out: ProjectDayStats = { cost, calls, savingsUSD, sessions, ...(base.path ? { path: base.path } : {}) }
   const subHasUsage = sub.cost > 0 || sub.calls > 0 || num(sub.savingsUSD) > 0
-  for (const field of ['inputTokens', 'outputTokens', 'reasoningTokens', 'cacheReadTokens', 'cacheWriteTokens'] as const) {
+  for (const field of ['inputTokens', 'outputTokens', 'reasoningTokens', 'additiveReasoningTokens', 'cacheReadTokens', 'cacheWriteTokens'] as const) {
     if (base[field] === undefined) continue
     if (subHasUsage && sub[field] === undefined) {
       // A basic-cost/calls subtraction without the token field cannot leave a
@@ -126,6 +132,7 @@ function subtractProjectStats(base: ProjectDayStats, sub: ProjectDayStats): Proj
   if (cost === 0 && calls === 0 && savingsUSD === 0 && sessions === 0
     && (out.inputTokens ?? 0) === 0 && (out.outputTokens ?? 0) === 0
     && (out.reasoningTokens ?? 0) === 0 && (out.cacheReadTokens ?? 0) === 0
+    && (out.additiveReasoningTokens ?? 0) === 0
     && (out.cacheWriteTokens ?? 0) === 0) return null
   return out
 }
@@ -151,6 +158,7 @@ function subtractSlice(base: ProviderDaySlice, sub: ProviderDaySlice): ProviderD
   const inputTokens = Math.max(0, num(base.inputTokens) - num(sub.inputTokens))
   const outputTokens = Math.max(0, num(base.outputTokens) - num(sub.outputTokens))
   const reasoningTokens = Math.max(0, num(base.reasoningTokens) - num(sub.reasoningTokens))
+  const additiveReasoningTokens = Math.max(0, num(base.additiveReasoningTokens) - num(sub.additiveReasoningTokens))
   const cacheReadTokens = Math.max(0, num(base.cacheReadTokens) - num(sub.cacheReadTokens))
   const cacheWriteTokens = Math.max(0, num(base.cacheWriteTokens) - num(sub.cacheWriteTokens))
   const editTurns = Math.max(0, num(base.editTurns) - num(sub.editTurns))
@@ -167,6 +175,8 @@ function subtractSlice(base: ProviderDaySlice, sub: ProviderDaySlice): ProviderD
     ...(base.inputTokens !== undefined || sub.inputTokens !== undefined ? { inputTokens } : {}),
     ...(base.outputTokens !== undefined || sub.outputTokens !== undefined ? { outputTokens } : {}),
     ...(base.reasoningTokens !== undefined || sub.reasoningTokens !== undefined ? { reasoningTokens } : {}),
+    ...(base.additiveReasoningTokens !== undefined || sub.additiveReasoningTokens !== undefined
+      ? { additiveReasoningTokens } : {}),
     ...(base.cacheReadTokens !== undefined || sub.cacheReadTokens !== undefined ? { cacheReadTokens } : {}),
     ...(base.cacheWriteTokens !== undefined || sub.cacheWriteTokens !== undefined ? { cacheWriteTokens } : {}),
     ...(base.editTurns !== undefined || sub.editTurns !== undefined ? { editTurns } : {}),
@@ -187,6 +197,9 @@ function modelDelta(base: ModelDayStats, reduced: ModelDayStats | undefined): Mo
     outputTokens: Math.max(0, base.outputTokens - num(reduced?.outputTokens)),
     ...(base.reasoningTokens !== undefined || reduced?.reasoningTokens !== undefined
       ? { reasoningTokens: Math.max(0, num(base.reasoningTokens) - num(reduced?.reasoningTokens)) }
+      : {}),
+    ...(base.additiveReasoningTokens !== undefined || reduced?.additiveReasoningTokens !== undefined
+      ? { additiveReasoningTokens: Math.max(0, num(base.additiveReasoningTokens) - num(reduced?.additiveReasoningTokens)) }
       : {}),
     cacheReadTokens: Math.max(0, base.cacheReadTokens - num(reduced?.cacheReadTokens)),
     cacheWriteTokens: Math.max(0, base.cacheWriteTokens - num(reduced?.cacheWriteTokens)),
@@ -212,7 +225,7 @@ function projectDelta(base: ProjectDayStats, reduced: ProjectDayStats | undefine
     sessions: Math.max(0, num(base.sessions) - num(reduced?.sessions)),
   }
   const reducedHasUsage = reduced !== undefined && (reduced.cost > 0 || reduced.calls > 0 || num(reduced.savingsUSD) > 0)
-  for (const field of ['inputTokens', 'outputTokens', 'reasoningTokens', 'cacheReadTokens', 'cacheWriteTokens'] as const) {
+  for (const field of ['inputTokens', 'outputTokens', 'reasoningTokens', 'additiveReasoningTokens', 'cacheReadTokens', 'cacheWriteTokens'] as const) {
     if (base[field] === undefined) continue
     if (reducedHasUsage && reduced?.[field] === undefined) {
       delete out[field]
@@ -257,6 +270,9 @@ function subtractSliceFromDay(day: DailyEntry, provider: string, sub: ProviderDa
   if (day.reasoningTokens !== undefined || current.reasoningTokens !== undefined || reduced?.reasoningTokens !== undefined) {
     day.reasoningTokens = Math.max(0, num(day.reasoningTokens) - (num(current.reasoningTokens) - num(reduced?.reasoningTokens)))
   }
+  if (day.additiveReasoningTokens !== undefined || current.additiveReasoningTokens !== undefined || reduced?.additiveReasoningTokens !== undefined) {
+    day.additiveReasoningTokens = Math.max(0, num(day.additiveReasoningTokens) - (num(current.additiveReasoningTokens) - num(reduced?.additiveReasoningTokens)))
+  }
   day.cacheReadTokens = Math.max(0, day.cacheReadTokens - (num(current.cacheReadTokens) - num(reduced?.cacheReadTokens)))
   day.cacheWriteTokens = Math.max(0, day.cacheWriteTokens - (num(current.cacheWriteTokens) - num(reduced?.cacheWriteTokens)))
   day.editTurns = Math.max(0, day.editTurns - (num(current.editTurns) - num(reduced?.editTurns)))
@@ -298,6 +314,7 @@ function hasPositiveDayContent(day: DailyEntry): boolean {
     || day.inputTokens > 0
     || day.outputTokens > 0
     || num(day.reasoningTokens) > 0
+    || num(day.additiveReasoningTokens) > 0
     || day.cacheReadTokens > 0
     || day.cacheWriteTokens > 0
     || day.editTurns > 0

--- a/src/day-aggregator.ts
+++ b/src/day-aggregator.ts
@@ -1,6 +1,7 @@
 import type { DailyEntry, ProjectDayStats, ProviderDaySlice } from './daily-cache.js'
 import type { PeriodData } from './menubar-json.js'
 import { CATEGORY_LABELS, type ProjectSummary, type TaskCategory, type TokenUsage } from './types.js'
+import { combineReasoningSemantics, type ReasoningTokenSemantics } from './token-semantics.js'
 
 // Raw model IDs remain human-readable in legacy daily caches. New rows use an
 // additive envelope so a source-recorded route can survive the daily
@@ -29,6 +30,16 @@ function decodeModelStorageKey(key: string): { name: string; modelProvider?: str
 
 function addSourceProvider(target: { sourceProviders?: string[] }, provider: string): void {
   target.sourceProviders = [...new Set([...(target.sourceProviders ?? []), provider])].sort()
+}
+
+function addCallReasoningSemantics(
+  target: { reasoningSemantics?: ReasoningTokenSemantics },
+  call: { reasoningSemantics?: ReasoningTokenSemantics },
+): void {
+  if (call.reasoningSemantics === undefined) return
+  target.reasoningSemantics = target.reasoningSemantics === undefined
+    ? call.reasoningSemantics
+    : combineReasoningSemantics([target.reasoningSemantics, call.reasoningSemantics])
 }
 
 function addProjectTokenUsage(target: ProjectDayStats, usage: TokenUsage): void {
@@ -232,6 +243,7 @@ export function aggregateProjectsIntoDays(
           model.cacheReadTokens += call.usage.cacheReadInputTokens
           model.cacheWriteTokens += call.usage.cacheCreationInputTokens
           if (call.modelProvider) model.modelProvider = call.modelProvider
+          addCallReasoningSemantics(model, call)
           addSourceProvider(model, call.provider)
           turnDay.models[modelKey] = model
 
@@ -266,6 +278,7 @@ export function aggregateProjectsIntoDays(
           sliceModel.cacheWriteTokens += call.usage.cacheCreationInputTokens
           if (call.modelProvider) sliceModel.modelProvider = call.modelProvider
           addSourceProvider(sliceModel, call.provider)
+          addCallReasoningSemantics(sliceModel, call)
           slice.models![modelKey] = sliceModel
         }
       }
@@ -292,6 +305,7 @@ export function buildPeriodDataFromDays(days: DailyEntry[], label: string): Peri
     cacheWriteTokens: number
     modelProvider?: string
     sourceProviders?: string[]
+    reasoningSemantics?: ReasoningTokenSemantics
   }> = {}
 
   for (const d of days) {
@@ -324,6 +338,11 @@ export function buildPeriodDataFromDays(days: DailyEntry[], label: string): Peri
       acc.inputTokens += m.inputTokens
       acc.outputTokens += m.outputTokens
       if (m.reasoningTokens !== undefined) acc.reasoningTokens = (acc.reasoningTokens ?? 0) + m.reasoningTokens
+      if (m.reasoningSemantics) {
+        acc.reasoningSemantics = acc.reasoningSemantics === undefined
+          ? m.reasoningSemantics
+          : combineReasoningSemantics([acc.reasoningSemantics, m.reasoningSemantics])
+      }
       acc.cacheReadTokens += m.cacheReadTokens
       acc.cacheWriteTokens += m.cacheWriteTokens
       if (m.modelProvider) acc.modelProvider = m.modelProvider
@@ -372,6 +391,7 @@ export function buildPeriodDataFromDays(days: DailyEntry[], label: string): Peri
           savingsUSD: d.savingsUSD,
           inputTokens: d.inputTokens,
           outputTokens: d.outputTokens,
+          ...(d.reasoningSemantics ? { reasoningSemantics: d.reasoningSemantics } : {}),
           ...(d.reasoningTokens !== undefined ? { reasoningTokens: d.reasoningTokens } : {}),
           cacheReadTokens: d.cacheReadTokens,
           cacheWriteTokens: d.cacheWriteTokens,

--- a/src/day-aggregator.ts
+++ b/src/day-aggregator.ts
@@ -1,7 +1,7 @@
 import type { DailyEntry, ProjectDayStats, ProviderDaySlice } from './daily-cache.js'
 import type { PeriodData } from './menubar-json.js'
 import { CATEGORY_LABELS, type ProjectSummary, type TaskCategory, type TokenUsage } from './types.js'
-import { combineReasoningSemantics, separatelyReportedReasoningTokens, type ReasoningTokenSemantics } from './token-semantics.js'
+import { combineReasoningSemantics, reasoningTokenTotals, type ReasoningTokenSemantics, type ReasoningTokenTotals } from './token-semantics.js'
 
 // Raw model IDs remain human-readable in legacy daily caches. New rows use an
 // additive envelope so a source-recorded route can survive the daily
@@ -42,17 +42,25 @@ function addCallReasoningSemantics(
     : combineReasoningSemantics([target.reasoningSemantics, call.reasoningSemantics])
 }
 
-function callReasoningTokens(call: { provider: string; usage: TokenUsage; reasoningSemantics?: ReasoningTokenSemantics }): number {
-  if (call.reasoningSemantics === undefined) return call.usage.reasoningTokens
-  return separatelyReportedReasoningTokens(call.usage.reasoningTokens, call.reasoningSemantics)
+function callReasoningTotals(call: { provider: string; usage: TokenUsage; reasoningSemantics?: ReasoningTokenSemantics }): ReasoningTokenTotals {
+  return reasoningTokenTotals(call.usage.reasoningTokens, call.reasoningSemantics)
 }
 
-function addProjectTokenUsage(target: ProjectDayStats, usage: TokenUsage, reasoningTokens: number): void {
+function addReasoningTotals(target: { reasoningTokens?: number; additiveReasoningTokens?: number }, totals: ReasoningTokenTotals): void {
+  if (totals.observedReasoningTokens > 0) {
+    target.reasoningTokens = (target.reasoningTokens ?? 0) + totals.observedReasoningTokens
+    // Keep an explicit zero for aggregate-output evidence so a durable row
+    // cannot later be mistaken for a legacy row with no additive authority.
+    target.additiveReasoningTokens = (target.additiveReasoningTokens ?? 0) + totals.additiveReasoningTokens
+  }
+}
+
+function addProjectTokenUsage(target: ProjectDayStats, usage: TokenUsage, reasoning: ReasoningTokenTotals): void {
   target.inputTokens = (target.inputTokens ?? 0) + usage.inputTokens
   target.outputTokens = (target.outputTokens ?? 0) + usage.outputTokens
   target.cacheReadTokens = (target.cacheReadTokens ?? 0) + usage.cacheReadInputTokens
   target.cacheWriteTokens = (target.cacheWriteTokens ?? 0) + usage.cacheCreationInputTokens
-  if (reasoningTokens > 0) target.reasoningTokens = (target.reasoningTokens ?? 0) + reasoningTokens
+  addReasoningTotals(target, reasoning)
 }
 
 function emptyEntry(date: string): DailyEntry {
@@ -217,14 +225,14 @@ export function aggregateProjectsIntoDays(
 
         for (const call of turn.assistantCalls) {
           const callSavings = call.savingsUSD ?? 0
-          const callReasoning = callReasoningTokens(call)
+          const callReasoning = callReasoningTotals(call)
 
           turnDay.cost += call.costUSD
           turnDay.savingsUSD += callSavings
           turnDay.calls += 1
           turnDay.inputTokens += call.usage.inputTokens
           turnDay.outputTokens += call.usage.outputTokens
-          if (callReasoning > 0) turnDay.reasoningTokens = (turnDay.reasoningTokens ?? 0) + callReasoning
+          addReasoningTotals(turnDay, callReasoning)
           turnDay.cacheReadTokens += call.usage.cacheReadInputTokens
           turnDay.cacheWriteTokens += call.usage.cacheCreationInputTokens
 
@@ -245,7 +253,7 @@ export function aggregateProjectsIntoDays(
           model.savingsUSD += callSavings
           model.inputTokens += call.usage.inputTokens
           model.outputTokens += call.usage.outputTokens
-          if (callReasoning > 0) model.reasoningTokens = (model.reasoningTokens ?? 0) + callReasoning
+          addReasoningTotals(model, callReasoning)
           model.cacheReadTokens += call.usage.cacheReadInputTokens
           model.cacheWriteTokens += call.usage.cacheCreationInputTokens
           if (call.modelProvider) model.modelProvider = call.modelProvider
@@ -259,7 +267,7 @@ export function aggregateProjectsIntoDays(
           slice.savingsUSD += callSavings
           slice.inputTokens! += call.usage.inputTokens
           slice.outputTokens! += call.usage.outputTokens
-          if (callReasoning > 0) slice.reasoningTokens = (slice.reasoningTokens ?? 0) + callReasoning
+          addReasoningTotals(slice, callReasoning)
           slice.cacheReadTokens! += call.usage.cacheReadInputTokens
           slice.cacheWriteTokens! += call.usage.cacheCreationInputTokens
 
@@ -279,7 +287,7 @@ export function aggregateProjectsIntoDays(
           sliceModel.savingsUSD += callSavings
           sliceModel.inputTokens += call.usage.inputTokens
           sliceModel.outputTokens += call.usage.outputTokens
-          if (callReasoning > 0) sliceModel.reasoningTokens = (sliceModel.reasoningTokens ?? 0) + callReasoning
+          addReasoningTotals(sliceModel, callReasoning)
           sliceModel.cacheReadTokens += call.usage.cacheReadInputTokens
           sliceModel.cacheWriteTokens += call.usage.cacheCreationInputTokens
           if (call.modelProvider) sliceModel.modelProvider = call.modelProvider
@@ -297,8 +305,9 @@ export function aggregateProjectsIntoDays(
 export function buildPeriodDataFromDays(days: DailyEntry[], label: string): PeriodData {
   let cost = 0, savingsUSD = 0, calls = 0, sessions = 0
   let inputTokens = 0, outputTokens = 0, cacheReadTokens = 0, cacheWriteTokens = 0
-  let reasoningTokens = 0
+  let reasoningTokens = 0, additiveReasoningTokens = 0
   let hasReasoningTokens = false
+  let hasAdditiveReasoningTokens = false
   const catTotals: Record<string, { turns: number; cost: number; savingsUSD: number; editTurns: number; oneShotTurns: number }> = {}
   const modelTotals: Record<string, {
     calls: number
@@ -307,6 +316,7 @@ export function buildPeriodDataFromDays(days: DailyEntry[], label: string): Peri
     inputTokens: number
     outputTokens: number
     reasoningTokens?: number
+    additiveReasoningTokens?: number
     cacheReadTokens: number
     cacheWriteTokens: number
     modelProvider?: string
@@ -324,6 +334,10 @@ export function buildPeriodDataFromDays(days: DailyEntry[], label: string): Peri
     if (d.reasoningTokens !== undefined) {
       reasoningTokens += d.reasoningTokens
       hasReasoningTokens = true
+    }
+    if (d.additiveReasoningTokens !== undefined) {
+      additiveReasoningTokens += d.additiveReasoningTokens
+      hasAdditiveReasoningTokens = true
     }
     cacheReadTokens += d.cacheReadTokens
     cacheWriteTokens += d.cacheWriteTokens
@@ -344,6 +358,7 @@ export function buildPeriodDataFromDays(days: DailyEntry[], label: string): Peri
       acc.inputTokens += m.inputTokens
       acc.outputTokens += m.outputTokens
       if (m.reasoningTokens !== undefined) acc.reasoningTokens = (acc.reasoningTokens ?? 0) + m.reasoningTokens
+      if (m.additiveReasoningTokens !== undefined) acc.additiveReasoningTokens = (acc.additiveReasoningTokens ?? 0) + m.additiveReasoningTokens
       if (m.reasoningSemantics) {
         acc.reasoningSemantics = acc.reasoningSemantics === undefined
           ? m.reasoningSemantics
@@ -377,6 +392,7 @@ export function buildPeriodDataFromDays(days: DailyEntry[], label: string): Peri
     inputTokens,
     outputTokens,
     ...(hasReasoningTokens ? { reasoningTokens } : {}),
+    ...(hasAdditiveReasoningTokens ? { additiveReasoningTokens } : {}),
     cacheReadTokens,
     cacheWriteTokens,
     categories: Object.entries(catTotals)
@@ -399,6 +415,7 @@ export function buildPeriodDataFromDays(days: DailyEntry[], label: string): Peri
           outputTokens: d.outputTokens,
           ...(d.reasoningSemantics ? { reasoningSemantics: d.reasoningSemantics } : {}),
           ...(d.reasoningTokens !== undefined ? { reasoningTokens: d.reasoningTokens } : {}),
+          ...(d.additiveReasoningTokens !== undefined ? { additiveReasoningTokens: d.additiveReasoningTokens } : {}),
           cacheReadTokens: d.cacheReadTokens,
           cacheWriteTokens: d.cacheWriteTokens,
         }

--- a/src/day-aggregator.ts
+++ b/src/day-aggregator.ts
@@ -1,7 +1,7 @@
 import type { DailyEntry, ProjectDayStats, ProviderDaySlice } from './daily-cache.js'
 import type { PeriodData } from './menubar-json.js'
 import { CATEGORY_LABELS, type ProjectSummary, type TaskCategory, type TokenUsage } from './types.js'
-import { combineReasoningSemantics, type ReasoningTokenSemantics } from './token-semantics.js'
+import { combineReasoningSemantics, separatelyReportedReasoningTokens, type ReasoningTokenSemantics } from './token-semantics.js'
 
 // Raw model IDs remain human-readable in legacy daily caches. New rows use an
 // additive envelope so a source-recorded route can survive the daily
@@ -42,12 +42,17 @@ function addCallReasoningSemantics(
     : combineReasoningSemantics([target.reasoningSemantics, call.reasoningSemantics])
 }
 
-function addProjectTokenUsage(target: ProjectDayStats, usage: TokenUsage): void {
+function callReasoningTokens(call: { provider: string; usage: TokenUsage; reasoningSemantics?: ReasoningTokenSemantics }): number {
+  if (call.reasoningSemantics === undefined) return call.usage.reasoningTokens
+  return separatelyReportedReasoningTokens(call.usage.reasoningTokens, call.reasoningSemantics)
+}
+
+function addProjectTokenUsage(target: ProjectDayStats, usage: TokenUsage, reasoningTokens: number): void {
   target.inputTokens = (target.inputTokens ?? 0) + usage.inputTokens
   target.outputTokens = (target.outputTokens ?? 0) + usage.outputTokens
   target.cacheReadTokens = (target.cacheReadTokens ?? 0) + usage.cacheReadInputTokens
   target.cacheWriteTokens = (target.cacheWriteTokens ?? 0) + usage.cacheCreationInputTokens
-  if (usage.reasoningTokens > 0) target.reasoningTokens = (target.reasoningTokens ?? 0) + usage.reasoningTokens
+  if (reasoningTokens > 0) target.reasoningTokens = (target.reasoningTokens ?? 0) + reasoningTokens
 }
 
 function emptyEntry(date: string): DailyEntry {
@@ -212,13 +217,14 @@ export function aggregateProjectsIntoDays(
 
         for (const call of turn.assistantCalls) {
           const callSavings = call.savingsUSD ?? 0
+          const callReasoning = callReasoningTokens(call)
 
           turnDay.cost += call.costUSD
           turnDay.savingsUSD += callSavings
           turnDay.calls += 1
           turnDay.inputTokens += call.usage.inputTokens
           turnDay.outputTokens += call.usage.outputTokens
-          if (call.usage.reasoningTokens > 0) turnDay.reasoningTokens = (turnDay.reasoningTokens ?? 0) + call.usage.reasoningTokens
+          if (callReasoning > 0) turnDay.reasoningTokens = (turnDay.reasoningTokens ?? 0) + callReasoning
           turnDay.cacheReadTokens += call.usage.cacheReadInputTokens
           turnDay.cacheWriteTokens += call.usage.cacheCreationInputTokens
 
@@ -226,7 +232,7 @@ export function aggregateProjectsIntoDays(
           dayProject.cost += call.costUSD
           dayProject.calls += 1
           dayProject.savingsUSD += callSavings
-          addProjectTokenUsage(dayProject, call.usage)
+          addProjectTokenUsage(dayProject, call.usage, callReasoning)
 
           const modelKey = modelStorageKey(call.model, call.modelProvider)
           const model = turnDay.models[modelKey] ?? {
@@ -239,7 +245,7 @@ export function aggregateProjectsIntoDays(
           model.savingsUSD += callSavings
           model.inputTokens += call.usage.inputTokens
           model.outputTokens += call.usage.outputTokens
-          if (call.usage.reasoningTokens > 0) model.reasoningTokens = (model.reasoningTokens ?? 0) + call.usage.reasoningTokens
+          if (callReasoning > 0) model.reasoningTokens = (model.reasoningTokens ?? 0) + callReasoning
           model.cacheReadTokens += call.usage.cacheReadInputTokens
           model.cacheWriteTokens += call.usage.cacheCreationInputTokens
           if (call.modelProvider) model.modelProvider = call.modelProvider
@@ -253,7 +259,7 @@ export function aggregateProjectsIntoDays(
           slice.savingsUSD += callSavings
           slice.inputTokens! += call.usage.inputTokens
           slice.outputTokens! += call.usage.outputTokens
-          if (call.usage.reasoningTokens > 0) slice.reasoningTokens = (slice.reasoningTokens ?? 0) + call.usage.reasoningTokens
+          if (callReasoning > 0) slice.reasoningTokens = (slice.reasoningTokens ?? 0) + callReasoning
           slice.cacheReadTokens! += call.usage.cacheReadInputTokens
           slice.cacheWriteTokens! += call.usage.cacheCreationInputTokens
 
@@ -261,7 +267,7 @@ export function aggregateProjectsIntoDays(
           sliceProject.cost += call.costUSD
           sliceProject.calls += 1
           sliceProject.savingsUSD += callSavings
-          addProjectTokenUsage(sliceProject, call.usage)
+          addProjectTokenUsage(sliceProject, call.usage, callReasoning)
 
           const sliceModel = slice.models![modelKey] ?? {
             calls: 0, cost: 0, savingsUSD: 0,
@@ -273,7 +279,7 @@ export function aggregateProjectsIntoDays(
           sliceModel.savingsUSD += callSavings
           sliceModel.inputTokens += call.usage.inputTokens
           sliceModel.outputTokens += call.usage.outputTokens
-          if (call.usage.reasoningTokens > 0) sliceModel.reasoningTokens = (sliceModel.reasoningTokens ?? 0) + call.usage.reasoningTokens
+          if (callReasoning > 0) sliceModel.reasoningTokens = (sliceModel.reasoningTokens ?? 0) + callReasoning
           sliceModel.cacheReadTokens += call.usage.cacheReadInputTokens
           sliceModel.cacheWriteTokens += call.usage.cacheCreationInputTokens
           if (call.modelProvider) sliceModel.modelProvider = call.modelProvider

--- a/src/durable-project-reconciliation.ts
+++ b/src/durable-project-reconciliation.ts
@@ -73,6 +73,7 @@ function sumProjects(projects: Record<string, ProjectDayStats>): ProjectDayStats
     if (stats.inputTokens !== undefined) total.inputTokens = (total.inputTokens ?? 0) + stats.inputTokens
     if (stats.outputTokens !== undefined) total.outputTokens = (total.outputTokens ?? 0) + stats.outputTokens
     if (stats.reasoningTokens !== undefined) total.reasoningTokens = (total.reasoningTokens ?? 0) + stats.reasoningTokens
+    if (stats.additiveReasoningTokens !== undefined) total.additiveReasoningTokens = (total.additiveReasoningTokens ?? 0) + stats.additiveReasoningTokens
     if (stats.cacheReadTokens !== undefined) total.cacheReadTokens = (total.cacheReadTokens ?? 0) + stats.cacheReadTokens
     if (stats.cacheWriteTokens !== undefined) total.cacheWriteTokens = (total.cacheWriteTokens ?? 0) + stats.cacheWriteTokens
   }
@@ -156,6 +157,7 @@ function projectScopedSlice(
     inputTokens: preserveDetailedBreakdown ? (slice.inputTokens ?? 0) : (totals.inputTokens ?? 0),
     outputTokens: preserveDetailedBreakdown ? (slice.outputTokens ?? 0) : (totals.outputTokens ?? 0),
     reasoningTokens: preserveDetailedBreakdown ? slice.reasoningTokens : totals.reasoningTokens,
+    additiveReasoningTokens: preserveDetailedBreakdown ? slice.additiveReasoningTokens : totals.additiveReasoningTokens,
     cacheReadTokens: preserveDetailedBreakdown ? (slice.cacheReadTokens ?? 0) : (totals.cacheReadTokens ?? 0),
     cacheWriteTokens: preserveDetailedBreakdown ? (slice.cacheWriteTokens ?? 0) : (totals.cacheWriteTokens ?? 0),
     editTurns: preserveDetailedBreakdown ? (slice.editTurns ?? 0) : 0,
@@ -198,6 +200,7 @@ export function sliceDayToProvider(day: DailyEntry, provider: string): DailyEntr
     sessions: slice.sessions ?? 0,
     inputTokens: slice.inputTokens ?? 0,
     outputTokens: slice.outputTokens ?? 0,
+    additiveReasoningTokens: slice.additiveReasoningTokens,
     cacheReadTokens: slice.cacheReadTokens ?? 0,
     cacheWriteTokens: slice.cacheWriteTokens ?? 0,
     editTurns: slice.editTurns ?? 0,
@@ -246,6 +249,7 @@ export function reconcileDurableProjectDay(
     inputTokens: preserveDetailedBreakdown ? day.inputTokens : (totals.inputTokens ?? 0),
     outputTokens: preserveDetailedBreakdown ? day.outputTokens : (totals.outputTokens ?? 0),
     reasoningTokens: preserveDetailedBreakdown ? day.reasoningTokens : totals.reasoningTokens,
+    additiveReasoningTokens: preserveDetailedBreakdown ? day.additiveReasoningTokens : totals.additiveReasoningTokens,
     cacheReadTokens: preserveDetailedBreakdown ? day.cacheReadTokens : (totals.cacheReadTokens ?? 0),
     cacheWriteTokens: preserveDetailedBreakdown ? day.cacheWriteTokens : (totals.cacheWriteTokens ?? 0),
     editTurns: preserveDetailedBreakdown ? day.editTurns : 0,

--- a/src/menubar-json.ts
+++ b/src/menubar-json.ts
@@ -18,7 +18,7 @@ export type PeriodData = {
   sessions: number
   inputTokens: number
   outputTokens: number
-  reasoningTokens?: number
+  reasoningTokens?: number; additiveReasoningTokens?: number
   cacheReadTokens: number
   cacheWriteTokens: number
   /// Total Codex credits consumed in the period (issues #408/#495). Optional so
@@ -39,7 +39,7 @@ export type PeriodData = {
     estimatedCostUSD?: number
     inputTokens?: number
     outputTokens?: number
-    reasoningTokens?: number
+    reasoningTokens?: number; additiveReasoningTokens?: number
     reasoningSemantics?: 'separate' | 'aggregate-output' | 'unavailable' | 'mixed'
     cacheReadTokens?: number
     cacheWriteTokens?: number

--- a/src/model-accounting-types.ts
+++ b/src/model-accounting-types.ts
@@ -32,4 +32,5 @@ export type ModelAccountingRow = {
   /** Whether active-generation timing is observed for this exact row. */
   timingCoverage?: 'observed' | 'partial' | 'unavailable'
   reasoningTokens?: number
+  additiveReasoningTokens?: number
 }

--- a/src/model-accounting.ts
+++ b/src/model-accounting.ts
@@ -1,7 +1,7 @@
 import type { MenubarPayload, ModelAccounting, PeriodData } from './menubar-json.js'
 import { getHistoricalPricingModelKey, getShortModelName } from './models.js'
 import { resolveModelBrandId, type ModelBrandId } from './model-brand.js'
-import { combineReasoningSemantics, providerHasSeparateReasoning, reasoningSemanticsForProviders, separatelyReportedReasoningTokens, type ReasoningTokenSemantics } from './token-semantics.js'
+import { combineReasoningSemantics, providerHasSeparateReasoning, reasoningSemanticsForProviders, reasoningTokenTotals, type ReasoningTokenSemantics } from './token-semantics.js'
 
 const TOP_MODELS_LIMIT = 20
 const SYNTHETIC_MODEL_NAME = '<synthetic>'
@@ -14,6 +14,7 @@ type MergedModelRow = {
   inputTokens: number
   outputTokens: number
   reasoningTokens?: number
+  additiveReasoningTokens?: number
   cacheReadTokens: number
   cacheWriteTokens: number
   tokenDetail: boolean
@@ -160,10 +161,17 @@ function mergedModelRows(models: PeriodData['models']): MergedModelRow[] {
       ? modelReasoningSemantics
       : combineReasoningSemantics([acc.reasoningSemantics, modelReasoningSemantics])
     if (hasTokenDetail && modelReasoningSemantics === 'separate') {
-      acc.reasoningTokens = (acc.reasoningTokens ?? 0) + (model.reasoningTokens ?? 0)
+      const totals = reasoningTokenTotals(model.reasoningTokens, modelReasoningSemantics)
+      if (totals.observedReasoningTokens > 0) {
+        acc.reasoningTokens = (acc.reasoningTokens ?? 0) + totals.observedReasoningTokens
+        acc.additiveReasoningTokens = (acc.additiveReasoningTokens ?? 0) + (model.additiveReasoningTokens ?? totals.additiveReasoningTokens)
+      }
     } else if (hasTokenDetail) {
-      const observedReasoning = separatelyReportedReasoningTokens(model.reasoningTokens, modelReasoningSemantics)
-      if (observedReasoning > 0) acc.reasoningTokens = (acc.reasoningTokens ?? 0) + observedReasoning
+      const totals = reasoningTokenTotals(model.reasoningTokens, modelReasoningSemantics)
+      if (totals.observedReasoningTokens > 0) {
+        acc.reasoningTokens = (acc.reasoningTokens ?? 0) + totals.observedReasoningTokens
+        acc.additiveReasoningTokens = (acc.additiveReasoningTokens ?? 0) + (model.additiveReasoningTokens ?? totals.additiveReasoningTokens)
+      }
     }
     if (
       typeof model.activeDurationMs === 'number' && Number.isFinite(model.activeDurationMs) && model.activeDurationMs > 0
@@ -241,6 +249,7 @@ export function buildModelAccounting(models: PeriodData['models'], totalCost: nu
     ...(row.semanticVariant ? { semanticVariant: row.semanticVariant } : {}),
     ...(row.reasoningSemantics && row.reasoningSemantics !== 'unavailable' ? { reasoningSemantics: row.reasoningSemantics } : {}),
     ...(row.reasoningTokens !== undefined ? { reasoningTokens: row.reasoningTokens } : {}),
+    ...(row.reasoningTokens !== undefined ? { additiveReasoningTokens: row.additiveReasoningTokens ?? 0 } : {}),
     ...(row.estimatedCostUSD > 0 ? { estimatedCostUSD: row.estimatedCostUSD } : {}),
     ...(row.costIsEstimated ? { costIsEstimated: true } : {}),
     ...(row.activeDurationMs > 0 && row.activeGeneratedTokens > 0

--- a/src/model-performance.ts
+++ b/src/model-performance.ts
@@ -1,5 +1,6 @@
 import { getShortModelName } from './models.js'
 import type { ProjectSummary } from './types.js'
+import { generatedTokensForReasoningMix } from './token-semantics.js'
 
 export type ObservedModelPerformance = {
   activeDurationMs: number
@@ -52,7 +53,7 @@ export function aggregateModelPerformanceByRoute(projects: ProjectSummary[]): Ma
       for (const turn of turns) {
         for (const call of turn.assistantCalls) {
           const durationMs = call.activeDurationMs ?? 0
-          const generatedTokens = call.activeGeneratedTokens ?? (call.usage.outputTokens + call.usage.reasoningTokens)
+          const generatedTokens = call.activeGeneratedTokens ?? generatedTokensForReasoningMix(call.usage.outputTokens, call.usage.reasoningTokens, call.reasoningSemantics)
           if (!(durationMs > 0) || !(generatedTokens > 0)) continue
           const model = modelKey(call.model)
           const routes = result.get(model) ?? new Map<string, ObservedModelPerformance>()

--- a/src/model-presentation.test.ts
+++ b/src/model-presentation.test.ts
@@ -79,9 +79,9 @@ describe('model presentation projection', () => {
     const mixed = projection.rows.find(value => value.name === 'Mixed evidence model')!
     const unavailable = projection.rows.find(value => value.name === 'Unavailable reasoning model')!
 
-    expect(separate).toMatchObject({ reasoningSemantics: 'separate', reasoningTokens: 9 })
-    expect(shared).toMatchObject({ reasoningSemantics: 'mixed', reasoningTokens: 17 })
-    expect(mixed).toMatchObject({ reasoningSemantics: 'mixed', reasoningTokens: 11 })
+    expect(separate).toMatchObject({ reasoningSemantics: 'separate', reasoningTokens: 9, additiveReasoningTokens: 9 })
+    expect(shared).toMatchObject({ reasoningSemantics: 'mixed', reasoningTokens: 17, additiveReasoningTokens: 17 })
+    expect(mixed).toMatchObject({ reasoningSemantics: 'mixed', reasoningTokens: 11, additiveReasoningTokens: 0 })
     expect(unavailable.reasoningSemantics).toBe('unavailable')
     expect(unavailable).not.toHaveProperty('reasoningTokens')
     expect(projection.rows.reduce((sum, value) => sum + (value.reasoningTokens ?? 0), 0)).toBe(37)

--- a/src/model-presentation.ts
+++ b/src/model-presentation.ts
@@ -3,7 +3,7 @@ import type { ModelAccounting, ModelAccountingRow } from './menubar-json.js'
 import {
   combineReasoningSemantics,
   reasoningSemanticsForProviders,
-  separatelyReportedReasoningTokens,
+  reasoningTokenTotals,
   type ReasoningTokenSemantics,
 } from './token-semantics.js'
 
@@ -20,6 +20,7 @@ export type ModelPresentationRow = {
   inputTokens: number
   outputTokens: number
   reasoningTokens?: number
+  additiveReasoningTokens?: number
   cacheReadTokens: number
   cacheWriteTokens: number
   tokenDetail: boolean
@@ -177,12 +178,16 @@ function buildRow(identity: PresentationIdentity, rows: ModelAccountingRow[]): M
     row.reasoningSemantics ?? reasoningSemanticsForProviders(row.sourceProviders),
   ))
   const tokenDetail = rows.every(row => row.tokenDetail)
-  const reasoningTokens = rows.reduce((sum, row) => {
+  const reasoning = rows.reduce((sum, row) => {
     const rowSemantics = row.reasoningSemantics ?? reasoningSemanticsForProviders(row.sourceProviders)
-    return sum + separatelyReportedReasoningTokens(row.reasoningTokens, rowSemantics)
-  }, 0)
-  const hasReasoningEvidence = reasoningSemantics === 'separate'
-    || (reasoningSemantics === 'mixed' && reasoningTokens > 0)
+    const totals = reasoningTokenTotals(row.reasoningTokens, rowSemantics)
+    return {
+      observedReasoningTokens: sum.observedReasoningTokens + totals.observedReasoningTokens,
+      additiveReasoningTokens: sum.additiveReasoningTokens
+        + (row.additiveReasoningTokens ?? totals.additiveReasoningTokens),
+    }
+  }, { observedReasoningTokens: 0, additiveReasoningTokens: 0 })
+  const hasReasoningEvidence = reasoningSemantics !== 'unavailable' && reasoning.observedReasoningTokens > 0
   const activeDurationMs = rows.reduce((sum, row) => sum + (row.activeDurationMs ?? 0), 0)
   const activeGeneratedTokens = rows.reduce((sum, row) => sum + (row.activeGeneratedTokens ?? 0), 0)
   const estimatedCostUSD = rows.reduce((sum, row) => sum + (row.estimatedCostUSD ?? 0), 0)
@@ -200,7 +205,8 @@ function buildRow(identity: PresentationIdentity, rows: ModelAccountingRow[]): M
     calls: rows.reduce((sum, row) => sum + row.calls, 0),
     inputTokens: rows.reduce((sum, row) => sum + row.inputTokens, 0),
     outputTokens: rows.reduce((sum, row) => sum + row.outputTokens, 0),
-    ...(hasReasoningEvidence ? { reasoningTokens } : {}),
+    ...(hasReasoningEvidence ? { reasoningTokens: reasoning.observedReasoningTokens } : {}),
+    ...(hasReasoningEvidence ? { additiveReasoningTokens: reasoning.additiveReasoningTokens } : {}),
     cacheReadTokens: rows.reduce((sum, row) => sum + row.cacheReadTokens, 0),
     cacheWriteTokens: rows.reduce((sum, row) => sum + row.cacheWriteTokens, 0),
     tokenDetail,

--- a/src/models-report-csv.ts
+++ b/src/models-report-csv.ts
@@ -1,0 +1,78 @@
+import { CATEGORY_LABELS, type TaskCategory } from './types.js'
+import type { ModelReportRow } from './models-report-types.js'
+function categoryLabel(category: TaskCategory): string {
+  return CATEGORY_LABELS[category] ?? category
+}
+function csvEscape(value: string | undefined | null): string {
+  if (value === undefined || value === null) return ''
+  if (value.includes(',') || value.includes('"') || value.includes('\n')) {
+    return '"' + value.replace(/"/g, '""') + '"'
+  }
+  return value
+}
+/** CSV renderer kept separate so the model aggregation module stays focused. */
+export function renderCsv(rows: ModelReportRow[], opts: { byTask?: boolean; byAgent?: boolean } = {}): string {
+  const byTask = opts.byTask ?? false
+  const byAgent = opts.byAgent ?? false
+  const header = byAgent
+    ? ['provider', 'model', 'agent', 'input_tokens', 'output_tokens', 'reasoning_tokens', 'additive_reasoning_tokens', 'cache_write_tokens', 'cache_read_tokens', 'total_tokens', 'calls', 'cost_usd', 'savings_usd', 'savings_baseline_model']
+    : byTask
+    ? ['provider', 'model', 'task', 'input_tokens', 'output_tokens', 'reasoning_tokens', 'additive_reasoning_tokens', 'cache_write_tokens', 'cache_read_tokens', 'total_tokens', 'calls', 'cost_usd', 'savings_usd', 'savings_baseline_model']
+    : ['provider', 'model', 'top_task', 'top_task_share', 'input_tokens', 'output_tokens', 'reasoning_tokens', 'additive_reasoning_tokens', 'cache_write_tokens', 'cache_read_tokens', 'total_tokens', 'calls', 'cost_usd', 'savings_usd', 'savings_baseline_model']
+  const lines: string[] = [header.join(',')]
+  for (const r of rows) {
+    const cells = byAgent
+      ? [
+          csvEscape(r.providerDisplayName),
+          csvEscape(r.modelDisplayName),
+          csvEscape(r.agentType ?? ''),
+          String(r.inputTokens),
+          String(r.outputTokens),
+          String(r.reasoningTokens ?? 0),
+          String(r.additiveReasoningTokens ?? 0),
+          String(r.cacheWriteTokens),
+          String(r.cacheReadTokens),
+          String(r.totalTokens),
+          String(r.calls),
+          r.costUSD.toFixed(6),
+          (r.savingsUSD ?? 0).toFixed(6),
+          csvEscape(r.savingsBaselineModel),
+        ]
+      : byTask
+      ? [
+          csvEscape(r.providerDisplayName),
+          csvEscape(r.modelDisplayName),
+          r.category ? categoryLabel(r.category) : '',
+          String(r.inputTokens),
+          String(r.outputTokens),
+          String(r.reasoningTokens ?? 0),
+          String(r.additiveReasoningTokens ?? 0),
+          String(r.cacheWriteTokens),
+          String(r.cacheReadTokens),
+          String(r.totalTokens),
+          String(r.calls),
+          r.costUSD.toFixed(6),
+          (r.savingsUSD ?? 0).toFixed(6),
+          csvEscape(r.savingsBaselineModel),
+        ]
+      : [
+          csvEscape(r.providerDisplayName),
+          csvEscape(r.modelDisplayName),
+          r.topCategory ? categoryLabel(r.topCategory) : '',
+          r.topCategoryShare !== undefined ? r.topCategoryShare.toFixed(4) : '',
+          String(r.inputTokens),
+          String(r.outputTokens),
+          String(r.reasoningTokens ?? 0),
+          String(r.additiveReasoningTokens ?? 0),
+          String(r.cacheWriteTokens),
+          String(r.cacheReadTokens),
+          String(r.totalTokens),
+          String(r.calls),
+          r.costUSD.toFixed(6),
+          (r.savingsUSD ?? 0).toFixed(6),
+          csvEscape(r.savingsBaselineModel),
+        ]
+    lines.push(cells.join(','))
+  }
+  return lines.join('\n')
+}

--- a/src/models-report-reasoning.test.ts
+++ b/src/models-report-reasoning.test.ts
@@ -17,7 +17,7 @@ describe('model report reasoning totals', () => {
     const codex = rows.find(row => row.provider === 'codex')!
     const zed = rows.find(row => row.provider === 'zed')!
 
-    expect(codex).toMatchObject({ outputTokens: 100, reasoningTokens: 40, reasoningSemantics: 'separate', totalTokens: 170 })
-    expect(zed).toMatchObject({ outputTokens: 100, reasoningTokens: 0, reasoningSemantics: 'unavailable', totalTokens: 130 })
+    expect(codex).toMatchObject({ outputTokens: 100, reasoningTokens: 40, additiveReasoningTokens: 40, reasoningSemantics: 'separate', totalTokens: 170 })
+    expect(zed).toMatchObject({ outputTokens: 100, reasoningTokens: 0, additiveReasoningTokens: 0, reasoningSemantics: 'unavailable', totalTokens: 130 })
   })
 })

--- a/src/models-report-types.ts
+++ b/src/models-report-types.ts
@@ -12,7 +12,10 @@ export type ModelReportRow = {
   agentType?: string | null
   inputTokens: number
   outputTokens: number
+  /** Factual observed reasoning-token breakdown; not necessarily additive to output. */
   reasoningTokens?: number
+  /** Only the reasoning subtotal that is additive to generated output. */
+  additiveReasoningTokens?: number
   reasoningSemantics?: ReasoningTokenSemantics
   cacheWriteTokens: number
   cacheReadTokens: number

--- a/src/models-report.ts
+++ b/src/models-report.ts
@@ -87,15 +87,9 @@ export async function aggregateModels(projects: ProjectSummary[], opts: Aggregat
           }
           bucket.inputTokens += call.usage.inputTokens
           bucket.outputTokens += call.usage.outputTokens
-          const callReasoningSemantics = call.reasoningSemantics
-            ?? reasoningSemanticsForProviders([call.provider])
-          bucket.reasoningSemantics = bucket.calls === 0
-            ? callReasoningSemantics
-            : combineReasoningSemantics([bucket.reasoningSemantics, callReasoningSemantics])
-          bucket.reasoningTokens += separatelyReportedReasoningTokens(
-            call.usage.reasoningTokens,
-            callReasoningSemantics,
-          )
+          const callReasoningSemantics = call.reasoningSemantics ?? reasoningSemanticsForProviders([call.provider])
+          bucket.reasoningSemantics = bucket.calls === 0 ? callReasoningSemantics : combineReasoningSemantics([bucket.reasoningSemantics, callReasoningSemantics])
+          bucket.reasoningTokens += separatelyReportedReasoningTokens(call.usage.reasoningTokens, callReasoningSemantics)
           bucket.cacheWriteTokens += call.usage.cacheCreationInputTokens
           // The two cache-read fields are provider vocabularies for the same tokens.
           bucket.cacheReadTokens += Math.max(call.usage.cacheReadInputTokens, call.usage.cachedInputTokens)

--- a/src/models-report.ts
+++ b/src/models-report.ts
@@ -6,7 +6,7 @@ import { formatCost, formatTokens } from './format.js'
 import { createModelPricingCounts, observeModelPricing, summarizeModelPricing, type ModelPricingCounts, type ModelPricingSummary } from './model-pricing-summary.js'
 import { getProvider } from './providers/index.js'
 import { CATEGORY_LABELS, type ProjectSummary, type TaskCategory } from './types.js'
-import { providerHasSeparateReasoning, type ReasoningTokenSemantics } from './token-semantics.js'
+import { combineReasoningSemantics, reasoningSemanticsForProviders, separatelyReportedReasoningTokens, type ReasoningTokenSemantics } from './token-semantics.js'
 import type { AggregateOptions, ModelReportRow } from './models-report-types.js'
 export type { AggregateOptions, ModelReportRow } from './models-report-types.js'
 
@@ -87,10 +87,15 @@ export async function aggregateModels(projects: ProjectSummary[], opts: Aggregat
           }
           bucket.inputTokens += call.usage.inputTokens
           bucket.outputTokens += call.usage.outputTokens
-          if (providerHasSeparateReasoning(call.provider)) {
-            bucket.reasoningTokens += call.usage.reasoningTokens
-            bucket.reasoningSemantics = 'separate'
-          }
+          const callReasoningSemantics = call.reasoningSemantics
+            ?? reasoningSemanticsForProviders([call.provider])
+          bucket.reasoningSemantics = bucket.calls === 0
+            ? callReasoningSemantics
+            : combineReasoningSemantics([bucket.reasoningSemantics, callReasoningSemantics])
+          bucket.reasoningTokens += separatelyReportedReasoningTokens(
+            call.usage.reasoningTokens,
+            callReasoningSemantics,
+          )
           bucket.cacheWriteTokens += call.usage.cacheCreationInputTokens
           // The two cache-read fields are provider vocabularies for the same tokens.
           bucket.cacheReadTokens += Math.max(call.usage.cacheReadInputTokens, call.usage.cachedInputTokens)

--- a/src/models-report.ts
+++ b/src/models-report.ts
@@ -6,7 +6,7 @@ import { formatCost, formatTokens } from './format.js'
 import { createModelPricingCounts, observeModelPricing, summarizeModelPricing, type ModelPricingCounts, type ModelPricingSummary } from './model-pricing-summary.js'
 import { getProvider } from './providers/index.js'
 import { CATEGORY_LABELS, type ProjectSummary, type TaskCategory } from './types.js'
-import { combineReasoningSemantics, reasoningSemanticsForProviders, separatelyReportedReasoningTokens, type ReasoningTokenSemantics } from './token-semantics.js'
+import { combineReasoningSemantics, reasoningSemanticsForProviders, reasoningTokenTotals, type ReasoningTokenSemantics } from './token-semantics.js'
 import type { AggregateOptions, ModelReportRow } from './models-report-types.js'
 export type { AggregateOptions, ModelReportRow } from './models-report-types.js'
 
@@ -17,7 +17,7 @@ type Bucket = {
   agentType: string | null
   inputTokens: number
   outputTokens: number
-  reasoningTokens: number
+  reasoningTokens: number; additiveReasoningTokens: number
   reasoningSemantics: ReasoningTokenSemantics
   cacheWriteTokens: number
   cacheReadTokens: number
@@ -73,7 +73,7 @@ export async function aggregateModels(projects: ProjectSummary[], opts: Aggregat
               agentType,
               inputTokens: 0,
               outputTokens: 0,
-              reasoningTokens: 0,
+              reasoningTokens: 0, additiveReasoningTokens: 0,
               reasoningSemantics: 'unavailable',
               cacheWriteTokens: 0,
               cacheReadTokens: 0,
@@ -88,8 +88,10 @@ export async function aggregateModels(projects: ProjectSummary[], opts: Aggregat
           bucket.inputTokens += call.usage.inputTokens
           bucket.outputTokens += call.usage.outputTokens
           const callReasoningSemantics = call.reasoningSemantics ?? reasoningSemanticsForProviders([call.provider])
+          const callReasoning = reasoningTokenTotals(call.usage.reasoningTokens, callReasoningSemantics)
           bucket.reasoningSemantics = bucket.calls === 0 ? callReasoningSemantics : combineReasoningSemantics([bucket.reasoningSemantics, callReasoningSemantics])
-          bucket.reasoningTokens += separatelyReportedReasoningTokens(call.usage.reasoningTokens, callReasoningSemantics)
+          bucket.reasoningTokens += callReasoning.observedReasoningTokens
+          bucket.additiveReasoningTokens += callReasoning.additiveReasoningTokens
           bucket.cacheWriteTokens += call.usage.cacheCreationInputTokens
           // The two cache-read fields are provider vocabularies for the same tokens.
           bucket.cacheReadTokens += Math.max(call.usage.cacheReadInputTokens, call.usage.cachedInputTokens)
@@ -130,7 +132,7 @@ export async function aggregateModels(projects: ProjectSummary[], opts: Aggregat
   const rows: ModelReportRow[] = []
   for (const bucket of buckets.values()) {
     const meta = await resolveProvider(bucket.provider)
-    const total = bucket.inputTokens + bucket.outputTokens + bucket.reasoningTokens + bucket.cacheWriteTokens + bucket.cacheReadTokens
+    const total = bucket.inputTokens + bucket.outputTokens + bucket.additiveReasoningTokens + bucket.cacheWriteTokens + bucket.cacheReadTokens
     const row: ModelReportRow = {
       provider: bucket.provider,
       providerDisplayName: meta.displayName,
@@ -140,7 +142,7 @@ export async function aggregateModels(projects: ProjectSummary[], opts: Aggregat
       agentType: bucket.agentType,
       inputTokens: bucket.inputTokens,
       outputTokens: bucket.outputTokens,
-      reasoningTokens: bucket.reasoningTokens,
+      reasoningTokens: bucket.reasoningTokens, additiveReasoningTokens: bucket.additiveReasoningTokens,
       reasoningSemantics: bucket.reasoningSemantics,
       cacheWriteTokens: bucket.cacheWriteTokens,
       cacheReadTokens: bucket.cacheReadTokens,
@@ -155,7 +157,7 @@ export async function aggregateModels(projects: ProjectSummary[], opts: Aggregat
         ? codexCredits(bucket.model, {
             inputTokens: bucket.inputTokens,
             cachedReadTokens: bucket.cacheReadTokens,
-            outputTokens: bucket.outputTokens + bucket.reasoningTokens,
+            outputTokens: bucket.outputTokens + bucket.additiveReasoningTokens,
           })
         : null,
     }
@@ -567,6 +569,7 @@ export function renderJson(rows: ModelReportRow[]): string {
       inputTokens: r.inputTokens,
       outputTokens: r.outputTokens,
       reasoningTokens: r.reasoningTokens ?? 0,
+      additiveReasoningTokens: r.additiveReasoningTokens ?? 0,
       reasoningSemantics: r.reasoningSemantics ?? 'unavailable',
       cacheWriteTokens: r.cacheWriteTokens,
       cacheReadTokens: r.cacheReadTokens,
@@ -675,10 +678,10 @@ export function renderCsv(rows: ModelReportRow[], opts: { byTask?: boolean; byAg
   // CSV intentionally repeats provider/model on every row so downstream
   // consumers can sort/filter without first reconstructing the grouping.
   const header = byAgent
-    ? ['provider', 'model', 'agent', 'input_tokens', 'output_tokens', 'reasoning_tokens', 'cache_write_tokens', 'cache_read_tokens', 'total_tokens', 'calls', 'cost_usd', 'savings_usd', 'savings_baseline_model']
+    ? ['provider', 'model', 'agent', 'input_tokens', 'output_tokens', 'reasoning_tokens', 'additive_reasoning_tokens', 'cache_write_tokens', 'cache_read_tokens', 'total_tokens', 'calls', 'cost_usd', 'savings_usd', 'savings_baseline_model']
     : byTask
-    ? ['provider', 'model', 'task', 'input_tokens', 'output_tokens', 'reasoning_tokens', 'cache_write_tokens', 'cache_read_tokens', 'total_tokens', 'calls', 'cost_usd', 'savings_usd', 'savings_baseline_model']
-    : ['provider', 'model', 'top_task', 'top_task_share', 'input_tokens', 'output_tokens', 'reasoning_tokens', 'cache_write_tokens', 'cache_read_tokens', 'total_tokens', 'calls', 'cost_usd', 'savings_usd', 'savings_baseline_model']
+    ? ['provider', 'model', 'task', 'input_tokens', 'output_tokens', 'reasoning_tokens', 'additive_reasoning_tokens', 'cache_write_tokens', 'cache_read_tokens', 'total_tokens', 'calls', 'cost_usd', 'savings_usd', 'savings_baseline_model']
+    : ['provider', 'model', 'top_task', 'top_task_share', 'input_tokens', 'output_tokens', 'reasoning_tokens', 'additive_reasoning_tokens', 'cache_write_tokens', 'cache_read_tokens', 'total_tokens', 'calls', 'cost_usd', 'savings_usd', 'savings_baseline_model']
   const lines: string[] = [header.join(',')]
   for (const r of rows) {
     const cells = byAgent
@@ -689,6 +692,7 @@ export function renderCsv(rows: ModelReportRow[], opts: { byTask?: boolean; byAg
           String(r.inputTokens),
           String(r.outputTokens),
           String(r.reasoningTokens ?? 0),
+          String(r.additiveReasoningTokens ?? 0),
           String(r.cacheWriteTokens),
           String(r.cacheReadTokens),
           String(r.totalTokens),
@@ -705,6 +709,7 @@ export function renderCsv(rows: ModelReportRow[], opts: { byTask?: boolean; byAg
           String(r.inputTokens),
           String(r.outputTokens),
            String(r.reasoningTokens ?? 0),
+          String(r.additiveReasoningTokens ?? 0),
           String(r.cacheWriteTokens),
           String(r.cacheReadTokens),
           String(r.totalTokens),
@@ -721,6 +726,7 @@ export function renderCsv(rows: ModelReportRow[], opts: { byTask?: boolean; byAg
           String(r.inputTokens),
           String(r.outputTokens),
           String(r.reasoningTokens ?? 0),
+          String(r.additiveReasoningTokens ?? 0),
           String(r.cacheWriteTokens),
           String(r.cacheReadTokens),
           String(r.totalTokens),

--- a/src/models-report.ts
+++ b/src/models-report.ts
@@ -8,7 +8,9 @@ import { getProvider } from './providers/index.js'
 import { CATEGORY_LABELS, type ProjectSummary, type TaskCategory } from './types.js'
 import { combineReasoningSemantics, reasoningSemanticsForProviders, reasoningTokenTotals, type ReasoningTokenSemantics } from './token-semantics.js'
 import type { AggregateOptions, ModelReportRow } from './models-report-types.js'
+import { renderCsv } from './models-report-csv.js'
 export type { AggregateOptions, ModelReportRow } from './models-report-types.js'
+export { renderCsv }
 
 type Bucket = {
   provider: string
@@ -585,13 +587,6 @@ export function renderJson(rows: ModelReportRow[]): string {
   )
 }
 
-function csvEscape(value: string | undefined | null): string {
-  if (value === undefined || value === null) return ''
-  if (value.includes(',') || value.includes('"') || value.includes('\n')) {
-    return `"${value.replace(/"/g, '""')}"`
-  }
-  return value
-}
 
 function mdEscape(value: string): string {
   // Pipes break GitHub-flavored markdown tables; escape them.
@@ -669,73 +664,5 @@ export function renderMarkdown(rows: ModelReportRow[], opts: { byTask?: boolean;
     lines.push(`| ${totalCells.join(' | ')} |`)
   }
 
-  return lines.join('\n')
-}
-
-export function renderCsv(rows: ModelReportRow[], opts: { byTask?: boolean; byAgent?: boolean } = {}): string {
-  const byTask = opts.byTask ?? false
-  const byAgent = opts.byAgent ?? false
-  // CSV intentionally repeats provider/model on every row so downstream
-  // consumers can sort/filter without first reconstructing the grouping.
-  const header = byAgent
-    ? ['provider', 'model', 'agent', 'input_tokens', 'output_tokens', 'reasoning_tokens', 'additive_reasoning_tokens', 'cache_write_tokens', 'cache_read_tokens', 'total_tokens', 'calls', 'cost_usd', 'savings_usd', 'savings_baseline_model']
-    : byTask
-    ? ['provider', 'model', 'task', 'input_tokens', 'output_tokens', 'reasoning_tokens', 'additive_reasoning_tokens', 'cache_write_tokens', 'cache_read_tokens', 'total_tokens', 'calls', 'cost_usd', 'savings_usd', 'savings_baseline_model']
-    : ['provider', 'model', 'top_task', 'top_task_share', 'input_tokens', 'output_tokens', 'reasoning_tokens', 'additive_reasoning_tokens', 'cache_write_tokens', 'cache_read_tokens', 'total_tokens', 'calls', 'cost_usd', 'savings_usd', 'savings_baseline_model']
-  const lines: string[] = [header.join(',')]
-  for (const r of rows) {
-    const cells = byAgent
-      ? [
-          csvEscape(r.providerDisplayName),
-          csvEscape(r.modelDisplayName),
-          csvEscape(r.agentType ?? ''),
-          String(r.inputTokens),
-          String(r.outputTokens),
-          String(r.reasoningTokens ?? 0),
-          String(r.additiveReasoningTokens ?? 0),
-          String(r.cacheWriteTokens),
-          String(r.cacheReadTokens),
-          String(r.totalTokens),
-          String(r.calls),
-          r.costUSD.toFixed(6),
-          (r.savingsUSD ?? 0).toFixed(6),
-          csvEscape(r.savingsBaselineModel),
-        ]
-      : byTask
-      ? [
-          csvEscape(r.providerDisplayName),
-          csvEscape(r.modelDisplayName),
-          r.category ? categoryLabel(r.category) : '',
-          String(r.inputTokens),
-          String(r.outputTokens),
-           String(r.reasoningTokens ?? 0),
-          String(r.additiveReasoningTokens ?? 0),
-          String(r.cacheWriteTokens),
-          String(r.cacheReadTokens),
-          String(r.totalTokens),
-          String(r.calls),
-          r.costUSD.toFixed(6),
-          (r.savingsUSD ?? 0).toFixed(6),
-          csvEscape(r.savingsBaselineModel),
-        ]
-      : [
-          csvEscape(r.providerDisplayName),
-          csvEscape(r.modelDisplayName),
-          r.topCategory ? categoryLabel(r.topCategory) : '',
-          r.topCategoryShare !== undefined ? r.topCategoryShare.toFixed(4) : '',
-          String(r.inputTokens),
-          String(r.outputTokens),
-          String(r.reasoningTokens ?? 0),
-          String(r.additiveReasoningTokens ?? 0),
-          String(r.cacheWriteTokens),
-          String(r.cacheReadTokens),
-          String(r.totalTokens),
-          String(r.calls),
-          r.costUSD.toFixed(6),
-          (r.savingsUSD ?? 0).toFixed(6),
-          csvEscape(r.savingsBaselineModel),
-        ]
-    lines.push(cells.join(','))
-  }
   return lines.join('\n')
 }

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -34,6 +34,11 @@ import {
   runtimeHistoricalPricingCacheKeyV1,
   withRuntimeHistoricalPricingV1,
 } from './pricing/runtime-cost-assignment.js'
+import {
+  migrateLegacyCopilotOtelCacheCall,
+  settleCachedCallCost,
+  settleSessionCacheCostsForRuntimeV1,
+} from './session-cache-cost-settlement.js'
 import { setLatestCompletedSessionCacheV1 } from './session-cache-authority.js'
 import type { ParsedProviderCall, SessionSource } from './providers/types.js'
 import type {
@@ -62,6 +67,7 @@ import { flushCopilotChatJournalInvalidations, queueCopilotChatJournalSource, re
 import { reconcileMissingProviderSources, shouldReconcileMissingProviderSources } from './parser-source-reconciliation.js'
 import { buildCwdEvidenceIndex, timeBoundCwdRefs } from './pr-attribution-time-bound.js'
 import { flattenString, flattenStringArray, flattenStringPrefix, flattenToolSequence } from './string-retention.js'
+export { settleSessionCacheCostsForRuntimeV1 } from './session-cache-cost-settlement.js'
 
 // Returns true for sessions whose canonical project key must NOT be derived
 // from the cwd. Cowork sessions come in two flavours:
@@ -2619,112 +2625,9 @@ function providerCallsToCachedTurns(calls: ParsedProviderCall[]): CachedTurn[] {
   return turns
 }
 
-function currentCostForCachedCall(call: CachedCall): number {
-  const u = call.usage
-  const outputForCost = billableOutputTokens(call.provider, u.outputTokens, u.reasoningTokens, call.reasoningSemantics)
-  return calculateCost(
-    call.model, u.inputTokens, outputForCost,
-    u.cacheCreationInputTokens, u.cacheReadInputTokens,
-    u.webSearchRequests, call.speed, u.cacheCreationOneHourTokens,
-  )
-}
-
-function settledCachedCall(call: CachedCall) {
-  return assignRuntimeCostV1({
-    provider: call.provider,
-    model: call.model,
-    modelProvider: call.modelProvider, pricingContext: call.pricingContext,
-    timestamp: call.timestamp,
-    speed: call.speed,
-    usage: call.usage,
-    reasoningSemantics: call.reasoningSemantics,
-    legacyCostUSD: call.legacyCostUSD ?? call.costUSD ?? currentCostForCachedCall(call),
-    isEstimated: call.isEstimated,
-    existingAssignment: call.costAssignment,
-    existingStoredCostUSD: call.costUSD,
-    existingLegacyCostUSD: call.legacyCostUSD,
-  })
-}
-
-function migrateLegacyCopilotOtelCacheCall(call: CachedCall): boolean {
-  if (call.provider !== 'copilot' || !call.deduplicationKey.startsWith('copilot-otel:')) return false
-  if (call.cacheTokenEvidence !== undefined) return false
-
-  const { inputTokens, cacheReadInputTokens, cacheCreationInputTokens } = call.usage
-  if (!Number.isFinite(inputTokens) || !Number.isFinite(cacheReadInputTokens) || !Number.isFinite(cacheCreationInputTokens)) return false
-  if (cacheReadInputTokens <= 0 || cacheCreationInputTokens <= 0) return false
-  const normalizedInput = inputTokens - cacheReadInputTokens - cacheCreationInputTokens
-  if (normalizedInput < 0) return false
-
-  const previousInput = call.usage.inputTokens
-  const previousCost = call.costUSD
-  const previousAssignment = call.costAssignment
-  const previousLegacyCost = call.legacyCostUSD
-  const previousEvidence = call.cacheTokenEvidence
-
-  try {
-    call.usage.inputTokens = normalizedInput
-    call.cacheTokenEvidence = 'complete'
-    delete call.costUSD
-    delete call.costAssignment
-    delete call.legacyCostUSD
-
-    const settlement = settledCachedCall(call)
-    if (settlement.storedCostUSD === undefined) delete call.costUSD
-    else call.costUSD = settlement.storedCostUSD
-    call.costAssignment = settlement.storedAssignment
-    if (settlement.storedLegacyCostUSD === undefined) delete call.legacyCostUSD
-    else call.legacyCostUSD = settlement.storedLegacyCostUSD
-    return true
-  } catch {
-    call.usage.inputTokens = previousInput
-    if (previousCost === undefined) delete call.costUSD
-    else call.costUSD = previousCost
-    if (previousAssignment === undefined) delete call.costAssignment
-    else call.costAssignment = previousAssignment
-    if (previousLegacyCost === undefined) delete call.legacyCostUSD
-    else call.legacyCostUSD = previousLegacyCost
-    if (previousEvidence === undefined) delete call.cacheTokenEvidence
-    else call.cacheTokenEvidence = previousEvidence
-    return false
-  }
-}
-
-export function settleSessionCacheCostsForRuntimeV1(cache: SessionCache): boolean {
-  let changed = false
-  for (const section of Object.values(cache.providers)) {
-    for (const file of Object.values(section.files)) {
-      for (const turn of file.turns) {
-        for (const call of turn.calls) {
-          const settlement = settledCachedCall(call)
-          const nextCost = settlement.storedCostUSD
-          if (nextCost === undefined) {
-            if (call.costUSD !== undefined) { delete call.costUSD; changed = true }
-          } else if (call.costUSD !== nextCost) {
-            call.costUSD = nextCost
-            changed = true
-          }
-          const nextAssignment = JSON.stringify(settlement.storedAssignment)
-          if (JSON.stringify(call.costAssignment) !== nextAssignment) {
-            call.costAssignment = settlement.storedAssignment
-            changed = true
-          }
-          if (settlement.storedLegacyCostUSD === undefined) {
-            if (call.legacyCostUSD !== undefined) { delete call.legacyCostUSD; changed = true }
-          } else if (call.legacyCostUSD !== settlement.storedLegacyCostUSD) {
-            call.legacyCostUSD = settlement.storedLegacyCostUSD
-            changed = true
-          }
-        }
-      }
-    }
-  }
-  return changed
-}
-
 export function cachedCallToApiCall(call: CachedCall): ParsedApiCall {
   const u = call.usage
-  const settlement = settledCachedCall(call)
+  const settlement = settleCachedCallCost(call)
   return applyLocalModelSavings({
     provider: call.provider,
     model: call.model,

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -3,6 +3,7 @@ import { lstat, readFile, readdir, stat } from 'fs/promises'
 import { basename, dirname, join, normalize, resolve, sep } from 'path'
 import { readSessionLines } from './fs-utils.js'
 import { calculateCost, calculateLocalModelSavings, getShortModelName, isProxiedPath, getProxyPathsConfigHash } from './models.js'
+import { billableOutputTokens } from './token-semantics.js'
 import { buildReasoningMix, reasoningLevelFromModelLabel, type ReasoningMixInput } from './reasoning-level.js'
 import { resolveSubagentAttribution, sessionIdentity } from './sessions-report.js'
 import { normalizeContentBlocks } from './content-utils.js'
@@ -1736,6 +1737,7 @@ function buildSessionSummary(
         reasoningLevelSource: call.reasoningLevelSource,
         outputTokens: call.usage.outputTokens,
         reasoningTokens: call.usage.reasoningTokens,
+        reasoningSemantics: call.reasoningSemantics,
         costUSD: call.costUSD,
       })
 
@@ -1760,7 +1762,7 @@ function buildSessionSummary(
       modelBreakdown[modelKey].tokens.reasoningTokens += call.usage.reasoningTokens
       if (call.activeDurationMs !== undefined) {
         modelBreakdown[modelKey].activeDurationMs = (modelBreakdown[modelKey].activeDurationMs ?? 0) + call.activeDurationMs
-        modelBreakdown[modelKey].activeGeneratedTokens = (modelBreakdown[modelKey].activeGeneratedTokens ?? 0) + (call.activeGeneratedTokens ?? call.usage.outputTokens + call.usage.reasoningTokens)
+        modelBreakdown[modelKey].activeGeneratedTokens = (modelBreakdown[modelKey].activeGeneratedTokens ?? 0) + (call.activeGeneratedTokens ?? billableOutputTokens(call.provider, call.usage.outputTokens, call.usage.reasoningTokens, call.reasoningSemantics))
         modelBreakdown[modelKey].toolWaitMs = (modelBreakdown[modelKey].toolWaitMs ?? 0) + (call.toolWaitMs ?? 0)
       }
 
@@ -2372,6 +2374,7 @@ export function providerCallToTurn(call: ParsedProviderCall): ParsedTurn {
     timestamp: call.timestamp,
     speed: call.speed,
     usage,
+    reasoningSemantics: call.reasoningSemantics,
     legacyCostUSD: call.costUSD,
     isEstimated: call.costIsEstimated,
     existingAssignment: call.costAssignment,
@@ -2385,6 +2388,8 @@ export function providerCallToTurn(call: ParsedProviderCall): ParsedTurn {
       reasoningLevel: call.reasoningLevel,
       reasoningLevelSource: call.reasoningLevelSource,
     } : {}),
+    ...(call.reasoningSemantics ? { reasoningSemantics: call.reasoningSemantics } : {}),
+    ...(call.cacheTokenEvidence ? { cacheTokenEvidence: call.cacheTokenEvidence } : {}),
     usage,
     costUSD: settlement.runtimeCostUSD,
     costAssignment: settlement.runtimeAssignment,
@@ -2431,6 +2436,7 @@ export function providerCallToCachedCall(call: ParsedProviderCall): CachedCall {
     timestamp: call.timestamp,
     speed: call.speed,
     usage,
+    reasoningSemantics: call.reasoningSemantics,
     legacyCostUSD: call.costUSD,
     isEstimated: call.costIsEstimated,
     existingAssignment: call.costAssignment,
@@ -2443,6 +2449,8 @@ export function providerCallToCachedCall(call: ParsedProviderCall): CachedCall {
       reasoningLevel: call.reasoningLevel,
       reasoningLevelSource: call.reasoningLevelSource,
     } : {}),
+    ...(call.reasoningSemantics ? { reasoningSemantics: call.reasoningSemantics } : {}),
+    ...(call.cacheTokenEvidence ? { cacheTokenEvidence: call.cacheTokenEvidence } : {}),
     usage,
     ...(settlement.storedCostUSD !== undefined ? { costUSD: settlement.storedCostUSD } : {}),
     costAssignment: settlement.storedAssignment,
@@ -2496,6 +2504,7 @@ export function apiCallToCachedCall(call: ParsedApiCall): CachedCall {
     timestamp: call.timestamp,
     speed: call.speed,
     usage,
+    reasoningSemantics: call.reasoningSemantics,
     legacyCostUSD: legacyApiEquivalentCost,
     isEstimated: call.isEstimated,
     existingAssignment: call.isLocalSavings ? undefined : call.costAssignment,
@@ -2508,6 +2517,8 @@ export function apiCallToCachedCall(call: ParsedApiCall): CachedCall {
       reasoningLevel: call.reasoningLevel,
       reasoningLevelSource: call.reasoningLevelSource,
     } : {}),
+    ...(call.reasoningSemantics ? { reasoningSemantics: call.reasoningSemantics } : {}),
+    ...(call.cacheTokenEvidence ? { cacheTokenEvidence: call.cacheTokenEvidence } : {}),
     usage,
     ...(settlement.storedCostUSD !== undefined ? { costUSD: settlement.storedCostUSD } : {}),
     costAssignment: settlement.storedAssignment,
@@ -2610,9 +2621,7 @@ function providerCallsToCachedTurns(calls: ParsedProviderCall[]): CachedTurn[] {
 
 function currentCostForCachedCall(call: CachedCall): number {
   const u = call.usage
-  const outputForCost = call.provider === 'claude'
-    ? u.outputTokens
-    : u.outputTokens + u.reasoningTokens
+  const outputForCost = billableOutputTokens(call.provider, u.outputTokens, u.reasoningTokens, call.reasoningSemantics)
   return calculateCost(
     call.model, u.inputTokens, outputForCost,
     u.cacheCreationInputTokens, u.cacheReadInputTokens,
@@ -2628,12 +2637,57 @@ function settledCachedCall(call: CachedCall) {
     timestamp: call.timestamp,
     speed: call.speed,
     usage: call.usage,
+    reasoningSemantics: call.reasoningSemantics,
     legacyCostUSD: call.legacyCostUSD ?? call.costUSD ?? currentCostForCachedCall(call),
     isEstimated: call.isEstimated,
     existingAssignment: call.costAssignment,
     existingStoredCostUSD: call.costUSD,
     existingLegacyCostUSD: call.legacyCostUSD,
   })
+}
+
+function migrateLegacyCopilotOtelCacheCall(call: CachedCall): boolean {
+  if (call.provider !== 'copilot' || !call.deduplicationKey.startsWith('copilot-otel:')) return false
+  if (call.cacheTokenEvidence !== undefined) return false
+
+  const { inputTokens, cacheReadInputTokens, cacheCreationInputTokens } = call.usage
+  if (!Number.isFinite(inputTokens) || !Number.isFinite(cacheReadInputTokens) || !Number.isFinite(cacheCreationInputTokens)) return false
+  if (cacheReadInputTokens <= 0 || cacheCreationInputTokens <= 0) return false
+  const normalizedInput = inputTokens - cacheReadInputTokens - cacheCreationInputTokens
+  if (normalizedInput < 0) return false
+
+  const previousInput = call.usage.inputTokens
+  const previousCost = call.costUSD
+  const previousAssignment = call.costAssignment
+  const previousLegacyCost = call.legacyCostUSD
+  const previousEvidence = call.cacheTokenEvidence
+
+  try {
+    call.usage.inputTokens = normalizedInput
+    call.cacheTokenEvidence = 'complete'
+    delete call.costUSD
+    delete call.costAssignment
+    delete call.legacyCostUSD
+
+    const settlement = settledCachedCall(call)
+    if (settlement.storedCostUSD === undefined) delete call.costUSD
+    else call.costUSD = settlement.storedCostUSD
+    call.costAssignment = settlement.storedAssignment
+    if (settlement.storedLegacyCostUSD === undefined) delete call.legacyCostUSD
+    else call.legacyCostUSD = settlement.storedLegacyCostUSD
+    return true
+  } catch {
+    call.usage.inputTokens = previousInput
+    if (previousCost === undefined) delete call.costUSD
+    else call.costUSD = previousCost
+    if (previousAssignment === undefined) delete call.costAssignment
+    else call.costAssignment = previousAssignment
+    if (previousLegacyCost === undefined) delete call.legacyCostUSD
+    else call.legacyCostUSD = previousLegacyCost
+    if (previousEvidence === undefined) delete call.cacheTokenEvidence
+    else call.cacheTokenEvidence = previousEvidence
+    return false
+  }
 }
 
 export function settleSessionCacheCostsForRuntimeV1(cache: SessionCache): boolean {
@@ -2679,6 +2733,8 @@ export function cachedCallToApiCall(call: CachedCall): ParsedApiCall {
       reasoningLevel: call.reasoningLevel,
       reasoningLevelSource: call.reasoningLevelSource,
     } : {}),
+    ...(call.reasoningSemantics ? { reasoningSemantics: call.reasoningSemantics } : {}),
+    ...(call.cacheTokenEvidence ? { cacheTokenEvidence: call.cacheTokenEvidence } : {}),
     usage: {
       inputTokens: u.inputTokens,
       outputTokens: u.outputTokens,
@@ -2959,6 +3015,7 @@ async function parseProviderSources(
   readOnly = false,
 ): Promise<ProjectSummary[]> {
   const provider = await getProvider(providerName)
+  const previousSection = diskCache.providers[providerName]
   if (!provider) return []
 
   const section = getOrCreateProviderSection(diskCache, providerName)
@@ -2966,7 +3023,11 @@ async function parseProviderSources(
   const servedSources = [...sources]
 
   const unchangedSources: Array<{ source: SessionSource; cached: CachedFile }> = []
-  const changedSources: Array<{ source: SessionSource; fp: NonNullable<Awaited<ReturnType<typeof fingerprintFile>>> }> = []
+  const changedSources: Array<{
+    source: SessionSource
+    fp: NonNullable<Awaited<ReturnType<typeof fingerprintFile>>>
+    cached?: CachedFile
+  }> = []
 
   for (const source of sources) {
     allDiscoveredFiles.add(source.path)
@@ -2991,7 +3052,19 @@ async function parseProviderSources(
     if (cached && (readOnly || (action.action === 'unchanged' && (cached.failed || !cachedFileNeedsProviderReparse(providerName, source.path, cached))))) {
       unchangedSources.push({ source, cached })
     } else if (!readOnly) {
-      changedSources.push(queueCopilotChatJournalSource(providerName, source, fp, cached?.turns ?? []))
+      const queued = queueCopilotChatJournalSource(
+        providerName,
+        source,
+        fp,
+        (cached ?? previousSection?.files[source.path])?.turns ?? [],
+      )
+      changedSources.push({
+        ...queued,
+        // A provider-authority change intentionally removes present files from
+        // the new section before reparse. Keep the prior durable file available
+        // as a fail-closed fallback if the raw source cannot be read.
+        cached: cached ?? previousSection?.files[source.path],
+      })
     }
   }
 
@@ -3027,7 +3100,7 @@ async function parseProviderSources(
   // being wiped on every iteration.
   const clearedPaths = new Set<string>()
   try {
-    for (const { source, fp } of changedSources) {
+    for (const { source, fp, cached: cachedFallback } of changedSources) {
       if (dateRange) {
         if (fp.mtimeMs < dateRange.start.getTime()) continue
       }
@@ -3056,7 +3129,7 @@ async function parseProviderSources(
         if (provider.durableSources) {
             const existingEntry = section.files[source.path]
             if (existingEntry) {
-              if (provider.durableFreshWins) {
+              if (provider.durableFreshWins || provider.durableFreshWinsForSource?.(source)) {
                 const freshKeys = new Set(turns.flatMap(t => t.calls.map(c => c.deduplicationKey)))
                 existingEntry.turns = existingEntry.turns.map(t => ({ ...t, calls: t.calls.filter(c => !freshKeys.has(c.deduplicationKey)) })).filter(t => t.calls.length > 0)
               }
@@ -3084,6 +3157,13 @@ async function parseProviderSources(
         ;(diskCache as { _dirty?: boolean })._dirty = true
       } catch (err) {
         if (isSqliteBusyError(err)) {
+          // A temporary SQLite lock must not turn an authority-triggered
+          // durable reparse into an apparent deletion. Preserve the prior
+          // entry with its old fingerprint so the next refresh retries it.
+          if (provider.durableSources && !section.files[source.path] && cachedFallback) {
+            section.files[source.path] = cachedFallback
+            ;(diskCache as { _dirty?: boolean })._dirty = true
+          }
           warnProviderReadFailureOnce(providerName, err)
           continue
         }
@@ -3093,7 +3173,15 @@ async function parseProviderSources(
         // current fingerprint so we don't re-read + re-throw this unchanged file
         // on every refresh; it re-parses only if it changes. Empty turns => no
         // usage contributed.
-        section.files[source.path] = { fingerprint: fp, mcpInventory: [], turns: [], failed: true }
+        if (provider.durableSources && (section.files[source.path] ?? cachedFallback)) {
+          section.files[source.path] = {
+            ...(section.files[source.path] ?? cachedFallback),
+            fingerprint: fp,
+            failed: true,
+          }
+        } else {
+          section.files[source.path] = { fingerprint: fp, mcpInventory: [], turns: [], failed: true }
+        }
         recordCopilotChatJournalSourceFailure(providerName, source.path)
         ;(diskCache as { _dirty?: boolean })._dirty = true
         warnProviderParseFailure(providerName, source.path, err)
@@ -3173,6 +3261,15 @@ async function parseProviderSources(
       if (allDiscoveredFiles.has(cachedPath)) continue  // already counted above
 
       for (const turn of cachedFile.turns) {
+        if (!readOnly) {
+          let migrated = false
+          for (const call of turn.calls) {
+            if (migrateLegacyCopilotOtelCacheCall(call)) migrated = true
+          }
+          if (migrated) {
+            ;(diskCache as { _dirty?: boolean })._dirty = true
+          }
+        }
         const projectedTurn = dateRange ? sliceCachedTurnToDateRange(turn, dateRange) : turn
         if (!projectedTurn) continue
 

--- a/src/pricing/runtime-cost-assignment.ts
+++ b/src/pricing/runtime-cost-assignment.ts
@@ -2,6 +2,7 @@ import { AsyncLocalStorage } from 'node:async_hooks'
 
 import catalogData from '../data/pricing-history/catalog.v1.json'
 import { explicitZeroReasonForModel, getHistoricalPricingModelKey } from '../models.js'
+import { billableOutputTokens, type ReasoningTokenSemantics } from '../token-semantics.js'
 import {
   CostAssignmentV1Schema,
   costUsdToMicrosV1,
@@ -53,6 +54,8 @@ export type RuntimeCostAssignmentInputV1 = {
   meteredCostSource?: RuntimeMeteredCostV1['source']
   timestamp: string
   speed: 'standard' | 'fast'
+  /** Source-specific inclusion authority; omitted preserves historic provider defaults. */
+  reasoningSemantics?: ReasoningTokenSemantics
   usage: RuntimePricingUsageV1
   legacyCostUSD: number
   isEstimated?: boolean
@@ -328,9 +331,7 @@ function explicitMeteredEvidence(input: RuntimeCostAssignmentInputV1): CostAssig
 }
 
 function usageForSettlement(input: RuntimeCostAssignmentInputV1) {
-  const outputTokens = input.provider === 'claude'
-    ? input.usage.outputTokens
-    : input.usage.outputTokens + input.usage.reasoningTokens
+  const outputTokens = billableOutputTokens(input.provider, input.usage.outputTokens, input.usage.reasoningTokens, input.reasoningSemantics)
   const pricingContext = contextForInput(input)
   return {
     inputTokens: input.usage.inputTokens,

--- a/src/project-scope.ts
+++ b/src/project-scope.ts
@@ -237,6 +237,7 @@ function addProjectTokenStats(target: ProjectDayStats, source: ProjectDayStats):
   if (source.inputTokens !== undefined) target.inputTokens = (target.inputTokens ?? 0) + source.inputTokens
   if (source.outputTokens !== undefined) target.outputTokens = (target.outputTokens ?? 0) + source.outputTokens
   if (source.reasoningTokens !== undefined) target.reasoningTokens = (target.reasoningTokens ?? 0) + source.reasoningTokens
+  if (source.additiveReasoningTokens !== undefined) target.additiveReasoningTokens = (target.additiveReasoningTokens ?? 0) + source.additiveReasoningTokens
   if (source.cacheReadTokens !== undefined) target.cacheReadTokens = (target.cacheReadTokens ?? 0) + source.cacheReadTokens
   if (source.cacheWriteTokens !== undefined) target.cacheWriteTokens = (target.cacheWriteTokens ?? 0) + source.cacheWriteTokens
 }
@@ -282,6 +283,7 @@ function scopedProviderSlice(
       inputTokens: slice.inputTokens,
       outputTokens: slice.outputTokens,
       reasoningTokens: slice.reasoningTokens,
+      additiveReasoningTokens: slice.additiveReasoningTokens,
       cacheReadTokens: slice.cacheReadTokens,
       cacheWriteTokens: slice.cacheWriteTokens,
       editTurns: slice.editTurns,
@@ -294,6 +296,7 @@ function scopedProviderSlice(
       inputTokens: totals.inputTokens ?? 0,
       outputTokens: totals.outputTokens ?? 0,
       reasoningTokens: totals.reasoningTokens,
+      additiveReasoningTokens: totals.additiveReasoningTokens,
       cacheReadTokens: totals.cacheReadTokens ?? 0,
       cacheWriteTokens: totals.cacheWriteTokens ?? 0,
       editTurns: 0,
@@ -328,6 +331,7 @@ export function filterDailyEntryByMetroraScope(
       inputTokens: day.inputTokens,
       outputTokens: day.outputTokens,
       reasoningTokens: day.reasoningTokens,
+      additiveReasoningTokens: day.additiveReasoningTokens,
       cacheReadTokens: day.cacheReadTokens,
       cacheWriteTokens: day.cacheWriteTokens,
       editTurns: day.editTurns,
@@ -338,6 +342,7 @@ export function filterDailyEntryByMetroraScope(
       inputTokens: totals.inputTokens ?? 0,
       outputTokens: totals.outputTokens ?? 0,
       reasoningTokens: totals.reasoningTokens,
+      additiveReasoningTokens: totals.additiveReasoningTokens,
       cacheReadTokens: totals.cacheReadTokens ?? 0,
       cacheWriteTokens: totals.cacheWriteTokens ?? 0,
       editTurns: 0,

--- a/src/providers/copilot-otel-token-semantics.ts
+++ b/src/providers/copilot-otel-token-semantics.ts
@@ -1,0 +1,127 @@
+import type { SqliteDatabase } from '../sqlite.js'
+import type { CacheTokenEvidence } from '../token-semantics.js'
+
+/** Attribute bag retained by the Copilot OTel SQLite reader. */
+export type CopilotOtelSpanAttributes = {
+  'gen_ai.operation.name'?: string
+  'gen_ai.response.model'?: string
+  'gen_ai.request.model'?: string
+  'gen_ai.usage.input_tokens'?: number
+  'gen_ai.usage.output_tokens'?: number
+  'gen_ai.usage.cache_read.input_tokens'?: number
+  'gen_ai.usage.cache_creation.input_tokens'?: number
+  'gen_ai.usage.reasoning.output_tokens'?: number
+  'gen_ai.usage.reasoning_tokens'?: number
+  'gen_ai.conversation.id'?: string
+  'gen_ai.agent.name'?: string
+  'gen_ai.tool.name'?: string
+  'gen_ai.tool.call.arguments'?: string
+  'copilot_chat.parent_chat_session_id'?: string
+  'github.copilot.chat.turn.id'?: string
+  [key: string]: unknown
+}
+
+export type CopilotOtelUsage = {
+  inputTokens: number
+  outputTokens: number
+  cacheReadTokens: number
+  cacheCreationTokens: number
+  reasoningTokens: number
+  cacheTokenEvidence: CacheTokenEvidence
+  reasoningSemantics: 'aggregate-output'
+}
+
+type NumericAttributeEvidence = {
+  present: boolean
+  valid: boolean
+  value: number
+}
+
+export function loadCopilotOtelSpanAttributes(
+  db: SqliteDatabase,
+  spanId: string,
+): CopilotOtelSpanAttributes {
+  try {
+    const rows = db.query<{ key: string; value: string | null }>(
+      `SELECT key, value FROM span_attributes WHERE span_id = ?`,
+      [spanId],
+    )
+    const attrs: CopilotOtelSpanAttributes = {}
+    for (const row of rows) {
+      if (row.key && row.value) {
+        try {
+          const numeric = Number(row.value)
+          attrs[row.key as keyof CopilotOtelSpanAttributes] = Number.isNaN(numeric)
+            ? row.value
+            : numeric
+        } catch {
+          attrs[row.key as keyof CopilotOtelSpanAttributes] = row.value
+        }
+      }
+    }
+    return attrs
+  } catch {
+    return {}
+  }
+}
+
+function readNumericAttribute(attrs: CopilotOtelSpanAttributes, key: string): NumericAttributeEvidence {
+  const raw = attrs[key]
+  const present = raw !== undefined && raw !== null && raw !== ''
+  if (!present) return { present: false, valid: false, value: 0 }
+
+  const value = typeof raw === 'number' ? raw : Number(raw)
+  const valid = Number.isFinite(value) && value >= 0
+  return { present: true, valid, value: valid ? value : 0 }
+}
+
+/**
+ * Normalize the verified Copilot OTel representation at the provider boundary.
+ * The input field is cache-inclusive; every valid cache component known to be
+ * included in it is removed, even when the other cache component is unknown.
+ */
+export function normalizeCopilotOtelUsage(attrs: CopilotOtelSpanAttributes): CopilotOtelUsage {
+  const input = readNumericAttribute(attrs, 'gen_ai.usage.input_tokens')
+  const output = readNumericAttribute(attrs, 'gen_ai.usage.output_tokens')
+  const cacheRead = readNumericAttribute(attrs, 'gen_ai.usage.cache_read.input_tokens')
+  const cacheCreation = readNumericAttribute(attrs, 'gen_ai.usage.cache_creation.input_tokens')
+
+  const anyCachePresent = cacheRead.present || cacheCreation.present
+  const invalidCacheField = (cacheRead.present && !cacheRead.valid) || (cacheCreation.present && !cacheCreation.valid)
+  const knownCache = cacheRead.value + cacheCreation.value
+  const cacheExceedsInput = input.valid && knownCache > input.value
+
+  let cacheTokenEvidence: CacheTokenEvidence
+  if (!input.valid || invalidCacheField || cacheExceedsInput) {
+    cacheTokenEvidence = 'inconsistent'
+  } else if (!anyCachePresent) {
+    cacheTokenEvidence = 'unavailable'
+  } else if (cacheRead.present && cacheCreation.present) {
+    cacheTokenEvidence = 'complete'
+  } else {
+    cacheTokenEvidence = 'partial'
+  }
+
+  // An invalid or impossible cache component is not allowed into canonical
+  // additive accounting. A valid subset remains useful when I is valid and
+  // the subset fits inside I; the evidence status preserves the uncertainty.
+  const canUseKnownCache = input.valid && knownCache <= input.value
+  const normalizedCacheRead = canUseKnownCache ? cacheRead.value : 0
+  const normalizedCacheCreation = canUseKnownCache ? cacheCreation.value : 0
+
+  const reasoningCanonical = readNumericAttribute(attrs, 'gen_ai.usage.reasoning.output_tokens')
+  const reasoningLegacy = readNumericAttribute(attrs, 'gen_ai.usage.reasoning_tokens')
+  // Canonical evidence wins whenever the key is present, including an explicit
+  // zero or malformed value. Legacy is only a bounded compatibility fallback.
+  const reasoning = reasoningCanonical.present ? reasoningCanonical : reasoningLegacy
+
+  return {
+    inputTokens: input.valid ? input.value - normalizedCacheRead - normalizedCacheCreation : 0,
+    outputTokens: output.value,
+    cacheReadTokens: normalizedCacheRead,
+    cacheCreationTokens: normalizedCacheCreation,
+    reasoningTokens: reasoning.valid ? reasoning.value : 0,
+    cacheTokenEvidence,
+    reasoningSemantics: 'aggregate-output',
+  }
+}

--- a/src/providers/copilot.ts
+++ b/src/providers/copilot.ts
@@ -72,7 +72,7 @@ import type {
   SessionParser,
   ParsedProviderCall,
 } from './types.js'
-import type { CacheTokenEvidence } from '../token-semantics.js'
+import { loadCopilotOtelSpanAttributes, normalizeCopilotOtelUsage } from './copilot-otel-token-semantics.js'
 import {
   getAgentTracesDbPath,
   getCopilotDoctorProbeRoots,
@@ -240,26 +240,6 @@ type ChatSessionRequest = Record<string, unknown>
 // The Copilot Budget extension reads from this same DB and uses per-span
 // token counts, confirming this schema is stable enough to depend on.
 
-// Parsed attribute bag from a span
-interface SpanAttributes {
-  'gen_ai.operation.name'?: string
-  'gen_ai.response.model'?: string
-  'gen_ai.request.model'?: string
-  'gen_ai.usage.input_tokens'?: number
-  'gen_ai.usage.output_tokens'?: number
-  'gen_ai.usage.cache_read.input_tokens'?: number
-  'gen_ai.usage.cache_creation.input_tokens'?: number
-  'gen_ai.usage.reasoning.output_tokens'?: number
-  'gen_ai.usage.reasoning_tokens'?: number
-  'gen_ai.conversation.id'?: string
-  'gen_ai.agent.name'?: string
-  'gen_ai.tool.name'?: string
-  'gen_ai.tool.call.arguments'?: string
-  'copilot_chat.parent_chat_session_id'?: string
-  'github.copilot.chat.turn.id'?: string
-  [key: string]: unknown
-}
-
 // ---------------------------------------------------------------------------
 
 /**
@@ -300,114 +280,6 @@ function parseCwd(yaml: string): string | null {
   // Strip surrounding single/double quotes
   raw = raw.replace(/^['"]|['"]$/g, '').trim()
   return raw || null
-}
-
-/**
- * Load span attributes from the span_attributes table (key-value pairs).
- * This handles the modern VS Code Copilot Chat schema where attributes
- * are stored as separate key-value rows rather than a JSON blob.
- */
-function loadSpanAttributesFromTable(
-  db: ReturnType<typeof import('../sqlite.js')['openDatabase']>,
-  spanId: string
-): SpanAttributes {
-  try {
-    const rows = db.query<{ key: string; value: string | null }>(
-      `SELECT key, value FROM span_attributes WHERE span_id = ?`,
-      [spanId]
-    )
-    const attrs: SpanAttributes = {}
-    for (const row of rows) {
-      if (row.key && row.value) {
-        try {
-          // Try to parse numeric values
-          const numValue = Number(row.value)
-          attrs[row.key as keyof SpanAttributes] = Number.isNaN(numValue) 
-            ? row.value
-            : numValue
-        } catch {
-          attrs[row.key as keyof SpanAttributes] = row.value
-        }
-      }
-    }
-    return attrs
-  } catch {
-    return {}
-  }
-}
-
-type NumericAttributeEvidence = {
-  present: boolean
-  valid: boolean
-  value: number
-}
-
-function readNumericOtelAttribute(attrs: SpanAttributes, key: string): NumericAttributeEvidence {
-  const raw = attrs[key]
-  const present = raw !== undefined && raw !== null && raw !== ''
-  if (!present) return { present: false, valid: false, value: 0 }
-
-  const value = typeof raw === 'number' ? raw : Number(raw)
-  const valid = Number.isFinite(value) && value >= 0
-  return { present: true, valid, value: valid ? value : 0 }
-}
-
-type NormalizedOtelUsage = {
-  inputTokens: number
-  outputTokens: number
-  cacheReadTokens: number
-  cacheCreationTokens: number
-  reasoningTokens: number
-  cacheTokenEvidence: CacheTokenEvidence
-  reasoningSemantics: 'aggregate-output'
-}
-
-/**
- * Normalize the verified VS Code Copilot OTel representation at the provider
- * boundary. In that representation input_tokens is cache-inclusive, while the
- * two cache fields are subfields of input_tokens. A missing cache subfield is
- * intentionally not treated as an emitted zero.
- */
-function normalizeOtelUsage(attrs: SpanAttributes): NormalizedOtelUsage {
-  const input = readNumericOtelAttribute(attrs, 'gen_ai.usage.input_tokens')
-  const output = readNumericOtelAttribute(attrs, 'gen_ai.usage.output_tokens')
-  const cacheRead = readNumericOtelAttribute(attrs, 'gen_ai.usage.cache_read.input_tokens')
-  const cacheCreation = readNumericOtelAttribute(attrs, 'gen_ai.usage.cache_creation.input_tokens')
-
-  const invalidEvidence = !input.valid
-    || !output.valid
-    || (cacheRead.present && !cacheRead.valid)
-    || (cacheCreation.present && !cacheCreation.valid)
-  const bothCacheFieldsPresent = cacheRead.present && cacheCreation.present
-  const cacheSum = cacheRead.value + cacheCreation.value
-
-  let cacheTokenEvidence: CacheTokenEvidence
-  if (invalidEvidence || (bothCacheFieldsPresent && cacheSum > input.value)) {
-    cacheTokenEvidence = 'inconsistent'
-  } else if (!cacheRead.present && !cacheCreation.present) {
-    cacheTokenEvidence = 'unavailable'
-  } else if (!bothCacheFieldsPresent) {
-    cacheTokenEvidence = 'partial'
-  } else {
-    cacheTokenEvidence = 'complete'
-  }
-
-  const subtractCaches = cacheTokenEvidence === 'complete'
-  const reasoningCanonical = readNumericOtelAttribute(attrs, 'gen_ai.usage.reasoning.output_tokens')
-  const reasoningLegacy = readNumericOtelAttribute(attrs, 'gen_ai.usage.reasoning_tokens')
-  // Canonical evidence wins whenever the key is present, including an explicit
-  // zero or malformed value. Legacy is only a bounded compatibility fallback.
-  const reasoning = reasoningCanonical.present ? reasoningCanonical : reasoningLegacy
-
-  return {
-    inputTokens: subtractCaches ? input.value - cacheSum : input.value,
-    outputTokens: output.value,
-    cacheReadTokens: cacheRead.value,
-    cacheCreationTokens: cacheCreation.value,
-    reasoningTokens: reasoning.valid ? reasoning.value : 0,
-    cacheTokenEvidence,
-    reasoningSemantics: 'aggregate-output',
-  }
 }
 
 /**
@@ -1691,7 +1563,7 @@ function createOtelParser(
 
             if (opName === 'execute_tool') {
               // Load tool name from attributes and normalise to display form
-              const attrs = loadSpanAttributesFromTable(db, span.span_id)
+              const attrs = loadCopilotOtelSpanAttributes(db, span.span_id)
               const rawToolName = attrs['gen_ai.tool.name'] as string | undefined
               if (rawToolName) {
                 const existing = toolsByTrace.get(span.trace_id) ?? []
@@ -1717,7 +1589,7 @@ function createOtelParser(
             // chat session. The root turn agent ('GitHub Copilot Chat') has no
             // parent session and is skipped to avoid a bogus agents-view entry.
             if (opName === 'invoke_agent') {
-              const attrs = loadSpanAttributesFromTable(db, span.span_id)
+              const attrs = loadCopilotOtelSpanAttributes(db, span.span_id)
               const parentSession = attrs['copilot_chat.parent_chat_session_id']
               const agentName = attrs['gen_ai.agent.name'] as string | undefined
               if (parentSession && agentName) {
@@ -1730,7 +1602,7 @@ function createOtelParser(
 
           // Yield one ParsedProviderCall per chat span
           for (const spanId of chatSpanIds) {
-            const attrs = loadSpanAttributesFromTable(db, spanId)
+            const attrs = loadCopilotOtelSpanAttributes(db, spanId)
 
             const spanMetadata = spanMetaById.get(spanId)
             if (!spanMetadata) continue
@@ -1741,9 +1613,9 @@ function createOtelParser(
               spanMetadata.response_model ??
               'unknown'
 
-            const usage = normalizeOtelUsage(attrs)
+            const usage = normalizeCopilotOtelUsage(attrs)
 
-            if (usage.inputTokens === 0 && usage.outputTokens === 0 && usage.cacheReadTokens === 0 && usage.cacheCreationTokens === 0) {
+            if (usage.inputTokens === 0 && usage.outputTokens === 0 && usage.cacheReadTokens === 0 && usage.cacheCreationTokens === 0 && usage.cacheTokenEvidence !== 'inconsistent') {
               continue
             }
 

--- a/src/providers/copilot.ts
+++ b/src/providers/copilot.ts
@@ -72,6 +72,7 @@ import type {
   SessionParser,
   ParsedProviderCall,
 } from './types.js'
+import type { CacheTokenEvidence } from '../token-semantics.js'
 import {
   getAgentTracesDbPath,
   getCopilotDoctorProbeRoots,
@@ -248,6 +249,8 @@ interface SpanAttributes {
   'gen_ai.usage.output_tokens'?: number
   'gen_ai.usage.cache_read.input_tokens'?: number
   'gen_ai.usage.cache_creation.input_tokens'?: number
+  'gen_ai.usage.reasoning.output_tokens'?: number
+  'gen_ai.usage.reasoning_tokens'?: number
   'gen_ai.conversation.id'?: string
   'gen_ai.agent.name'?: string
   'gen_ai.tool.name'?: string
@@ -330,6 +333,80 @@ function loadSpanAttributesFromTable(
     return attrs
   } catch {
     return {}
+  }
+}
+
+type NumericAttributeEvidence = {
+  present: boolean
+  valid: boolean
+  value: number
+}
+
+function readNumericOtelAttribute(attrs: SpanAttributes, key: string): NumericAttributeEvidence {
+  const raw = attrs[key]
+  const present = raw !== undefined && raw !== null && raw !== ''
+  if (!present) return { present: false, valid: false, value: 0 }
+
+  const value = typeof raw === 'number' ? raw : Number(raw)
+  const valid = Number.isFinite(value) && value >= 0
+  return { present: true, valid, value: valid ? value : 0 }
+}
+
+type NormalizedOtelUsage = {
+  inputTokens: number
+  outputTokens: number
+  cacheReadTokens: number
+  cacheCreationTokens: number
+  reasoningTokens: number
+  cacheTokenEvidence: CacheTokenEvidence
+  reasoningSemantics: 'aggregate-output'
+}
+
+/**
+ * Normalize the verified VS Code Copilot OTel representation at the provider
+ * boundary. In that representation input_tokens is cache-inclusive, while the
+ * two cache fields are subfields of input_tokens. A missing cache subfield is
+ * intentionally not treated as an emitted zero.
+ */
+function normalizeOtelUsage(attrs: SpanAttributes): NormalizedOtelUsage {
+  const input = readNumericOtelAttribute(attrs, 'gen_ai.usage.input_tokens')
+  const output = readNumericOtelAttribute(attrs, 'gen_ai.usage.output_tokens')
+  const cacheRead = readNumericOtelAttribute(attrs, 'gen_ai.usage.cache_read.input_tokens')
+  const cacheCreation = readNumericOtelAttribute(attrs, 'gen_ai.usage.cache_creation.input_tokens')
+
+  const invalidEvidence = !input.valid
+    || !output.valid
+    || (cacheRead.present && !cacheRead.valid)
+    || (cacheCreation.present && !cacheCreation.valid)
+  const bothCacheFieldsPresent = cacheRead.present && cacheCreation.present
+  const cacheSum = cacheRead.value + cacheCreation.value
+
+  let cacheTokenEvidence: CacheTokenEvidence
+  if (invalidEvidence || (bothCacheFieldsPresent && cacheSum > input.value)) {
+    cacheTokenEvidence = 'inconsistent'
+  } else if (!cacheRead.present && !cacheCreation.present) {
+    cacheTokenEvidence = 'unavailable'
+  } else if (!bothCacheFieldsPresent) {
+    cacheTokenEvidence = 'partial'
+  } else {
+    cacheTokenEvidence = 'complete'
+  }
+
+  const subtractCaches = cacheTokenEvidence === 'complete'
+  const reasoningCanonical = readNumericOtelAttribute(attrs, 'gen_ai.usage.reasoning.output_tokens')
+  const reasoningLegacy = readNumericOtelAttribute(attrs, 'gen_ai.usage.reasoning_tokens')
+  // Canonical evidence wins whenever the key is present, including an explicit
+  // zero or malformed value. Legacy is only a bounded compatibility fallback.
+  const reasoning = reasoningCanonical.present ? reasoningCanonical : reasoningLegacy
+
+  return {
+    inputTokens: subtractCaches ? input.value - cacheSum : input.value,
+    outputTokens: output.value,
+    cacheReadTokens: cacheRead.value,
+    cacheCreationTokens: cacheCreation.value,
+    reasoningTokens: reasoning.valid ? reasoning.value : 0,
+    cacheTokenEvidence,
+    reasoningSemantics: 'aggregate-output',
   }
 }
 
@@ -1664,12 +1741,9 @@ function createOtelParser(
               spanMetadata.response_model ??
               'unknown'
 
-            const inputTokens = Number(attrs['gen_ai.usage.input_tokens'] ?? 0)
-            const outputTokens = Number(attrs['gen_ai.usage.output_tokens'] ?? 0)
-            const cacheReadTokens = Number(attrs['gen_ai.usage.cache_read.input_tokens'] ?? 0)
-            const cacheCreationTokens = Number(attrs['gen_ai.usage.cache_creation.input_tokens'] ?? 0)
+            const usage = normalizeOtelUsage(attrs)
 
-            if (inputTokens === 0 && outputTokens === 0 && cacheReadTokens === 0 && cacheCreationTokens === 0) {
+            if (usage.inputTokens === 0 && usage.outputTokens === 0 && usage.cacheReadTokens === 0 && usage.cacheCreationTokens === 0) {
               continue
             }
 
@@ -1695,11 +1769,11 @@ function createOtelParser(
             // calculateCost with FULL token data — this is the key improvement.
             const costUSD = calculateCost(
               model,
-              inputTokens,
-              outputTokens,
-              cacheCreationTokens,
-              cacheReadTokens,
-              0 // reasoningTokens — not exposed in current OTel schema
+              usage.inputTokens,
+              usage.outputTokens,
+              usage.cacheCreationTokens,
+              usage.cacheReadTokens,
+              0 // reasoning is included in OTel output_tokens
             )
 
             yield {
@@ -1707,12 +1781,14 @@ function createOtelParser(
               sessionId: conversationId,
               project,
               model,
-              inputTokens,
-              outputTokens,
-              cacheCreationInputTokens: cacheCreationTokens,
-              cacheReadInputTokens: cacheReadTokens,
+              inputTokens: usage.inputTokens,
+              outputTokens: usage.outputTokens,
+              cacheCreationInputTokens: usage.cacheCreationTokens,
+              cacheReadInputTokens: usage.cacheReadTokens,
               cachedInputTokens: 0,
-              reasoningTokens: 0,
+              reasoningTokens: usage.reasoningTokens,
+              cacheTokenEvidence: usage.cacheTokenEvidence,
+              reasoningSemantics: usage.reasoningSemantics,
               webSearchRequests: 0,
               costUSD,
               tools,
@@ -2184,6 +2260,7 @@ export function createCopilotProvider(
     displayName: 'Copilot',
     durableSources: true,
     probeRoots: async () => getCopilotDoctorProbeRoots(sessionStateDir, workspaceStorageDir, globalStorageDir, jetbrainsDir),
+    durableFreshWinsForSource: source => (source as { sourceType?: unknown }).sourceType === 'otel',
 
     modelDisplayName(model: string): string {
       for (const [key, display] of modelDisplayEntries) {

--- a/src/providers/types.ts
+++ b/src/providers/types.ts
@@ -1,5 +1,6 @@
 import type { DateRange, ToolCall } from '../types.js'
 import type { ReasoningLevel, ReasoningLevelSource } from '../reasoning-level.js'
+import type { CacheTokenEvidence, ReasoningTokenSemantics } from '../token-semantics.js'
 import type { CostAssignmentV1 } from '../pricing/cost-assignment.js'
 import type { HistoricalPricingContextV1 } from '../pricing/pricing-context.js'
 
@@ -35,6 +36,11 @@ export type ParsedProviderCall = {
   /** Optional bounded delivery/pricing evidence preserved separately from model labels. */
   pricingContext?: HistoricalPricingContextV1
   reasoningLevel?: ReasoningLevel
+  /** Explicit source semantics; absent preserves the provider's existing default. */
+  reasoningSemantics?: ReasoningTokenSemantics
+  /** Whether OTel cache subfields were complete, partial, unavailable, or inconsistent. */
+  cacheTokenEvidence?: CacheTokenEvidence
+
   reasoningLevelSource?: ReasoningLevelSource
   inputTokens: number
   outputTokens: number
@@ -103,6 +109,10 @@ export type Provider = {
   // Fresh derivation for a present durable source replaces cached calls with the
   // same native identity while retaining cached calls absent from that derivation.
   durableFreshWins?: boolean
+  // Optional source-aware variant used when only one durable source's parser
+  // authority is changing; other provider paths retain their cached calls.
+  durableFreshWinsForSource?: (source: SessionSource) => boolean
+
   modelDisplayName(model: string): string
   toolDisplayName(rawTool: string): string
   discoverSessions(): Promise<SessionSource[]>

--- a/src/reasoning-level.ts
+++ b/src/reasoning-level.ts
@@ -1,3 +1,4 @@
+import { generatedTokensForReasoningMix, type ReasoningTokenSemantics } from './token-semantics.js'
 export const REASONING_LEVELS = [
   'none',
   'minimal',
@@ -41,6 +42,7 @@ export type ReasoningMixInput = {
   outputTokens?: number
   reasoningTokens?: number
   costUSD?: number
+  reasoningSemantics?: ReasoningTokenSemantics
 }
 
 const LEVEL_SET = new Set<string>(REASONING_LEVELS)
@@ -180,7 +182,7 @@ export function buildReasoningMix(calls: ReasoningMixInput[]): ReasoningMix {
       sources: new Set<ReasoningLevelSource>(),
     }
     row.calls++
-    row.generatedTokens += finiteNonNegative(call.outputTokens) + finiteNonNegative(call.reasoningTokens)
+    row.generatedTokens += generatedTokensForReasoningMix(finiteNonNegative(call.outputTokens), finiteNonNegative(call.reasoningTokens), call.reasoningSemantics)
     row.reasoningTokens += finiteNonNegative(call.reasoningTokens)
     row.costUSD += finiteNonNegative(call.costUSD)
     if (call.reasoningLevelSource) row.sources.add(call.reasoningLevelSource)

--- a/src/session-cache-cost-settlement.ts
+++ b/src/session-cache-cost-settlement.ts
@@ -1,0 +1,114 @@
+import { calculateCost } from './models.js'
+import { billableOutputTokens } from './token-semantics.js'
+import type { CachedCall, SessionCache } from './session-cache.js'
+import {
+  assignRuntimeCostV1,
+} from './pricing/runtime-cost-assignment.js'
+
+function currentCostForCachedCall(call: CachedCall): number {
+  const u = call.usage
+  const outputForCost = billableOutputTokens(call.provider, u.outputTokens, u.reasoningTokens, call.reasoningSemantics)
+  return calculateCost(
+    call.model, u.inputTokens, outputForCost,
+    u.cacheCreationInputTokens, u.cacheReadInputTokens,
+    u.webSearchRequests, call.speed, u.cacheCreationOneHourTokens,
+  )
+}
+
+export function settleCachedCallCost(call: CachedCall) {
+  return assignRuntimeCostV1({
+    provider: call.provider,
+    model: call.model,
+    modelProvider: call.modelProvider, pricingContext: call.pricingContext,
+    timestamp: call.timestamp,
+    speed: call.speed,
+    usage: call.usage,
+    reasoningSemantics: call.reasoningSemantics,
+    legacyCostUSD: call.legacyCostUSD ?? call.costUSD ?? currentCostForCachedCall(call),
+    isEstimated: call.isEstimated,
+    existingAssignment: call.costAssignment,
+    existingStoredCostUSD: call.costUSD,
+    existingLegacyCostUSD: call.legacyCostUSD,
+  })
+}
+
+/**
+ * Migrate only legacy Copilot OTel rows whose two positive cache buckets prove
+ * the old parser stored cache-inclusive input. A zero bucket is ambiguous and
+ * remains untouched because old zeroes may have been parser fallbacks.
+ */
+export function migrateLegacyCopilotOtelCacheCall(call: CachedCall): boolean {
+  if (call.provider !== 'copilot' || !call.deduplicationKey.startsWith('copilot-otel:')) return false
+  if (call.cacheTokenEvidence !== undefined) return false
+
+  const { inputTokens, cacheReadInputTokens, cacheCreationInputTokens } = call.usage
+  if (!Number.isFinite(inputTokens) || !Number.isFinite(cacheReadInputTokens) || !Number.isFinite(cacheCreationInputTokens)) return false
+  if (cacheReadInputTokens <= 0 || cacheCreationInputTokens <= 0) return false
+  const normalizedInput = inputTokens - cacheReadInputTokens - cacheCreationInputTokens
+  if (normalizedInput < 0) return false
+
+  const previousInput = call.usage.inputTokens
+  const previousCost = call.costUSD
+  const previousAssignment = call.costAssignment
+  const previousLegacyCost = call.legacyCostUSD
+  const previousEvidence = call.cacheTokenEvidence
+
+  try {
+    call.usage.inputTokens = normalizedInput
+    call.cacheTokenEvidence = 'complete'
+    delete call.costUSD
+    delete call.costAssignment
+    delete call.legacyCostUSD
+
+    const settlement = settleCachedCallCost(call)
+    if (settlement.storedCostUSD === undefined) delete call.costUSD
+    else call.costUSD = settlement.storedCostUSD
+    call.costAssignment = settlement.storedAssignment
+    if (settlement.storedLegacyCostUSD === undefined) delete call.legacyCostUSD
+    else call.legacyCostUSD = settlement.storedLegacyCostUSD
+    return true
+  } catch {
+    call.usage.inputTokens = previousInput
+    if (previousCost === undefined) delete call.costUSD
+    else call.costUSD = previousCost
+    if (previousAssignment === undefined) delete call.costAssignment
+    else call.costAssignment = previousAssignment
+    if (previousLegacyCost === undefined) delete call.legacyCostUSD
+    else call.legacyCostUSD = previousLegacyCost
+    if (previousEvidence === undefined) delete call.cacheTokenEvidence
+    else call.cacheTokenEvidence = previousEvidence
+    return false
+  }
+}
+
+export function settleSessionCacheCostsForRuntimeV1(cache: SessionCache): boolean {
+  let changed = false
+  for (const section of Object.values(cache.providers)) {
+    for (const file of Object.values(section.files)) {
+      for (const turn of file.turns) {
+        for (const call of turn.calls) {
+          const settlement = settleCachedCallCost(call)
+          const nextCost = settlement.storedCostUSD
+          if (nextCost === undefined) {
+            if (call.costUSD !== undefined) { delete call.costUSD; changed = true }
+          } else if (call.costUSD !== nextCost) {
+            call.costUSD = nextCost
+            changed = true
+          }
+          const nextAssignment = JSON.stringify(settlement.storedAssignment)
+          if (JSON.stringify(call.costAssignment) !== nextAssignment) {
+            call.costAssignment = settlement.storedAssignment
+            changed = true
+          }
+          if (settlement.storedLegacyCostUSD === undefined) {
+            if (call.legacyCostUSD !== undefined) { delete call.legacyCostUSD; changed = true }
+          } else if (call.legacyCostUSD !== settlement.storedLegacyCostUSD) {
+            call.legacyCostUSD = settlement.storedLegacyCostUSD
+            changed = true
+          }
+        }
+      }
+    }
+  }
+  return changed
+}

--- a/src/session-cache-token-authority.ts
+++ b/src/session-cache-token-authority.ts
@@ -1,0 +1,9 @@
+import type { CacheTokenEvidence, ReasoningTokenSemantics } from './token-semantics.js'
+
+/** Optional source authority carried across the durable CachedCall boundary. */
+export type CachedCallTokenAuthority = {
+  /** Source-specific reasoning inclusion authority, when one was proven. */
+  reasoningSemantics?: ReasoningTokenSemantics
+  /** OTel cache subfield evidence; absent on legacy/provider paths and old cache. */
+  cacheTokenEvidence?: CacheTokenEvidence
+}

--- a/src/session-cache-validation.ts
+++ b/src/session-cache-validation.ts
@@ -30,6 +30,21 @@ function isOptionalBool(value: unknown): boolean {
   return value === undefined || typeof value === 'boolean'
 }
 
+function isOptionalReasoningSemantics(value: unknown): boolean {
+  return value === undefined
+    || value === 'separate'
+    || value === 'aggregate-output'
+    || value === 'unavailable'
+    || value === 'mixed'
+}
+
+function isOptionalCacheTokenEvidence(value: unknown): boolean {
+  return value === undefined
+    || value === 'complete'
+    || value === 'partial'
+    || value === 'unavailable'
+    || value === 'inconsistent'
+}
 // A plain object whose every value is a string. Used for the sidechain
 // `agentSpawnLinks` map (agentId -> spawn tool_use id).
 function isOptionalStringRecord(value: unknown): boolean {
@@ -92,6 +107,8 @@ function validateCall(value: unknown): value is CachedCall {
     && typeof call['model'] === 'string'
     && isOptionalString(call['modelProvider'])
     && (call['pricingContext'] === undefined || HistoricalPricingContextV1Schema.safeParse(call['pricingContext']).success)
+    && isOptionalReasoningSemantics(call['reasoningSemantics'])
+    && isOptionalCacheTokenEvidence(call['cacheTokenEvidence'])
     && typeof call['deduplicationKey'] === 'string'
     && typeof call['timestamp'] === 'string'
     && (call['speed'] === 'standard' || call['speed'] === 'fast')

--- a/src/session-cache.ts
+++ b/src/session-cache.ts
@@ -238,7 +238,7 @@ export const PROVIDER_PARSE_VERSIONS: Record<string, string> = {
   codex: 'mcp-attribution-v5-est-cost-active-timing-mcp-wait-rich-capture-v1-cross-provider-pr-v1-reasoning-attribution-v1-pricing-context-tags-v1-pricing-evidence-provider-routes-v1',
   cursor: 'composer-anchored-crediting-v1-est-cost',
   'cursor-agent': 'workspaceless-transcript-v2-estimated-cost',
-  copilot: 'cli-shutdown-cost-v3-source-provenance-otel-token-semantics-v1',
+  copilot: 'cli-shutdown-cost-v3-source-provenance-otel-token-semantics-v1-reasoning-evidence-v1',
   goose: 'sqlite-session-v1-provider-provenance',
   grok: 'estimated-cost-v1',
   hermes: 'reasoning-output-accounting-v2-provider-provenance-cost-semantics-v2-pricing-evidence-v1',

--- a/src/session-cache.ts
+++ b/src/session-cache.ts
@@ -4,6 +4,7 @@ import { createHash, randomBytes } from 'crypto'
 import { join } from 'path'
 import type { ReasoningLevel, ReasoningLevelSource } from './reasoning-level.js'
 import type { ToolCall } from './types.js'
+import type { CacheTokenEvidence, ReasoningTokenSemantics } from './token-semantics.js'
 import type { CostAssignmentV1 } from './pricing/cost-assignment.js'
 import { fingerprintSourceFile, type SQLiteWalFingerprint } from './sqlite-source-fingerprint.js'
 import { getMetroraCacheDir } from './product-paths.js'
@@ -28,6 +29,11 @@ export type CachedCall = {
   /** Explicit model/API provider preserved from the source when available. */
   modelProvider?: string; pricingContext?: import('./pricing/pricing-context.js').HistoricalPricingContextV1
   reasoningLevel?: ReasoningLevel
+  /** Source-specific reasoning inclusion authority, when one was proven. */
+  reasoningSemantics?: ReasoningTokenSemantics
+  /** OTel cache subfield evidence; absent on legacy/provider paths and old cache. */
+  cacheTokenEvidence?: CacheTokenEvidence
+
   reasoningLevelSource?: ReasoningLevelSource
   usage: CachedUsage
   costUSD?: number
@@ -238,7 +244,7 @@ export const PROVIDER_PARSE_VERSIONS: Record<string, string> = {
   codex: 'mcp-attribution-v5-est-cost-active-timing-mcp-wait-rich-capture-v1-cross-provider-pr-v1-reasoning-attribution-v1-pricing-context-tags-v1-pricing-evidence-provider-routes-v1',
   cursor: 'composer-anchored-crediting-v1-est-cost',
   'cursor-agent': 'workspaceless-transcript-v2-estimated-cost',
-  copilot: 'cli-shutdown-cost-v3-source-provenance',
+  copilot: 'cli-shutdown-cost-v3-source-provenance-otel-token-semantics-v1',
   goose: 'sqlite-session-v1-provider-provenance',
   grok: 'estimated-cost-v1',
   hermes: 'reasoning-output-accounting-v2-provider-provenance-cost-semantics-v2-pricing-evidence-v1',

--- a/src/session-cache.ts
+++ b/src/session-cache.ts
@@ -4,7 +4,6 @@ import { createHash, randomBytes } from 'crypto'
 import { join } from 'path'
 import type { ReasoningLevel, ReasoningLevelSource } from './reasoning-level.js'
 import type { ToolCall } from './types.js'
-import type { CacheTokenEvidence, ReasoningTokenSemantics } from './token-semantics.js'
 import type { CostAssignmentV1 } from './pricing/cost-assignment.js'
 import { fingerprintSourceFile, type SQLiteWalFingerprint } from './sqlite-source-fingerprint.js'
 import { getMetroraCacheDir } from './product-paths.js'
@@ -29,11 +28,6 @@ export type CachedCall = {
   /** Explicit model/API provider preserved from the source when available. */
   modelProvider?: string; pricingContext?: import('./pricing/pricing-context.js').HistoricalPricingContextV1
   reasoningLevel?: ReasoningLevel
-  /** Source-specific reasoning inclusion authority, when one was proven. */
-  reasoningSemantics?: ReasoningTokenSemantics
-  /** OTel cache subfield evidence; absent on legacy/provider paths and old cache. */
-  cacheTokenEvidence?: CacheTokenEvidence
-
   reasoningLevelSource?: ReasoningLevelSource
   usage: CachedUsage
   costUSD?: number
@@ -74,7 +68,7 @@ export type CachedCall = {
   activeDurationMs?: number
   activeGeneratedTokens?: number
   toolWaitMs?: number
-}
+} & import('./session-cache-token-authority.js').CachedCallTokenAuthority
 
 export type CachedTurn = {
   timestamp: string

--- a/src/session-projection.ts
+++ b/src/session-projection.ts
@@ -1,6 +1,6 @@
 import type { ReasoningMix } from './reasoning-level.js'
 import type { ProjectSummary, SessionSummary } from './types.js'
-import { combineReasoningSemantics, reasoningSemanticsForProviders, separatelyReportedReasoningTokens, type ReasoningTokenSemantics } from './token-semantics.js'
+import { combineReasoningSemantics, reasoningSemanticsForProviders, reasoningTokenTotals, type ReasoningTokenSemantics } from './token-semantics.js'
 
 export type SessionRow = {
   sessionId: string
@@ -19,6 +19,7 @@ export type SessionRow = {
   cacheReadTokens: number
   cacheWriteTokens: number
   reasoningTokens?: number
+  additiveReasoningTokens?: number
   reasoningSemantics: ReasoningTokenSemantics
   reasoningMix?: ReasoningMix
   startedAt: string
@@ -54,17 +55,22 @@ function sessionKey(session: SessionSummary, project: string, provider: string):
   return [provider, session.sessionId, project, sessionAuthority(session, project)].join('\u0000')
 }
 
-function reasoningDetails(session: SessionSummary): { semantics: ReasoningTokenSemantics; reasoningTokens: number } {
+function reasoningDetails(session: SessionSummary): { semantics: ReasoningTokenSemantics; reasoningTokens: number; additiveReasoningTokens: number } {
   const values = session.turns.flatMap(turn => turn.assistantCalls.map(call =>
     call.reasoningSemantics ?? reasoningSemanticsForProviders([call.provider]),
   ))
   const semantics = combineReasoningSemantics(values)
-  const reasoningTokens = session.turns.reduce((sum, turn) => sum + turn.assistantCalls.reduce((calls, call) =>
-    calls + separatelyReportedReasoningTokens(
+  const totals = session.turns.reduce((sum, turn) => turn.assistantCalls.reduce((calls, call) => {
+    const callTotals = reasoningTokenTotals(
       call.usage?.reasoningTokens,
       call.reasoningSemantics ?? reasoningSemanticsForProviders([call.provider]),
-    ), 0), 0)
-  return { semantics, reasoningTokens }
+    )
+    return {
+      observedReasoningTokens: calls.observedReasoningTokens + callTotals.observedReasoningTokens,
+      additiveReasoningTokens: calls.additiveReasoningTokens + callTotals.additiveReasoningTokens,
+    }
+  }, sum), { observedReasoningTokens: 0, additiveReasoningTokens: 0 })
+  return { semantics, reasoningTokens: totals.observedReasoningTokens, additiveReasoningTokens: totals.additiveReasoningTokens }
 }
 
 export function aggregateSessions(projects: ProjectSummary[]): SessionRow[] {
@@ -88,6 +94,7 @@ export function aggregateSessions(projects: ProjectSummary[]): SessionRow[] {
       cacheReadTokens: session.totalCacheReadTokens,
       cacheWriteTokens: session.totalCacheWriteTokens,
       ...(reasoning.semantics !== 'unavailable' ? { reasoningTokens: reasoning.reasoningTokens } : {}),
+      ...(reasoning.semantics !== 'unavailable' ? { additiveReasoningTokens: reasoning.additiveReasoningTokens } : {}),
       reasoningSemantics: reasoning.semantics,
       ...(session.reasoningMix ? { reasoningMix: session.reasoningMix } : {}),
       startedAt: session.firstTimestamp,

--- a/src/session-projection.ts
+++ b/src/session-projection.ts
@@ -1,6 +1,6 @@
 import type { ReasoningMix } from './reasoning-level.js'
 import type { ProjectSummary, SessionSummary } from './types.js'
-import { combineReasoningSemantics, providerHasSeparateReasoning, reasoningSemanticsForProviders, type ReasoningTokenSemantics } from './token-semantics.js'
+import { combineReasoningSemantics, reasoningSemanticsForProviders, separatelyReportedReasoningTokens, type ReasoningTokenSemantics } from './token-semantics.js'
 
 export type SessionRow = {
   sessionId: string
@@ -56,11 +56,14 @@ function sessionKey(session: SessionSummary, project: string, provider: string):
 
 function reasoningDetails(session: SessionSummary): { semantics: ReasoningTokenSemantics; reasoningTokens: number } {
   const values = session.turns.flatMap(turn => turn.assistantCalls.map(call =>
-    reasoningSemanticsForProviders([call.provider]),
+    call.reasoningSemantics ?? reasoningSemanticsForProviders([call.provider]),
   ))
   const semantics = combineReasoningSemantics(values)
   const reasoningTokens = session.turns.reduce((sum, turn) => sum + turn.assistantCalls.reduce((calls, call) =>
-    calls + (providerHasSeparateReasoning(call.provider) ? (call.usage?.reasoningTokens ?? 0) : 0), 0), 0)
+    calls + separatelyReportedReasoningTokens(
+      call.usage?.reasoningTokens,
+      call.reasoningSemantics ?? reasoningSemanticsForProviders([call.provider]),
+    ), 0), 0)
   return { semantics, reasoningTokens }
 }
 

--- a/src/sessions-report.test.ts
+++ b/src/sessions-report.test.ts
@@ -80,6 +80,6 @@ describe('session projection identity', () => {
       }],
     }] as unknown as ProjectSummary[])
 
-    expect(rows[0]).toMatchObject({ reasoningSemantics: 'mixed', reasoningTokens: 7 })
+    expect(rows[0]).toMatchObject({ reasoningSemantics: 'mixed', reasoningTokens: 7, additiveReasoningTokens: 7 })
   })
 })

--- a/src/token-semantics.test.ts
+++ b/src/token-semantics.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { combineReasoningSemantics, providerHasSeparateReasoning, reasoningSemanticsForProviders, separatelyReportedReasoningTokens } from './token-semantics.js'
+import { combineReasoningSemantics, providerHasSeparateReasoning, reasoningSemanticsForProviders, reasoningTokenTotals, separatelyReportedReasoningTokens } from './token-semantics.js'
 
 describe('reasoning token semantics', () => {
   it('recognizes providers whose parser contract carries reasoning separately', () => {
@@ -23,7 +23,13 @@ describe('reasoning token semantics', () => {
     expect(combineReasoningSemantics(['separate', 'unavailable'])).toBe('mixed')
     expect(reasoningSemanticsForProviders(['gemini', 'zed'])).toBe('mixed')
     expect(reasoningSemanticsForProviders(['gemini', 'zed'], true)).toBe('mixed')
-    expect(separatelyReportedReasoningTokens(123, 'mixed')).toBe(123)
+    expect(separatelyReportedReasoningTokens(123, 'mixed')).toBe(0)
     expect(separatelyReportedReasoningTokens(undefined, 'mixed')).toBe(0)
+  })
+
+  it('keeps observed reasoning separate from the additive subtotal', () => {
+    expect(reasoningTokenTotals(20, 'aggregate-output')).toEqual({ observedReasoningTokens: 20, additiveReasoningTokens: 0 })
+    expect(reasoningTokenTotals(30, 'separate')).toEqual({ observedReasoningTokens: 30, additiveReasoningTokens: 30 })
+    expect(reasoningTokenTotals(50, 'mixed')).toEqual({ observedReasoningTokens: 50, additiveReasoningTokens: 0 })
   })
 })

--- a/src/token-semantics.ts
+++ b/src/token-semantics.ts
@@ -6,6 +6,13 @@
  */
 export type ReasoningTokenSemantics = 'separate' | 'aggregate-output' | 'unavailable' | 'mixed'
 
+export type ReasoningTokenTotals = {
+  /** Factual reasoning-token evidence retained for breakdown/reporting. */
+  observedReasoningTokens: number
+  /** Only the reasoning subtotal that is additive to output. */
+  additiveReasoningTokens: number
+}
+
 /**
  * Evidence quality for the two OTel cache subfields. `partial` is deliberate:
  * a missing cache subfield is not equivalent to an emitted zero.
@@ -50,18 +57,53 @@ export function combineReasoningSemantics(values: readonly ReasoningTokenSemanti
   return values.every(value => value === first) ? first : 'mixed'
 }
 
+function finiteReasoningTokens(reasoningTokens: number | undefined): number {
+  return typeof reasoningTokens === 'number' && Number.isFinite(reasoningTokens) && reasoningTokens > 0
+    ? reasoningTokens
+    : 0
+}
+
+/**
+ * Split a reasoning count into the factual breakdown and the generated-token
+ * subtotal. `mixed` is intentionally non-additive: its constituents are not
+ * available at this boundary, so the aggregate must carry an explicit
+ * additive subtotal instead of inferring it from the observed total.
+ *
+ * An omitted authority preserves the historic collector behavior. Explicit
+ * `unavailable` remains out of normalized aggregate evidence.
+ */
+export function reasoningTokenTotals(
+  reasoningTokens: number | undefined,
+  semantics: ReasoningTokenSemantics | undefined,
+): ReasoningTokenTotals {
+  const observedReasoningTokens = semantics === 'unavailable' ? 0 : finiteReasoningTokens(reasoningTokens)
+  const additiveReasoningTokens = semantics === 'separate' || semantics === undefined
+    ? finiteReasoningTokens(reasoningTokens)
+    : 0
+  return { observedReasoningTokens, additiveReasoningTokens }
+}
+
+export function observedReasoningTokens(
+  reasoningTokens: number | undefined,
+  semantics?: ReasoningTokenSemantics,
+): number {
+  return reasoningTokenTotals(reasoningTokens, semantics).observedReasoningTokens
+}
+
+export function additiveReasoningTokens(
+  reasoningTokens: number | undefined,
+  semantics?: ReasoningTokenSemantics,
+): number {
+  return reasoningTokenTotals(reasoningTokens, semantics).additiveReasoningTokens
+}
+
+/** Compatibility name retained for existing consumers; it now means only the
+ * independently additive subtotal and never infers from `mixed`. */
 export function separatelyReportedReasoningTokens(
   reasoningTokens: number | undefined,
   semantics: ReasoningTokenSemantics | undefined,
 ): number {
-  // A mixed row may retain a positive subtotal from the independently observed
-  // constituent(s). Preserve that evidence, while the mixed status tells the
-  // presentation that other constituents are unavailable or aggregate-output;
-  // no missing reasoning is estimated.
-  if (semantics !== 'separate' && semantics !== 'mixed') return 0
-  return typeof reasoningTokens === 'number' && Number.isFinite(reasoningTokens) && reasoningTokens > 0
-    ? reasoningTokens
-    : 0
+  return additiveReasoningTokens(reasoningTokens, semantics)
 }
 
 /**
@@ -75,10 +117,10 @@ export function billableOutputTokens(
   reasoningTokens: number,
   semantics?: ReasoningTokenSemantics,
 ): number {
-  const includeReasoning = semantics === 'separate'
-    || semantics === 'mixed'
-    || (semantics === undefined && provider !== 'claude')
-  return outputTokens + (includeReasoning ? reasoningTokens : 0)
+  const additive = semantics === undefined && provider === 'claude'
+    ? 0
+    : additiveReasoningTokens(reasoningTokens, semantics)
+  return outputTokens + additive
 }
 
 /**
@@ -90,7 +132,5 @@ export function generatedTokensForReasoningMix(
   reasoningTokens: number,
   semantics?: ReasoningTokenSemantics,
 ): number {
-  return semantics === 'aggregate-output' || semantics === 'unavailable'
-    ? outputTokens
-    : outputTokens + reasoningTokens
+  return outputTokens + additiveReasoningTokens(reasoningTokens, semantics)
 }

--- a/src/token-semantics.ts
+++ b/src/token-semantics.ts
@@ -6,6 +6,12 @@
  */
 export type ReasoningTokenSemantics = 'separate' | 'aggregate-output' | 'unavailable' | 'mixed'
 
+/**
+ * Evidence quality for the two OTel cache subfields. `partial` is deliberate:
+ * a missing cache subfield is not equivalent to an emitted zero.
+ */
+export type CacheTokenEvidence = 'complete' | 'partial' | 'unavailable' | 'inconsistent'
+
 const SEPARATE_REASONING_PROVIDERS = new Set([
   'antigravity',
   'codex',
@@ -56,4 +62,35 @@ export function separatelyReportedReasoningTokens(
   return typeof reasoningTokens === 'number' && Number.isFinite(reasoningTokens) && reasoningTokens > 0
     ? reasoningTokens
     : 0
+}
+
+/**
+ * The canonical cost contract prices output inclusively only when the source
+ * says reasoning is separate. The undefined branch preserves the historic
+ * provider defaults used by collectors that predate explicit semantics.
+ */
+export function billableOutputTokens(
+  provider: string | undefined,
+  outputTokens: number,
+  reasoningTokens: number,
+  semantics?: ReasoningTokenSemantics,
+): number {
+  const includeReasoning = semantics === 'separate'
+    || semantics === 'mixed'
+    || (semantics === undefined && provider !== 'claude')
+  return outputTokens + (includeReasoning ? reasoningTokens : 0)
+}
+
+/**
+ * Generated-token display for a single call. Aggregate-output reasoning is
+ * already inside the producer's output count and must not be added again.
+ */
+export function generatedTokensForReasoningMix(
+  outputTokens: number,
+  reasoningTokens: number,
+  semantics?: ReasoningTokenSemantics,
+): number {
+  return semantics === 'aggregate-output' || semantics === 'unavailable'
+    ? outputTokens
+    : outputTokens + reasoningTokens
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,6 @@
 import type { ReasoningLevel, ReasoningLevelSource, ReasoningMix } from './reasoning-level.js'
 import type { CostAssignmentV1 } from './pricing/cost-assignment.js'
+import type { CacheTokenEvidence, ReasoningTokenSemantics } from './token-semantics.js'
 import type { HistoricalPricingContextV1 } from './pricing/pricing-context.js'
 
 export type TokenUsage = {
@@ -118,6 +119,11 @@ export type ParsedApiCall = {
   modelProvider?: string
   pricingContext?: HistoricalPricingContextV1
   reasoningLevel?: ReasoningLevel
+  /** Source-specific reasoning inclusion authority; absent preserves legacy defaults. */
+  reasoningSemantics?: ReasoningTokenSemantics
+  /** Bounded OTel cache-subfield evidence; absent for non-OTel sources. */
+  cacheTokenEvidence?: CacheTokenEvidence
+
   reasoningLevelSource?: ReasoningLevelSource
   usage: TokenUsage
   costUSD: number

--- a/tests/audit-report.test.ts
+++ b/tests/audit-report.test.ts
@@ -86,8 +86,9 @@ describe('aggregateAudit', () => {
     expect(r.raw.reasoningTokens).toBe(10)
     expect(r.raw.cacheReadInputTokens).toBe(200)
     expect(r.raw.cachedInputTokens).toBe(300)
-    // reasoning folds into output for pricing
-    expect(r.displayed.outputTokens).toBe(110)
+    // reasoning remains visible as a breakdown; this legacy Claude call is
+    // still additive for pricing because its authority was omitted.
+    expect(r.displayed).toMatchObject({ outputTokens: 110, reasoningTokens: 10, additiveReasoningTokens: 10 })
     // cache read is the SUM of per-call max(anthropic, openai), not max of sums
     expect(r.displayed.cacheReadTokens).toBe(500)
     // attributed cost is preserved exactly

--- a/tests/copilot-otel-history-migration.test.ts
+++ b/tests/copilot-otel-history-migration.test.ts
@@ -1,0 +1,203 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { mkdtemp, rm, writeFile } from 'fs/promises'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { createRequire } from 'node:module'
+
+import { getDailyCacheConfigHash } from '../src/daily-cache-config.js'
+import { parseAllSessions, clearSessionCache } from '../src/parser.js'
+import { isSqliteAvailable } from '../src/sqlite.js'
+import { loadCache, saveCache, PROVIDER_PARSE_VERSIONS } from '../src/session-cache.js'
+
+const requireForTest = createRequire(import.meta.url)
+
+type TestDb = {
+  exec(sql: string): void
+  prepare(sql: string): { run(...params: unknown[]): void }
+  close(): void
+}
+
+function createOtelDb(dbPath: string): void {
+  const { DatabaseSync } = requireForTest('node:sqlite') as { DatabaseSync: new (path: string) => TestDb }
+  const db = new DatabaseSync(dbPath)
+  db.exec(`
+    CREATE TABLE spans (
+      span_id TEXT PRIMARY KEY NOT NULL,
+      trace_id TEXT NOT NULL,
+      operation_name TEXT,
+      start_time_ms INTEGER NOT NULL DEFAULT 0,
+      response_model TEXT
+    );
+    CREATE TABLE span_attributes (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      span_id TEXT NOT NULL,
+      key TEXT NOT NULL,
+      value TEXT
+    );
+  `)
+  db.close()
+}
+
+function insertChatSpan(dbPath: string): void {
+  const { DatabaseSync } = requireForTest('node:sqlite') as { DatabaseSync: new (path: string) => TestDb }
+  const db = new DatabaseSync(dbPath)
+  db.prepare(
+    `INSERT INTO spans (span_id, trace_id, operation_name, start_time_ms, response_model)
+     VALUES (?, ?, ?, ?, ?)`,
+  ).run('span-history', 'trace-history', 'chat', Date.now() - 60_000, null)
+  const attrs: Record<string, number | string> = {
+    'gen_ai.conversation.id': 'conversation-history',
+    'gen_ai.response.model': 'gpt-4.1',
+    'gen_ai.usage.input_tokens': 1000,
+    'gen_ai.usage.output_tokens': 100,
+    'gen_ai.usage.cache_read.input_tokens': 300,
+    'gen_ai.usage.cache_creation.input_tokens': 200,
+    'gen_ai.usage.reasoning.output_tokens': 20,
+  }
+  const attrStmt = db.prepare(`INSERT INTO span_attributes (span_id, key, value) VALUES (?, ?, ?)`)
+  for (const [key, value] of Object.entries(attrs)) attrStmt.run('span-history', key, String(value))
+  db.close()
+}
+
+describe('Copilot OTel history migration policy', () => {
+  let tempDir: string
+  let dbPath: string
+
+  beforeEach(async () => {
+    clearSessionCache()
+    tempDir = await mkdtemp(join(tmpdir(), 'metrora-copilot-otel-history-'))
+    dbPath = join(tempDir, 'agent-traces.db')
+    vi.stubEnv('METRORA_CACHE_DIR', join(tempDir, 'metrora-cache'))
+    vi.stubEnv('METRORA_COPILOT_OTEL_DB', dbPath)
+    vi.stubEnv('METRORA_COPILOT_DISABLE_OTEL', '')
+    vi.stubEnv('METRORA_COPILOT_SESSION_STATE_DIR', join(tempDir, 'missing-session-state'))
+    vi.stubEnv('METRORA_COPILOT_WS_STORAGE_DIR', join(tempDir, 'missing-workspace-storage'))
+    vi.stubEnv('METRORA_COPILOT_GLOBAL_STORAGE_DIR', join(tempDir, 'missing-global-storage'))
+    vi.stubEnv('METRORA_COPILOT_JETBRAINS_DIR', join(tempDir, 'missing-jetbrains'))
+  })
+
+  afterEach(async () => {
+    clearSessionCache()
+    vi.unstubAllEnvs()
+    await rm(tempDir, { recursive: true, force: true })
+  })
+
+  function firstCall(projects: Awaited<ReturnType<typeof parseAllSessions>>) {
+    const call = projects.flatMap(project => project.sessions.flatMap(session => session.turns.flatMap(turn => turn.assistantCalls)))[0]
+    if (!call) throw new Error('Expected one synthetic Copilot call')
+    return call
+  }
+
+  async function parseSyntheticSource() {
+    createOtelDb(dbPath)
+    insertChatSpan(dbPath)
+    return parseAllSessions(undefined, 'copilot')
+  }
+
+  it('reparses a surviving OTel source when Copilot parse authority changes', async () => {
+    if (!isSqliteAvailable()) return
+
+    const initial = await parseSyntheticSource()
+    expect(firstCall(initial).usage).toMatchObject({ inputTokens: 500, cacheReadInputTokens: 300, cacheCreationInputTokens: 200 })
+
+    const cache = await loadCache()
+    const cached = cache.providers.copilot?.files[dbPath]?.turns[0]?.calls[0]
+    if (!cached) throw new Error('Expected the synthetic OTel call in session cache')
+    cached.usage.inputTokens = 1000
+    delete cached.cacheTokenEvidence
+    delete cached.reasoningSemantics
+    delete cached.costAssignment
+    await saveCache(cache)
+
+    const authority = PROVIDER_PARSE_VERSIONS.copilot
+    try {
+      PROVIDER_PARSE_VERSIONS.copilot = authority + '-test-reparse'
+      clearSessionCache()
+      const reparsed = await parseAllSessions(undefined, 'copilot')
+      const call = firstCall(reparsed)
+      expect(call.usage.inputTokens).toBe(500)
+      expect(call.usage.cacheReadInputTokens).toBe(300)
+      expect(call.usage.cacheCreationInputTokens).toBe(200)
+      expect(call.reasoningSemantics).toBe('aggregate-output')
+    } finally {
+      PROVIDER_PARSE_VERSIONS.copilot = authority
+    }
+  })
+
+  it('changes the daily cache hash with the Copilot provider authority only', () => {
+    const authority = PROVIDER_PARSE_VERSIONS.copilot
+    const before = getDailyCacheConfigHash()
+    try {
+      PROVIDER_PARSE_VERSIONS.copilot = authority + '-test-daily-hash'
+      expect(getDailyCacheConfigHash()).not.toBe(before)
+    } finally {
+      PROVIDER_PARSE_VERSIONS.copilot = authority
+    }
+  })
+
+  it('preserves durable-cache-only history and does not fabricate discarded reasoning after restart', async () => {
+    if (!isSqliteAvailable()) return
+
+    await parseSyntheticSource()
+    const cache = await loadCache()
+    const cached = cache.providers.copilot?.files[dbPath]?.turns[0]?.calls[0]
+    if (!cached) throw new Error('Expected the synthetic OTel call in session cache')
+    cached.usage.inputTokens = 1000
+    cached.usage.reasoningTokens = 0
+    delete cached.reasoningSemantics
+    delete cached.cacheTokenEvidence
+    delete cached.costAssignment
+    await saveCache(cache)
+
+    await rm(dbPath, { force: true })
+    clearSessionCache()
+    const afterRestart = await parseAllSessions(undefined, 'copilot')
+    const carried = firstCall(afterRestart)
+    expect(carried.usage.inputTokens).toBe(500)
+    expect(carried.cacheTokenEvidence).toBe('complete')
+    expect(carried.usage.reasoningTokens).toBe(0)
+    expect(carried.reasoningSemantics).toBeUndefined()
+    expect(afterRestart.length).toBeGreaterThan(0)
+    const partialCache = await loadCache()
+    const partial = partialCache.providers.copilot?.files[dbPath]?.turns[0]?.calls[0]
+    if (!partial) throw new Error('Expected carried OTel call for partial-evidence check')
+    partial.usage.inputTokens = 1000
+    partial.usage.cacheReadInputTokens = 300
+    partial.usage.cacheCreationInputTokens = 0
+    delete partial.reasoningSemantics
+    delete partial.cacheTokenEvidence
+    delete partial.costUSD
+    delete partial.costAssignment
+    delete partial.legacyCostUSD
+    await saveCache(partialCache)
+    clearSessionCache()
+    const partialAfterRestart = await parseAllSessions(undefined, 'copilot')
+    const partialCall = firstCall(partialAfterRestart)
+    expect(partialCall.usage.inputTokens).toBe(1000)
+    expect(partialCall.cacheTokenEvidence).toBeUndefined()
+  })
+
+  it('retains durable OTel calls when an authority-triggered raw reparse fails', async () => {
+    if (!isSqliteAvailable()) return
+
+    await parseSyntheticSource()
+    const authority = PROVIDER_PARSE_VERSIONS.copilot
+    await writeFile(dbPath, 'not a sqlite database')
+    try {
+      PROVIDER_PARSE_VERSIONS.copilot = authority + '-test-failed-reparse'
+      clearSessionCache()
+      const afterFailure = await parseAllSessions(undefined, 'copilot')
+      const carried = firstCall(afterFailure)
+      expect(carried.usage.inputTokens).toBe(500)
+      expect(carried.usage.cacheReadInputTokens).toBe(300)
+      expect(carried.usage.cacheCreationInputTokens).toBe(200)
+      expect(carried.reasoningSemantics).toBe('aggregate-output')
+      const failedCache = await loadCache()
+      expect(failedCache.providers.copilot?.files[dbPath]?.failed).toBe(true)
+      expect(failedCache.providers.copilot?.files[dbPath]?.turns).toHaveLength(1)
+    } finally {
+      PROVIDER_PARSE_VERSIONS.copilot = authority
+    }
+  })
+
+})

--- a/tests/copilot-otel-reasoning-aggregation.test.ts
+++ b/tests/copilot-otel-reasoning-aggregation.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from 'vitest'
+
+import { aggregateAudit } from '../src/audit-report.js'
+import { aggregateModelStats } from '../src/compare-stats.js'
+import { aggregateProjectsIntoDays, buildPeriodDataFromDays } from '../src/day-aggregator.js'
+import { aggregateModelPerformanceByRoute } from '../src/model-performance.js'
+import { buildModelAccounting } from '../src/model-accounting.js'
+import { buildModelPresentation } from '../src/model-presentation.js'
+import { aggregateModels } from '../src/models-report.js'
+import { aggregateSessions } from '../src/session-projection.js'
+import { billableOutputTokens, generatedTokensForReasoningMix } from '../src/token-semantics.js'
+import { calculateCost } from '../src/models.js'
+import type { ClassifiedTurn, ParsedApiCall, ProjectSummary, SessionSummary, TokenUsage } from '../src/types.js'
+
+const TIMESTAMP = '2026-08-20T10:00:00.000Z'
+
+function usage(inputTokens: number, outputTokens: number, reasoningTokens: number): TokenUsage {
+  return {
+    inputTokens,
+    outputTokens,
+    cacheCreationInputTokens: 0,
+    cacheReadInputTokens: 0,
+    cachedInputTokens: 0,
+    reasoningTokens,
+    webSearchRequests: 0,
+  }
+}
+
+function call(
+  provider: string,
+  reasoningSemantics: 'aggregate-output' | 'separate',
+  inputTokens: number,
+  outputTokens: number,
+  reasoningTokens: number,
+  costUSD: number,
+): ParsedApiCall {
+  return {
+    provider,
+    model: 'mixed-model',
+    usage: usage(inputTokens, outputTokens, reasoningTokens),
+    reasoningSemantics,
+    costUSD,
+    tools: [],
+    mcpTools: [],
+    skills: [],
+    subagentTypes: [],
+    hasAgentSpawn: false,
+    hasPlanMode: false,
+    speed: 'standard',
+    timestamp: TIMESTAMP,
+    bashCommands: [],
+    deduplicationKey: `${provider}-mixed-call`,
+    activeDurationMs: 10,
+  }
+}
+
+function projectWithCalls(calls: ParsedApiCall[]): ProjectSummary {
+  const turn: ClassifiedTurn = {
+    userMessage: 'synthetic mixed reasoning fixture',
+    assistantCalls: calls,
+    timestamp: TIMESTAMP,
+    sessionId: 'mixed-session',
+    category: 'coding',
+    retries: 0,
+    hasEdits: false,
+  }
+  const session: SessionSummary = {
+    sessionId: 'mixed-session',
+    project: 'synthetic-project',
+    firstTimestamp: TIMESTAMP,
+    lastTimestamp: TIMESTAMP,
+    totalCostUSD: calls.reduce((sum, item) => sum + item.costUSD, 0),
+    totalSavingsUSD: 0,
+    totalInputTokens: calls.reduce((sum, item) => sum + item.usage.inputTokens, 0),
+    totalOutputTokens: calls.reduce((sum, item) => sum + item.usage.outputTokens, 0),
+    totalReasoningTokens: calls.reduce((sum, item) => sum + item.usage.reasoningTokens, 0),
+    totalCacheReadTokens: 0,
+    totalCacheWriteTokens: 0,
+    apiCalls: calls.length,
+    turns: [turn],
+    modelBreakdown: {},
+    toolBreakdown: {},
+    mcpBreakdown: {},
+    bashBreakdown: {},
+    categoryBreakdown: {},
+    skillBreakdown: {},
+    subagentBreakdown: {},
+  }
+  return {
+    project: 'synthetic-project',
+    projectPath: '/synthetic-project',
+    sessions: [session],
+    totalCostUSD: session.totalCostUSD,
+    totalSavingsUSD: 0,
+    totalApiCalls: calls.length,
+    totalProxiedCostUSD: 0,
+  }
+}
+
+describe('mixed reasoning aggregation', () => {
+  const copilotCall = call('copilot', 'aggregate-output', 10, 100, 20, calculateCost('gpt-4.1', 10, 100, 0, 0, 0))
+  const separateCall = call('codex', 'separate', 20, 100, 30, calculateCost('gpt-4.1', 20, 130, 0, 0, 0))
+  const project = projectWithCalls([copilotCall, separateCall])
+
+  it('keeps the true generated total at 230 across live, session, and daily model views', async () => {
+    const modelRows = await aggregateModels([project])
+    expect(modelRows.reduce((sum, row) => sum + row.outputTokens + (row.reasoningTokens ?? 0), 0)).toBe(230)
+    expect(modelRows.find(row => row.provider === 'copilot')).toMatchObject({ outputTokens: 100, reasoningTokens: 0, reasoningSemantics: 'aggregate-output' })
+    expect(modelRows.find(row => row.provider === 'codex')).toMatchObject({ outputTokens: 100, reasoningTokens: 30, reasoningSemantics: 'separate' })
+
+    const compare = aggregateModelStats([project])[0]!
+    expect(compare).toMatchObject({ outputTokens: 200, reasoningTokens: 30, reasoningSemantics: 'mixed' })
+    expect(compare.outputTokens + compare.reasoningTokens).toBe(230)
+
+    const session = aggregateSessions([project])[0]!
+    expect(session).toMatchObject({ outputTokens: 200, reasoningTokens: 30, reasoningSemantics: 'mixed' })
+    expect(session.outputTokens + (session.reasoningTokens ?? 0)).toBe(230)
+
+    const day = aggregateProjectsIntoDays([project])[0]!
+    expect(day.outputTokens).toBe(200)
+    expect(day.reasoningTokens).toBe(30)
+    expect(day.models['mixed-model']).toMatchObject({ outputTokens: 200, reasoningTokens: 30, reasoningSemantics: 'mixed' })
+    const period = buildPeriodDataFromDays([day], 'synthetic')
+    expect(period.models[0]).toMatchObject({ outputTokens: 200, reasoningTokens: 30, reasoningSemantics: 'mixed' })
+    expect(period.models[0]!.outputTokens! + period.models[0]!.reasoningTokens!).toBe(230)
+
+    const accounting = buildModelAccounting(period.models, period.cost, period.calls)
+    expect(accounting.rows[0]).toMatchObject({ outputTokens: 200, reasoningTokens: 30, reasoningSemantics: 'mixed' })
+    expect(accounting.rows[0]!.outputTokens + (accounting.rows[0]!.reasoningTokens ?? 0)).toBe(230)
+    const presentation = buildModelPresentation(accounting)
+    expect(presentation.rows[0]).toMatchObject({ outputTokens: 200, reasoningTokens: 30, reasoningSemantics: 'mixed' })
+    expect(presentation.rows[0]!.outputTokens + (presentation.rows[0]!.reasoningTokens ?? 0)).toBe(230)
+  })
+
+  it('keeps raw audit evidence while displaying only separately additive reasoning', async () => {
+    const rows = await aggregateAudit([project])
+    expect(rows).toHaveLength(2)
+    expect(rows.reduce((sum, row) => sum + row.raw.reasoningTokens, 0)).toBe(50)
+    expect(rows.reduce((sum, row) => sum + row.displayed.outputTokens, 0)).toBe(230)
+    expect(rows.find(row => row.provider === 'copilot')!.displayed.outputTokens).toBe(100)
+    expect(rows.find(row => row.provider === 'codex')!.displayed.outputTokens).toBe(130)
+  })
+
+  it('uses the same 230 generated-token denominator for observed performance', () => {
+    const routes = aggregateModelPerformanceByRoute([project]).get('mixed-model')!
+    expect(routes.get('collector:copilot')?.activeGeneratedTokens).toBe(100)
+    expect(routes.get('collector:codex')?.activeGeneratedTokens).toBe(130)
+    expect([...routes.values()].reduce((sum, value) => sum + value.activeGeneratedTokens, 0)).toBe(230)
+  })
+
+  it('prices Copilot OTel output once and never treats reasoning as a second output bucket', () => {
+    const aggregateOutput = billableOutputTokens('copilot', 100, 20, 'aggregate-output')
+    const separateOutput = billableOutputTokens('codex', 100, 30, 'separate')
+    expect(aggregateOutput).toBe(100)
+    expect(separateOutput).toBe(130)
+    expect(calculateCost('gpt-4.1', 10, aggregateOutput, 0, 0, 0)).toBe(calculateCost('gpt-4.1', 10, 100, 0, 0, 0))
+    expect(generatedTokensForReasoningMix(100, 20, 'aggregate-output')).toBe(100)
+    expect(generatedTokensForReasoningMix(100, 30, 'separate')).toBe(130)
+  })
+})

--- a/tests/copilot-otel-reasoning-aggregation.test.ts
+++ b/tests/copilot-otel-reasoning-aggregation.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it } from 'vitest'
 
 import { aggregateAudit } from '../src/audit-report.js'
 import { aggregateModelStats } from '../src/compare-stats.js'
+import { migrateDays } from '../src/daily-cache-core.js'
 import { aggregateProjectsIntoDays, buildPeriodDataFromDays } from '../src/day-aggregator.js'
+import { mergeDayEntries } from '../src/daily-cache-merge.js'
 import { aggregateModelPerformanceByRoute } from '../src/model-performance.js'
 import { buildModelAccounting } from '../src/model-accounting.js'
 import { buildModelPresentation } from '../src/model-presentation.js'
@@ -102,43 +104,44 @@ describe('mixed reasoning aggregation', () => {
   const separateCall = call('codex', 'separate', 20, 100, 30, calculateCost('gpt-4.1', 20, 130, 0, 0, 0))
   const project = projectWithCalls([copilotCall, separateCall])
 
-  it('keeps the true generated total at 230 across live, session, and daily model views', async () => {
+  it('preserves observed reasoning while keeping the generated total at 230 across live, session, and daily model views', async () => {
     const modelRows = await aggregateModels([project])
-    expect(modelRows.reduce((sum, row) => sum + row.outputTokens + (row.reasoningTokens ?? 0), 0)).toBe(230)
-    expect(modelRows.find(row => row.provider === 'copilot')).toMatchObject({ outputTokens: 100, reasoningTokens: 0, reasoningSemantics: 'aggregate-output' })
-    expect(modelRows.find(row => row.provider === 'codex')).toMatchObject({ outputTokens: 100, reasoningTokens: 30, reasoningSemantics: 'separate' })
+    expect(modelRows.reduce((sum, row) => sum + row.outputTokens + (row.additiveReasoningTokens ?? 0), 0)).toBe(230)
+    expect(modelRows.find(row => row.provider === 'copilot')).toMatchObject({ outputTokens: 100, reasoningTokens: 20, additiveReasoningTokens: 0, reasoningSemantics: 'aggregate-output', totalTokens: 110 })
+    expect(modelRows.find(row => row.provider === 'codex')).toMatchObject({ outputTokens: 100, reasoningTokens: 30, additiveReasoningTokens: 30, reasoningSemantics: 'separate', totalTokens: 150 })
 
     const compare = aggregateModelStats([project])[0]!
-    expect(compare).toMatchObject({ outputTokens: 200, reasoningTokens: 30, reasoningSemantics: 'mixed' })
-    expect(compare.outputTokens + compare.reasoningTokens).toBe(230)
+    expect(compare).toMatchObject({ outputTokens: 200, reasoningTokens: 50, additiveReasoningTokens: 30, reasoningSemantics: 'mixed' })
+    expect(compare.outputTokens + compare.additiveReasoningTokens).toBe(230)
 
     const session = aggregateSessions([project])[0]!
-    expect(session).toMatchObject({ outputTokens: 200, reasoningTokens: 30, reasoningSemantics: 'mixed' })
-    expect(session.outputTokens + (session.reasoningTokens ?? 0)).toBe(230)
+    expect(session).toMatchObject({ outputTokens: 200, reasoningTokens: 50, additiveReasoningTokens: 30, reasoningSemantics: 'mixed' })
+    expect(session.outputTokens + (session.additiveReasoningTokens ?? 0)).toBe(230)
 
     const day = aggregateProjectsIntoDays([project])[0]!
     expect(day.outputTokens).toBe(200)
-    expect(day.reasoningTokens).toBe(30)
-    expect(day.models['mixed-model']).toMatchObject({ outputTokens: 200, reasoningTokens: 30, reasoningSemantics: 'mixed' })
+    expect(day.reasoningTokens).toBe(50)
+    expect(day.additiveReasoningTokens).toBe(30)
+    expect(day.models['mixed-model']).toMatchObject({ outputTokens: 200, reasoningTokens: 50, additiveReasoningTokens: 30, reasoningSemantics: 'mixed' })
     const period = buildPeriodDataFromDays([day], 'synthetic')
-    expect(period.models[0]).toMatchObject({ outputTokens: 200, reasoningTokens: 30, reasoningSemantics: 'mixed' })
-    expect(period.models[0]!.outputTokens! + period.models[0]!.reasoningTokens!).toBe(230)
+    expect(period.models[0]).toMatchObject({ outputTokens: 200, reasoningTokens: 50, additiveReasoningTokens: 30, reasoningSemantics: 'mixed' })
+    expect(period.models[0]!.outputTokens! + (period.models[0]!.additiveReasoningTokens ?? 0)).toBe(230)
 
     const accounting = buildModelAccounting(period.models, period.cost, period.calls)
-    expect(accounting.rows[0]).toMatchObject({ outputTokens: 200, reasoningTokens: 30, reasoningSemantics: 'mixed' })
-    expect(accounting.rows[0]!.outputTokens + (accounting.rows[0]!.reasoningTokens ?? 0)).toBe(230)
+    expect(accounting.rows[0]).toMatchObject({ outputTokens: 200, reasoningTokens: 50, additiveReasoningTokens: 30, reasoningSemantics: 'mixed' })
+    expect(accounting.rows[0]!.outputTokens + (accounting.rows[0]!.additiveReasoningTokens ?? 0)).toBe(230)
     const presentation = buildModelPresentation(accounting)
-    expect(presentation.rows[0]).toMatchObject({ outputTokens: 200, reasoningTokens: 30, reasoningSemantics: 'mixed' })
-    expect(presentation.rows[0]!.outputTokens + (presentation.rows[0]!.reasoningTokens ?? 0)).toBe(230)
+    expect(presentation.rows[0]).toMatchObject({ outputTokens: 200, reasoningTokens: 50, additiveReasoningTokens: 30, reasoningSemantics: 'mixed' })
+    expect(presentation.rows[0]!.outputTokens + (presentation.rows[0]!.additiveReasoningTokens ?? 0)).toBe(230)
   })
 
-  it('keeps raw audit evidence while displaying only separately additive reasoning', async () => {
+  it('keeps raw and observed audit evidence while displaying only additive generated output', async () => {
     const rows = await aggregateAudit([project])
     expect(rows).toHaveLength(2)
     expect(rows.reduce((sum, row) => sum + row.raw.reasoningTokens, 0)).toBe(50)
     expect(rows.reduce((sum, row) => sum + row.displayed.outputTokens, 0)).toBe(230)
-    expect(rows.find(row => row.provider === 'copilot')!.displayed.outputTokens).toBe(100)
-    expect(rows.find(row => row.provider === 'codex')!.displayed.outputTokens).toBe(130)
+    expect(rows.find(row => row.provider === 'copilot')!.displayed).toMatchObject({ outputTokens: 100, reasoningTokens: 20, additiveReasoningTokens: 0 })
+    expect(rows.find(row => row.provider === 'codex')!.displayed).toMatchObject({ outputTokens: 130, reasoningTokens: 30, additiveReasoningTokens: 30 })
   })
 
   it('uses the same 230 generated-token denominator for observed performance', () => {
@@ -156,5 +159,41 @@ describe('mixed reasoning aggregation', () => {
     expect(calculateCost('gpt-4.1', 10, aggregateOutput, 0, 0, 0)).toBe(calculateCost('gpt-4.1', 10, 100, 0, 0, 0))
     expect(generatedTokensForReasoningMix(100, 20, 'aggregate-output')).toBe(100)
     expect(generatedTokensForReasoningMix(100, 30, 'separate')).toBe(130)
+  })
+
+  it('keeps a single aggregate-output call visible without adding it to generated volume', async () => {
+    const onlyCopilot = projectWithCalls([copilotCall])
+    const model = (await aggregateModels([onlyCopilot]))[0]!
+    const session = aggregateSessions([onlyCopilot])[0]!
+    const day = aggregateProjectsIntoDays([onlyCopilot])[0]!
+    expect(model).toMatchObject({ outputTokens: 100, reasoningTokens: 20, additiveReasoningTokens: 0, totalTokens: 110 })
+    expect(session).toMatchObject({ outputTokens: 100, reasoningTokens: 20, additiveReasoningTokens: 0 })
+    expect(day).toMatchObject({ outputTokens: 100, reasoningTokens: 20, additiveReasoningTokens: 0 })
+  })
+
+  it('keeps legacy daily rows readable without fabricating a new subtotal', () => {
+    const legacyDay = {
+      date: '2026-08-19', cost: 1, savingsUSD: 0, calls: 1, sessions: 1,
+      inputTokens: 10, outputTokens: 100, reasoningTokens: 20,
+      cacheReadTokens: 0, cacheWriteTokens: 0, editTurns: 0, oneShotTurns: 0,
+      models: { 'mixed-model': {
+        calls: 1, cost: 1, savingsUSD: 0, inputTokens: 10, outputTokens: 100,
+        reasoningTokens: 20, reasoningSemantics: 'aggregate-output' as const,
+        cacheReadTokens: 0, cacheWriteTokens: 0,
+      } },
+      categories: {}, providers: {},
+    }
+    const period = buildPeriodDataFromDays([legacyDay], 'legacy')
+    expect(period.models[0]).toMatchObject({ reasoningTokens: 20, reasoningSemantics: 'aggregate-output' })
+    expect(period.models[0]).not.toHaveProperty('additiveReasoningTokens')
+  })
+
+  it('persists observed and additive reasoning through synthetic daily-cache migration and merge', () => {
+    const day = aggregateProjectsIntoDays([project])[0]!
+    const migrated = migrateDays([day as unknown as Record<string, unknown>])[0]!
+    const merged = mergeDayEntries([migrated], [], false)[0]!
+    expect(merged).toMatchObject({ reasoningTokens: 50, additiveReasoningTokens: 30 })
+    expect(merged.models['mixed-model']).toMatchObject({ reasoningTokens: 50, additiveReasoningTokens: 30 })
+    expect(merged.providers.copilot).toMatchObject({ reasoningTokens: 20, additiveReasoningTokens: 0 })
   })
 })

--- a/tests/copilot-otel-token-semantics.test.ts
+++ b/tests/copilot-otel-token-semantics.test.ts
@@ -1,0 +1,212 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { mkdtemp, rm } from 'fs/promises'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { createRequire } from 'node:module'
+
+import { createCopilotProvider } from '../src/providers/copilot.js'
+import { isSqliteAvailable } from '../src/sqlite.js'
+import { calculateCost } from '../src/models.js'
+import { buildReasoningMix } from '../src/reasoning-level.js'
+import type { ParsedProviderCall } from '../src/providers/types.js'
+
+const requireForTest = createRequire(import.meta.url)
+
+type TestDb = {
+  exec(sql: string): void
+  prepare(sql: string): { run(...params: unknown[]): void }
+  close(): void
+}
+
+function createOtelDb(dbPath: string): void {
+  const { DatabaseSync } = requireForTest('node:sqlite') as { DatabaseSync: new (path: string) => TestDb }
+  const db = new DatabaseSync(dbPath)
+  db.exec(`
+    CREATE TABLE spans (
+      span_id TEXT PRIMARY KEY NOT NULL,
+      trace_id TEXT NOT NULL,
+      operation_name TEXT,
+      start_time_ms INTEGER NOT NULL DEFAULT 0,
+      response_model TEXT
+    );
+    CREATE TABLE span_attributes (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      span_id TEXT NOT NULL,
+      key TEXT NOT NULL,
+      value TEXT
+    );
+  `)
+  db.close()
+}
+
+function insertChatSpan(dbPath: string, attrs: Record<string, string | number>): void {
+  const { DatabaseSync } = requireForTest('node:sqlite') as { DatabaseSync: new (path: string) => TestDb }
+  const db = new DatabaseSync(dbPath)
+  db.prepare(
+    `INSERT INTO spans (span_id, trace_id, operation_name, start_time_ms, response_model)
+     VALUES (?, ?, ?, ?, ?)`,
+  ).run('span-otel-semantics', 'trace-otel-semantics', 'chat', 1_774_000_000_000, null)
+  const attrStmt = db.prepare(`INSERT INTO span_attributes (span_id, key, value) VALUES (?, ?, ?)`)
+  for (const [key, value] of Object.entries(attrs)) attrStmt.run('span-otel-semantics', key, String(value))
+  db.close()
+}
+
+describe('Copilot OTel token semantics', () => {
+  let tempDir: string
+  let dbPath: string
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'metrora-copilot-otel-semantics-'))
+    dbPath = join(tempDir, 'agent-traces.db')
+    vi.stubEnv('METRORA_COPILOT_OTEL_DB', dbPath)
+    vi.stubEnv('METRORA_COPILOT_DISABLE_OTEL', '')
+  })
+
+  afterEach(async () => {
+    vi.unstubAllEnvs()
+    await rm(tempDir, { recursive: true, force: true })
+  })
+
+  async function parseCall(overrides: Record<string, string | number> = {}): Promise<ParsedProviderCall> {
+    await rm(dbPath, { force: true })
+    createOtelDb(dbPath)
+    insertChatSpan(dbPath, {
+      'gen_ai.conversation.id': 'conversation-otel-semantics',
+      'gen_ai.response.model': 'gpt-4.1',
+      'gen_ai.usage.input_tokens': 1000,
+      'gen_ai.usage.output_tokens': 100,
+      ...overrides,
+    })
+    const provider = createCopilotProvider('/missing-jsonl', '/missing-workspace', '/missing-global', '/missing-jetbrains')
+    const source = (await provider.discoverSessions()).find(candidate => candidate.path === dbPath)
+    if (!source) throw new Error('Synthetic OTel source was not discovered')
+    const calls: ParsedProviderCall[] = []
+    for await (const call of provider.createSessionParser(source, new Set()).parse()) calls.push(call)
+    if (calls.length !== 1) throw new Error('Expected one synthetic OTel call, got ' + calls.length)
+    return calls[0]!
+  }
+
+  it('normalizes complete, partial, explicit-zero, and absent cache evidence', async () => {
+    if (!isSqliteAvailable()) return
+
+    const cases = [
+      {
+        name: 'complete read plus creation',
+        attrs: { 'gen_ai.usage.cache_read.input_tokens': 300, 'gen_ai.usage.cache_creation.input_tokens': 200 },
+        input: 500, read: 300, creation: 200, evidence: 'complete',
+      },
+      {
+        name: 'read only',
+        attrs: { 'gen_ai.usage.cache_read.input_tokens': 300 },
+        input: 1000, read: 300, creation: 0, evidence: 'partial',
+      },
+      {
+        name: 'creation only',
+        attrs: { 'gen_ai.usage.cache_creation.input_tokens': 200 },
+        input: 1000, read: 0, creation: 200, evidence: 'partial',
+      },
+      {
+        name: 'explicit zeros',
+        attrs: { 'gen_ai.usage.cache_read.input_tokens': 0, 'gen_ai.usage.cache_creation.input_tokens': 0 },
+        input: 1000, read: 0, creation: 0, evidence: 'complete',
+      },
+      {
+        name: 'absent cache detail',
+        attrs: {},
+        input: 1000, read: 0, creation: 0, evidence: 'unavailable',
+      },
+    ] as const
+
+    for (const fixture of cases) {
+      const call = await parseCall(fixture.attrs)
+      expect(call.inputTokens, fixture.name).toBe(fixture.input)
+      expect(call.cacheReadInputTokens, fixture.name).toBe(fixture.read)
+      expect(call.cacheCreationInputTokens, fixture.name).toBe(fixture.creation)
+      expect(call.cacheTokenEvidence, fixture.name).toBe(fixture.evidence)
+      expect(call.outputTokens, fixture.name).toBe(100)
+    }
+
+    const complete = await parseCall({
+      'gen_ai.usage.cache_read.input_tokens': 300,
+      'gen_ai.usage.cache_creation.input_tokens': 200,
+    })
+    expect(complete.inputTokens + complete.cacheReadInputTokens + complete.cacheCreationInputTokens + complete.outputTokens).toBe(1100)
+    expect(complete.inputTokens + complete.cacheReadInputTokens + complete.cacheCreationInputTokens + complete.outputTokens).not.toBe(1600)
+  })
+
+  it('handles malformed and inconsistent evidence deterministically without negative input', async () => {
+    if (!isSqliteAvailable()) return
+
+    const malformed = await parseCall({
+      'gen_ai.usage.cache_read.input_tokens': 'not-a-number',
+      'gen_ai.usage.cache_creation.input_tokens': -1,
+    })
+    expect(malformed.inputTokens).toBe(1000)
+    expect(malformed.cacheReadInputTokens).toBe(0)
+    expect(malformed.cacheCreationInputTokens).toBe(0)
+    expect(malformed.cacheTokenEvidence).toBe('inconsistent')
+    expect(malformed.inputTokens).toBeGreaterThanOrEqual(0)
+
+    const inconsistent = await parseCall({
+      'gen_ai.usage.input_tokens': 100,
+      'gen_ai.usage.cache_read.input_tokens': 80,
+      'gen_ai.usage.cache_creation.input_tokens': 30,
+    })
+    expect(inconsistent.inputTokens).toBe(100)
+    expect(inconsistent.cacheReadInputTokens).toBe(80)
+    expect(inconsistent.cacheCreationInputTokens).toBe(30)
+    expect(inconsistent.cacheTokenEvidence).toBe('inconsistent')
+    expect(inconsistent.inputTokens).toBeGreaterThanOrEqual(0)
+  })
+
+  it('prefers canonical reasoning evidence and marks OTel output as aggregate', async () => {
+    if (!isSqliteAvailable()) return
+
+    const canonical = await parseCall({
+      'gen_ai.usage.cache_read.input_tokens': 0,
+      'gen_ai.usage.cache_creation.input_tokens': 0,
+      'gen_ai.usage.reasoning.output_tokens': 20,
+    })
+    expect(canonical.reasoningTokens).toBe(20)
+    expect(canonical.reasoningSemantics).toBe('aggregate-output')
+
+    const legacy = await parseCall({
+      'gen_ai.usage.cache_read.input_tokens': 0,
+      'gen_ai.usage.cache_creation.input_tokens': 0,
+      'gen_ai.usage.reasoning_tokens': 12,
+    })
+    expect(legacy.reasoningTokens).toBe(12)
+    expect(legacy.reasoningSemantics).toBe('aggregate-output')
+
+    const both = await parseCall({
+      'gen_ai.usage.cache_read.input_tokens': 0,
+      'gen_ai.usage.cache_creation.input_tokens': 0,
+      'gen_ai.usage.reasoning.output_tokens': 20,
+      'gen_ai.usage.reasoning_tokens': 99,
+    })
+    expect(both.reasoningTokens).toBe(20)
+    expect(both.reasoningSemantics).toBe('aggregate-output')
+  })
+
+  it('keeps reasoning inside inclusive output totals and preserves response-model precedence', async () => {
+    if (!isSqliteAvailable()) return
+
+    const call = await parseCall({
+      'gen_ai.request.model': 'claude-sonnet-4-6',
+      'gen_ai.usage.cache_read.input_tokens': 0,
+      'gen_ai.usage.cache_creation.input_tokens': 0,
+      'gen_ai.usage.reasoning.output_tokens': 20,
+    })
+    expect(call.model).toBe('gpt-4.1')
+    expect(call.costUSD).toBe(calculateCost('gpt-4.1', 1000, 100, 0, 0, 0))
+
+    const mix = buildReasoningMix([{
+      outputTokens: 100,
+      reasoningTokens: 20,
+      reasoningSemantics: 'aggregate-output',
+      costUSD: call.costUSD,
+    }])
+    expect(mix.rows[0]!.generatedTokens).toBe(100)
+    expect(mix.rows[0]!.generatedTokens).not.toBe(120)
+  })
+})

--- a/tests/copilot-otel-token-semantics.test.ts
+++ b/tests/copilot-otel-token-semantics.test.ts
@@ -98,12 +98,12 @@ describe('Copilot OTel token semantics', () => {
       {
         name: 'read only',
         attrs: { 'gen_ai.usage.cache_read.input_tokens': 300 },
-        input: 1000, read: 300, creation: 0, evidence: 'partial',
+        input: 700, read: 300, creation: 0, evidence: 'partial',
       },
       {
         name: 'creation only',
         attrs: { 'gen_ai.usage.cache_creation.input_tokens': 200 },
-        input: 1000, read: 0, creation: 200, evidence: 'partial',
+        input: 800, read: 0, creation: 200, evidence: 'partial',
       },
       {
         name: 'explicit zeros',
@@ -124,6 +124,10 @@ describe('Copilot OTel token semantics', () => {
       expect(call.cacheCreationInputTokens, fixture.name).toBe(fixture.creation)
       expect(call.cacheTokenEvidence, fixture.name).toBe(fixture.evidence)
       expect(call.outputTokens, fixture.name).toBe(100)
+      expect(
+        call.inputTokens + call.cacheReadInputTokens + call.cacheCreationInputTokens + call.outputTokens,
+        fixture.name,
+      ).toBe(1100)
     }
 
     const complete = await parseCall({
@@ -146,6 +150,46 @@ describe('Copilot OTel token semantics', () => {
     expect(malformed.cacheCreationInputTokens).toBe(0)
     expect(malformed.cacheTokenEvidence).toBe('inconsistent')
     expect(malformed.inputTokens).toBeGreaterThanOrEqual(0)
+    expect(malformed.inputTokens + malformed.cacheReadInputTokens + malformed.cacheCreationInputTokens + malformed.outputTokens).toBe(1100)
+
+    const validReadMalformedCreation = await parseCall({
+      'gen_ai.usage.cache_read.input_tokens': 300,
+      'gen_ai.usage.cache_creation.input_tokens': 'garbage',
+    })
+    expect(validReadMalformedCreation.inputTokens).toBe(700)
+    expect(validReadMalformedCreation.cacheReadInputTokens).toBe(300)
+    expect(validReadMalformedCreation.cacheCreationInputTokens).toBe(0)
+    expect(validReadMalformedCreation.cacheTokenEvidence).toBe('inconsistent')
+    expect(validReadMalformedCreation.inputTokens + validReadMalformedCreation.cacheReadInputTokens + validReadMalformedCreation.cacheCreationInputTokens + validReadMalformedCreation.outputTokens).toBe(1100)
+
+    const validCreationMalformedRead = await parseCall({
+      'gen_ai.usage.cache_read.input_tokens': 'garbage',
+      'gen_ai.usage.cache_creation.input_tokens': 200,
+    })
+    expect(validCreationMalformedRead.inputTokens).toBe(800)
+    expect(validCreationMalformedRead.cacheReadInputTokens).toBe(0)
+    expect(validCreationMalformedRead.cacheCreationInputTokens).toBe(200)
+    expect(validCreationMalformedRead.cacheTokenEvidence).toBe('inconsistent')
+    expect(validCreationMalformedRead.inputTokens + validCreationMalformedRead.cacheReadInputTokens + validCreationMalformedRead.cacheCreationInputTokens + validCreationMalformedRead.outputTokens).toBe(1100)
+
+    const invalidInput = await parseCall({
+      'gen_ai.usage.input_tokens': 'garbage',
+      'gen_ai.usage.cache_read.input_tokens': 300,
+    })
+    expect(invalidInput.inputTokens).toBe(0)
+    expect(invalidInput.cacheReadInputTokens).toBe(0)
+    expect(invalidInput.cacheTokenEvidence).toBe('inconsistent')
+    expect(invalidInput.inputTokens + invalidInput.cacheReadInputTokens + invalidInput.cacheCreationInputTokens + invalidInput.outputTokens).toBe(100)
+
+    const invalidOutput = await parseCall({
+      'gen_ai.usage.cache_read.input_tokens': 300,
+      'gen_ai.usage.cache_creation.input_tokens': 200,
+      'gen_ai.usage.output_tokens': 'garbage',
+    })
+    expect(invalidOutput.inputTokens).toBe(500)
+    expect(invalidOutput.cacheTokenEvidence).toBe('complete')
+    expect(invalidOutput.outputTokens).toBe(0)
+    expect(invalidOutput.inputTokens + invalidOutput.cacheReadInputTokens + invalidOutput.cacheCreationInputTokens + invalidOutput.outputTokens).toBe(1000)
 
     const inconsistent = await parseCall({
       'gen_ai.usage.input_tokens': 100,
@@ -153,10 +197,11 @@ describe('Copilot OTel token semantics', () => {
       'gen_ai.usage.cache_creation.input_tokens': 30,
     })
     expect(inconsistent.inputTokens).toBe(100)
-    expect(inconsistent.cacheReadInputTokens).toBe(80)
-    expect(inconsistent.cacheCreationInputTokens).toBe(30)
+    expect(inconsistent.cacheReadInputTokens).toBe(0)
+    expect(inconsistent.cacheCreationInputTokens).toBe(0)
     expect(inconsistent.cacheTokenEvidence).toBe('inconsistent')
     expect(inconsistent.inputTokens).toBeGreaterThanOrEqual(0)
+    expect(inconsistent.inputTokens + inconsistent.cacheReadInputTokens + inconsistent.cacheCreationInputTokens + inconsistent.outputTokens).toBe(200)
   })
 
   it('prefers canonical reasoning evidence and marks OTel output as aggregate', async () => {

--- a/tests/model-accounting-payload.test.ts
+++ b/tests/model-accounting-payload.test.ts
@@ -421,11 +421,13 @@ describe('model accounting payload', () => {
     expect(accounting.rows).toHaveLength(1)
     expect(accounting.rows[0]).toMatchObject({
       reasoningTokens: 57_133,
+      additiveReasoningTokens: 0,
       reasoningSemantics: 'mixed',
     })
     expect(presentation.rows).toHaveLength(1)
     expect(presentation.rows[0]).toMatchObject({
       reasoningTokens: 57_133,
+      additiveReasoningTokens: 0,
       reasoningSemantics: 'mixed',
       deliveryRows: [accounting.rows[0]],
     })

--- a/tests/models-report.test.ts
+++ b/tests/models-report.test.ts
@@ -625,6 +625,7 @@ describe('renderJson', () => {
       topCategory: 'feature',
       inputTokens: 100,
       outputTokens: 50,
+      additiveReasoningTokens: 0,
       totalTokens: 150,
       calls: 1,
     })
@@ -678,8 +679,8 @@ describe('renderCsv', () => {
     ]
     const csv = renderCsv(rows)
     const lines = csv.split('\n')
-    expect(lines[0]).toBe('provider,model,top_task,top_task_share,input_tokens,output_tokens,reasoning_tokens,cache_write_tokens,cache_read_tokens,total_tokens,calls,cost_usd,savings_usd,savings_baseline_model')
-    expect(lines[1]).toBe('Claude,Sonnet 4.6,Feature Dev,0.6000,100,50,0,0,0,150,1,1.500000,0.000000,')
+    expect(lines[0]).toBe('provider,model,top_task,top_task_share,input_tokens,output_tokens,reasoning_tokens,additive_reasoning_tokens,cache_write_tokens,cache_read_tokens,total_tokens,calls,cost_usd,savings_usd,savings_baseline_model')
+    expect(lines[1]).toBe('Claude,Sonnet 4.6,Feature Dev,0.6000,100,50,0,0,0,0,150,1,1.500000,0.000000,')
   })
 
   it('emits an agent column in byAgent mode', () => {
@@ -704,8 +705,8 @@ describe('renderCsv', () => {
     ]
     const csv = renderCsv(rows, { byAgent: true })
     const lines = csv.split('\n')
-    expect(lines[0]).toBe('provider,model,agent,input_tokens,output_tokens,reasoning_tokens,cache_write_tokens,cache_read_tokens,total_tokens,calls,cost_usd,savings_usd,savings_baseline_model')
-    expect(lines[1]).toBe('Claude,Opus 4.8,planner,100,50,0,0,0,150,1,6.000000,0.000000,')
+    expect(lines[0]).toBe('provider,model,agent,input_tokens,output_tokens,reasoning_tokens,additive_reasoning_tokens,cache_write_tokens,cache_read_tokens,total_tokens,calls,cost_usd,savings_usd,savings_baseline_model')
+    expect(lines[1]).toBe('Claude,Opus 4.8,planner,100,50,0,0,0,0,150,1,6.000000,0.000000,')
   })
 
   it('escapes commas in provider/model cells', () => {

--- a/tests/otel-cache-aggregation.test.ts
+++ b/tests/otel-cache-aggregation.test.ts
@@ -126,11 +126,11 @@ describe.skipIf(!isSqliteAvailable())(
 
       const conversations: ConvSpec[] = [
         { spanId: 'span-1', traceId: 'trace-1', convId: 'conv-1', model: 'claude-haiku-4-5-20251001',
-          input: 1_000, output: 100, cacheRead: 50_000, cacheCreate: 500 },
+          input: 51_500, output: 100, cacheRead: 50_000, cacheCreate: 500 },
         { spanId: 'span-2', traceId: 'trace-2', convId: 'conv-2', model: 'claude-haiku-4-5-20251001',
-          input: 2_000, output: 200, cacheRead: 60_000, cacheCreate: 600 },
+          input: 62_600, output: 200, cacheRead: 60_000, cacheCreate: 600 },
         { spanId: 'span-3', traceId: 'trace-3', convId: 'conv-3', model: 'claude-haiku-4-5-20251001',
-          input: 3_000, output: 300, cacheRead: 70_000, cacheCreate: 700 },
+          input: 73_700, output: 300, cacheRead: 70_000, cacheCreate: 700 },
       ]
       for (const c of conversations) insertConversation(dbPath, c)
 
@@ -174,9 +174,9 @@ describe.skipIf(!isSqliteAvailable())(
 
       const conversations: ConvSpec[] = [
         { spanId: 'span-a', traceId: 'trace-a', convId: 'conv-a', model: 'claude-haiku-4-5-20251001',
-          input: 500, output: 50, cacheRead: 25_000, cacheCreate: 250 },
+          input: 25_750, output: 50, cacheRead: 25_000, cacheCreate: 250 },
         { spanId: 'span-b', traceId: 'trace-b', convId: 'conv-b', model: 'claude-haiku-4-5-20251001',
-          input: 500, output: 50, cacheRead: 25_000, cacheCreate: 250 },
+          input: 25_750, output: 50, cacheRead: 25_000, cacheCreate: 250 },
       ]
       for (const c of conversations) insertConversation(dbPath, c)
 

--- a/tests/providers/copilot.test.ts
+++ b/tests/providers/copilot.test.ts
@@ -1060,6 +1060,16 @@ function insertSpan(dbPath: string, span: SpanDef): void {
   db.close()
 }
 
+async function parseSingleOtelCall(dbPath: string): Promise<ParsedProviderCall> {
+  const provider = createCopilotProvider('/nonexistent/jsonl', '/nonexistent/ws', '/nonexistent/global', '/nonexistent/jetbrains')
+  const source = (await provider.discoverSessions()).find(candidate => candidate.path === dbPath)
+  if (!source) throw new Error('OTel source not discovered: ' + dbPath)
+  const calls: ParsedProviderCall[] = []
+  for await (const call of provider.createSessionParser(source, new Set()).parse()) calls.push(call)
+  if (calls.length !== 1) throw new Error('Expected one OTel call, got ' + calls.length)
+  return calls[0]!
+}
+
 describe('copilot provider - OTel cache token parsing', () => {
   let tmpDir: string
   let dbPath: string

--- a/tests/providers/copilot.test.ts
+++ b/tests/providers/copilot.test.ts
@@ -1104,7 +1104,7 @@ describe('copilot provider - OTel cache token parsing', () => {
       attrs: {
         'gen_ai.conversation.id': 'conv-001',
         'gen_ai.response.model': 'gpt-4.1',
-        'gen_ai.usage.input_tokens': 1000,
+        'gen_ai.usage.input_tokens': 51500,
         'gen_ai.usage.output_tokens': 200,
         'gen_ai.usage.cache_read.input_tokens': 50000,
         'gen_ai.usage.cache_creation.input_tokens': 500,
@@ -1144,7 +1144,7 @@ describe('copilot provider - OTel cache token parsing', () => {
       attrs: {
         'gen_ai.conversation.id': 'conv-alpha',
         'gen_ai.response.model': 'gpt-4.1',
-        'gen_ai.usage.input_tokens': 800,
+        'gen_ai.usage.input_tokens': 41200,
         'gen_ai.usage.output_tokens': 100,
         'gen_ai.usage.cache_read.input_tokens': 40000,
         'gen_ai.usage.cache_creation.input_tokens': 400,
@@ -1155,7 +1155,7 @@ describe('copilot provider - OTel cache token parsing', () => {
       attrs: {
         'gen_ai.conversation.id': 'conv-beta',
         'gen_ai.response.model': 'claude-sonnet-4',
-        'gen_ai.usage.input_tokens': 600,
+        'gen_ai.usage.input_tokens': 30900,
         'gen_ai.usage.output_tokens': 80,
         'gen_ai.usage.cache_read.input_tokens': 30000,
         'gen_ai.usage.cache_creation.input_tokens': 300,
@@ -1190,7 +1190,7 @@ describe('copilot provider - OTel cache token parsing', () => {
       attrs: {
         'gen_ai.conversation.id': 'conv-c',
         'gen_ai.response.model': 'gpt-4.1',
-        'gen_ai.usage.input_tokens': 500,
+        'gen_ai.usage.input_tokens': 20700,
         'gen_ai.usage.output_tokens': 100,
         'gen_ai.usage.cache_read.input_tokens': 20000,
         'gen_ai.usage.cache_creation.input_tokens': 200,
@@ -1201,7 +1201,7 @@ describe('copilot provider - OTel cache token parsing', () => {
       attrs: {
         'gen_ai.conversation.id': 'conv-d',
         'gen_ai.response.model': 'gpt-4.1',
-        'gen_ai.usage.input_tokens': 700,
+        'gen_ai.usage.input_tokens': 36050,
         'gen_ai.usage.output_tokens': 150,
         'gen_ai.usage.cache_read.input_tokens': 35000,
         'gen_ai.usage.cache_creation.input_tokens': 350,
@@ -1238,7 +1238,7 @@ describe('copilot provider - OTel cache token parsing', () => {
       attrs: {
         'gen_ai.conversation.id': 'conv-e',
         'gen_ai.response.model': 'gpt-4.1',
-        'gen_ai.usage.input_tokens': 300,
+        'gen_ai.usage.input_tokens': 10400,
         'gen_ai.usage.output_tokens': 50,
         'gen_ai.usage.cache_read.input_tokens': 10000,
         'gen_ai.usage.cache_creation.input_tokens': 100,
@@ -1295,8 +1295,9 @@ describe('copilot provider - OTel cache token parsing', () => {
     expect(calls).toHaveLength(1)
     expect(calls[0]!.inputTokens).toBe(0)
     expect(calls[0]!.outputTokens).toBe(0)
-    expect(calls[0]!.cacheReadInputTokens).toBe(50000)
-    expect(calls[0]!.cacheCreationInputTokens).toBe(500)
+    expect(calls[0]!.cacheReadInputTokens).toBe(0)
+    expect(calls[0]!.cacheCreationInputTokens).toBe(0)
+    expect(calls[0]!.cacheTokenEvidence).toBe('inconsistent')
   })
 
   it('OTel source path equals the plain DB file path and durableSources is true', async () => {


### PR DESCRIPTION
## Scope

- Exact base: `main` at `0b071439cc6e113403e8139c6d2a109c5eea8712`.
- Existing PR #199 only; previous reviewed HEAD: `89fb51ba52c9b7bfe6b77e51fdfd75b63541eeb8`.
- Converged HEAD: `d7f78b15ed9439d99b6a7b1fafb98310168047af`.
- This remains the bounded `COPILOT_OTEL_TOKEN_SEMANTICS` P0 accounting correction plus the minimum safe history migration.
- No generic OpenTelemetry adoption, OTLP, OTel Collector, OTel SDK dependency, unrelated Copilot collectors, unrelated provider changes, or privacy expansion.

## P0 cache correction preserved

The Copilot OTel SQLite path receives cache-inclusive `gen_ai.usage.input_tokens`. At the provider boundary it normalizes to Metrora's separate-cache contract:

- complete: `input = I - CR - CW`, cache read `CR`, cache creation `CW`, output `O`;
- CR-only: `I=1000, CR=300, CW absent` becomes `input=700, read=300, write=0`, evidence `partial`;
- CW-only: `I=1000, CR absent, CW=200` becomes `input=800, read=0, write=200`, evidence `partial`;
- explicit zero remains present evidence; omitted cache detail remains unavailable;
- a valid cache subset remains usable when its counterpart is malformed, while evidence remains marked `inconsistent` where appropriate;
- impossible evidence such as `I=100, CR=80, CW=30` retains reliable inclusive input/output as `input=100, read=0, write=0, output=100`, status `inconsistent`; it never creates negative input or enters pricing as factual cache detail;
- malformed input/output values remain non-negative and cache completeness is not misclassified from unrelated output validity.

The existing Copilot CLI `session.shutdown` cache normalization is unchanged and covered.

## Reasoning evidence contract

- `reasoningTokens` means the factual observed reasoning-token breakdown.
- `additiveReasoningTokens` means only the reasoning subtotal that must be added to output for generated/billable volume.
- `reasoningSemantics` is the inclusion authority: `aggregate-output`, `separate`, `unavailable`, or `mixed`. `mixed` alone never infers an additive subtotal.

The OTel path prefers `gen_ai.usage.reasoning.output_tokens`, falls back to `gen_ai.usage.reasoning_tokens` only when canonical evidence is absent, and carries source-specific `aggregate-output` authority.

Examples:

- OTel `output=100, reasoning=20, aggregate-output` → observed reasoning `20`, additive reasoning `0`, generated total `100`.
- Separate source `output=100, reasoning=30, separate` → observed `30`, additive `30`, generated total `130`.
- Mixed aggregate with Copilot `100/20` plus separate `100/30` → output `200`, observed reasoning `50`, additive reasoning `30`, generated total `230`; never `250` and never an erased reasoning breakdown.

The distinction is retained through live model aggregation, session projection, daily/model/provider slices, project-day totals, daily-cache merge and timezone reconciliation, period reconstruction, model accounting/presentation, compare, audit, performance denominators, and cost/provenance coverage. Report Reasoning values remain factual breakdowns; generated/output totals use the additive subtotal.

## Semantic authority

- Frozen semantic authority: [open-telemetry/semantic-conventions-genai](https://github.com/open-telemetry/semantic-conventions-genai) at `a685613a207a580163353b8e48a7ad88967e7b42`.
- Producer emission evidence: [microsoft/vscode](https://github.com/microsoft/vscode) at `aa4ccf2adb55c82cf0ce00c8f5eca911884b93a8`.

This is independently implemented Metrora-owned compatibility code. No substantial upstream generated material is copied.

## History and authority

- `PROVIDER_PARSE_VERSIONS.copilot` is now `cli-shutdown-cost-v3-source-provenance-otel-token-semantics-v1-reasoning-evidence-v1`.
- Global session `CACHE_VERSION` remains `8`; the existing daily configuration hash already includes the Copilot provider parse authority.
- `RAW_OTEL_STILL_AVAILABLE`: reparse the retained source under the new authority and preserve observed/additive reasoning.
- `DURABLE_CACHE_ONLY`: preserve NEVER-LOSE; retain the safe prior migration rule for provable legacy complete evidence. Ambiguous legacy partial/zero rows are carried forward unchanged.
- `NO_SUFFICIENT_EVIDENCE`: carry the call/day/session forward; do not fabricate corrected cache state or historical reasoning.
- Reparse failure, temporary locks, source disappearance, and restart continue to preserve durable history and failed markers.

New optional additive-reasoning fields are backward-compatible. Legacy daily/cache records without the field remain readable. Historical reasoning that the old parser discarded is never reconstructed.

## Architecture and validation

The existing focused OTel normalization/history helpers and prior parser/cache extraction remain bounded. The aggregate remediation keeps token-semantics logic focused and extracts the coherent CSV rendering responsibility into `src/models-report-csv.ts`; `src/models-report.ts` is reduced below the prior oversized-module count. The source-size gate passes against the exact PR base; no threshold or exception was changed.

- `npx tsc --noEmit` — PASS.
- `npm run build:cli` — PASS.
- `node scripts/check-source-size-ratchet.mjs` with base `0b071439cc6e113403e8139c6d2a109c5eea8712` — PASS.
- Focused reasoning/report suite: 7 files, 32 tests — PASS.
- Model/report/cost suite: 12 files, 94 tests — PASS.
- Daily aggregation/reconstruction/report/runtime suite: 21 files, 166 tests — PASS.
- Copilot/provider/OTel/history/session-cache suite: 17 files, 288 tests — PASS.
- Parser/reparse-failure suite: 3 files, 14 tests — PASS.
- Final post-extraction model/report suite: 4 files, 42 tests — PASS.

All fixtures use synthetic data and temporary directories/SQLite. No real user databases, Copilot state, Metrora cache/history, or editor settings were touched. The #199 semantic diff remains independent of #198; it is now based on main containing the Founder-approved SQLite boundary. Draft only; do not merge.

## Desktop renderer reasoning contract remediation

The desktop renderer now mirrors the backend contract:

- `reasoningTokens` is factual observed reasoning evidence.
- `additiveReasoningTokens` is the only reasoning subtotal added to output totals and Cost / 1M.
- `reasoningSemantics=separate` uses explicit additive evidence, with the legacy fallback to `reasoningTokens` when the optional field is absent.
- `aggregate-output` contributes zero separately.
- `mixed` uses explicit `additiveReasoningTokens`; absent additive evidence contributes zero and never infers from the full observed subtotal.

Required mixed proof:

- Backend: `output=200`, observed `reasoning=50`, additive `30` → generated total `230`.
- Desktop before this remediation: `250`.
- Desktop after this remediation: `230`.

Models, durable Models, Sessions, and Compare now carry the optional mirror field through shared `usageMetrics` denominator logic. User-facing Reasoning remains the observed breakdown; explanatory copy states that only the additive subset contributes separately to Total. The existing public renderer type surface re-exports a focused usage-projection contract module so the source-size ratchet remains passing without weakening its threshold.

Renderer validation for this delta:

- focused renderer suite: 5 files, 39 tests — PASS;
- bounded Models/Sessions/Compare regression: 8 files, 47 tests — PASS;
- root and desktop typechecks — PASS;
- CLI build and renderer build — PASS;
- source-size ratchet against base `0b071439cc6e113403e8139c6d2a109c5eea8712` — PASS.

Backend cache accounting, reasoning parsing, pricing, history migration, durable representation, and NEVER-LOSE behavior are unchanged by this desktop-only remediation.

## Post-SQLite convergence validation

- Previous reviewed #199 HEAD: `89fb51ba52c9b7bfe6b77e51fdfd75b63541eeb8`.
- New main containing merged PR #198: `0b071439cc6e113403e8139c6d2a109c5eea8712`.
- Merged SQLite implementation HEAD: `23b21445ef2fbd07a0fa5b644f8e8476c09c2a38`.
- Converged HEAD: `d7f78b15ed9439d99b6a7b1fafb98310168047af`.
- Method: clean rebase of all five #199 commits onto the exact new main; no conflicts. The range-diff is commit-for-commit equivalent to the previously reviewed #199 series.
- The committed #199 semantic files remain unchanged by convergence; no SQLite file is part of the replayed #199 delta.
- Combined synthetic WAL smoke passed: Copilot `agent-traces.db` was read through shared `openDatabase()`; committed WAL rows were visible; producer `db`, `-wal`, `-shm`, and `-journal` state remained unchanged.
- Canonical OTel result: input `500`, cache read `300`, cache creation `200`, output `100`, reasoning `20`, `aggregate-output`, canonical total `1100`.
- Projection smoke passed through session, daily, model, accounting, and presentation projections; observed reasoning remained `20` and additive reasoning remained `0`.
- Post-convergence targeted validation: SQLite/Copilot/history/parser/session-cache suite `14` files / `247` tests; renderer suite `5` files / `39` tests; accounting/report/audit suite `7` files / `62` tests — all PASS.
- Root and desktop typechecks, CLI and renderer builds, source-size ratchet against `0b071439cc6e113403e8139c6d2a109c5eea8712`, and `git diff --check` all PASS.
- All fixtures used temporary synthetic data only; no real producer database, Copilot state, Metrora cache/history, or editor settings were touched.
