### PR TITLE
fix(android): replace ML Kit QR scanning with ZXing Core

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -230,7 +230,7 @@ dependencies {
     implementation(libs.camera.camera2)
     implementation(libs.camera.lifecycle)
     implementation(libs.camera.view)
-    implementation(libs.mlkit.barcode)
+    implementation(libs.zxing.core)
     implementation(libs.exifinterface)
     implementation(libs.lifecycle.runtime.compose)
     implementation(libs.datastore.preferences)

--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -1,15 +1,4 @@
 # Metrora uses no reflection-based network model in the Android companion.
 
-# ML Kit discovers these barcode/common/vision components from manifest metadata
-# and constructs each registrar through its no-argument constructor. Keep only
-# those reflective entry points; the rest of the ML Kit implementation remains
-# minified.
--keep class com.google.mlkit.vision.barcode.internal.BarcodeRegistrar {
-    public <init>();
-}
--keep class com.google.mlkit.vision.common.internal.VisionCommonRegistrar {
-    public <init>();
-}
--keep class com.google.mlkit.common.internal.CommonComponentRegistrar {
-    public <init>();
-}
+# QR decoding uses ZXing Core directly. No scanner-specific reflective
+# component registrars or keep rules are required.

--- a/android/app/src/main/kotlin/eu/metrora/app/ui/QrCodeDecoder.kt
+++ b/android/app/src/main/kotlin/eu/metrora/app/ui/QrCodeDecoder.kt
@@ -1,0 +1,81 @@
+package eu.metrora.app.ui
+
+import com.google.zxing.BinaryBitmap
+import com.google.zxing.LuminanceSource
+import com.google.zxing.PlanarYUVLuminanceSource
+import com.google.zxing.RGBLuminanceSource
+import com.google.zxing.ReaderException
+import com.google.zxing.common.HybridBinarizer
+import com.google.zxing.multi.qrcode.QRCodeMultiReader
+import com.google.zxing.qrcode.QRCodeReader
+
+/**
+ * QR-only decoding helpers backed by ZXing Core.
+ *
+ * These helpers are deliberately local and provider-free: they receive pixels
+ * or luminance bytes already present on-device and return only the decoded raw
+ * QR payload. Pairing validation remains owned by the existing Metrora pairing
+ * authority.
+ */
+internal fun decodeSingleQrLuminance(
+    width: Int,
+    height: Int,
+    luminance: ByteArray,
+): String? {
+    require(width > 0 && height > 0) { "QR frame dimensions must be positive" }
+    require(luminance.size >= width * height) { "QR frame luminance buffer is too small" }
+
+    return decodeSingleQr(
+        PlanarYUVLuminanceSource(
+            luminance,
+            width,
+            height,
+            0,
+            0,
+            width,
+            height,
+            false,
+        ),
+    )
+}
+
+internal fun decodeQrBitmapPixels(
+    width: Int,
+    height: Int,
+    pixels: IntArray,
+): List<String> {
+    require(width > 0 && height > 0) { "QR image dimensions must be positive" }
+    require(pixels.size >= width * height) { "QR image pixel buffer is too small" }
+
+    return decodeMultipleQr(RGBLuminanceSource(width, height, pixels))
+}
+
+private fun decodeSingleQr(source: LuminanceSource): String? =
+    decodeSingleQrAttempt(source) ?: decodeSingleQrAttempt(source.invert())
+
+private fun decodeSingleQrAttempt(source: LuminanceSource): String? {
+    val reader = QRCodeReader()
+    return try {
+        reader.decode(BinaryBitmap(HybridBinarizer(source))).text
+    } catch (_: ReaderException) {
+        null
+    } finally {
+        reader.reset()
+    }
+}
+
+private fun decodeMultipleQr(source: LuminanceSource): List<String> {
+    val direct = decodeMultipleQrAttempt(source)
+    return if (direct.isNotEmpty()) direct else decodeMultipleQrAttempt(source.invert())
+}
+
+private fun decodeMultipleQrAttempt(source: LuminanceSource): List<String> {
+    val reader = QRCodeMultiReader()
+    return try {
+        reader.decodeMultiple(BinaryBitmap(HybridBinarizer(source))).map { it.text }
+    } catch (_: ReaderException) {
+        emptyList()
+    } finally {
+        reader.reset()
+    }
+}

--- a/android/app/src/main/kotlin/eu/metrora/app/ui/QrImageDecoder.kt
+++ b/android/app/src/main/kotlin/eu/metrora/app/ui/QrImageDecoder.kt
@@ -10,11 +10,6 @@ import android.os.Build
 import android.util.Size
 import androidx.core.content.ContextCompat
 import androidx.exifinterface.media.ExifInterface
-import com.google.android.gms.tasks.Tasks
-import com.google.mlkit.vision.barcode.BarcodeScannerOptions
-import com.google.mlkit.vision.barcode.BarcodeScanning
-import com.google.mlkit.vision.barcode.common.Barcode
-import com.google.mlkit.vision.common.InputImage
 import java.io.Closeable
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
@@ -53,7 +48,7 @@ internal fun shouldApplySourceExifOrientation(source: QrImageBitmapSource): Bool
     source == QrImageBitmapSource.DIRECT_DECODE
 
 /**
- * Converts the bounded ML Kit result into a single image-import outcome.
+ * Converts the bounded QR decoder result into a single image-import outcome.
  * Payload parsing intentionally remains outside this boundary.
  */
 internal fun classifyQrImageResults(rawValues: List<String?>): QrImageImportResult = when {
@@ -101,17 +96,12 @@ internal class QrImageDecodeOperation internal constructor() {
 
 /**
  * Local, QR-only static-image decoder. The source bitmap is downsampled and
- * released after ML Kit finishes; the selected Uri is never copied or stored.
+ * released after ZXing finishes; the selected Uri is never copied or stored.
  */
 internal class QrImageDecoder(context: Context) : Closeable {
     private val applicationContext = context.applicationContext
     private val worker: ExecutorService = Executors.newSingleThreadExecutor()
     private val callbackExecutor = ContextCompat.getMainExecutor(applicationContext)
-    private val scanner = BarcodeScanning.getClient(
-        BarcodeScannerOptions.Builder()
-            .setBarcodeFormats(Barcode.FORMAT_QR_CODE)
-            .build(),
-    )
     private val closed = AtomicBoolean(false)
 
     internal fun decode(
@@ -137,7 +127,6 @@ internal class QrImageDecoder(context: Context) : Closeable {
     override fun close() {
         if (!closed.compareAndSet(false, true)) return
         worker.shutdownNow()
-        scanner.close()
     }
 
     private fun decodeOnWorker(
@@ -152,10 +141,21 @@ internal class QrImageDecoder(context: Context) : Closeable {
             bitmap = decodedBitmap
             if (!operation.isActive()) return
 
-            val barcodes = Tasks.await(scanner.process(InputImage.fromBitmap(decodedBitmap, 0)))
+            val pixels = IntArray(decodedBitmap.width * decodedBitmap.height)
+            decodedBitmap.getPixels(
+                pixels,
+                0,
+                decodedBitmap.width,
+                0,
+                0,
+                decodedBitmap.width,
+                decodedBitmap.height,
+            )
             deliver(
                 operation = operation,
-                result = classifyQrImageResults(barcodes.map { it.rawValue }),
+                result = classifyQrImageResults(
+                    decodeQrBitmapPixels(decodedBitmap.width, decodedBitmap.height, pixels),
+                ),
                 onResult = onResult,
             )
         } catch (_: InterruptedException) {

--- a/android/app/src/main/kotlin/eu/metrora/app/ui/QrScanner.kt
+++ b/android/app/src/main/kotlin/eu/metrora/app/ui/QrScanner.kt
@@ -5,11 +5,11 @@ import android.app.Activity
 import android.content.pm.PackageManager
 import android.net.Uri
 import androidx.activity.compose.rememberLauncherForActivityResult
-import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.result.PickVisualMediaRequest
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.camera.core.CameraSelector
-import androidx.camera.core.ExperimentalGetImage
 import androidx.camera.core.ImageAnalysis
+import androidx.camera.core.ImageProxy
 import androidx.camera.core.Preview
 import androidx.camera.lifecycle.ProcessCameraProvider
 import androidx.camera.view.PreviewView
@@ -29,6 +29,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
@@ -56,8 +57,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalLifecycleOwner
@@ -68,12 +69,7 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import androidx.compose.foundation.layout.widthIn
 import androidx.core.content.ContextCompat
-import com.google.mlkit.vision.barcode.BarcodeScannerOptions
-import com.google.mlkit.vision.barcode.BarcodeScanning
-import com.google.mlkit.vision.barcode.common.Barcode
-import com.google.mlkit.vision.common.InputImage
 import eu.metrora.app.R
 import java.util.concurrent.Executors
 
@@ -381,20 +377,12 @@ private fun ScannerAmbientGlow(modifier: Modifier) {
 }
 
 @Composable
-@androidx.annotation.OptIn(markerClass = [ExperimentalGetImage::class])
 private fun QrCameraPreview(onDetected: (String) -> Unit) {
     val context = LocalContext.current
     val lifecycleOwner = LocalLifecycleOwner.current
     val latestOnDetected by rememberUpdatedState(onDetected)
     val previewView = remember { PreviewView(context) }
     val executor = remember { Executors.newSingleThreadExecutor() }
-    val scanner = remember {
-        BarcodeScanning.getClient(
-            BarcodeScannerOptions.Builder()
-                .setBarcodeFormats(Barcode.FORMAT_QR_CODE)
-                .build(),
-        )
-    }
 
     DisposableEffect(lifecycleOwner) {
         var cameraProvider: ProcessCameraProvider? = null
@@ -408,17 +396,17 @@ private fun QrCameraPreview(onDetected: (String) -> Unit) {
                 .setBackpressureStrategy(ImageAnalysis.STRATEGY_KEEP_ONLY_LATEST)
                 .build()
             analysis.setAnalyzer(executor) { imageProxy ->
-                val mediaImage = imageProxy.image
-                if (mediaImage == null) {
-                    imageProxy.close()
-                } else {
-                    scanner.process(
-                        InputImage.fromMediaImage(mediaImage, imageProxy.imageInfo.rotationDegrees),
-                    ).addOnSuccessListener { codes ->
-                        codes.firstOrNull()?.rawValue?.let(latestOnDetected)
-                    }.addOnCompleteListener {
-                        imageProxy.close()
+                try {
+                    val luminance = imageProxy.copyLuminancePlane()
+                    if (luminance != null) {
+                        decodeSingleQrLuminance(
+                            imageProxy.width,
+                            imageProxy.height,
+                            luminance,
+                        )?.takeIf(String::isNotBlank)?.let(latestOnDetected)
                     }
+                } finally {
+                    imageProxy.close()
                 }
             }
             runCatching {
@@ -434,7 +422,6 @@ private fun QrCameraPreview(onDetected: (String) -> Unit) {
         providerFuture.addListener(listener, ContextCompat.getMainExecutor(context))
         onDispose {
             cameraProvider?.unbindAll()
-            scanner.close()
             executor.shutdown()
         }
     }
@@ -443,4 +430,28 @@ private fun QrCameraPreview(onDetected: (String) -> Unit) {
         factory = { previewView },
         modifier = Modifier.fillMaxSize().clip(RoundedCornerShape(21.dp)),
     )
+}
+
+private fun ImageProxy.copyLuminancePlane(): ByteArray? {
+    val plane = planes.firstOrNull() ?: return null
+    val frameWidth = width
+    val frameHeight = height
+    if (frameWidth <= 0 || frameHeight <= 0) return null
+
+    val output = ByteArray(frameWidth * frameHeight)
+    val buffer = plane.buffer.duplicate()
+    val baseOffset = buffer.position()
+    val limit = buffer.limit()
+    val rowStride = plane.rowStride
+    val pixelStride = plane.pixelStride
+
+    for (row in 0 until frameHeight) {
+        val rowOffset = baseOffset + row * rowStride
+        for (column in 0 until frameWidth) {
+            val sourceIndex = rowOffset + column * pixelStride
+            if (sourceIndex < baseOffset || sourceIndex >= limit) return null
+            output[row * frameWidth + column] = buffer.get(sourceIndex)
+        }
+    }
+    return output
 }

--- a/android/app/src/test/kotlin/eu/metrora/app/ui/QrImageDecoderTest.kt
+++ b/android/app/src/test/kotlin/eu/metrora/app/ui/QrImageDecoderTest.kt
@@ -1,5 +1,8 @@
 package eu.metrora.app.ui
 
+import com.google.zxing.BarcodeFormat
+import com.google.zxing.common.BitMatrix
+import com.google.zxing.qrcode.QRCodeWriter
 import eu.metrora.app.network.PairingBootstrap
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -165,5 +168,55 @@ class QrImageDecoderTest {
         assertTrue(
             shouldApplySourceExifOrientation(QrImageBitmapSource.DIRECT_DECODE),
         )
+    }
+
+    @Test
+    fun zxing_camera_luminance_decoder_round_trips_pairing_payload() {
+        val raw = "metrora://connect?host=desktop.local&port=7777&token=test"
+        val matrix = qrMatrix(raw)
+
+        assertEquals(
+            raw,
+            decodeSingleQrLuminance(matrix.width, matrix.height, matrix.toLuminance()),
+        )
+    }
+
+    @Test
+    fun zxing_camera_luminance_decoder_handles_inverted_qr() {
+        val raw = "metrora://connect?host=desktop.local&port=7777&token=inverted"
+        val matrix = qrMatrix(raw)
+        val inverted = matrix.toLuminance().also { bytes ->
+            for (index in bytes.indices) {
+                bytes[index] = (255 - (bytes[index].toInt() and 0xff)).toByte()
+            }
+        }
+
+        assertEquals(raw, decodeSingleQrLuminance(matrix.width, matrix.height, inverted))
+    }
+
+    @Test
+    fun zxing_bitmap_pixel_decoder_round_trips_imported_qr() {
+        val raw = "metrora://connect?host=desktop.local&port=7777&token=image"
+        val matrix = qrMatrix(raw)
+
+        assertEquals(
+            listOf(raw),
+            decodeQrBitmapPixels(matrix.width, matrix.height, matrix.toArgbPixels()),
+        )
+    }
+
+    private fun qrMatrix(raw: String): BitMatrix =
+        QRCodeWriter().encode(raw, BarcodeFormat.QR_CODE, 256, 256)
+
+    private fun BitMatrix.toLuminance(): ByteArray = ByteArray(width * height) { index ->
+        val x = index % width
+        val y = index / width
+        if (get(x, y)) 0 else 0xff.toByte()
+    }
+
+    private fun BitMatrix.toArgbPixels(): IntArray = IntArray(width * height) { index ->
+        val x = index % width
+        val y = index / width
+        if (get(x, y)) 0xff000000.toInt() else 0xffffffff.toInt()
     }
 }

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -4,7 +4,7 @@ composeBom = "2026.06.01"
 camera = "1.4.2"
 datastore = "1.2.1"
 coroutines = "1.11.0"
-mlkitBarcode = "17.3.0"
+zxing = "3.5.4"
 exifinterface = "1.4.2"
 lifecycle = "2.9.4"
 junit = "4.13.2"
@@ -14,14 +14,14 @@ orgJson = "20250517"
 activity-compose = { module = "androidx.activity:activity-compose", version.ref = "activity" }
 compose-bom = { module = "androidx.compose:compose-bom", version.ref = "composeBom" }
 compose-ui = { module = "androidx.compose.ui:ui" }
-compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling" }
+compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling", version.ref = "composeBom" }
 compose-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview" }
 compose-material3 = { module = "androidx.compose.material3:material3" }
 compose-icons = { module = "androidx.compose.material:material-icons-extended" }
 camera-camera2 = { module = "androidx.camera:camera-camera2", version.ref = "camera" }
 camera-lifecycle = { module = "androidx.camera:camera-lifecycle", version.ref = "camera" }
 camera-view = { module = "androidx.camera:camera-view", version.ref = "camera" }
-mlkit-barcode = { module = "com.google.mlkit:barcode-scanning", version.ref = "mlkitBarcode" }
+zxing-core = { module = "com.google.zxing:core", version.ref = "zxing" }
 exifinterface = { module = "androidx.exifinterface:exifinterface", version.ref = "exifinterface" }
 lifecycle-runtime-compose = { module = "androidx.lifecycle:lifecycle-runtime-compose", version.ref = "lifecycle" }
 datastore-preferences = { module = "androidx.datastore:datastore-preferences", version.ref = "datastore" }

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -14,7 +14,7 @@ orgJson = "20250517"
 activity-compose = { module = "androidx.activity:activity-compose", version.ref = "activity" }
 compose-bom = { module = "androidx.compose:compose-bom", version.ref = "composeBom" }
 compose-ui = { module = "androidx.compose.ui:ui" }
-compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling", version.ref = "composeBom" }
+compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling" }
 compose-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview" }
 compose-material3 = { module = "androidx.compose.material3:material3" }
 compose-icons = { module = "androidx.compose.material:material-icons-extended" }

--- a/scripts/verify-android-release.node-test.mjs
+++ b/scripts/verify-android-release.node-test.mjs
@@ -100,23 +100,32 @@ test('SHA256SUMS parsing rejects malformed or duplicate entries', () => {
   assert.throws(() => parseSha256Sums(`${apk} *artifact.apk\n`))
 })
 
-test('release scanner keeps ML Kit registrars and camera-independent image import', () => {
+test('release scanner uses ZXing core and keeps camera-independent image import', () => {
+  const versionCatalog = readRepositoryFile('android/gradle/libs.versions.toml')
+  const buildGradle = readRepositoryFile('android/app/build.gradle.kts')
   const proguardRules = readRepositoryFile('android/app/proguard-rules.pro')
-  for (const registrar of [
-    'com.google.mlkit.vision.barcode.internal.BarcodeRegistrar',
-    'com.google.mlkit.vision.common.internal.VisionCommonRegistrar',
-    'com.google.mlkit.common.internal.CommonComponentRegistrar',
-  ]) {
-    const escapedRegistrar = registrar.replaceAll('.', '\\.')
-    assert.match(
-      proguardRules,
-      new RegExp(`-keep class ${escapedRegistrar}\\s*\\{\\s*public <init>\\(\\);\\s*\\}`),
-    )
-  }
-
   const scannerSource = readRepositoryFile(
     'android/app/src/main/kotlin/eu/metrora/app/ui/QrScanner.kt',
   )
+  const imageDecoderSource = readRepositoryFile(
+    'android/app/src/main/kotlin/eu/metrora/app/ui/QrImageDecoder.kt',
+  )
+  const zxingDecoderSource = readRepositoryFile(
+    'android/app/src/main/kotlin/eu/metrora/app/ui/QrCodeDecoder.kt',
+  )
+
+  assert.match(versionCatalog, /zxing = "3\.5\.4"/)
+  assert.match(versionCatalog, /com\.google\.zxing:core/)
+  assert.match(buildGradle, /implementation\(libs\.zxing\.core\)/)
+  assert.match(zxingDecoderSource, /QRCodeReader/)
+  assert.match(zxingDecoderSource, /QRCodeMultiReader/)
+
+  for (const source of [versionCatalog, buildGradle, proguardRules, scannerSource, imageDecoderSource]) {
+    assert.doesNotMatch(source, /com\.google\.mlkit/)
+  }
+  assert.doesNotMatch(versionCatalog, /mlkitBarcode|mlkit-barcode/)
+  assert.doesNotMatch(imageDecoderSource, /com\.google\.android\.gms\.tasks/)
+
   const cameraBranch = scannerSource.indexOf('if (hasPermission)')
   const cameraBranchEnd = scannerSource.indexOf('\n        OutlinedButton(', cameraBranch)
   const imageImport = scannerSource.indexOf('R.string.import_qr_from_image')


### PR DESCRIPTION
## Purpose

Replace the Android companion's ML Kit barcode scanner dependency with the smaller open ZXing Core QR decoder while preserving the existing local pairing UX and authority boundaries.

## Base

`96bf0b49e980a86d91d7061a541878c66582a32e`

## Reviewed HEAD

`63d1a54bc07dd6959e6f6cbd9a83f9a52716a72d`

## Scope

- replace `com.google.mlkit:barcode-scanning` with `com.google.zxing:core:3.5.4`;
- keep CameraX preview/camera permission behavior unchanged;
- decode live CameraX luminance frames locally with ZXing `QRCodeReader`;
- decode imported QR images locally with ZXing `QRCodeMultiReader`;
- preserve the existing `onPayload` / `PairingBootstrap` validation authority;
- preserve image bounding, EXIF orientation, cancellation and fail-closed multi-QR behavior;
- remove ML Kit registrar ProGuard rules and Google Tasks usage;
- add release guardrails against accidental ML Kit reintroduction;
- add pure ZXing camera/image round-trip tests, including inverted QR.

## Privacy / product boundary

This PR is a technical dependency migration only. It does not itself publish or rewrite the Google Play privacy policy/Data Safety form. It removes the ML Kit barcode SDK from the post-migration Android dependency/runtime path so the separate Play/privacy review can describe the actual submitted build.

The scanner remains on-device. CameraX still requires `CAMERA` only for live scanning; image import continues through the Android photo picker. No pairing protocol, account, analytics, telemetry, cloud, remote service, versionCode, signing or release channel is changed.

The already-published `0.1.0-alpha.3` GitHub APK is immutable historical release evidence and is not rewritten by this source migration. Channel/privacy statements must therefore bind to the actual artifact being described or submitted.

## Licensing

ZXing Core is Apache-2.0. No ZXing source is copied into Metrora; Metrora consumes the published library dependency.

## Verification

Android companion #106 passed completely.

Its release-validation step ran and passed:

- `:app:testGithubDebugUnitTest`;
- `:app:lint`;
- `:app:assembleGithubRelease`;
- `:app:assembleFdroidRelease`;
- `:app:bundlePlayRelease`.

The workflow also successfully assembled/uploaded the QA physical-acceptance APK and validation artifacts.

Public Identity, Architecture Boundaries and Brand Boundary also passed; Windows Candidate was correctly skipped.

Metrora CI #1127's generic complete-core fallback reported three unrelated `tests/models.test.ts` DeepSeek-v4 pricing expectation failures. No Android/ZXing test failed, and this PR does not modify pricing/model code. That unrelated pricing work is intentionally not imported into this Android migration.

## Boundaries

- Android QR acquisition/decoding only;
- no C14/C08/upstream parser work;
- no Play listing/submission mutation;
- no versionCode/versionName bump;
- no release/signing changes;
- no Pro/private logic;
- draft/unmerged pending final authorization.