### PR TITLE
fix(optimize): enforce provider action authority

### DIFF
--- a/src/act/optimize-apply.ts
+++ b/src/act/optimize-apply.ts
@@ -13,6 +13,10 @@ export type ApplyOptions = {
   yes?: boolean
   dryRun?: boolean
   only?: string
+  // Mirrors optimize --provider. The scan below can read Claude transcripts
+  // and this path can plan/apply changes, so a non-Claude scope must never
+  // offer Claude config or archive actions from a hidden rescan.
+  provider?: string
   actionsDir?: string
   ctx?: PlanContext
   // Test seams: crafted findings skip the session scan; streams default to
@@ -114,7 +118,7 @@ export async function runOptimizeApply(
   let costRate = opts.costRate ?? 0
   if (!findings) {
     errout.write(chalk.dim('  Analyzing your sessions...\n'))
-    const scanned = await scanAndDetect(projects, dateRange)
+    const scanned = await scanAndDetect(projects, dateRange, opts.provider)
     findings = scanned.findings
     costRate = scanned.costRate
   }

--- a/src/act/optimize-apply.ts
+++ b/src/act/optimize-apply.ts
@@ -122,7 +122,10 @@ export async function runOptimizeApply(
     findings = scanned.findings
     costRate = scanned.costRate
   }
-  const plans = planFindings(findings, opts.ctx)
+  const plans = planFindings(findings, {
+    ...opts.ctx,
+    provider: opts.provider ?? opts.ctx?.provider,
+  })
 
   let appliable = plans.filter(p => p.plan !== null)
   const manual = plans.filter(p => p.plan === null)

--- a/src/act/plan-authority.ts
+++ b/src/act/plan-authority.ts
@@ -2,11 +2,13 @@ import { join } from 'path'
 import { normalizeOptimizeProvider } from '../optimize-cache-key.js'
 import { actionTargetAuthorized } from '../optimize-provider-authority.js'
 import type { BuiltPlan, ResolvedPaths } from './plans.js'
+import type { FindingId } from '../optimize.js'
 
 export function authorizeBuiltPlan(
   built: BuiltPlan,
   provider: string | undefined,
   r: ResolvedPaths,
+  findingId: FindingId,
 ): BuiltPlan {
   if (!built.plan) return built
   const claudePaths = [
@@ -15,7 +17,7 @@ export function authorizeBuiltPlan(
     r.projectMcpJson, r.userSettings, r.skillsDir, r.agentsDir, r.commandsDir,
     r.projectSettings, r.projectSettingsLocal,
   ]
-  if (actionTargetAuthorized(provider, built.plan, claudePaths)) return built
+  if (actionTargetAuthorized(provider, built.plan, claudePaths, findingId)) return built
 
   return {
     plan: null,

--- a/src/act/plan-authority.ts
+++ b/src/act/plan-authority.ts
@@ -1,0 +1,27 @@
+import { join } from 'path'
+import { normalizeOptimizeProvider } from '../optimize-cache-key.js'
+import { actionTargetAuthorized } from '../optimize-provider-authority.js'
+import type { BuiltPlan, ResolvedPaths } from './plans.js'
+
+export function authorizeBuiltPlan(
+  built: BuiltPlan,
+  provider: string | undefined,
+  r: ResolvedPaths,
+): BuiltPlan {
+  if (!built.plan) return built
+  const claudePaths = [
+    join(r.homeDir, '.claude'), r.userClaudeJson,
+    join(r.cwd, '.claude'), r.projectClaudeMd,
+    r.projectMcpJson, r.userSettings, r.skillsDir, r.agentsDir, r.commandsDir,
+    r.projectSettings, r.projectSettingsLocal,
+  ]
+  if (actionTargetAuthorized(provider, built.plan, claudePaths)) return built
+
+  return {
+    plan: null,
+    notes: [
+      ...built.notes,
+      'manual: ' + built.plan.kind + ' targets Claude-managed state and is not auto-appliable under provider=' + normalizeOptimizeProvider(provider),
+    ],
+  }
+}

--- a/src/act/plans.ts
+++ b/src/act/plans.ts
@@ -98,12 +98,12 @@ function resolvePaths(ctx: PlanContext): ResolvedPaths {
 
 export function planFor(finding: WasteFinding, ctx: PlanContext = {}): ActionPlan | null {
   const r = resolvePaths(ctx)
-  return authorizeBuiltPlan(buildPlanForFinding(finding, r), ctx.provider, r).plan
+  return authorizeBuiltPlan(buildPlanForFinding(finding, r), ctx.provider, r, finding.id).plan
 }
 
 export function planFindings(findings: WasteFinding[], ctx: PlanContext = {}): FindingPlan[] {
   const r = resolvePaths(ctx)
-  return findings.map(finding => ({ finding, ...authorizeBuiltPlan(buildPlanForFinding(finding, r), ctx.provider, r) }))
+  return findings.map(finding => ({ finding, ...authorizeBuiltPlan(buildPlanForFinding(finding, r), ctx.provider, r, finding.id) }))
 }
 
 function buildPlanForFinding(finding: WasteFinding, r: ResolvedPaths): BuiltPlan {

--- a/src/act/plans.ts
+++ b/src/act/plans.ts
@@ -12,6 +12,7 @@ import {
   versionPredates,
 } from '../optimize.js'
 import type { WasteFinding } from '../optimize.js'
+import { authorizeBuiltPlan } from './plan-authority.js'
 
 // Turns an optimize finding into a concrete, journaled file-mutation plan.
 // Only config-class findings are appliable; everything else yields plan: null
@@ -25,6 +26,7 @@ export type PlanContext = {
   // Installed Claude Code version (null when undeterminable). Injectable so
   // tests never shell out; production defaults to probing `claude --version`.
   claudeVersion?: () => string | null
+  provider?: string // action-target authority; omitted preserves all-provider behavior
 }
 
 export type BuiltPlan = {
@@ -38,7 +40,7 @@ export type BuiltPlan = {
 
 export type FindingPlan = BuiltPlan & { finding: WasteFinding }
 
-type ResolvedPaths = {
+export type ResolvedPaths = {
   homeDir: string
   cwd: string
   projectMcpJson: string
@@ -95,15 +97,16 @@ function resolvePaths(ctx: PlanContext): ResolvedPaths {
 }
 
 export function planFor(finding: WasteFinding, ctx: PlanContext = {}): ActionPlan | null {
-  return buildPlan(finding, resolvePaths(ctx)).plan
+  const r = resolvePaths(ctx)
+  return authorizeBuiltPlan(buildPlanForFinding(finding, r), ctx.provider, r).plan
 }
 
 export function planFindings(findings: WasteFinding[], ctx: PlanContext = {}): FindingPlan[] {
   const r = resolvePaths(ctx)
-  return findings.map(finding => ({ finding, ...buildPlan(finding, r) }))
+  return findings.map(finding => ({ finding, ...authorizeBuiltPlan(buildPlanForFinding(finding, r), ctx.provider, r) }))
 }
 
-function buildPlan(finding: WasteFinding, r: ResolvedPaths): BuiltPlan {
+function buildPlanForFinding(finding: WasteFinding, r: ResolvedPaths): BuiltPlan {
   switch (finding.id) {
     case 'mcp-low-coverage': return buildMcpRemove(finding, r)
     case 'unused-mcp': return buildMcpRemove(finding, r)
@@ -115,11 +118,7 @@ function buildPlan(finding: WasteFinding, r: ResolvedPaths): BuiltPlan {
     case 'unused-agents': return buildArchive(finding, r, 'agent')
     case 'unused-commands': return buildArchive(finding, r, 'command')
     case 'bash-output-cap': return buildShellConfig(finding, r)
-    default:
-      if (finding.fix.type === 'paste' && finding.fix.destination === 'claude-md') {
-        return buildClaudeMdRule(finding, r)
-      }
-      return { plan: null, notes: [] }
+    default: return finding.fix.type === 'paste' && finding.fix.destination === 'claude-md' ? buildClaudeMdRule(finding, r) : { plan: null, notes: [] }
   }
 }
 

--- a/src/dashboard.tsx
+++ b/src/dashboard.tsx
@@ -1037,14 +1037,14 @@ function InteractiveDashboard({ initialProjects, initialDailyHistoryProjects, in
     const generation = reloadGenerationRef.current
     setOptimizeLoading(true)
     try {
-      const result = await scanAndDetect(projects, currentRange())
+      const result = await scanAndDetect(projects, currentRange(), activeProvider)
       if (reloadGenerationRef.current === generation) setOptimizeResult(result)
     } catch (error) {
       console.error(error)
     } finally {
       if (reloadGenerationRef.current === generation) setOptimizeLoading(false)
     }
-  }, [optimizeAvailable, projects, currentRange, optimizeLoading, optimizeResult])
+  }, [optimizeAvailable, projects, currentRange, optimizeLoading, optimizeResult, activeProvider])
 
   useEffect(() => {
     if (!refreshSeconds || refreshSeconds <= 0) return

--- a/src/main.ts
+++ b/src/main.ts
@@ -1816,7 +1816,7 @@ program
     const projects = await parseAllSessions(range, opts.provider)
     if (opts.apply) {
       const { runOptimizeApply } = await import('./act/optimize-apply.js')
-      await runOptimizeApply(projects, range, { yes: opts.yes, dryRun: opts.dryRun, only: opts.only })
+      await runOptimizeApply(projects, range, { yes: opts.yes, dryRun: opts.dryRun, only: opts.only, provider: opts.provider })
       return
     }
     assertFormat(format, ['text', 'json'], 'optimize')
@@ -1834,9 +1834,9 @@ program
         appliedHeader = buildOptimizeAppliedHeader(applied) ?? undefined
         previouslyApplied = applied.appliedByFinding
       } catch { /* the header is optional; never block the findings */ }
-      await runOptimize(projects, label, range, { format, appliedHeader, previouslyApplied })
+      await runOptimize(projects, label, range, { format, appliedHeader, previouslyApplied, provider: opts.provider })
     } else {
-      await runOptimize(projects, label, range, { format })
+      await runOptimize(projects, label, range, { format, provider: opts.provider })
     }
   })
 

--- a/src/optimize-cache-key.ts
+++ b/src/optimize-cache-key.ts
@@ -2,7 +2,18 @@ import { createHash } from 'node:crypto'
 
 import type { DateRange, ProjectSummary } from './types.js'
 
-const OPTIMIZE_CACHE_KEY_VERSION = 'optimize-project-summary-v1'
+const OPTIMIZE_CACHE_KEY_VERSION = 'optimize-project-summary-v2'
+
+/**
+ * Keep the cache and detector-scope decisions on the same canonical provider
+ * value. CLI callers already pass validated provider names; this also keeps
+ * direct library callers from creating distinct keys for casing/whitespace
+ * variants and makes an omitted provider mean the existing all-provider view.
+ */
+export function normalizeOptimizeProvider(provider?: string): string {
+  const normalized = provider?.trim().toLowerCase()
+  return normalized || 'all'
+}
 
 function dateScope(dateRange: DateRange | undefined): string {
   return dateRange
@@ -18,10 +29,14 @@ function dateScope(dateRange: DateRange | undefined): string {
 export function optimizeResultCacheKey(
   projects: ProjectSummary[],
   dateRange: DateRange | undefined,
+  provider?: string,
 ): string {
+  const providerScope = normalizeOptimizeProvider(provider)
   const scope = dateScope(dateRange)
   const hash = createHash('sha256')
   hash.update(OPTIMIZE_CACHE_KEY_VERSION)
+  hash.update('\0')
+  hash.update(providerScope)
   hash.update('\0')
   hash.update(scope)
 
@@ -30,5 +45,5 @@ export function optimizeResultCacheKey(
     hash.update(JSON.stringify(project))
   }
 
-  return `${OPTIMIZE_CACHE_KEY_VERSION}:${scope}:${hash.digest('base64url')}`
+  return `${OPTIMIZE_CACHE_KEY_VERSION}:${providerScope}:${scope}:${hash.digest('base64url')}`
 }

--- a/src/optimize-provider-authority.ts
+++ b/src/optimize-provider-authority.ts
@@ -1,5 +1,6 @@
 import { normalizeOptimizeProvider } from './optimize-cache-key.js'
 import type { ActionKind, ActionPlan } from './act/types.js'
+import type { FindingId } from './optimize.js'
 
 /** Optimize's transcript/config evidence is currently Claude-specific. */
 export function providerCoversClaude(provider?: string): boolean {
@@ -34,6 +35,28 @@ export const ACTION_TARGET_AUTHORITY: Readonly<Record<ActionKind, ActionTargetAu
   'model-default': 'manual-only',
 }
 
+export type FindingEvidenceRequirement = 'claude-evidence-included' | 'explicit-claude-scope'
+
+/**
+ * Every current finding that can produce an automatic plan is listed here.
+ * ProjectSummary MCP findings require explicit Claude scope; the other
+ * automatic plans are only eligible after a Claude scan was included.
+ */
+export const FINDING_EVIDENCE_REQUIREMENT: Readonly<Partial<Record<FindingId, FindingEvidenceRequirement>>> = {
+  'read-edit-ratio': 'claude-evidence-included',
+  'build-folder-reads': 'claude-evidence-included',
+  'mcp-low-coverage': 'explicit-claude-scope',
+  'unused-mcp': 'claude-evidence-included',
+  'mcp-project-scope': 'explicit-claude-scope',
+  'mcp-deferral-off': 'claude-evidence-included',
+  'mcp-alwaysload-hygiene': 'claude-evidence-included',
+  'mcp-defer-threshold': 'claude-evidence-included',
+  'unused-skills': 'claude-evidence-included',
+  'unused-agents': 'claude-evidence-included',
+  'unused-commands': 'claude-evidence-included',
+  'bash-output-cap': 'claude-evidence-included',
+}
+
 function under(path: string, root: string): boolean {
   const normalize = (value: string): string => value.replaceAll('\\', '/').replace(/\/+$/, '')
   const [candidate, base] = [normalize(path), normalize(root)]
@@ -47,9 +70,17 @@ export function actionTargetAuthorized(
   provider: string | undefined,
   plan: ActionPlan,
   claudePaths: readonly string[],
+  findingId?: FindingId,
 ): boolean {
   const authority = ACTION_TARGET_AUTHORITY[plan.kind]
-  if (authority === 'claude-targeted') return providerCoversClaude(provider)
+  if (authority === 'claude-targeted') {
+    if (!providerCoversClaude(provider)) return false
+    const requirement = findingId ? FINDING_EVIDENCE_REQUIREMENT[findingId] : undefined
+    if (!requirement) return normalizeOptimizeProvider(provider) === 'claude'
+    return requirement === 'explicit-claude-scope'
+      ? normalizeOptimizeProvider(provider) === 'claude'
+      : true
+  }
   if (authority !== 'provider-neutral') return false
   if (providerCoversClaude(provider)) return true
   return plan.changes.every(change => {

--- a/src/optimize-provider-authority.ts
+++ b/src/optimize-provider-authority.ts
@@ -1,4 +1,5 @@
 import { normalizeOptimizeProvider } from './optimize-cache-key.js'
+import type { ActionKind, ActionPlan } from './act/types.js'
 
 /** Optimize's transcript/config evidence is currently Claude-specific. */
 export function providerCoversClaude(provider?: string): boolean {
@@ -12,4 +13,47 @@ export function claudeOnlyDetector<T>(
   detect: () => T | null,
 ): () => T | null {
   return providerCoversClaude(provider) ? detect : () => null
+}
+
+export type ActionTargetAuthority = 'claude-targeted' | 'provider-neutral' | 'manual-only'
+
+/** Current Optimize action ownership. Unknown/future actions fail closed. */
+export const ACTION_TARGET_AUTHORITY: Readonly<Record<ActionKind, ActionTargetAuthority>> = {
+  'mcp-remove': 'claude-targeted',
+  'mcp-project-scope': 'claude-targeted',
+  'defer-enable': 'claude-targeted',
+  'defer-alwaysload': 'claude-targeted',
+  'defer-threshold': 'claude-targeted',
+  'archive-skill': 'claude-targeted',
+  'archive-agent': 'claude-targeted',
+  'archive-command': 'claude-targeted',
+  'claude-md-rule': 'claude-targeted',
+  'shell-config': 'claude-targeted',
+  'guard-install': 'manual-only',
+  'guard-uninstall': 'manual-only',
+  'model-default': 'manual-only',
+}
+
+function under(path: string, root: string): boolean {
+  const normalize = (value: string): string => value.replaceAll('\\', '/').replace(/\/+$/, '')
+  const [candidate, base] = [normalize(path), normalize(root)]
+  const compare = process.platform === 'win32' ? (value: string) => value.toLowerCase() : (value: string) => value
+  const [normalizedCandidate, normalizedBase] = [compare(candidate), compare(base)]
+  return normalizedCandidate === normalizedBase || normalizedCandidate.startsWith(normalizedBase + '/')
+}
+
+/** A neutral action must not smuggle a Claude-owned destination into a plan. */
+export function actionTargetAuthorized(
+  provider: string | undefined,
+  plan: ActionPlan,
+  claudePaths: readonly string[],
+): boolean {
+  const authority = ACTION_TARGET_AUTHORITY[plan.kind]
+  if (authority === 'claude-targeted') return providerCoversClaude(provider)
+  if (authority !== 'provider-neutral') return false
+  if (providerCoversClaude(provider)) return true
+  return plan.changes.every(change => {
+    const paths = change.op === 'move' ? [change.path, change.movedTo] : [change.path]
+    return paths.every(path => !claudePaths.some(root => under(path, root)))
+  })
 }

--- a/src/optimize-provider-authority.ts
+++ b/src/optimize-provider-authority.ts
@@ -1,0 +1,15 @@
+import { normalizeOptimizeProvider } from './optimize-cache-key.js'
+
+/** Optimize's transcript/config evidence is currently Claude-specific. */
+export function providerCoversClaude(provider?: string): boolean {
+  const scope = normalizeOptimizeProvider(provider)
+  return scope === 'all' || scope === 'claude'
+}
+
+/** Do not turn a deliberately skipped Claude scan into observed-empty evidence. */
+export function claudeOnlyDetector<T>(
+  provider: string | undefined,
+  detect: () => T | null,
+): () => T | null {
+  return providerCoversClaude(provider) ? detect : () => null
+}

--- a/src/optimize.ts
+++ b/src/optimize.ts
@@ -13,6 +13,7 @@ import { formatTokens } from './format.js'
 import { recommendModelDefault, type ModelDefaultRecommendation } from './act/model-defaults.js'
 import { aggregateFileChurn, buildCoachingNotes, scanUserCorrections, medianTimeToFirstEditMs, worstOneShotCategory, type ReworkedFile } from './workflow-insights.js'
 import { optimizeResultCacheKey } from './optimize-cache-key.js'
+import { claudeOnlyDetector, providerCoversClaude } from './optimize-provider-authority.js'
 import { shortHomePath } from './optimize-paths.js'
 
 // ============================================================================
@@ -548,7 +549,8 @@ export async function scanJsonlFile(
   return { calls, cwds, apiCalls, userMessages }
 }
 
-async function scanSessions(dateRange?: DateRange): Promise<ScanData> {
+async function scanSessions(dateRange?: DateRange, provider?: string): Promise<ScanData | null> {
+  if (!providerCoversClaude(provider)) return null
   const sources = await discoverAllSessions('claude')
   const allCalls: ToolCall[] = []
   const allCwds = new Set<string>()
@@ -2965,17 +2967,18 @@ const resultCache = new Map<string, CacheEntry>()
 export async function scanAndDetect(
   projects: ProjectSummary[],
   dateRange?: DateRange,
+  provider?: string,
 ): Promise<OptimizeResult> {
   if (projects.length === 0) {
     return { findings: [], costRate: 0, healthScore: 100, healthGrade: 'A', modelRecommendations: [] }
   }
 
-  const key = optimizeResultCacheKey(projects, dateRange)
+  const key = optimizeResultCacheKey(projects, dateRange, provider)
   const cached = resultCache.get(key)
   if (cached && Date.now() - cached.ts < RESULT_CACHE_TTL_MS) return cached.data
 
   const costRate = computeInputCostRate(projects)
-  const { toolCalls, projectCwds, apiCalls, userMessages } = await scanSessions(dateRange)
+  const { toolCalls, projectCwds, apiCalls, userMessages } = await scanSessions(dateRange, provider) ?? { toolCalls: [], projectCwds: new Set<string>(), apiCalls: [], userMessages: [] }
   const mcpCoverage = aggregateMcpCoverage(projects)
 
   const findings: WasteFinding[] = []
@@ -2990,40 +2993,37 @@ export async function scanAndDetect(
   )
   const firstSessionIds = findYoungProjectFirstSessionIds(projects)
   const outlierExclusions = new Set([...lowWorthSessionIds, ...contextBloatVisibleIds, ...firstSessionIds])
+
   const syncDetectors: Array<() => WasteFinding | null> = [
-    () => detectCacheBloat(apiCalls, projects, dateRange),
-    () => detectLowReadEditRatio(toolCalls),
-    () => detectJunkReads(toolCalls, dateRange),
-    () => detectDuplicateReads(toolCalls, dateRange),
-    () => detectUnusedMcp(toolCalls, projects, projectCwds, mcpCoverage),
+    claudeOnlyDetector(provider, () => detectCacheBloat(apiCalls, projects, dateRange)),
+    claudeOnlyDetector(provider, () => detectLowReadEditRatio(toolCalls)),
+    claudeOnlyDetector(provider, () => detectJunkReads(toolCalls, dateRange)),
+    claudeOnlyDetector(provider, () => detectDuplicateReads(toolCalls, dateRange)),
+    claudeOnlyDetector(provider, () => detectUnusedMcp(toolCalls, projects, projectCwds, mcpCoverage)),
     () => detectMcpToolCoverage(projects, mcpCoverage),
     () => detectMcpProfileAdvisor(projects, mcpCoverage),
     // mcp-deferral-gaps family (#614): detection only, no apply plans yet.
-    () => detectMcpDeferralOff(toolCalls, projects, projectCwds, apiCalls),
-    () => detectMcpAlwaysLoadHygiene(projects, projectCwds, apiCalls, mcpCoverage),
-    () => detectMcpDeferThreshold(projects, projectCwds),
+    claudeOnlyDetector(provider, () => detectMcpDeferralOff(toolCalls, projects, projectCwds, apiCalls)),
+    claudeOnlyDetector(provider, () => detectMcpAlwaysLoadHygiene(projects, projectCwds, apiCalls, mcpCoverage)),
+    claudeOnlyDetector(provider, () => detectMcpDeferThreshold(projects, projectCwds)),
     () => detectCapabilityReliability(projects),
     () => detectLowWorthSessions(projects),
     () => detectContextBloat(projects, lowWorthSessionIds),
     () => detectSessionOutliers(projects, outlierExclusions),
-    () => detectBloatedClaudeMd(projectCwds),
-    () => detectBashBloat(),
+    claudeOnlyDetector(provider, () => detectBloatedClaudeMd(projectCwds)),
+    claudeOnlyDetector(provider, () => detectBashBloat()),
   ]
   for (const detect of syncDetectors) {
     const finding = detect()
     if (finding) findings.push(finding)
   }
 
-  const ghostResults = await Promise.all([
-    detectGhostAgents(toolCalls),
-    detectGhostSkills(toolCalls),
-    detectGhostCommands(userMessages),
-  ])
+  const ghostResults = await Promise.all(providerCoversClaude(provider) ? [detectGhostAgents(toolCalls), detectGhostSkills(toolCalls), detectGhostCommands(userMessages)] : [])
   for (const f of ghostResults) if (f) findings.push(f)
 
   findings.sort((a, b) => urgencyScore(b) - urgencyScore(a))
   const { score, grade } = computeHealth(findings)
-  
+
   const modelRecommendations: ModelDefaultRecommendation[] = []
   for (const project of projects) {
     const rec = recommendModelDefault(project, { now: dateRange?.end })
@@ -3246,7 +3246,7 @@ export async function runOptimize(
   projects: ProjectSummary[],
   periodLabel: string,
   dateRange?: DateRange,
-  opts: { format?: 'text' | 'json'; appliedHeader?: string; previouslyApplied?: Record<string, string> } = {},
+  opts: { format?: 'text' | 'json'; appliedHeader?: string; previouslyApplied?: Record<string, string>; provider?: string } = {},
 ): Promise<void> {
   const format = opts.format ?? 'text'
   if (projects.length === 0 && format === 'text') {
@@ -3258,7 +3258,7 @@ export async function runOptimize(
     process.stderr.write(chalk.dim('  Analyzing your sessions...\n'))
   }
 
-  const result = await scanAndDetect(projects, dateRange)
+  const result = await scanAndDetect(projects, dateRange, opts.provider)
   const { findings, costRate, healthScore, healthGrade } = result
   const sessions = projects.flatMap(p => p.sessions)
   const periodCost = projects.reduce((s, p) => s + p.totalCostUSD, 0)

--- a/src/usage-aggregator.ts
+++ b/src/usage-aggregator.ts
@@ -654,7 +654,7 @@ export async function buildMenubarPayloadForRange(periodInfo: PeriodInfo, opts: 
 
   const breakdowns = buildUsageBreakdowns(scanProjects)
 
-  const optimize = opts.optimize === false ? null : await scanAndDetect(scanProjects, scanRange)
+  const optimize = opts.optimize === false ? null : await scanAndDetect(scanProjects, scanRange, pf)
   const granularRange = opts.daysSelection?.range ?? scanRange
   const granularHistory = opts.timeline === false ? undefined : buildGranularHistory(scanProjects, granularRange)
   const periodDailyHistory = cacheDaysForPeriod ? dailyEntriesToHistory(cacheDaysForPeriod) : undefined

--- a/tests/optimize-action-target-authority.test.ts
+++ b/tests/optimize-action-target-authority.test.ts
@@ -9,7 +9,7 @@ import { runAction } from '../src/act/apply.js'
 import { undoAction } from '../src/act/undo.js'
 import { planFindings, planFor, type PlanContext } from '../src/act/plans.js'
 import { runOptimizeApply } from '../src/act/optimize-apply.js'
-import { ACTION_TARGET_AUTHORITY } from '../src/optimize-provider-authority.js'
+import { ACTION_TARGET_AUTHORITY, FINDING_EVIDENCE_REQUIREMENT } from '../src/optimize-provider-authority.js'
 import { scanAndDetect, type FindingApply, type FindingId, type WasteAction, type WasteFinding } from '../src/optimize.js'
 import type { ActionKind } from '../src/act/types.js'
 import type { ProjectSummary } from '../src/types.js'
@@ -104,6 +104,18 @@ const planCases: PlanCase[] = [
     setup: mcpRemoveSetup,
     finding: () => makeFinding('mcp-low-coverage', CMD_FIX, { kind: 'mcp-remove', servers: ['server'] }),
     actionKind: 'mcp-remove',
+    authority: 'claude-targeted',
+  },
+  {
+    name: 'build-folder-reads',
+    setup: () => {},
+    finding: () => makeFinding('build-folder-reads', {
+      type: 'paste',
+      destination: 'claude-md',
+      label: '',
+      text: 'Avoid generated folders.',
+    }),
+    actionKind: 'claude-md-rule',
     authority: 'claude-targeted',
   },
   {
@@ -238,19 +250,27 @@ describe('Optimize action-target authority', () => {
       'shell-config': 'claude-targeted',
     })
 
+    expect(FINDING_EVIDENCE_REQUIREMENT).toMatchObject({
+      'mcp-low-coverage': 'explicit-claude-scope',
+      'mcp-project-scope': 'explicit-claude-scope',
+    })
+
     for (const row of planCases) {
       const fx = makeFixture()
       row.setup(fx)
       const finding = row.finding(fx)
       expect(ACTION_TARGET_AUTHORITY[row.actionKind]).toBe(row.authority)
+      expect(FINDING_EVIDENCE_REQUIREMENT[finding.id]).toBeDefined()
 
       const codex = planFindings([finding], context(fx, 'codex'))[0]!
       const claude = planFindings([finding], context(fx, 'claude'))[0]!
       const all = planFindings([finding], context(fx, 'all'))[0]!
+      const allAutomatic = !['mcp-low-coverage', 'mcp-project-scope'].includes(finding.id)
 
       expect(codex.plan !== null, row.name).toBe(row.authority === 'provider-neutral')
       expect(claude.plan, row.name).not.toBeNull()
-      expect(all.plan, row.name).not.toBeNull()
+      expect(all.plan !== null, row.name).toBe(allAutomatic)
+      expect(planFor(finding, context(fx, 'all')) !== null, row.name).toBe(allAutomatic)
       if (row.authority === 'claude-targeted') {
         expect(codex.notes.join('\n')).toContain('not auto-appliable under provider=codex')
       }
@@ -279,6 +299,39 @@ describe('Optimize action-target authority', () => {
         expect(io.stderr(), row.name).toContain(finding.id)
         expect(io.stderr(), row.name).toContain('not-appliable')
         expect(existsSync(fx.actionsDir), row.name).toBe(false)
+      }
+    } finally {
+      process.exitCode = previousExitCode
+    }
+  })
+
+  it('rejects --only for ambiguous ProjectSummary MCP actions under all', async () => {
+    const previousExitCode = process.exitCode
+    try {
+      for (const id of ['mcp-low-coverage', 'mcp-project-scope'] as const) {
+        const fx = makeFixture()
+        mcpRemoveSetup(fx)
+        const finding = id === 'mcp-low-coverage'
+          ? makeFinding(id, CMD_FIX, { kind: 'mcp-remove', servers: ['server'] })
+          : makeFinding(id, CMD_FIX, {
+            kind: 'mcp-project-scope',
+            servers: [{ server: 'server', keepProjects: [fx.keeper], removeProjects: [] }],
+          })
+        process.exitCode = undefined
+        const io = captureIo()
+        await runOptimizeApply([], undefined, {
+          provider: 'all',
+          findings: [finding],
+          only: id,
+          actionsDir: fx.actionsDir,
+          ctx: context(fx, 'all'),
+          output: io.output,
+          errorOutput: io.errorOutput,
+        })
+        expect(process.exitCode, id).toBe(2)
+        expect(io.stderr(), id).toContain(id)
+        expect(io.stderr(), id).toContain('not-appliable')
+        expect(existsSync(fx.actionsDir), id).toBe(false)
       }
     } finally {
       process.exitCode = previousExitCode
@@ -316,6 +369,20 @@ describe('Optimize action-target authority', () => {
       errorOutput: applyIo.errorOutput,
     })
     expect(applyIo.stdout()).toContain('not auto-appliable')
+    expect(readFileSync(fx.claudeJson)).toEqual(original)
+    expect(existsSync(fx.actionsDir)).toBe(false)
+    const allIo = captureIo()
+    await runOptimizeApply([], undefined, {
+      provider: 'all',
+      findings: [finding],
+      dryRun: true,
+      actionsDir: fx.actionsDir,
+      ctx: context(fx, 'all'),
+      output: allIo.output,
+      errorOutput: allIo.errorOutput,
+    })
+    expect(allIo.stdout()).toContain('not auto-appliable')
+    expect(planFor(finding, context(fx, 'all'))).toBeNull()
     expect(readFileSync(fx.claudeJson)).toEqual(original)
     expect(existsSync(fx.actionsDir)).toBe(false)
 
@@ -380,6 +447,40 @@ describe('Optimize action-target authority', () => {
     expect(existsSync(codexFx.keeper)).toBe(false)
     expect(existsSync(codexFx.actionsDir)).toBe(false)
 
+    const allFx = makeFixture()
+    mcpRemoveSetup(allFx)
+    const allFinding = makeFinding('mcp-project-scope', CMD_FIX, {
+      kind: 'mcp-project-scope',
+      servers: [{ server: 'server', keepProjects: [allFx.keeper], removeProjects: [] }],
+    })
+    const allDryIo = captureIo()
+    await runOptimizeApply([], undefined, {
+      provider: 'all',
+      findings: [allFinding],
+      dryRun: true,
+      actionsDir: allFx.actionsDir,
+      ctx: context(allFx, 'all'),
+      output: allDryIo.output,
+      errorOutput: allDryIo.errorOutput,
+    })
+    expect(allDryIo.stdout()).toContain('not auto-appliable')
+    expect(planFor(allFinding, context(allFx, 'all'))).toBeNull()
+    expect(readFileSync(allFx.claudeJson)).toEqual(readFileSync(codexFx.claudeJson))
+    expect(existsSync(allFx.keeper)).toBe(false)
+    expect(existsSync(allFx.actionsDir)).toBe(false)
+
+    await runOptimizeApply([], undefined, {
+      provider: 'all',
+      findings: [allFinding],
+      yes: true,
+      actionsDir: allFx.actionsDir,
+      ctx: context(allFx, 'all'),
+      output: captureIo().output,
+      errorOutput: captureIo().errorOutput,
+    })
+    expect(readFileSync(allFx.claudeJson)).toEqual(readFileSync(codexFx.claudeJson))
+    expect(existsSync(allFx.keeper)).toBe(false)
+    expect(existsSync(allFx.actionsDir)).toBe(false)
     const claudeFx = makeFixture()
     mcpRemoveSetup(claudeFx)
     const claudeFinding = makeFinding('mcp-project-scope', CMD_FIX, {

--- a/tests/optimize-action-target-authority.test.ts
+++ b/tests/optimize-action-target-authority.test.ts
@@ -1,0 +1,496 @@
+import { afterAll, describe, expect, it, vi } from 'vitest'
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { spawnSync } from 'node:child_process'
+import { Writable } from 'node:stream'
+
+import { runAction } from '../src/act/apply.js'
+import { undoAction } from '../src/act/undo.js'
+import { planFindings, planFor, type PlanContext } from '../src/act/plans.js'
+import { runOptimizeApply } from '../src/act/optimize-apply.js'
+import { ACTION_TARGET_AUTHORITY } from '../src/optimize-provider-authority.js'
+import { scanAndDetect, type FindingApply, type FindingId, type WasteAction, type WasteFinding } from '../src/optimize.js'
+import type { ActionKind } from '../src/act/types.js'
+import type { ProjectSummary } from '../src/types.js'
+
+vi.setConfig({ testTimeout: 30_000 })
+
+const roots: string[] = []
+const CMD_FIX: WasteAction = { type: 'command', label: '', text: '' }
+
+type Fixture = {
+  root: string
+  home: string
+  project: string
+  claudeJson: string
+  projectMcp: string
+  settings: string
+  keeper: string
+  actionsDir: string
+}
+
+function makeFixture(): Fixture {
+  const root = mkdtempSync(join(tmpdir(), 'metrora-action-target-'))
+  roots.push(root)
+  const home = join(root, 'home')
+  const project = join(root, 'project')
+  mkdirSync(home, { recursive: true })
+  mkdirSync(project, { recursive: true })
+  return {
+    root,
+    home,
+    project,
+    claudeJson: join(home, '.claude.json'),
+    projectMcp: join(project, '.mcp.json'),
+    settings: join(project, '.claude', 'settings.json'),
+    keeper: join(root, 'keeper'),
+    actionsDir: join(root, 'actions'),
+  }
+}
+
+function writeJson(path: string, value: unknown): void {
+  mkdirSync(dirname(path), { recursive: true })
+  writeFileSync(path, JSON.stringify(value, null, 2) + '\n')
+}
+
+function makeFinding(id: FindingId, fix: WasteAction, apply?: FindingApply): WasteFinding {
+  return { id, title: id, explanation: '', impact: 'medium', tokensSaved: 1000, fix, ...(apply ? { apply } : {}) }
+}
+
+function context(fx: Fixture, provider: string): PlanContext {
+  return {
+    homeDir: fx.home,
+    cwd: fx.project,
+    shell: '/bin/zsh',
+    provider,
+    claudeVersion: () => '2.1.130',
+  }
+}
+
+type Io = {
+  output: Writable
+  errorOutput: Writable
+  stdout: () => string
+  stderr: () => string
+}
+
+function captureIo(): Io {
+  let stdout = ''
+  let stderr = ''
+  return {
+    output: new Writable({ write(chunk, _encoding, callback) { stdout += chunk.toString(); callback() } }),
+    errorOutput: new Writable({ write(chunk, _encoding, callback) { stderr += chunk.toString(); callback() } }),
+    stdout: () => stdout.replace(/\u001b\[[0-9;]*m/g, ''),
+    stderr: () => stderr.replace(/\u001b\[[0-9;]*m/g, ''),
+  }
+}
+
+function mcpRemoveSetup(fx: Fixture): void {
+  writeJson(fx.claudeJson, { mcpServers: { server: { command: 'node' } } })
+}
+
+type PlanCase = {
+  name: string
+  finding: (fx: Fixture) => WasteFinding
+  setup: (fx: Fixture) => void
+  actionKind: ActionKind
+  authority: 'claude-targeted' | 'provider-neutral'
+}
+
+const planCases: PlanCase[] = [
+  {
+    name: 'mcp-low-coverage',
+    setup: mcpRemoveSetup,
+    finding: () => makeFinding('mcp-low-coverage', CMD_FIX, { kind: 'mcp-remove', servers: ['server'] }),
+    actionKind: 'mcp-remove',
+    authority: 'claude-targeted',
+  },
+  {
+    name: 'unused-mcp',
+    setup: mcpRemoveSetup,
+    finding: () => makeFinding('unused-mcp', CMD_FIX, { kind: 'mcp-remove', servers: ['server'] }),
+    actionKind: 'mcp-remove',
+    authority: 'claude-targeted',
+  },
+  {
+    name: 'mcp-project-scope',
+    setup: fx => {
+      mcpRemoveSetup(fx)
+      mkdirSync(fx.keeper, { recursive: true })
+    },
+    finding: fx => makeFinding('mcp-project-scope', CMD_FIX, {
+      kind: 'mcp-project-scope',
+      servers: [{ server: 'server', keepProjects: [fx.keeper], removeProjects: [] }],
+    }),
+    actionKind: 'mcp-project-scope',
+    authority: 'claude-targeted',
+  },
+  {
+    name: 'mcp-deferral-off',
+    setup: fx => writeJson(fx.settings, { env: { ENABLE_TOOL_SEARCH: 'false' } }),
+    finding: fx => makeFinding('mcp-deferral-off', CMD_FIX, {
+      kind: 'defer-enable',
+      cause: 'env-false',
+      settingPath: fx.settings,
+      settingScope: 'settings',
+      value: 'false',
+    }),
+    actionKind: 'defer-enable',
+    authority: 'claude-targeted',
+  },
+  {
+    name: 'mcp-alwaysload-hygiene',
+    setup: fx => writeJson(fx.projectMcp, { mcpServers: { server: { command: 'node', alwaysLoad: true } } }),
+    finding: fx => makeFinding('mcp-alwaysload-hygiene', CMD_FIX, {
+      kind: 'defer-alwaysload',
+      servers: [{ server: 'server', paths: [fx.projectMcp] }],
+    }),
+    actionKind: 'defer-alwaysload',
+    authority: 'claude-targeted',
+  },
+  {
+    name: 'mcp-defer-threshold',
+    setup: fx => writeJson(fx.settings, { env: { ENABLE_TOOL_SEARCH: 'auto:50' } }),
+    finding: fx => makeFinding('mcp-defer-threshold', CMD_FIX, {
+      kind: 'defer-threshold',
+      settingPath: fx.settings,
+      settingScope: 'settings',
+      value: 'auto:50',
+      recommendedPercent: 10,
+      removeOverride: false,
+    }),
+    actionKind: 'defer-threshold',
+    authority: 'claude-targeted',
+  },
+  {
+    name: 'unused-skills',
+    setup: fx => {
+      mkdirSync(join(fx.home, '.claude', 'skills', 'skill'), { recursive: true })
+      writeFileSync(join(fx.home, '.claude', 'skills', 'skill', 'SKILL.md'), 'skill\n')
+    },
+    finding: () => makeFinding('unused-skills', CMD_FIX, { kind: 'archive', names: ['skill'] }),
+    actionKind: 'archive-skill',
+    authority: 'claude-targeted',
+  },
+  {
+    name: 'unused-agents',
+    setup: fx => {
+      mkdirSync(join(fx.home, '.claude', 'agents'), { recursive: true })
+      writeFileSync(join(fx.home, '.claude', 'agents', 'agent.md'), 'agent\n')
+    },
+    finding: () => makeFinding('unused-agents', CMD_FIX, { kind: 'archive', names: ['agent'] }),
+    actionKind: 'archive-agent',
+    authority: 'claude-targeted',
+  },
+  {
+    name: 'unused-commands',
+    setup: fx => {
+      mkdirSync(join(fx.home, '.claude', 'commands'), { recursive: true })
+      writeFileSync(join(fx.home, '.claude', 'commands', 'command.md'), 'command\n')
+    },
+    finding: () => makeFinding('unused-commands', CMD_FIX, { kind: 'archive', names: ['command'] }),
+    actionKind: 'archive-command',
+    authority: 'claude-targeted',
+  },
+  {
+    name: 'claude-md-rule',
+    setup: () => {},
+    finding: () => makeFinding('read-edit-ratio', {
+      type: 'paste',
+      destination: 'claude-md',
+      label: '',
+      text: 'Read before editing.',
+    }),
+    actionKind: 'claude-md-rule',
+    authority: 'claude-targeted',
+  },
+  {
+    name: 'bash-output-cap',
+    setup: () => {},
+    finding: () => makeFinding('bash-output-cap', {
+      type: 'paste',
+      destination: 'shell-config',
+      label: '',
+      text: 'export BASH_MAX_OUTPUT_LENGTH=15000',
+    }),
+    actionKind: 'shell-config',
+    authority: 'claude-targeted',
+  },
+]
+
+afterAll(() => {
+  for (const root of roots) rmSync(root, { recursive: true, force: true })
+})
+
+describe('Optimize action-target authority', () => {
+  it('classifies every current automatic plan and fails Claude targets closed for Codex', () => {
+    expect(ACTION_TARGET_AUTHORITY).toMatchObject({
+      'mcp-remove': 'claude-targeted',
+      'mcp-project-scope': 'claude-targeted',
+      'defer-enable': 'claude-targeted',
+      'defer-alwaysload': 'claude-targeted',
+      'defer-threshold': 'claude-targeted',
+      'archive-skill': 'claude-targeted',
+      'archive-agent': 'claude-targeted',
+      'archive-command': 'claude-targeted',
+      'claude-md-rule': 'claude-targeted',
+      'shell-config': 'claude-targeted',
+    })
+
+    for (const row of planCases) {
+      const fx = makeFixture()
+      row.setup(fx)
+      const finding = row.finding(fx)
+      expect(ACTION_TARGET_AUTHORITY[row.actionKind]).toBe(row.authority)
+
+      const codex = planFindings([finding], context(fx, 'codex'))[0]!
+      const claude = planFindings([finding], context(fx, 'claude'))[0]!
+      const all = planFindings([finding], context(fx, 'all'))[0]!
+
+      expect(codex.plan !== null, row.name).toBe(row.authority === 'provider-neutral')
+      expect(claude.plan, row.name).not.toBeNull()
+      expect(all.plan, row.name).not.toBeNull()
+      if (row.authority === 'claude-targeted') {
+        expect(codex.notes.join('\n')).toContain('not auto-appliable under provider=codex')
+      }
+    }
+  })
+
+  it('rejects --only for every Claude-targeted automatic plan under Codex', async () => {
+    const previousExitCode = process.exitCode
+    try {
+      for (const row of planCases.filter(item => item.authority === 'claude-targeted')) {
+        const fx = makeFixture()
+        row.setup(fx)
+        const finding = row.finding(fx)
+        process.exitCode = undefined
+        const io = captureIo()
+        await runOptimizeApply([], undefined, {
+          provider: 'codex',
+          findings: [finding],
+          only: finding.id,
+          actionsDir: fx.actionsDir,
+          ctx: context(fx, 'codex'),
+          output: io.output,
+          errorOutput: io.errorOutput,
+        })
+        expect(process.exitCode, row.name).toBe(2)
+        expect(io.stderr(), row.name).toContain(finding.id)
+        expect(io.stderr(), row.name).toContain('not-appliable')
+        expect(existsSync(fx.actionsDir), row.name).toBe(false)
+      }
+    } finally {
+      process.exitCode = previousExitCode
+    }
+  })
+  it('rejects a crafted mcp-low-coverage plan at runOptimizeApply, including --only', async () => {
+    const fx = makeFixture()
+    mcpRemoveSetup(fx)
+    const original = readFileSync(fx.claudeJson)
+    const finding = makeFinding('mcp-low-coverage', CMD_FIX, { kind: 'mcp-remove', servers: ['server'] })
+
+    const dryIo = captureIo()
+    await runOptimizeApply([], undefined, {
+      provider: 'codex',
+      findings: [finding],
+      dryRun: true,
+      actionsDir: fx.actionsDir,
+      ctx: context(fx, 'codex'),
+      output: dryIo.output,
+      errorOutput: dryIo.errorOutput,
+    })
+    expect(dryIo.stdout()).toContain('mcp-low-coverage')
+    expect(dryIo.stdout()).toContain('not auto-appliable')
+    expect(readFileSync(fx.claudeJson)).toEqual(original)
+    expect(existsSync(fx.actionsDir)).toBe(false)
+
+    const applyIo = captureIo()
+    await runOptimizeApply([], undefined, {
+      provider: 'codex',
+      findings: [finding],
+      yes: true,
+      actionsDir: fx.actionsDir,
+      ctx: context(fx, 'codex'),
+      output: applyIo.output,
+      errorOutput: applyIo.errorOutput,
+    })
+    expect(applyIo.stdout()).toContain('not auto-appliable')
+    expect(readFileSync(fx.claudeJson)).toEqual(original)
+    expect(existsSync(fx.actionsDir)).toBe(false)
+
+    const previousExitCode = process.exitCode
+    try {
+      process.exitCode = undefined
+      const onlyIo = captureIo()
+      await runOptimizeApply([], undefined, {
+        provider: 'codex',
+        findings: [finding],
+        only: 'mcp-low-coverage',
+        actionsDir: fx.actionsDir,
+        ctx: context(fx, 'codex'),
+        output: onlyIo.output,
+        errorOutput: onlyIo.errorOutput,
+      })
+      expect(process.exitCode).toBe(2)
+      expect(onlyIo.stderr()).toContain('mcp-low-coverage')
+      expect(onlyIo.stderr()).toContain('not-appliable')
+      expect(readFileSync(fx.claudeJson)).toEqual(original)
+      expect(existsSync(fx.actionsDir)).toBe(false)
+    } finally {
+      process.exitCode = previousExitCode
+    }
+  })
+
+  it('rejects crafted mcp-project-scope under Codex but preserves the Claude plan and undo', async () => {
+    const codexFx = makeFixture()
+    mcpRemoveSetup(codexFx)
+    const original = readFileSync(codexFx.claudeJson)
+    const finding = makeFinding('mcp-project-scope', CMD_FIX, {
+      kind: 'mcp-project-scope',
+      servers: [{ server: 'server', keepProjects: [codexFx.keeper], removeProjects: [] }],
+    })
+
+    const dryIo = captureIo()
+    await runOptimizeApply([], undefined, {
+      provider: 'codex',
+      findings: [finding],
+      dryRun: true,
+      actionsDir: codexFx.actionsDir,
+      ctx: context(codexFx, 'codex'),
+      output: dryIo.output,
+      errorOutput: dryIo.errorOutput,
+    })
+    expect(dryIo.stdout()).toContain('mcp-project-scope')
+    expect(dryIo.stdout()).toContain('not auto-appliable')
+    expect(readFileSync(codexFx.claudeJson)).toEqual(original)
+    expect(existsSync(codexFx.keeper)).toBe(false)
+    expect(existsSync(codexFx.actionsDir)).toBe(false)
+
+    await runOptimizeApply([], undefined, {
+      provider: 'codex',
+      findings: [finding],
+      yes: true,
+      actionsDir: codexFx.actionsDir,
+      ctx: context(codexFx, 'codex'),
+      output: captureIo().output,
+      errorOutput: captureIo().errorOutput,
+    })
+    expect(readFileSync(codexFx.claudeJson)).toEqual(original)
+    expect(existsSync(codexFx.keeper)).toBe(false)
+    expect(existsSync(codexFx.actionsDir)).toBe(false)
+
+    const claudeFx = makeFixture()
+    mcpRemoveSetup(claudeFx)
+    const claudeFinding = makeFinding('mcp-project-scope', CMD_FIX, {
+      kind: 'mcp-project-scope',
+      servers: [{ server: 'server', keepProjects: [claudeFx.keeper], removeProjects: [] }],
+    })
+    mkdirSync(claudeFx.keeper, { recursive: true })
+    const plan = planFor(claudeFinding, context(claudeFx, 'claude'))
+    expect(plan).not.toBeNull()
+    const record = await runAction(plan!, claudeFx.actionsDir)
+    expect(JSON.parse(readFileSync(claudeFx.claudeJson, 'utf-8')).mcpServers).toEqual({})
+    expect(JSON.parse(readFileSync(join(claudeFx.keeper, '.mcp.json'), 'utf-8')).mcpServers).toEqual({ server: { command: 'node' } })
+    await undoAction({ id: record.id }, { actionsDir: claudeFx.actionsDir })
+    expect(readFileSync(claudeFx.claudeJson)).toEqual(readFileSync(codexFx.claudeJson))
+    expect(existsSync(join(claudeFx.keeper, '.mcp.json'))).toBe(false)
+  })
+
+  it('keeps Codex MCP reporting while rejecting its current Claude-targeted mutation', async () => {
+    const fx = makeFixture()
+    mcpRemoveSetup(fx)
+    const inventory = Array.from({ length: 12 }, (_, i) => 'mcp__server__tool-' + i)
+    const makeSession = (sessionId: string): ProjectSummary['sessions'][number] => ({
+      sessionId,
+      project: 'codex-reporting',
+      firstTimestamp: '2026-08-01T00:00:00.000Z',
+      lastTimestamp: '2026-08-01T00:01:00.000Z',
+      totalCostUSD: 1,
+      totalSavingsUSD: 0,
+      totalInputTokens: 100,
+      totalOutputTokens: 20,
+      totalReasoningTokens: 0,
+      totalCacheReadTokens: 0,
+      totalCacheWriteTokens: 0,
+      apiCalls: 1,
+      turns: [],
+      modelBreakdown: {},
+      toolBreakdown: {},
+      mcpBreakdown: { server: { calls: 0 } },
+      bashBreakdown: {},
+      categoryBreakdown: {},
+      skillBreakdown: {},
+      subagentBreakdown: {},
+      mcpInventory: inventory,
+    })
+    const project: ProjectSummary = {
+      project: 'codex-reporting',
+      projectPath: fx.project,
+      sessions: [makeSession('one'), makeSession('two')],
+      totalCostUSD: 2,
+      totalSavingsUSD: 0,
+      totalApiCalls: 2,
+      totalProxiedCostUSD: 0,
+    }
+    const result = await scanAndDetect([project], undefined, 'codex')
+    const finding = result.findings.find(item => item.id === 'mcp-low-coverage')
+    expect(finding).toBeDefined()
+
+    const io = captureIo()
+    await runOptimizeApply([project], undefined, {
+      provider: 'codex',
+      findings: [finding!],
+      dryRun: true,
+      actionsDir: fx.actionsDir,
+      ctx: context(fx, 'codex'),
+      output: io.output,
+      errorOutput: io.errorOutput,
+    })
+    expect(io.stdout()).toContain('mcp-low-coverage')
+    expect(io.stdout()).toContain('not auto-appliable')
+    const original = readFileSync(fx.claudeJson)
+    expect(readFileSync(fx.claudeJson)).toEqual(original)
+    expect(existsSync(fx.actionsDir)).toBe(false)
+  })
+
+  it('uses the same provider-aware action eligibility on the real CLI path', () => {
+    const fx = makeFixture()
+    const codexDir = join(fx.home, '.codex', 'sessions', '2026', '08', '01')
+    mkdirSync(codexDir, { recursive: true })
+    writeFileSync(join(codexDir, 'rollout.jsonl'), [
+      JSON.stringify({ type: 'session_meta', timestamp: '2026-08-01T10:00:00.000Z', payload: { session_id: 'cli-codex', model: 'gpt-5.3-codex', cwd: fx.project, originator: 'codex-cli' } }),
+      JSON.stringify({ type: 'response_item', timestamp: '2026-08-01T10:00:01.000Z', payload: { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'inspect' }] } }),
+      JSON.stringify({ type: 'event_msg', timestamp: '2026-08-01T10:00:02.000Z', payload: { type: 'token_count', info: { last_token_usage: { input_tokens: 100, output_tokens: 20, total_tokens: 120 }, total_token_usage: { input_tokens: 100, output_tokens: 20, total_tokens: 120 } } } }),
+    ].join('\n') + '\n')
+    mcpRemoveSetup(fx)
+
+    const env = {
+      ...process.env,
+      HOME: fx.home,
+      USERPROFILE: fx.home,
+      HOMEPATH: fx.home,
+      HOMEDRIVE: '',
+      APPDATA: join(fx.home, 'AppData', 'Roaming'),
+      LOCALAPPDATA: join(fx.home, 'AppData', 'Local'),
+      CLAUDE_CONFIG_DIR: join(fx.home, '.claude'),
+      CODEX_HOME: join(fx.home, '.codex'),
+      METRORA_CACHE_DIR: join(fx.home, 'metrora-cache'),
+      METRORA_CONFIG_DIR: join(fx.home, 'metrora-config'),
+      XDG_CONFIG_HOME: join(fx.home, '.config'),
+      XDG_DATA_HOME: join(fx.home, '.local', 'share'),
+      OPENCODE_DATA_DIR: join(fx.home, '.local', 'share', 'opencode'),
+      TZ: 'UTC',
+    }
+    const result = spawnSync(process.execPath, ['--import', 'tsx', 'src/cli.ts', 'optimize', '--provider', 'codex', '--from', '2026-08-01', '--to', '2026-08-01', '--apply', '--dry-run'], {
+      cwd: process.cwd(),
+      env,
+      encoding: 'utf-8',
+      timeout: 30_000,
+    })
+    expect(result.status).toBe(0)
+    expect(result.stdout).not.toContain('.claude')
+    expect(result.stdout).not.toContain('mcp-low-coverage')
+    expect(existsSync(fx.actionsDir)).toBe(false)
+  })
+})

--- a/tests/optimize-apply.test.ts
+++ b/tests/optimize-apply.test.ts
@@ -83,7 +83,7 @@ describe('mcp-remove plan', () => {
     await writeFile(join(fx.project, '.mcp.json'), JSON.stringify({ mcpServers: { gamma: {} } }, null, 2) + '\n')
 
     const finding = makeFinding('mcp-low-coverage', CMD_FIX, { kind: 'mcp-remove', servers: ['beta'] })
-    const plan = planFor(finding, { homeDir: fx.home, cwd: fx.project })
+    const plan = planFor(finding, { homeDir: fx.home, cwd: fx.project, provider: 'claude' })
     expect(plan).not.toBeNull()
     expect(plan!.changes).toHaveLength(1)
     expect(plan!.changes[0]!.path).toBe(claudeJson)
@@ -121,7 +121,7 @@ describe('mcp-project-scope plan', () => {
       kind: 'mcp-project-scope',
       servers: [{ server: 'srv', keepProjects: [keeper], removeProjects: [] }],
     })
-    const plan = planFor(finding, { homeDir: fx.home, cwd: fx.project })
+    const plan = planFor(finding, { homeDir: fx.home, cwd: fx.project, provider: 'claude' })
     expect(plan).not.toBeNull()
 
     const rec = await runAction(plan!, fx.actionsDir)
@@ -145,7 +145,7 @@ describe('unparseable config file', () => {
     await writeFile(brokenMcp, '{ this is not valid json,,, ')
 
     const finding = makeFinding('mcp-low-coverage', CMD_FIX, { kind: 'mcp-remove', servers: ['good', 'bad'] })
-    const { plan, notes } = planFindings([finding], { homeDir: fx.home, cwd: fx.project })[0]!
+    const { plan, notes } = planFindings([finding], { homeDir: fx.home, cwd: fx.project, provider: 'claude' })[0]!
 
     expect(notes.some(n => /could not parse/.test(n) && n.includes('.mcp.json'))).toBe(true)
     expect(notes.some(n => n.includes('bad'))).toBe(true)
@@ -173,7 +173,7 @@ describe('archive plan', () => {
     await writeFile(join(agentsDir, 'bar.md'), 'agent body')
 
     const skillFinding = makeFinding('unused-skills', CMD_FIX, { kind: 'archive', names: ['foo'] })
-    const skillPlan = planFor(skillFinding, { homeDir: fx.home, cwd: fx.project })
+    const skillPlan = planFor(skillFinding, { homeDir: fx.home, cwd: fx.project, provider: 'claude' })
     expect(skillPlan!.changes[0]).toMatchObject({
       op: 'move',
       path: join(skillsDir, 'foo'),
@@ -186,7 +186,7 @@ describe('archive plan', () => {
     expect(await readFile(join(skillsDir, '.archived', 'foo', 'SKILL.md'), 'utf-8')).toBe('old archived')
 
     const agentFinding = makeFinding('unused-agents', CMD_FIX, { kind: 'archive', names: ['bar'] })
-    const agentPlan = planFor(agentFinding, { homeDir: fx.home, cwd: fx.project })
+    const agentPlan = planFor(agentFinding, { homeDir: fx.home, cwd: fx.project, provider: 'claude' })
     expect(agentPlan!.changes[0]).toMatchObject({
       op: 'move',
       path: join(agentsDir, 'bar.md'),
@@ -211,7 +211,7 @@ describe('claude-md rule plan', () => {
     await writeFile(claudeMd, original)
 
     const first = makeFinding('read-edit-ratio', { type: 'paste', destination: 'claude-md', label: '', text: 'Read before editing.' })
-    const firstPlan = planFor(first, { homeDir: fx.home, cwd: fx.project })
+    const firstPlan = planFor(first, { homeDir: fx.home, cwd: fx.project, provider: 'claude' })
     const firstRec = await runAction(firstPlan!, fx.actionsDir)
 
     let body = await readFile(claudeMd, 'utf-8')
@@ -222,7 +222,7 @@ describe('claude-md rule plan', () => {
 
     // Second apply with the same id replaces the block instead of duplicating.
     const second = makeFinding('read-edit-ratio', { type: 'paste', destination: 'claude-md', label: '', text: 'Read first, then edit.' })
-    const secondPlan = planFor(second, { homeDir: fx.home, cwd: fx.project })
+    const secondPlan = planFor(second, { homeDir: fx.home, cwd: fx.project, provider: 'claude' })
     const secondRec = await runAction(secondPlan!, fx.actionsDir)
 
     body = await readFile(claudeMd, 'utf-8')
@@ -240,7 +240,7 @@ describe('shell-config plan', () => {
   it('writes the bash cap inside # markers to the rc chosen from $SHELL', async () => {
     const fx = await makeFixture()
     const finding = makeFinding('bash-output-cap', { type: 'paste', destination: 'shell-config', label: '', text: 'export BASH_MAX_OUTPUT_LENGTH=15000' })
-    const plan = planFor(finding, { homeDir: fx.home, cwd: fx.project, shell: '/bin/zsh' })
+    const plan = planFor(finding, { homeDir: fx.home, cwd: fx.project, provider: 'claude', shell: '/bin/zsh' })
     expect(plan!.changes[0]!.path).toBe(join(fx.home, '.zshrc'))
 
     await runAction(plan!, fx.actionsDir)
@@ -265,7 +265,7 @@ describe('dry-run', () => {
     ]
 
     const before = await hashTree(fx.root)
-    const plans = planFindings(findings, { homeDir: fx.home, cwd: fx.project, shell: '/bin/zsh' })
+    const plans = planFindings(findings, { homeDir: fx.home, cwd: fx.project, provider: 'claude', shell: '/bin/zsh' })
     // Exercise the exact rendering the dry-run path prints.
     renderApplyList(plans.filter(p => p.plan !== null), plans.filter(p => p.plan === null), 0.000002)
     const after = await hashTree(fx.root)
@@ -332,7 +332,7 @@ describe('unused-mcp plan', () => {
     }, null, 2) + '\n')
 
     const finding = makeFinding('unused-mcp', CMD_FIX, { kind: 'mcp-remove', servers: ['u'] })
-    const plan = planFor(finding, { homeDir: fx.home, cwd: fx.project })
+    const plan = planFor(finding, { homeDir: fx.home, cwd: fx.project, provider: 'claude' })
     expect(plan).not.toBeNull()
     expect(plan!.kind).toBe('mcp-remove')
 
@@ -351,7 +351,7 @@ describe('BOM handling', () => {
 
     const { plan, notes } = planFindings(
       [makeFinding('mcp-low-coverage', CMD_FIX, { kind: 'mcp-remove', servers: ['b'] })],
-      { homeDir: fx.home, cwd: fx.project },
+      { homeDir: fx.home, cwd: fx.project, provider: 'claude' },
     )[0]!
     expect(notes).toEqual([])
     expect(plan).not.toBeNull()
@@ -391,7 +391,7 @@ function makeIo(answer?: string): Io {
 }
 
 function applyOpts(fx: Fixture, io: Io, extra: Partial<ApplyOptions> & { findings: WasteFinding[] }): ApplyOptions {
-  const ctx: PlanContext = { homeDir: fx.home, cwd: fx.project, shell: '/bin/zsh' }
+  const ctx: PlanContext = { homeDir: fx.home, cwd: fx.project, provider: 'claude', shell: '/bin/zsh' }
   return {
     ctx,
     actionsDir: fx.actionsDir,
@@ -594,7 +594,7 @@ describe('stale-plan detection', () => {
     await writeFile(claudeJson, JSON.stringify({ mcpServers: { s: {} } }, null, 2) + '\n')
     const plan = planFor(
       makeFinding('mcp-low-coverage', CMD_FIX, { kind: 'mcp-remove', servers: ['s'] }),
-      { homeDir: fx.home, cwd: fx.project },
+      { homeDir: fx.home, cwd: fx.project, provider: 'claude' },
     )
     expect(plan).not.toBeNull()
 
@@ -613,7 +613,7 @@ describe('stale-plan detection', () => {
     const claudeMd = join(fx.project, 'CLAUDE.md')
     const plan = planFor(
       makeFinding('read-edit-ratio', { type: 'paste', destination: 'claude-md', label: '', text: 'rule' }),
-      { homeDir: fx.home, cwd: fx.project },
+      { homeDir: fx.home, cwd: fx.project, provider: 'claude' },
     )
     expect(plan!.changes[0]).toMatchObject({ op: 'create', expectedHash: null })
 
@@ -630,7 +630,7 @@ describe('stale-plan detection', () => {
     await writeFile(claudeJson, JSON.stringify({ mcpServers: { s: {} } }, null, 2) + '\n')
     const plan = planFor(
       makeFinding('mcp-low-coverage', CMD_FIX, { kind: 'mcp-remove', servers: ['s'] }),
-      { homeDir: fx.home, cwd: fx.project },
+      { homeDir: fx.home, cwd: fx.project, provider: 'claude' },
     )
     expect(plan!.changes[0]!.op === 'move' ? undefined : plan!.changes[0]!.expectedHash).toMatch(/^[0-9a-f]{64}$/)
 

--- a/tests/optimize-cache-key.test.ts
+++ b/tests/optimize-cache-key.test.ts
@@ -119,9 +119,25 @@ describe('Optimize content-addressed result cache key', () => {
     )
   })
 
+  it('isolates provider scopes and normalizes the provider authority', () => {
+    const input = [project('alpha')]
+    expect(optimizeResultCacheKey(input, range(), 'claude')).not.toBe(
+      optimizeResultCacheKey(input, range(), 'codex'),
+    )
+    expect(optimizeResultCacheKey(input, range(), 'all')).not.toBe(
+      optimizeResultCacheKey(input, range(), 'codex'),
+    )
+    expect(optimizeResultCacheKey(input, range())).toBe(
+      optimizeResultCacheKey(input, range(), ' ALL '),
+    )
+    expect(optimizeResultCacheKey(input, range(), ' CoDeX ')).toBe(
+      optimizeResultCacheKey(input, range(), 'codex'),
+    )
+  })
+
   it('returns only version, scope, and digest without raw project content', () => {
     const key = optimizeResultCacheKey([project('secret-project')], range())
-    expect(key).toMatch(/^optimize-project-summary-v1:\d+-\d+:[A-Za-z0-9_-]{43}$/)
+    expect(key).toMatch(/^optimize-project-summary-v2:all:\d+-\d+:[A-Za-z0-9_-]{43}$/)
     expect(key).not.toContain('secret-project')
     expect(key).not.toContain('/private/')
   })

--- a/tests/optimize-provider-authority.test.ts
+++ b/tests/optimize-provider-authority.test.ts
@@ -1,0 +1,271 @@
+import { afterAll, describe, expect, it, vi } from 'vitest'
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { Writable } from 'node:stream'
+import { spawnSync } from 'node:child_process'
+
+vi.setConfig({ testTimeout: 30_000 })
+
+vi.mock('os', async () => {
+  const actual = await vi.importActual<typeof import('os')>('os')
+  const fs = await vi.importActual<typeof import('fs')>('fs')
+  const fakeHome = fs.mkdtempSync(actual.tmpdir() + '/metrora-optimize-authority-home-')
+  fs.mkdirSync(fakeHome + '/.claude', { recursive: true })
+  process.env['METRORA_TEST_OPTIMIZE_AUTHORITY_HOME'] = fakeHome
+  return { ...actual, homedir: () => fakeHome }
+})
+
+const FAKE_HOME = process.env['METRORA_TEST_OPTIMIZE_AUTHORITY_HOME']!
+const roots = [FAKE_HOME]
+let fixtureNumber = 0
+
+import { runOptimizeApply } from '../src/act/optimize-apply.js'
+import { scanAndDetect } from '../src/optimize.js'
+import type { ProjectSummary } from '../src/types.js'
+
+type Fixture = {
+  root: string
+  project: ProjectSummary
+  skillPath: string
+  claudeProjectDir: string
+  actionsDir: string
+}
+
+function makeProjectSummary(name: string, projectPath: string): ProjectSummary {
+  return {
+    project: name,
+    projectPath,
+    sessions: [{
+      sessionId: `${name}-summary-session`,
+      project: name,
+      firstTimestamp: '2026-08-01T00:00:00.000Z',
+      lastTimestamp: '2026-08-01T00:01:00.000Z',
+      totalCostUSD: 1,
+      totalSavingsUSD: 0,
+      totalInputTokens: 100,
+      totalOutputTokens: 20,
+      totalReasoningTokens: 0,
+      totalCacheReadTokens: 0,
+      totalCacheWriteTokens: 0,
+      apiCalls: 1,
+      turns: [],
+      modelBreakdown: {},
+      toolBreakdown: {},
+      mcpBreakdown: {},
+      bashBreakdown: {},
+      categoryBreakdown: {},
+      skillBreakdown: {},
+      subagentBreakdown: {},
+    }],
+    totalCostUSD: 1,
+    totalSavingsUSD: 0,
+    totalApiCalls: 1,
+    totalProxiedCostUSD: 0,
+  }
+}
+
+function makeFixture(): Fixture {
+  const id = `${++fixtureNumber}-${Date.now()}`
+  const root = mkdtempSync(join(tmpdir(), 'metrora-optimize-authority-'))
+  roots.push(root)
+  const projectPath = join(root, 'project')
+  mkdirSync(projectPath, { recursive: true })
+
+  const claudeProjectDir = join(FAKE_HOME, '.claude', 'projects', `authority-${id}`)
+  mkdirSync(claudeProjectDir, { recursive: true })
+  writeFileSync(join(claudeProjectDir, 'session.jsonl'), JSON.stringify({
+    type: 'user',
+    sessionId: `claude-${id}`,
+    timestamp: '2026-08-01T00:00:00.000Z',
+    message: { role: 'user', content: 'inspect the project' },
+  }) + '\n')
+
+  const codexSessionDir = join(FAKE_HOME, '.codex', 'sessions', '2026', '08', '01')
+  mkdirSync(codexSessionDir, { recursive: true })
+  const codexSessionId = 'codex-' + id
+  writeFileSync(join(codexSessionDir, 'rollout-' + id + '.jsonl'), [
+    JSON.stringify({ type: 'session_meta', timestamp: '2026-08-01T10:00:00.000Z', payload: { session_id: codexSessionId, model: 'gpt-5.3-codex', cwd: projectPath, originator: 'codex-cli' } }),
+    JSON.stringify({ type: 'response_item', timestamp: '2026-08-01T10:00:01.000Z', payload: { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'inspect the project' }] } }),
+    JSON.stringify({ type: 'event_msg', timestamp: '2026-08-01T10:00:02.000Z', payload: { type: 'token_count', info: { last_token_usage: { input_tokens: 100, output_tokens: 20, total_tokens: 120 }, total_token_usage: { input_tokens: 100, output_tokens: 20, total_tokens: 120 } } } }),
+  ].join('\n') + '\n')
+  const skillPath = join(FAKE_HOME, '.claude', 'skills', `authority-unused-${id}`, 'SKILL.md')
+  mkdirSync(join(skillPath, '..'), { recursive: true })
+  writeFileSync(skillPath, '# Disposable unused skill\n')
+
+  return {
+    root,
+    project: makeProjectSummary(`authority-${id}`, projectPath),
+    skillPath,
+    claudeProjectDir,
+    actionsDir: join(root, 'actions'),
+  }
+}
+
+function sink(): Writable {
+  return new Writable({ write(_chunk, _encoding, callback) { callback() } })
+}
+
+function findingIds(result: Awaited<ReturnType<typeof scanAndDetect>>): string[] {
+  return result.findings.map(finding => finding.id)
+}
+
+function runCli(args: string[]): ReturnType<typeof spawnSync> {
+  const configDir = join(FAKE_HOME, 'metrora-config')
+  return spawnSync(process.execPath, ['--import', 'tsx', 'src/cli.ts', ...args], {
+    cwd: process.cwd(),
+    env: {
+      ...process.env,
+      HOME: FAKE_HOME,
+      USERPROFILE: FAKE_HOME,
+      HOMEPATH: FAKE_HOME,
+      HOMEDRIVE: '',
+      APPDATA: join(FAKE_HOME, 'AppData', 'Roaming'),
+      LOCALAPPDATA: join(FAKE_HOME, 'AppData', 'Local'),
+      CLAUDE_CONFIG_DIR: join(FAKE_HOME, '.claude'),
+      CODEX_HOME: join(FAKE_HOME, '.codex'),
+      METRORA_CACHE_DIR: join(FAKE_HOME, 'metrora-cache'),
+      METRORA_CONFIG_DIR: configDir,
+      XDG_CONFIG_HOME: join(FAKE_HOME, '.config'),
+      XDG_DATA_HOME: join(FAKE_HOME, '.local', 'share'),
+      OPENCODE_DATA_DIR: join(FAKE_HOME, '.local', 'share', 'opencode'),
+      TZ: 'UTC',
+    },
+    encoding: 'utf-8',
+    timeout: 30_000,
+  })
+}
+
+function cleanupFixture(fixture: Fixture): void {
+  rmSync(fixture.claudeProjectDir, { recursive: true, force: true })
+  rmSync(join(fixture.skillPath, '..', '..'), { recursive: true, force: true })
+  rmSync(fixture.root, { recursive: true, force: true })
+}
+
+afterAll(() => {
+  for (const root of roots) rmSync(root, { recursive: true, force: true })
+})
+
+describe('Optimize provider authority', () => {
+  it('distinguishes Claude observed-empty evidence from non-Claude NOT_SCANNED', async () => {
+    const fixture = makeFixture()
+    try {
+      const projects = [fixture.project]
+      const claude = await scanAndDetect(projects, undefined, 'claude')
+      const codex = await scanAndDetect(projects, undefined, 'codex')
+      const all = await scanAndDetect(projects, undefined, 'all')
+
+      // Claude was actually scanned and found no Skill invocation, so the
+      // disposable skill is a valid unused-skills control finding.
+      expect(findingIds(claude)).toContain('unused-skills')
+      // Codex intentionally skipped the Claude transcript/config scan. It must
+      // not reinterpret that absence as zero Claude usage.
+      expect(findingIds(codex)).not.toContain('unused-skills')
+      expect(findingIds(codex)).not.toContain('unused-agents')
+      expect(findingIds(codex)).not.toContain('unused-commands')
+      // All-provider mode retains the real Claude evidence.
+      expect(findingIds(all)).toContain('unused-skills')
+    } finally {
+      cleanupFixture(fixture)
+    }
+  })
+
+  it('isolates cached Claude, Codex, and all-provider results in either order', async () => {
+    const fixture = makeFixture()
+    try {
+      const firstProjects = [fixture.project]
+      const claudeFirst = await scanAndDetect(firstProjects, undefined, 'claude')
+      const codexAfterClaude = await scanAndDetect(firstProjects, undefined, 'codex')
+      expect(findingIds(claudeFirst)).toContain('unused-skills')
+      expect(findingIds(codexAfterClaude)).not.toContain('unused-skills')
+
+      const reverseProjects = [makeProjectSummary('reverse-cache', fixture.project.projectPath)]
+      const codexFirst = await scanAndDetect(reverseProjects, undefined, 'codex')
+      const claudeAfterCodex = await scanAndDetect(reverseProjects, undefined, 'claude')
+      const allAfterClaude = await scanAndDetect(reverseProjects, undefined, 'all')
+      expect(findingIds(codexFirst)).not.toContain('unused-skills')
+      expect(findingIds(claudeAfterCodex)).toContain('unused-skills')
+      expect(findingIds(allAfterClaude)).toContain('unused-skills')
+    } finally {
+      cleanupFixture(fixture)
+    }
+  })
+
+  it('keeps Codex dry-run and real apply from planning or mutating Claude state', async () => {
+    const fixture = makeFixture()
+    const before = readFileSync(fixture.skillPath)
+    try {
+      await runOptimizeApply([fixture.project], undefined, {
+        provider: 'codex',
+        dryRun: true,
+        actionsDir: fixture.actionsDir,
+        output: sink(),
+        errorOutput: sink(),
+      })
+      expect(readFileSync(fixture.skillPath)).toEqual(before)
+      expect(existsSync(fixture.actionsDir)).toBe(false)
+
+      await runOptimizeApply([fixture.project], undefined, {
+        provider: 'codex',
+        yes: true,
+        actionsDir: fixture.actionsDir,
+        output: sink(),
+        errorOutput: sink(),
+      })
+      expect(readFileSync(fixture.skillPath)).toEqual(before)
+      expect(existsSync(fixture.actionsDir)).toBe(false)
+    } finally {
+      cleanupFixture(fixture)
+    }
+  })
+
+  it('keeps CLI text, JSON, dry-run, and real apply provider-consistent', () => {
+    const fixture = makeFixture()
+    const before = readFileSync(fixture.skillPath)
+    const args = ['optimize', '--provider', 'codex', '--from', '2026-08-01', '--to', '2026-08-01']
+    try {
+      const text = runCli(args)
+      const json = runCli([...args, '--format', 'json'])
+      const dryRun = runCli([...args, '--apply', '--dry-run'])
+      const apply = runCli([...args, '--apply', '--yes'])
+
+      expect(text.status).toBe(0)
+      expect(json.status).toBe(0)
+      expect(dryRun.status).toBe(0)
+      expect(apply.status).toBe(0)
+      expect(text.stdout).not.toContain('unused-skills')
+      expect(text.stdout).not.toContain('.claude')
+      const report = JSON.parse(json.stdout) as { summary: { findingCount: number }; findings: unknown[] }
+      expect(report.summary.findingCount).toBe(0)
+      expect(report.findings).toEqual([])
+      expect(dryRun.stdout).not.toContain('unused-skills')
+      expect(dryRun.stdout).not.toContain('.claude')
+      expect(apply.stdout).not.toContain('unused-skills')
+      expect(readFileSync(fixture.skillPath)).toEqual(before)
+      expect(existsSync(join(FAKE_HOME, 'metrora-config', 'actions'))).toBe(false)
+    } finally {
+      cleanupFixture(fixture)
+    }
+  })
+  it('keeps a real Claude finding actionable in dry-run and leaves it unmutated', async () => {
+    const fixture = makeFixture()
+    const before = readFileSync(fixture.skillPath)
+    let output = ''
+    const capture = new Writable({ write(chunk, _encoding, callback) { output += chunk.toString(); callback() } })
+    try {
+      await runOptimizeApply([fixture.project], undefined, {
+        provider: 'claude',
+        dryRun: true,
+        actionsDir: fixture.actionsDir,
+        output: capture,
+        errorOutput: sink(),
+      })
+      expect(output).toContain('Appliable config-class fixes:')
+      expect(output).toContain('unused')
+      expect(readFileSync(fixture.skillPath)).toEqual(before)
+      expect(existsSync(fixture.actionsDir)).toBe(false)
+    } finally {
+      cleanupFixture(fixture)
+    }
+  })
+})

--- a/tests/optimize-provider-authority.test.ts
+++ b/tests/optimize-provider-authority.test.ts
@@ -21,7 +21,7 @@ const roots = [FAKE_HOME]
 let fixtureNumber = 0
 
 import { runOptimizeApply } from '../src/act/optimize-apply.js'
-import { scanAndDetect } from '../src/optimize.js'
+import { buildOptimizeJsonReport, runOptimize, scanAndDetect } from '../src/optimize.js'
 import type { ProjectSummary } from '../src/types.js'
 
 type Fixture = {
@@ -62,6 +62,22 @@ function makeProjectSummary(name: string, projectPath: string): ProjectSummary {
     totalSavingsUSD: 0,
     totalApiCalls: 1,
     totalProxiedCostUSD: 0,
+  }
+}
+
+function makeMcpProjectSummary(name: string, projectPath: string): ProjectSummary {
+  const inventory = Array.from({ length: 12 }, (_, i) => 'mcp__server__tool-' + i)
+  const project = makeProjectSummary(name, projectPath)
+  const template = project.sessions[0]
+  if (!template) throw new Error('MCP fixture requires a session')
+  const sessions = [template, { ...template, sessionId: name + '-second' }]
+  return {
+    ...project,
+    sessions: sessions.map(session => ({
+      ...session,
+      mcpBreakdown: { server: { calls: 0 } },
+      mcpInventory: inventory,
+    })),
   }
 }
 
@@ -265,6 +281,114 @@ describe('Optimize provider authority', () => {
       expect(readFileSync(fixture.skillPath)).toEqual(before)
       expect(existsSync(fixture.actionsDir)).toBe(false)
     } finally {
+      cleanupFixture(fixture)
+    }
+  })
+  it('keeps a Claude-scan-derived action available in all-provider scope', async () => {
+    const fixture = makeFixture()
+    const before = readFileSync(fixture.skillPath)
+    let output = ''
+    const capture = new Writable({ write(chunk, _encoding, callback) { output += chunk.toString(); callback() } })
+    try {
+      const result = await scanAndDetect([fixture.project], undefined, 'all')
+      const finding = result.findings.find(item => item.id === 'unused-skills')
+      expect(finding).toBeDefined()
+
+      await runOptimizeApply([fixture.project], undefined, {
+        provider: 'all',
+        findings: [finding!],
+        dryRun: true,
+        actionsDir: fixture.actionsDir,
+        output: capture,
+        errorOutput: sink(),
+      })
+      expect(output).toContain('Appliable config-class fixes:')
+      expect(output).toContain('unused')
+      expect(readFileSync(fixture.skillPath)).toEqual(before)
+      expect(existsSync(fixture.actionsDir)).toBe(false)
+    } finally {
+      cleanupFixture(fixture)
+    }
+  })
+
+  it('preserves all-provider MCP reporting while denying ambiguous mutation authority', async () => {
+    const fixture = makeFixture()
+    const configPath = join(FAKE_HOME, '.claude.json')
+    writeFileSync(configPath, JSON.stringify({ mcpServers: { server: { command: 'node' } } }) + '\n')
+    const before = readFileSync(configPath)
+    try {
+      rmSync(fixture.claudeProjectDir, { recursive: true, force: true })
+      rmSync(join(fixture.skillPath, '..', '..'), { recursive: true, force: true })
+
+      const codexProject = makeMcpProjectSummary('codex-only', fixture.project.projectPath)
+      const all = await scanAndDetect([codexProject], undefined, 'all')
+      const finding = all.findings.find(item => item.id === 'mcp-low-coverage')
+      expect(finding).toBeDefined()
+
+      const json = buildOptimizeJsonReport([codexProject], '2026-08-01', all)
+      expect(json.summary.findingCount).toBeGreaterThan(0)
+      expect(json.findings.map(item => item.id)).toContain('mcp-low-coverage')
+
+      let text = ''
+      const log = vi.spyOn(console, 'log').mockImplementation((...args: unknown[]) => {
+        text += args.map(String).join(' ')
+      })
+      try {
+        await runOptimize([codexProject], '2026-08-01', undefined, { provider: 'all' })
+      } finally {
+        log.mockRestore()
+      }
+      expect(text.toLowerCase()).toContain('low tool coverage')
+
+      const dryIo = new Writable({ write(_chunk, _encoding, callback) { callback() } })
+      let dryOutput = ''
+      const dryCapture = new Writable({ write(chunk, _encoding, callback) { dryOutput += chunk.toString(); callback() } })
+      await runOptimizeApply([codexProject], undefined, {
+        provider: 'all',
+        findings: [finding!],
+        dryRun: true,
+        actionsDir: fixture.actionsDir,
+        ctx: { homeDir: FAKE_HOME, cwd: fixture.project.projectPath },
+        output: dryCapture,
+        errorOutput: dryIo,
+      })
+      expect(dryOutput).toContain('mcp-low-coverage')
+      expect(dryOutput).toContain('not auto-appliable')
+      expect(readFileSync(configPath)).toEqual(before)
+      expect(existsSync(fixture.actionsDir)).toBe(false)
+
+      await runOptimizeApply([codexProject], undefined, {
+        provider: 'all',
+        findings: [finding!],
+        yes: true,
+        actionsDir: fixture.actionsDir,
+        ctx: { homeDir: FAKE_HOME, cwd: fixture.project.projectPath },
+        output: sink(),
+        errorOutput: sink(),
+      })
+      expect(readFileSync(configPath)).toEqual(before)
+      expect(existsSync(fixture.actionsDir)).toBe(false)
+
+      const mixedProject = makeMcpProjectSummary('claude-mixed', join(fixture.root, 'mixed-project'))
+      const mixed = await scanAndDetect([codexProject, mixedProject], undefined, 'all')
+      const mixedFinding = mixed.findings.find(item => item.id === 'mcp-low-coverage')
+      expect(mixedFinding).toBeDefined()
+      let mixedOutput = ''
+      const mixedCapture = new Writable({ write(chunk, _encoding, callback) { mixedOutput += chunk.toString(); callback() } })
+      await runOptimizeApply([codexProject, mixedProject], undefined, {
+        provider: 'all',
+        findings: [mixedFinding!],
+        dryRun: true,
+        actionsDir: fixture.actionsDir,
+        ctx: { homeDir: FAKE_HOME, cwd: fixture.project.projectPath },
+        output: mixedCapture,
+        errorOutput: sink(),
+      })
+      expect(mixedOutput).toContain('not auto-appliable')
+      expect(readFileSync(configPath)).toEqual(before)
+      expect(existsSync(fixture.actionsDir)).toBe(false)
+    } finally {
+      rmSync(configPath, { force: true })
       cleanupFixture(fixture)
     }
   })

--- a/tests/usage-aggregator.test.ts
+++ b/tests/usage-aggregator.test.ts
@@ -4,6 +4,7 @@ vi.setConfig({ testTimeout: 30_000 })
 import { buildMenubarPayloadForRange } from '../src/usage-aggregator.js'
 import { getDateRange } from '../src/cli-date.js'
 import { loadPricing } from '../src/models.js'
+import * as optimize from '../src/optimize.js'
 
 describe('buildMenubarPayloadForRange', () => {
   beforeAll(async () => {
@@ -25,5 +26,26 @@ describe('buildMenubarPayloadForRange', () => {
     expect(payload.current.codexCredits).toBeGreaterThanOrEqual(0)
     // optimize:false => scanAndDetect skipped => empty optimize block regardless of data
     expect(payload.optimize).toEqual({ findingCount: 0, savingsUSD: 0, topFindings: [] })
+  })
+
+  it('forwards the selected provider to Optimize for menubar payloads', async () => {
+    const scan = vi.spyOn(optimize, 'scanAndDetect').mockResolvedValue({
+      findings: [],
+      costRate: 0,
+      healthScore: 100,
+      healthGrade: 'A',
+      modelRecommendations: [],
+    })
+    try {
+      await buildMenubarPayloadForRange(getDateRange('today'), {
+        provider: 'codex',
+        optimize: true,
+        timeline: false,
+      })
+      const lastCall = scan.mock.calls.at(-1)
+      expect(lastCall?.[2]).toBe('codex')
+    } finally {
+      scan.mockRestore()
+    }
   })
 })


### PR DESCRIPTION
## Summary

Enforces Metrora Optimize authority boundaries so the selected provider scope, finding evidence authority, and action-target authority remain distinct.

## Behavior

- Selected provider scope controls which sessions/config evidence is scanned; NOT_SCANNED is never treated as OBSERVED_EMPTY.
- Finding evidence authority determines whether a finding can authorize its current remediation.
- Action-target authority independently determines whether an `ActionPlan` may mutate the owned state.
- `all` remains an analysis union, not blanket cross-provider mutation authority.
- Provider-valid reporting findings remain visible even when the current remediation is manual/non-appliable.
- Existing reversible backup, journal and undo behavior is preserved.

## Action evidence

- `mcp-low-coverage` and `mcp-project-scope` remain reporting-only/manual outside explicit supported mutation authority.
- Claude-scan-derived automatic findings require Claude evidence to be included in the scan.
- Unknown future plan-producing findings fail closed outside explicit supported authority.
- No new cross-provider mutation implementation was introduced.

## Verification

- Focused action-target suite: 7 tests passed.
- Focused provider-authority suite: 7 tests passed.
- Relevant regression matrix: 21 test files, 405 tests passed.
- `npx tsc --noEmit` passed.
- `npm run build:cli` passed.
- Source-size ratchet passed.
- `git diff --check` passed.

No real provider configuration, transcripts, cache/history, journal, backups, or user data were used or mutated.

Merged as `96bf0b49e980a86d91d7061a541878c66582a32e`.