### PR TITLE
docs: converge RC11 and Android distribution state

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Understand where AI time, tokens and money go across tools, models, projects and
 </div>
 
 > [!IMPORTANT]
-> Metrora for Windows is available on the **Microsoft Store**, published by Vensent. The **Android companion is publicly available as the production-signed `0.1.0-alpha.3` GitHub pre-release**. The live Store package remains the frozen RC10 Windows distribution while the RC11 update is in Microsoft certification; until Microsoft publishes RC11, Android pairing requires a current Desktop source build with the companion runtime. Repository builds and historical GitHub Windows pre-releases remain separate development or archival artifacts.
+> Metrora for Windows is available on the **Microsoft Store**, published by Vensent. The current Store update is the accepted **RC11** Windows line and includes the companion runtime used for local Android pairing. The **Android companion is publicly available now as the production-signed `0.1.0-alpha.3` GitHub pre-release**, with a Google Play release planned within 30 days. Repository builds and historical GitHub Windows pre-releases remain separate development or archival artifacts.
 
 ## Install Metrora
 
@@ -35,7 +35,7 @@ The current public Android alpha is [`0.1.0-alpha.3`](https://github.com/maikols
 - verify the public manifest and `SHA256SUMS` attached to the release;
 - for Obtainium, add `https://github.com/maikolsiragusaa/metrora` and track the `android-v*` releases.
 
-`0.1.0-alpha.1` remains an immutable historical release and `0.1.0-alpha.2` was never published. This is an early direct-install channel, not a Google Play or F-Droid release. The companion pairs locally with Metrora Desktop and does not become a second collection or accounting authority. Until the live Windows Store package includes the current companion runtime, use a current Desktop source build for Android pairing.
+`0.1.0-alpha.1` remains an immutable historical release and `0.1.0-alpha.2` was never published. The direct GitHub APK remains available now; Google Play publication is planned within 30 days and remains a separate release channel until it is actually live. The companion pairs locally with the current Microsoft Store Desktop and does not become a second collection or accounting authority. F-Droid remains separately gated.
 
 ## What Metrora helps you understand
 
@@ -161,16 +161,16 @@ Historical API-equivalent pricing is date-effective and non-retroactive by defau
 
 | Surface | Role | Current status |
 | --- | --- | --- |
-| Desktop | Primary local analysis and configuration | **Available on Microsoft Store for Windows** |
+| Desktop | Primary local analysis and configuration | **Available on Microsoft Store for Windows; RC11 current Store line** |
 | CLI | Automation, inspection, export and keyboard-first analysis | Bundled with the Windows Store app; also available from source for development |
 | Local web dashboard | Browser view served from the local machine | Available locally |
-| Android companion | Read-focused local-network companion for a paired Desktop | **Public GitHub pre-release `0.1.0-alpha.3`; production-signed direct APK** |
+| Android companion | Read-focused local-network companion for a paired Desktop | **Public GitHub pre-release `0.1.0-alpha.3`; Google Play release planned within 30 days** |
 | macOS menubar | Compact local usage view | Development source retained; not an official Metrora distribution |
 | GNOME extension | Compact Linux panel view | Development source retained; not an official Metrora distribution |
 
 Windows is the first supported public desktop distribution. Source support for other desktop platforms does not imply that an accepted public package exists for those platforms.
 
-The Android companion is publicly distributed through the [`android-v0.1.0-alpha.3`](https://github.com/maikolsiragusaa/metrora/releases/tag/android-v0.1.0-alpha.3) GitHub pre-release. It pairs with Metrora Desktop on the same LAN, can show a fresh Desktop-generated usage overview or an encrypted offline snapshot, and consumes bounded Project-aware Home, Activity Sessions/Pull Requests, Analyze/Models, Analyze/Spend and capability-driven Workspace projections. Activity uses additive cursor-paged metadata contracts and does not expose prompt/response content. QR pairing, image import, SAS/Desktop approval and mutual-TLS device trust remain the local security boundary. The Android app does not duplicate collection, parsing, pricing, history or evidence authority. The live Microsoft Store package is still the frozen RC10 line while RC11 is in Microsoft certification; until that Store update is published with the current companion runtime, Android pairing requires a current Desktop source build.
+The Android companion is publicly distributed through the [`android-v0.1.0-alpha.3`](https://github.com/maikolsiragusaa/metrora/releases/tag/android-v0.1.0-alpha.3) GitHub pre-release. It pairs with Metrora Desktop on the same LAN, can show a fresh Desktop-generated usage overview or an encrypted offline snapshot, and consumes bounded Project-aware Home, Activity Sessions/Pull Requests, Analyze/Models, Analyze/Spend and capability-driven Workspace projections. Activity uses additive cursor-paged metadata contracts and does not expose prompt/response content. QR pairing, image import, SAS/Desktop approval and mutual-TLS device trust remain the local security boundary. The Android app does not duplicate collection, parsing, pricing, history or evidence authority. The current Microsoft Store RC11 line includes the companion runtime required by this pairing path. Google Play publication is planned within 30 days; until that channel is actually live, GitHub remains the current public Android distribution authority.
 
 ## Privacy model
 
@@ -206,6 +206,7 @@ Start from the [documentation index](docs/README.md):
 - [Android public distribution v1](docs/ANDROID_PUBLIC_DISTRIBUTION_V1.md)
 - [Local companion API v1](docs/LOCAL_COMPANION_API.md)
 - [Windows distribution boundary](docs/WINDOWS_DISTRIBUTION.md)
+- [Community and commercial boundary](docs/COMMERCIAL_BOUNDARY.md)
 
 ## Repository map
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -2,7 +2,7 @@
 
 Metrora does not yet have an official stable desktop release. Windows is
 currently distributed publicly through the Microsoft Store, published by
-Vensent, with RC10 as the frozen Store authority. This document defines the
+Vensent, with RC11 as the current Store authority. This document defines the
 current public release boundary.
 
 ## Canonical identity
@@ -11,9 +11,10 @@ current public release boundary.
 - Domain: **metrora.eu**
 - Repository: `maikolsiragusaa/metrora`
 - Canonical command: `metrora`
-- Published Store source line: `1.0.0-rc.10`
-- Published desktop build version: `1.0.0.10`
-- Current Store update candidate: `1.0.0-rc.11` / Desktop `1.0.0.11` / Store `1.0.1.0`
+- Published Store source line: `1.0.0-rc.11`
+- Published desktop build version: `1.0.0.11`
+- Published Store package version: `1.0.1.0`
+- Previous published Store line: `1.0.0-rc.10` / Desktop `1.0.0.10` / Store `1.0.0.0`
 - Latest published GitHub technical preview: `1.0.0-rc.7`
 
 The published command is `metrora`. Historical protocol and signed-data
@@ -24,28 +25,22 @@ The root npm package is private and must not be published from this repository.
 
 ## Current engineering authority
 
-`1.0.0-rc.10` is the **frozen Microsoft Store source line** for the live
-Windows distribution published by Vensent. It advances RC9 because audited
-source-completeness and durable-history reconciliation materially changed
-user-visible accounting after the RC9 candidate was established. RC9 had
-already introduced the explicit durable-vs-surviving-detail accounting
-boundary and the sealed packaged Store CLI runtime. Post-RC10 development is
-separate from the published package; any future Store update requires its own
-candidate, acceptance, submission and publication decision.
+`1.0.0-rc.11` is the current **published Microsoft Store source line** for the
+Windows distribution published by Vensent. It was accepted by Microsoft as the
+Store update with Desktop build version `1.0.0.11` and Store package identity
+version `1.0.1.0`.
 
-The current post-RC10 engineering candidate is `1.0.0-rc.11`, with Desktop
-build version `1.0.0.11` and Store package identity version `1.0.1.0`. It has
-been submitted to Microsoft Partner Center and is undergoing certification; it
-is not publicly live. The published Store remains RC10 until Microsoft
-publishes a later package.
+RC10 remains immutable historical publication evidence. RC9 and earlier
+candidate lines remain bound to their own source and acceptance records.
+Post-RC11 development is separate from the Store artifact; any future Store
+update requires its own candidate, acceptance, submission and publication
+decision.
 
 `1.0.0-rc.7` remains the latest published GitHub Windows technical preview. That channel is unsigned, manually updated and not Microsoft Store certified. Its source, release assets, manifests and checksums remain immutable historical publication evidence.
 
 The Microsoft Store path is separate from source builds and GitHub technical
-pre-releases. Metrora has an assigned Store identity, and RC10 passed its
-source-bound package and physical acceptance boundary before publication.
-The live Store listing is the supported public Windows install path; later
-source work does not retroactively change the frozen RC10 authority.
+pre-releases. The live Store listing is the supported public Windows install
+path; later source work does not retroactively change the frozen RC11 authority.
 
 Exact source commits and artifact digests belong in the applicable workflow/release acceptance evidence rather than being copied into general release guidance.
 
@@ -53,15 +48,16 @@ Exact source commits and artifact digests belong in the applicable workflow/rele
 
 Metrora deliberately separates three version forms:
 
-- product/source SemVer: `1.0.0-rc.11` for the current candidate;
-- desktop build version: `1.0.0.11` for the current candidate;
-- Microsoft Store AppX package identity version: `1.0.1.0` for the current candidate;
-- published Store baseline: RC10 / `1.0.0.0`.
+- product/source SemVer: `1.0.0-rc.11` for the current published Store line;
+- desktop build version: `1.0.0.11` for that published line;
+- Microsoft Store AppX package identity version: `1.0.1.0` for that published line;
+- previous Store baseline: RC10 / `1.0.0.0`.
 
 The Store's four-component package identity is a platform contract and must not
-be confused with the desktop build counter or the SemVer pre-release label. The
-published baseline and candidate are maintained in
-`release/windows-store-package-version.v1.json`. See
+be confused with the desktop build counter or the SemVer pre-release label.
+`release/windows-store-package-version.v1.json` records the RC10-to-RC11
+packaging transition used for the published update. It must be advanced under a
+separate release decision before another Store candidate is derived. See
 [`docs/VERSIONING.md`](docs/VERSIONING.md).
 
 ## Release responsibilities
@@ -111,11 +107,12 @@ An unsigned GitHub pre-release must state that its portable/installer assets are
 
 ## Microsoft Store candidate boundary
 
-The RC11 Store candidate must be built from the exact reviewed source commit
-using the non-publishing Store workflow. The candidate carries the current
-Desktop companion runtime in `resources/cli.asar` and must pass an import-only
-smoke through the bundled Electron runtime before physical pairing is attempted.
-A submitted artifact remains bound to that source line:
+The published RC11 Store package was built from its exact reviewed source commit
+using the non-publishing Store workflow. The accepted package carries the
+Desktop companion runtime in `resources/cli.asar` and passed the bundled-runtime
+checks used for the submission boundary.
+
+For any future Store candidate:
 
 1. the exact AppX artifact and workflow manifest must verify;
 2. Store identity, publisher, architecture, capabilities and package version must match reviewed configuration;
@@ -175,9 +172,10 @@ materializes them only for the protected signing step and does not persist
 them in `GITHUB_ENV` or release metadata.
 
 The QA physical-acceptance identity is not a production release identity.
-Google Play and F-Droid remain separate gates. The alpha.3 public-availability
-claim is limited to its immutable GitHub prerelease and direct APK; it does not
-imply Play or F-Droid distribution.
+Google Play publication is planned within 30 days but remains a separate channel
+until the Play listing is actually public. The alpha.3 GitHub APK remains the
+current public Android authority in the meantime. F-Droid remains separately
+gated.
 
 ## Prohibitions
 
@@ -187,4 +185,5 @@ imply Play or F-Droid distribution.
 - no publication from an unverified local build;
 - no silent replacement of accepted artifacts;
 - no claim of Microsoft Store certification/publication before Microsoft actually accepts that channel;
+- no claim of Google Play publication before the listing is actually public;
 - no claim of an official stable release before the relevant channel passes acceptance.

--- a/app/DISTRIBUTION.md
+++ b/app/DISTRIBUTION.md
@@ -8,12 +8,12 @@ This document defines the desktop packaging boundary. Platform-specific release 
 - Desktop app ID: `eu.metrora.desktop`
 - Website: `https://metrora.eu`
 - Microsoft Store: `https://apps.microsoft.com/detail/9NXSZFQSBBDX`
-- Published Store source line: `1.0.0-rc.10`
-- Published desktop build version: `1.0.0.10`
-- Published Store AppX identity version: `1.0.0.0`
-- Current Store update candidate: `1.0.0-rc.11`
-- Current candidate desktop build version: `1.0.0.11`
-- Current candidate Store AppX identity version: `1.0.1.0`
+- Published Store source line: `1.0.0-rc.11`
+- Published desktop build version: `1.0.0.11`
+- Published Store AppX identity version: `1.0.1.0`
+- Previous published Store source line: `1.0.0-rc.10`
+- Previous published desktop build version: `1.0.0.10`
+- Previous published Store AppX identity version: `1.0.0.0`
 - Historical GitHub technical preview: `1.0.0-rc.7`
 
 Inherited names may remain only where required for compatibility or provenance. They are not Metrora distribution names.
@@ -27,12 +27,10 @@ The root CLI build keeps its normal production dependency closure external. `app
 The Store payload must not expose a loose CLI `node_modules` tree. Keeping `@scope/package` paths inside `cli.asar` prevents AppX packaging from rewriting those path segments. The Store package workflow executes the CLI from the extracted AppX layout with packaged `Metrora.exe`, so module resolution is tested as shipped rather than inferred from file presence.
 
 The packaged companion runtime is the sealed module at
-`app/resources/cli.asar/dist/desktop-share-runtime.js`. The Store workflow
-imports that exact module through the bundled Electron runtime and requires the
-`createDesktopShareRuntime` entry point without starting a listener or creating
-pairing state. Store package versions are maintained in the canonical
-`../release/windows-store-package-version.v1.json` authority and are not derived
-from product SemVer.
+`app/resources/cli.asar/dist/desktop-share-runtime.js`. The current RC11 Store
+line includes that runtime. Store package versions are maintained through the
+canonical `../release/windows-store-package-version.v1.json` packaging
+authority and are not derived from product SemVer.
 
 Persisted Workspace endpoint metadata is reconciled to the current packaged Metrora/collector version without replacing endpoint identity, Workspace membership or evidence history.
 
@@ -48,7 +46,7 @@ npm --prefix app run package:store    # Windows AppX x64, development packaging
 npm --prefix app run package:linux    # Linux AppImage, deb and rpm x64
 ```
 
-These commands create development or engineering artifacts. They do not by themselves create an official release or replace the Microsoft Store distribution. The RC11 Store output is an unsigned submitted candidate undergoing Microsoft certification; it is not publicly published until the remaining release gates pass.
+These commands create development or engineering artifacts. They do not by themselves create an official release or replace the Microsoft Store distribution. RC11 is already the current published Store line; any later Store output remains only a candidate until its own acceptance, submission and Microsoft publication gates pass.
 
 ## Official distribution requirements
 
@@ -67,7 +65,7 @@ An official desktop package must:
 
 ### Windows
 
-The supported public Windows distribution is the Microsoft Store package published by Vensent.
+The supported public Windows distribution is the Microsoft Store package published by Vensent. RC11 is the current Store line.
 
 Development Windows installers may still be produced for engineering validation. They are not the recommended public install path and must not be represented as Store-distributed packages.
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -144,7 +144,7 @@ npm --prefix app run typecheck
 npm --prefix app run build
 ```
 
-Development builds are not official Store-signed releases. Windows is the first supported public desktop distribution, and the Microsoft Store package is the recommended Windows install path. The live Store line remains RC10 while RC11 is in Microsoft certification. Repository packaging commands remain development and verification tools rather than alternate public distribution channels.
+Development builds are not official Store-signed releases. Windows is the first supported public desktop distribution, and the Microsoft Store package is the recommended Windows install path. The current live Store line is RC11 (`1.0.0-rc.11`, Desktop `1.0.0.11`, Store package `1.0.1.0`). Repository packaging commands remain development and verification tools rather than alternate public distribution channels.
 
 See [Windows distribution](WINDOWS_DISTRIBUTION.md), [Versioning authority](VERSIONING.md) and [`RELEASING.md`](../RELEASING.md).
 
@@ -152,13 +152,15 @@ See [Windows distribution](WINDOWS_DISTRIBUTION.md), [Versioning authority](VERS
 
 The current public GitHub pre-release is [`0.1.0-alpha.3`](https://github.com/maikolsiragusaa/metrora/releases/tag/android-v0.1.0-alpha.3), distributed as a production-signed direct APK for `eu.metrora.app` with `versionCode = 3`. `0.1.0-alpha.1` remains immutable historical release evidence; `0.1.0-alpha.2` was never published.
 
-Until Microsoft publishes the RC11 Store update with the current companion runtime, pair alpha.3 with a current Metrora Desktop source build. The Android companion remains read-focused and does not become a second collection, pricing, accounting or history authority.
+The current RC11 Microsoft Store Desktop includes the companion runtime used by alpha.3, so ordinary Windows users can pair the Android companion with the Store installation. The Android companion remains read-focused and does not become a second collection, pricing, accounting or history authority.
 
 For direct installation:
 
 - download `Metrora-Android-0.1.0-alpha.3.apk` from the alpha.3 GitHub Release;
 - verify the attached manifest and `SHA256SUMS` if desired;
 - Obtainium users can track the repository's `android-v*` releases.
+
+Google Play publication is planned within 30 days. Until that channel is actually live, the production-signed GitHub APK remains the current public Android distribution authority. F-Droid remains separately gated.
 
 For repository Android development use:
 

--- a/docs/VERSIONING.md
+++ b/docs/VERSIONING.md
@@ -4,11 +4,12 @@ Metrora uses semantic versioning for public product identity and separate numeri
 
 ## Current line
 
-- Published Store source line: `1.0.0-rc.10`
-- Published Desktop build version: `1.0.0.10`
-- Current Store update candidate source line: `1.0.0-rc.11`
-- Current candidate Desktop build version: `1.0.0.11`
-- Current candidate Store package version: `1.0.1.0`
+- Published Store source line: `1.0.0-rc.11`
+- Published Desktop build version: `1.0.0.11`
+- Published Store package version: `1.0.1.0`
+- Previous published Store source line: `1.0.0-rc.10`
+- Previous published Desktop build version: `1.0.0.10`
+- Previous published Store package version: `1.0.0.0`
 - Latest published GitHub technical preview: `1.0.0-rc.7`
 - First intended stable release: `1.0.0`
 
@@ -36,27 +37,29 @@ The Microsoft Store AppX/MSIX manifest has a separate four-component package ide
 
 The final component is `0` for the Store package contract. The SemVer pre-release suffix (`-rc.N`) is **not** encoded into the AppX identity version, and the desktop build counter (`MAJOR.MINOR.PATCH.N`) must not be presented as the Store package version.
 
-The published baseline and the next candidate are separate authorities:
+The current and previous published authorities are:
 
-- published RC10 source/product line: `1.0.0-rc.10`;
-- published RC10 Desktop build version: `1.0.0.10`;
-- published Store AppX identity version: `1.0.0.0`;
-- current RC11 source/product candidate: `1.0.0-rc.11`;
+- current RC11 source/product line: `1.0.0-rc.11`;
 - current RC11 Desktop build version: `1.0.0.11`;
-- current candidate Store AppX identity version: `1.0.1.0`.
+- current Store AppX identity version: `1.0.1.0`;
+- previous RC10 source/product line: `1.0.0-rc.10`;
+- previous RC10 Desktop build version: `1.0.0.10`;
+- previous Store AppX identity version: `1.0.0.0`.
 
 The machine-readable Store package authority is
-`release/windows-store-package-version.v1.json`. It is the single source for
-the published baseline and candidate package versions. The AppX hook reads it
-after electron-builder creates the manifest; it does not derive a package
-version from product SemVer or the Desktop build counter. A local build with a
-known identity version is not, by itself, evidence of the live listing; later
+`release/windows-store-package-version.v1.json`. Its current values encode the
+RC10-to-RC11 package transition that produced the now-published RC11 update.
+Before another Store candidate is derived, that authority must be advanced by a
+separate reviewed release decision so the published baseline reflects
+`1.0.1.0` and any next candidate remains strictly greater. A local build with a
+known identity version is not, by itself, evidence of a live listing; later
 Store updates must pass their own acceptance and publication gates.
 
 ## Android version authority
 
 Android uses the native `versionName` and integer `versionCode` declared in
-`android/app/build.gradle.kts`. The immutable public Android release is:
+`android/app/build.gradle.kts`. The immutable historical public Android release
+is:
 
 - `versionName = 0.1.0-alpha.1`;
 - `versionCode = 1`;
@@ -74,12 +77,13 @@ public. Alpha.3 is the current public GitHub prerelease under tag
 `Metrora-Android-0.1.0-alpha.3.apk`. The public alpha.1 artifact consumed
 `versionCode = 1`; every later publicly installable Android upgrade must use a
 strictly larger `versionCode`.
+
 The human-readable `versionName` is used in the deterministic GitHub identity
 `android-v<versionName>` and asset name
 `Metrora-Android-<versionName>.apk`. Android's version line is independent of
-the frozen Windows Store package version. A future Play path keeps the same
-application ID and monotonic package line, subject to its separate signing and
-publication gates.
+the Windows Store package version. The planned Google Play release keeps the
+same application ID and monotonic package line; Google Play publication is
+planned within 30 days but remains non-authoritative until the listing is live.
 
 ## Ordering
 
@@ -105,7 +109,7 @@ The following values must agree where they represent the same authority:
 - root `package.json` and root `package-lock.json` — product SemVer;
 - desktop `app/package.json` and `app/package-lock.json` — product SemVer;
 - desktop `buildVersion` — desktop numeric build mapping;
-- `release/windows-store-package-version.v1.json` — published and candidate Store package versions;
+- `release/windows-store-package-version.v1.json` — Store package transition authority for candidate derivation;
 - Store AppX manifest — candidate Store package-version mapping after the hook;
 - current-version declarations in `RELEASING.md`;
 - current desktop declarations in `app/DISTRIBUTION.md`;
@@ -119,6 +123,6 @@ CI executes the same check on pull requests and pushes to `main`.
 
 ## Historical evidence
 
-Historical version references are immutable evidence, not active version authorities. Published RC7 release records and accepted 0.9.19 candidate reports, manifests, migration fixtures, provenance notices and changelog history retain their original version/source binding.
+Historical version references are immutable evidence, not active version authorities. Published RC7, RC10 and earlier accepted candidate reports, manifests, migration fixtures, provenance notices and changelog history retain their original version/source binding.
 
 Never rename an old report or artifact to the current version, and never treat an accepted artifact as evidence for a later source commit.

--- a/docs/WINDOWS_DISTRIBUTION.md
+++ b/docs/WINDOWS_DISTRIBUTION.md
@@ -8,9 +8,9 @@ Metrora for Windows is available on the **Microsoft Store**, published by Vensen
 
 The Microsoft Store package is the supported public Windows distribution. Repository builds and historical GitHub pre-releases remain separate development or archival artifacts and are not the recommended install path.
 
-The currently published Store line is traceable to source candidate `1.0.0-rc.10`, desktop build version `1.0.0.10`, and Store AppX identity version `1.0.0.0`. The current post-RC10 engineering candidate is `1.0.0-rc.11`, desktop build `1.0.0.11`, and Store AppX identity `1.0.1.0`; it has been submitted to Microsoft Partner Center and is undergoing certification, but is not publicly live. Development on `main` may advance independently after that published line.
+The currently published Store line is traceable to source candidate `1.0.0-rc.11`, desktop build version `1.0.0.11`, and Store AppX identity version `1.0.1.0`. RC11 was accepted through Microsoft certification and published as the Store update. The previous RC10 line (`1.0.0-rc.10`, Desktop `1.0.0.10`, Store `1.0.0.0`) remains immutable historical publication evidence. Development on `main` may advance independently after the published RC11 line.
 
-Historical 0.9.19 and RC7 acceptance material remains immutable evidence for those source lines only.
+Historical 0.9.19, RC7 and RC10 acceptance material remains immutable evidence for those source lines only.
 
 ## Identity
 
@@ -20,16 +20,14 @@ An official distribution uses the exact Metrora product and publisher identity a
 
 Windows uses multiple version authorities deliberately:
 
-- published Store source line: `1.0.0-rc.10`;
-- published desktop build version: `1.0.0.10`;
-- published Microsoft Store AppX identity version: `1.0.0.0`.
-- current candidate source line: `1.0.0-rc.11`;
-- current candidate desktop build version: `1.0.0.11`;
-- current candidate Store AppX identity version: `1.0.1.0`.
+- current published Store source line: `1.0.0-rc.11`;
+- current published desktop build version: `1.0.0.11`;
+- current published Microsoft Store AppX identity version: `1.0.1.0`;
+- previous published Store source line: `1.0.0-rc.10`;
+- previous published desktop build version: `1.0.0.10`;
+- previous published Store AppX identity version: `1.0.0.0`.
 
-The Store AppX four-part identity is not the desktop build counter. The
-published baseline and candidate are maintained in
-`release/windows-store-package-version.v1.json`. See [Versioning authority](VERSIONING.md).
+The Store AppX four-part identity is not the desktop build counter. The machine-readable packaging authority in `release/windows-store-package-version.v1.json` records the RC10-to-RC11 package-version transition used to derive this update. It must be advanced under a separately reviewed future Store-candidate decision before another Store package is derived; RC11 publication does not itself authorize RC12 or any later package version. See [Versioning authority](VERSIONING.md).
 
 ## Package requirements
 
@@ -54,7 +52,7 @@ The existing RC7 release remains immutable as a historical technical preview. La
 
 The Store workflow derives an x64 AppX from reviewed source and validates its identity, architecture, capabilities and bundled runtime boundary. It also imports `app/resources/cli.asar/dist/desktop-share-runtime.js` through the bundled Electron runtime and requires `createDesktopShareRuntime` without starting a listener. The Store manifest's four-part package identity remains separate from the desktop build counter.
 
-The published Store line passed its source-bound package and physical-runtime acceptance before publication. RC11 is the submitted, in-certification candidate; later source work remains separate until a future Store update is explicitly certified, published and made available.
+RC10 established the first published Store line. RC11 subsequently passed the source/package submission boundary, Microsoft certification and publication, and is now the current Store update. Later source work remains separate until a future Store update is explicitly reviewed, certified, published and made available.
 
 ## Accounting presentation boundary
 
@@ -78,10 +76,7 @@ For each future official Windows Store update, verify:
 10. no private data enters package metadata, reports or provenance;
 11. published artifacts remain bound to reviewed public source.
 
-The controlled RC10-to-RC11 update/profile-preservation test remains a deferred
-Founder-run acceptance step. The repository currently performs only the safe
-machine-verifiable package-version ordering check; it does not install over a
-real Store package or claim Microsoft Store-managed update certification.
+The RC10-to-RC11 Store publication is complete. Any separate Founder-run physical profile-preservation/update reproduction remains acceptance evidence rather than a prerequisite for truthfully stating Microsoft's publication result; the repository does not claim to simulate or control Microsoft Store-managed rollout behavior.
 
 ## Responsibility boundary
 

--- a/docs/WINDOWS_STORE_IDENTITY_V1.md
+++ b/docs/WINDOWS_STORE_IDENTITY_V1.md
@@ -1,6 +1,6 @@
 # Windows Store package identity v1
 
-**Status:** identity assigned / RC11 submitted and in certification / not published
+**Status:** identity assigned / RC11 accepted and published
 
 ## Purpose
 
@@ -8,14 +8,7 @@ Define the separate Windows Store packaging boundary for Metrora.
 
 The exact manifest values are maintained in the reviewed desktop build configuration. They must match the Store authority byte-for-byte and must not be duplicated across public documentation.
 
-RC10 is the frozen source line associated with the published Store package. The
-current engineering candidate is RC11 (`1.0.0-rc.11`) with Desktop build
-`1.0.0.11` and candidate Store package version `1.0.1.0`. RC11 has been
-submitted to Microsoft Partner Center and is undergoing certification; this
-document does not claim certification acceptance, publication or availability
-for RC11. Post-RC10 development is separate from the published artifact. It also does not
-authorize a different submission or any change to the already published
-GitHub `1.0.0-rc.7` artifacts.
+RC10 is the frozen source line associated with the first published Store package. RC11 (`1.0.0-rc.11`), Desktop build `1.0.0.11` and Store package version `1.0.1.0` was subsequently accepted by Microsoft and published as the current Store update. Post-RC11 development is separate from that published artifact and this document does not authorize RC12, another Store submission or any mutation of the already published GitHub `1.0.0-rc.7` artifacts.
 
 ## Build boundary
 
@@ -27,13 +20,9 @@ npm --prefix app run package:store
 
 The command produces one non-publishing x64 AppX candidate with the assigned Store identity and the required full-trust desktop capability.
 
-The Store package identity version is not derived from product SemVer or the
-Desktop build version. The single machine-readable authority is
-`release/windows-store-package-version.v1.json`, which records the published
-baseline `1.0.0.0` and the RC11 candidate `1.0.1.0`. The supported
-`appxManifestCreated` hook validates the generated `Package/Identity` shape and
-replaces only its Version value; it fails closed on an unexpected, missing or
-ambiguous identity.
+The Store package identity version is not derived from product SemVer or the Desktop build version. The machine-readable authority is `release/windows-store-package-version.v1.json`. Its current values record the RC10 published baseline and the RC11 package-version slot used for the now-published update. Before another Store candidate is derived, that authority must be advanced through a separately reviewed release decision so the published baseline becomes `1.0.1.0` and any next candidate remains strictly greater. RC11 publication alone does not authorize the next package version.
+
+The supported `appxManifestCreated` hook validates the generated `Package/Identity` shape and replaces only its Version value; it fails closed on an unexpected, missing or ambiguous identity.
 
 The existing technical-user installer remains separate:
 
@@ -47,17 +36,12 @@ Neither channel inherits the signature, certification or publication status of t
 
 The guided local path is documented in [`WINDOWS_STORE_LOCAL_TEST_GUIDED.md`](WINDOWS_STORE_LOCAL_TEST_GUIDED.md).
 
-It signs only a temporary copy. The public test certificate is trusted at machine level while its private key remains in the current-user personal store; both are removed with the installed package after validation. The unsigned submitted candidate is not modified.
+It signs only a temporary copy. The public test certificate is trusted at machine level while its private key remains in the current-user personal store; both are removed with the installed package after validation. The unsigned submission candidate is not modified.
 
 A local PASS is not Store certification and does not authorize publication or availability claims.
 
-## Current limitations
+## Current distribution state
 
-The Store target has a separate package identity and local-acceptance path. The
-RC11 candidate is not yet a publicly available Microsoft channel or an
-automatic update for existing installations. Submission and certification in
-progress do not constitute publication.
+RC11 is the current published Microsoft Store line under the assigned Metrora/Vensent identity. The previous RC10 package remains immutable historical publication evidence. Microsoft certification and publication do not make repository `main` byte-identical to the Store artifact; later source changes remain separate until a future Store update is reviewed and published.
 
-The RC10 source line and `1.0.0.0` package remain the live Store authority;
-certification, publication and Store-managed update behavior remain distinct
-gates. No post-RC10 code is part of the published RC10 artifact.
+Exact Store identity values remain only where technically required. Private verification documents, account details, addresses, tax identifiers, D-U-N-S data, credentials and recovery material must not be committed to the public repository.


### PR DESCRIPTION
## Purpose

Converge public distribution documentation after the RC11 Microsoft Store update was accepted/published and the Android distribution plan advanced.

## Current public state

- Microsoft Store: RC11 is the current published Windows line (`1.0.0-rc.11`, Desktop `1.0.0.11`, Store `1.0.1.0`), published by Vensent.
- RC10 remains immutable historical publication evidence.
- Android: production-signed `0.1.0-alpha.3` remains publicly downloadable from GitHub now.
- Google Play: release is planned within 30 days, but is not described as live until the listing is actually public.
- Current RC11 Store package contains the companion runtime used for Android pairing.

## Boundaries

- documentation/current-state only;
- no runtime/provider/accounting changes;
- no new Store candidate or RC12 authorization;
- no change to Android application identity/version;
- no D-U-N-S number, private verification documents, account identifiers, tax/address data or credentials exposed;
- historical evidence remains historical and is not relabeled.

The machine-readable Store package transition authority is deliberately not advanced to an invented next candidate; a later Store package version requires a separate release decision.