### PR TITLE
feat(desktop): simplify Overview measurement details

### DIFF
--- a/app/renderer/sections/Overview.test.tsx
+++ b/app/renderer/sections/Overview.test.tsx
@@ -4,8 +4,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { Polled } from '../hooks/usePolled'
 import { setActiveCurrency } from '../lib/format'
-import type { ActReportJson, DailyHistoryEntry, MenubarPayload, YieldJsonReport } from '../lib/types'
+import type { ActReportJson, DailyHistoryEntry, DurableModelAccountingRow, MenubarPayload, YieldJsonReport } from '../lib/types'
 import { Overview, OverviewContent, deriveSignals, localDateKey } from './Overview'
+import { asOverviewCurrent, deriveOverviewPricing, deriveOverviewUsage } from './overviewUsage'
 
 function polled(data: MenubarPayload): Polled<MenubarPayload> {
   return { data, error: null, loading: false, switching: false, lastSuccessAt: Date.now(), refresh: vi.fn(), refreshFresh: vi.fn() }
@@ -166,6 +167,43 @@ function signalsPayload(now: Date, over: {
   }
 }
 
+function withTokenAccounting(payload: MenubarPayload, row: Partial<DurableModelAccountingRow> = {}, accounting: Partial<NonNullable<MenubarPayload['current']['modelAccounting']>> = {}): MenubarPayload {
+  const baseRow: DurableModelAccountingRow = {
+    name: 'claude-opus-4',
+    cost: payload.current.cost,
+    savingsUSD: 0,
+    calls: payload.current.calls,
+    inputTokens: 1200,
+    outputTokens: 500,
+    reasoningTokens: 100,
+    additiveReasoningTokens: 100,
+    cacheReadTokens: 300,
+    cacheWriteTokens: 50,
+    tokenDetail: true,
+    reasoningSemantics: 'separate',
+    ...row,
+  }
+  const rows = [baseRow]
+  return {
+    ...payload,
+    current: {
+      ...payload.current,
+      inputTokens: baseRow.inputTokens,
+      outputTokens: baseRow.outputTokens,
+      cacheReadTokens: baseRow.cacheReadTokens,
+      cacheWriteTokens: baseRow.cacheWriteTokens,
+      pricingCoverage: payload.current.pricingCoverage ?? 1,
+      modelAccounting: {
+        rows,
+        gap: { cost: 0, savingsUSD: 0, calls: 0 },
+        coverage: { cost: 1, calls: 1 },
+        tokenCoverage: { cost: 1, calls: 1 },
+        ...accounting,
+      },
+    },
+  }
+}
+
 /** N consecutive days ending today; `cost(i)` sets each day's spend (i = oldest→0). */
 function consecutiveDays(now: Date, count: number, cost: (index: number) => number): DailyHistoryEntry[] {
   return Array.from({ length: count }, (_, i) => mkDay(localDateKey(new Date(now.getFullYear(), now.getMonth(), now.getDate() - (count - 1 - i))), cost(i)))
@@ -192,15 +230,17 @@ describe('Overview', () => {
 
     // The hero shows the SELECTED PERIOD's total (current.cost) + label, not
     // just today — so a 30-day view reads $312.40 under "Last 30 days".
-    expect(await screen.findByText('$312.40')).toBeInTheDocument()
+    expect(await screen.findByTestId('overview-hero-cost')).toHaveTextContent('$312.40')
     expect(screen.getByText('Last 30 days')).toBeInTheDocument()
     expect(container.querySelector('.ov-streak')).toHaveTextContent('30-day streak')
 
-    // The unified hero keeps spend/savings, activity, and efficiency in one
-    // divided card. Success/cache now live only in the scorecard column.
+    // The unified hero keeps spend/savings and activity in one divided card.
+    // Token/evidence language stays behind the collapsed cost-details disclosure.
     const kpis = screen.getByLabelText('Key performance indicators')
     expect(within(kpis).getByText('$84.20')).toBeInTheDocument()
     expect(within(kpis).getByText('Current cost and activity for the selected scope.')).toBeInTheDocument()
+    expect(within(kpis).getByLabelText('Usage summary')).toHaveTextContent(/4,200 calls\s*·\s*88 sessions/)
+    expect(within(kpis).getByTestId('overview-cost-details')).not.toHaveAttribute('open')
     expect(within(kpis).getByLabelText('What changed and what matters next')).toBeInTheDocument()
     expect(kpis.querySelector('.ov-efficiency')).not.toBeInTheDocument()
     const efficiency = screen.getByText(/Efficiency diagnostics/).closest('details')
@@ -289,7 +329,10 @@ describe('Overview', () => {
     render(<Overview period="30days" provider="all" />)
 
     expect(await screen.findByLabelText('What changed and what matters next')).toBeInTheDocument()
-    expect(screen.getByText('Coverage unknown')).toBeInTheDocument()
+    const costDetails = screen.getByTestId('overview-cost-details')
+    expect(costDetails).not.toHaveAttribute('open')
+    fireEvent.click(costDetails.querySelector('summary') as HTMLElement)
+    expect(within(costDetails).getByText('Coverage unavailable')).toBeInTheDocument()
     const outcome = screen.getByText('Cost per outcome').closest('.ov-panel')
     expect(outcome).not.toBeNull()
     expect(within(outcome as HTMLElement).getByText('$25.00')).toBeInTheDocument()
@@ -542,7 +585,7 @@ describe('Overview', () => {
     render(<OverviewContent period="30days" provider="all" overview={polled(payload)} />)
 
     expect(await screen.findByRole('status')).toHaveTextContent('Showing canonical last-good data')
-    expect(screen.getByText('$312.40')).toBeInTheDocument()
+    expect(screen.getByTestId('overview-hero-cost')).toHaveTextContent('$312.40')
   })
 
   it('groups current-driven signals into wins and improvements', () => {
@@ -674,9 +717,290 @@ describe('Overview', () => {
     render(<OverviewContent period="30days" provider="all" overview={polled(payload)} />)
 
     expect(await screen.findByLabelText('What changed and what matters next')).toBeInTheDocument()
-    expect(screen.getByText('Coverage unknown')).toBeInTheDocument()
+    const costDetails = screen.getByTestId('overview-cost-details')
+    expect(costDetails).not.toHaveAttribute('open')
+    fireEvent.click(costDetails.querySelector('summary') as HTMLElement)
+    expect(within(costDetails).getByText('Coverage unavailable')).toBeInTheDocument()
     expect(screen.getByText('Review recoverable spend')).toBeInTheDocument()
     expect(screen.queryByLabelText('Coaching signals')).not.toBeInTheDocument()
+  })
+
+  it('expands factual usage and cost details without changing the headline hierarchy', async () => {
+    const now = new Date()
+    const payload = withTokenAccounting(makePayload(now))
+
+    render(<OverviewContent period="30days" provider="all" overview={polled(payload)} />)
+
+    expect(screen.getByTestId('overview-hero-cost')).toHaveTextContent('$312.40')
+    const details = screen.getByTestId('overview-cost-details')
+    expect(details).not.toHaveAttribute('open')
+    expect(screen.getByLabelText('Usage summary')).toBeInTheDocument()
+
+    const summary = details.querySelector('summary') as HTMLElement
+    expect(summary.tagName).toBe('SUMMARY')
+    summary.focus()
+    expect(document.activeElement).toBe(summary)
+    fireEvent.click(summary)
+
+    expect(details).toHaveAttribute('open')
+    expect(within(details).getByTestId('overview-token-input')).toHaveTextContent('1.2K')
+    expect(within(details).getByTestId('overview-token-output')).toHaveTextContent('500')
+    expect(within(details).getByTestId('overview-token-cache-read')).toHaveTextContent('300')
+    expect(within(details).getByTestId('overview-token-cache-write')).toHaveTextContent('50')
+    expect(within(details).getByTestId('overview-token-reasoning')).toHaveTextContent('100')
+    expect(within(details).getByText('Fully priced')).toBeInTheDocument()
+    expect(within(details).getByText('$312.40')).toBeInTheDocument()
+  })
+
+  it('keeps explicit zero distinct from unavailable token evidence', () => {
+    const now = new Date()
+    const explicitZero = withTokenAccounting(makePayload(now), {
+      inputTokens: 0,
+      outputTokens: 0,
+      reasoningTokens: 0,
+      additiveReasoningTokens: 0,
+      cacheReadTokens: 0,
+      cacheWriteTokens: 0,
+      reasoningSemantics: 'separate',
+    })
+    const unavailable = withTokenAccounting(makePayload(now), {
+      inputTokens: 0,
+      outputTokens: 0,
+      reasoningTokens: undefined,
+      additiveReasoningTokens: undefined,
+      cacheReadTokens: 0,
+      cacheWriteTokens: 0,
+      tokenDetail: false,
+      reasoningSemantics: undefined,
+    })
+
+    const exact = deriveOverviewUsage(explicitZero.current)
+    expect(exact.input).toEqual({ value: 0, state: 'available' })
+    expect(exact.cacheRead).toEqual({ value: 0, state: 'available' })
+    expect(exact.reasoning).toMatchObject({ observedTokens: 0, semantics: 'separate', state: 'available' })
+
+    const missing = deriveOverviewUsage(unavailable.current)
+    expect(missing.input).toEqual({ value: null, state: 'unavailable' })
+    expect(missing.cacheRead).toEqual({ value: null, state: 'unavailable' })
+    expect(missing.reasoning).toMatchObject({ observedTokens: null, semantics: 'unavailable', state: 'unavailable' })
+  })
+
+  it('keeps Project period totals factual when model token detail is absent', () => {
+    const now = new Date()
+    const project = withTokenAccounting(makePayload(now), { tokenDetail: false, reasoningTokens: undefined, additiveReasoningTokens: undefined, reasoningSemantics: undefined })
+    const projectCurrent = asOverviewCurrent(project.current)
+    projectCurrent.inputTokens = 4_321
+    projectCurrent.outputTokens = 987
+    projectCurrent.cacheReadTokens = 654
+    projectCurrent.cacheWriteTokens = 123
+    projectCurrent.projectDetailCoverage = { models: 'partial', tokens: 'complete', categories: 'partial', historical: true }
+    projectCurrent.modelAccounting!.rows = []
+
+    const usage = deriveOverviewUsage(projectCurrent)
+    expect(usage.input).toEqual({ value: 4_321, state: 'available' })
+    expect(usage.output).toEqual({ value: 987, state: 'available' })
+    expect(usage.cacheRead).toEqual({ value: 654, state: 'available' })
+    expect(usage.cacheWrite).toEqual({ value: 123, state: 'available' })
+    expect(usage.reasoning).toMatchObject({ observedTokens: null, semantics: 'unavailable', state: 'unavailable' })
+  })
+
+  it('keeps a factual Project token subtotal visible with Partial state', () => {
+    const now = new Date()
+    const project = withTokenAccounting(makePayload(now), { tokenDetail: false })
+    const projectCurrent = asOverviewCurrent(project.current)
+    projectCurrent.inputTokens = 4_321
+    projectCurrent.outputTokens = 987
+    projectCurrent.cacheReadTokens = 654
+    projectCurrent.cacheWriteTokens = 123
+    projectCurrent.projectDetailCoverage = { models: 'partial', tokens: 'partial', categories: 'partial', historical: true }
+
+    const usage = deriveOverviewUsage(projectCurrent)
+    expect(usage.input).toEqual({ value: 4_321, state: 'partial' })
+    expect(usage.output).toEqual({ value: 987, state: 'partial' })
+    expect(usage.cacheRead).toEqual({ value: 654, state: 'partial' })
+    expect(usage.cacheWrite).toEqual({ value: 123, state: 'partial' })
+  })
+
+  it('does not present Project token coverage unavailable as factual zero', () => {
+    const now = new Date()
+    const project = withTokenAccounting(makePayload(now), { tokenDetail: false })
+    const projectCurrent = asOverviewCurrent(project.current)
+    projectCurrent.inputTokens = 0
+    projectCurrent.outputTokens = 0
+    projectCurrent.cacheReadTokens = 0
+    projectCurrent.cacheWriteTokens = 0
+    projectCurrent.projectDetailCoverage = { models: 'unavailable', tokens: 'unavailable', categories: 'unavailable', historical: true }
+    projectCurrent.modelAccounting!.rows = []
+
+    const usage = deriveOverviewUsage(projectCurrent)
+    expect(usage.input).toEqual({ value: null, state: 'unavailable' })
+    expect(usage.output).toEqual({ value: null, state: 'unavailable' })
+    expect(usage.cacheRead).toEqual({ value: null, state: 'unavailable' })
+    expect(usage.cacheWrite).toEqual({ value: null, state: 'unavailable' })
+  })
+
+  it('ignores model-accounting token coverage when Project period coverage is complete', () => {
+    const now = new Date()
+    const project = withTokenAccounting(makePayload(now), { tokenDetail: false }, { tokenCoverage: { cost: 0.4, calls: 0.4 } })
+    const projectCurrent = asOverviewCurrent(project.current)
+    projectCurrent.inputTokens = 4_321
+    projectCurrent.outputTokens = 987
+    projectCurrent.cacheReadTokens = 654
+    projectCurrent.cacheWriteTokens = 123
+    projectCurrent.projectDetailCoverage = { models: 'partial', tokens: 'complete', categories: 'partial', historical: true }
+
+    const usage = deriveOverviewUsage(projectCurrent)
+    expect(usage.input).toEqual({ value: 4_321, state: 'available' })
+    expect(usage.output).toEqual({ value: 987, state: 'available' })
+    expect(usage.cacheRead).toEqual({ value: 654, state: 'available' })
+    expect(usage.cacheWrite).toEqual({ value: 123, state: 'available' })
+  })
+
+  it('uses current headline token totals for unscoped payloads', () => {
+    const now = new Date()
+    const unscoped = withTokenAccounting(makePayload(now), {
+      inputTokens: 11,
+      outputTokens: 22,
+      cacheReadTokens: 33,
+      cacheWriteTokens: 44,
+    }, { tokenCoverage: { cost: 0.4, calls: 0.4 } })
+    const unscopedCurrent = asOverviewCurrent(unscoped.current)
+    unscopedCurrent.inputTokens = 4_321
+    unscopedCurrent.outputTokens = 987
+    unscopedCurrent.cacheReadTokens = 654
+    unscopedCurrent.cacheWriteTokens = 123
+    delete unscopedCurrent.projectDetailCoverage
+
+    const usage = deriveOverviewUsage(unscopedCurrent)
+    expect(usage.input).toEqual({ value: 4_321, state: 'available' })
+    expect(usage.output).toEqual({ value: 987, state: 'available' })
+    expect(usage.cacheRead).toEqual({ value: 654, state: 'available' })
+    expect(usage.cacheWrite).toEqual({ value: 123, state: 'available' })
+  })
+
+  it('uses partial pricing language and mainstream reasoning semantics', () => {
+    const now = new Date()
+    const payload = withTokenAccounting(makePayload(now), { reasoningSemantics: 'aggregate-output', reasoningTokens: 100, additiveReasoningTokens: 0 })
+    payload.current.pricingCoverage = 0.92
+
+    expect(deriveOverviewPricing(payload.current)).toEqual({
+      label: '92% priced',
+      detail: 'Some usage could not be priced; cost is partially calculated.',
+      state: 'partial',
+    })
+    const usage = deriveOverviewUsage(payload.current)
+    expect(usage.output).toEqual({ value: 500, state: 'available' })
+    expect(usage.reasoning).toMatchObject({ observedTokens: 100, semantics: 'aggregate-output', state: 'available' })
+
+    render(<OverviewContent period="30days" provider="all" overview={polled(payload)} />)
+    const details = screen.getByTestId('overview-cost-details')
+    fireEvent.click(details.querySelector('summary') as HTMLElement)
+    expect(within(details).getByText('92% priced')).toBeInTheDocument()
+    expect(within(details).getByText('Some usage could not be priced; cost is partially calculated.')).toBeInTheDocument()
+    expect(within(details).getByTestId('overview-token-reasoning')).toHaveTextContent('Included in output')
+    expect(within(details).getByTestId('overview-token-reasoning')).toHaveTextContent('not counted again')
+    expect(within(details).getByTestId('overview-token-output')).toHaveTextContent('500')
+  })
+
+  it('marks estimated pricing without presenting it as fully settled', () => {
+    const now = new Date()
+    const payload = withTokenAccounting(makePayload(now), { costIsEstimated: true })
+    payload.current.pricingCoverage = 1
+
+    expect(deriveOverviewPricing(payload.current)).toEqual({
+      label: 'Fully priced · some estimated',
+      detail: 'Pricing is present, but part of the cost uses estimated usage.',
+      state: 'estimated',
+    })
+  })
+
+  it('shows partial and unavailable reasoning without inventing zero evidence', () => {
+    const now = new Date()
+    const mixed = withTokenAccounting(makePayload(now), { reasoningSemantics: 'mixed', reasoningTokens: 80, additiveReasoningTokens: 20 })
+    const missing = withTokenAccounting(makePayload(now), { tokenDetail: false, reasoningSemantics: undefined, reasoningTokens: undefined, additiveReasoningTokens: undefined })
+
+    expect(deriveOverviewUsage(mixed.current).reasoning).toMatchObject({ semantics: 'mixed', state: 'partial', observedTokens: 80 })
+    expect(deriveOverviewUsage(missing.current).reasoning).toMatchObject({ semantics: 'unavailable', state: 'unavailable', observedTokens: null })
+
+    render(<OverviewContent period="30days" provider="all" overview={polled(mixed)} />)
+    const mixedDetails = screen.getByTestId('overview-cost-details')
+    fireEvent.click(mixedDetails.querySelector('summary') as HTMLElement)
+    expect(within(mixedDetails).getByTestId('overview-token-reasoning')).toHaveTextContent('Partial')
+    expect(within(mixedDetails).getByTestId('overview-token-reasoning')).toHaveTextContent('only separately additive usage contributes')
+  })
+
+  it('keeps reasoning evidence independent from Project input-token coverage', () => {
+    const now = new Date()
+    const project = withTokenAccounting(makePayload(now), { reasoningSemantics: 'separate', reasoningTokens: 80, additiveReasoningTokens: 80 })
+    const projectCurrent = asOverviewCurrent(project.current)
+    projectCurrent.projectDetailCoverage = { models: 'partial', tokens: 'partial', categories: 'partial', historical: true }
+
+    const usage = deriveOverviewUsage(projectCurrent)
+    expect(usage.input.state).toBe('partial')
+    expect(usage.reasoning).toMatchObject({ observedTokens: 80, semantics: 'separate', state: 'available' })
+
+    const completeInputUnavailableReasoning = withTokenAccounting(makePayload(now), { tokenDetail: false, reasoningSemantics: undefined, reasoningTokens: undefined, additiveReasoningTokens: undefined })
+    const completeCurrent = asOverviewCurrent(completeInputUnavailableReasoning.current)
+    completeCurrent.projectDetailCoverage = { models: 'partial', tokens: 'complete', categories: 'partial', historical: true }
+    completeCurrent.modelAccounting!.rows = []
+    const completeUsage = deriveOverviewUsage(completeCurrent)
+    expect(completeUsage.input.state).toBe('available')
+    expect(completeUsage.reasoning.state).toBe('unavailable')
+  })
+
+  it('keeps material pricing quality visible in the collapsed Home', () => {
+    const now = new Date()
+    const partial = makePayload(now)
+    partial.current.pricingCoverage = 0.92
+    render(<OverviewContent period="30days" provider="all" overview={polled(partial)} />)
+
+    const quality = screen.getByTestId('overview-cost-quality')
+    expect(quality).toHaveAttribute('data-state', 'partial')
+    expect(quality).toHaveTextContent('92% priced')
+    expect(screen.getByTestId('overview-cost-details')).not.toHaveAttribute('open')
+  })
+
+  it('keeps unavailable pricing quality visible in the collapsed Home', () => {
+    const now = new Date()
+    const unavailable = makePayload(now)
+    unavailable.current.pricingCoverage = null
+    render(<OverviewContent period="30days" provider="all" overview={polled(unavailable)} />)
+
+    const quality = screen.getByTestId('overview-cost-quality')
+    expect(quality).toHaveAttribute('data-state', 'unavailable')
+    expect(quality).toHaveTextContent('Coverage unavailable')
+    expect(screen.getByTestId('overview-cost-details')).not.toHaveAttribute('open')
+  })
+
+  it('keeps estimation visible even when pricing coverage is complete', () => {
+    const now = new Date()
+    const estimated = withTokenAccounting(makePayload(now), { costIsEstimated: true })
+    estimated.current.pricingCoverage = 1
+    render(<OverviewContent period="30days" provider="all" overview={polled(estimated)} />)
+
+    const quality = screen.getByTestId('overview-cost-quality')
+    expect(quality).toHaveAttribute('data-state', 'estimated')
+    expect(quality).toHaveTextContent('Some cost estimated')
+  })
+
+  it('omits unnecessary cost-quality warning clutter for fully settled pricing', () => {
+    const now = new Date()
+    const complete = withTokenAccounting(makePayload(now))
+    complete.current.pricingCoverage = 1
+    render(<OverviewContent period="30days" provider="all" overview={polled(complete)} />)
+
+    expect(screen.queryByTestId('overview-cost-quality')).not.toBeInTheDocument()
+  })
+
+  it('keeps Overview navigation actions available beside the disclosure', () => {
+    const now = new Date()
+    const onNavigate = vi.fn()
+    render(<OverviewContent period="30days" provider="all" overview={polled(withTokenAccounting(makePayload(now)))} onNavigate={onNavigate} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open report →' }))
+    expect(onNavigate).toHaveBeenCalledWith('optimize')
+    fireEvent.click(screen.getByRole('button', { name: 'See all →' }))
+    expect(onNavigate).toHaveBeenCalledWith('sessions')
   })
 
   it('renders no Signals card when every group is empty', async () => {
@@ -765,7 +1089,7 @@ describe('Overview workflow card', () => {
 
     render(<Overview period="30days" provider="all" />)
 
-    await screen.findByText('$312.40')
+    await screen.findByTestId('overview-hero-cost')
     expect(screen.queryByRole('heading', { name: 'Workflow' })).not.toBeInTheDocument()
   })
 
@@ -779,7 +1103,7 @@ describe('Overview workflow card', () => {
 
     render(<Overview period="30days" provider="all" />)
 
-    await screen.findByText('$312.40')
+    await screen.findByTestId('overview-hero-cost')
     expect(screen.queryByRole('heading', { name: 'Workflow' })).not.toBeInTheDocument()
   })
 

--- a/app/renderer/sections/OverviewHomeSummary.tsx
+++ b/app/renderer/sections/OverviewHomeSummary.tsx
@@ -1,10 +1,11 @@
 import { useEffect, useRef } from 'react'
 import gsap from 'gsap'
 
-import { formatUsd } from '../lib/format'
+import { formatCompact, formatUsd } from '../lib/format'
 import { motionEnabled } from '../lib/motion'
 import type { MenubarPayload } from '../lib/types'
 import type { OverviewDecision, OverviewDecisionFact, OverviewDecisionTarget } from './overviewDecision'
+import { deriveOverviewPricing, deriveOverviewUsage, type OverviewReasoning, type OverviewTokenMetric } from './overviewUsage'
 
 function CountUp({ value, animateKey }: { value: number; animateKey: string }) {
   const ref = useRef<HTMLDivElement>(null)
@@ -29,7 +30,7 @@ function CountUp({ value, animateKey }: { value: number; animateKey: string }) {
     return () => { tween.kill() }
   }, [value, animateKey])
 
-  return <div ref={ref} className="ov-hero-num" data-countup={value}>{formatUsd(value)}</div>
+  return <div ref={ref} className="ov-hero-num" data-countup={value} data-testid="overview-hero-cost">{formatUsd(value)}</div>
 }
 
 function DecisionFact({
@@ -62,6 +63,116 @@ function DecisionFact({
   )
 }
 
+function metricValue(metric: OverviewTokenMetric): string {
+  return metric.value === null ? 'Unavailable' : formatCompact(metric.value)
+}
+
+function metricState(metric: OverviewTokenMetric): string {
+  if (metric.state === 'partial') return 'Partial'
+  if (metric.state === 'unavailable') return 'Unavailable'
+  return 'Reported'
+}
+
+function UsageMetric({ label, metric, testId }: { label: string; metric: OverviewTokenMetric; testId: string }) {
+  return (
+    <div className={`ov-home-token-metric ov-home-token-${metric.state}`} data-testid={testId} data-state={metric.state}>
+      <dt>{label}</dt>
+      <dd><strong>{metricValue(metric)}</strong><small>{metricState(metric)}</small></dd>
+    </div>
+  )
+}
+
+function CostQualityIndicator({ current }: { current: MenubarPayload['current'] }) {
+  const pricing = deriveOverviewPricing(current)
+  if (pricing.state === 'complete') return null
+
+  const label = pricing.state === 'estimated' ? 'Some cost estimated' : pricing.label
+  return (
+    <div
+      className={`ov-home-cost-quality ov-home-cost-quality-${pricing.state}`}
+      data-testid="overview-cost-quality"
+      data-state={pricing.state}
+      aria-label={`Cost quality: ${pricing.label}. ${pricing.detail}`}
+    >
+      <span className="ov-label">Cost quality</span>
+      <strong>{label}</strong>
+    </div>
+  )
+}
+
+function reasoningPresentation(reasoning: OverviewReasoning): { value: string; detail: string; state: OverviewTokenMetric['state'] } {
+  if (reasoning.semantics === 'unavailable') {
+    return { value: 'Unavailable', detail: 'No reasoning evidence was reported for this scope.', state: 'unavailable' }
+  }
+  if (reasoning.semantics === 'aggregate-output') {
+    return {
+      value: 'Included in output',
+      detail: reasoning.state === 'partial' ? 'Already included in Output; reasoning evidence is partial.' : 'Already included in Output; it is not counted again.',
+      state: reasoning.state,
+    }
+  }
+  if (reasoning.semantics === 'separate') {
+    if (reasoning.state === 'partial') {
+      return { value: 'Partial', detail: 'Separate reasoning is evidenced for part of this scope.', state: 'partial' }
+    }
+    return {
+      value: reasoning.observedTokens === null ? 'Unavailable' : formatCompact(reasoning.observedTokens),
+      detail: 'Reported separately and included in total usage.',
+      state: reasoning.observedTokens === null ? 'unavailable' : 'available',
+    }
+  }
+  const observed = reasoning.observedTokens && reasoning.observedTokens > 0 ? ` ${formatCompact(reasoning.observedTokens)} observed.` : ''
+  return {
+    value: 'Partial',
+    detail: `Reasoning evidence is mixed; only separately additive usage contributes to totals.${observed}`,
+    state: 'partial',
+  }
+}
+
+function CostDetails({ current }: { current: MenubarPayload['current'] }) {
+  const usage = deriveOverviewUsage(current)
+  const pricing = deriveOverviewPricing(current)
+  const reasoning = reasoningPresentation(usage.reasoning)
+
+  return (
+    <details className="ov-home-details" data-testid="overview-cost-details">
+      <summary>
+        <span>Cost details</span>
+        <span className="ov-home-details-hint">View usage and pricing</span>
+      </summary>
+      <div className="ov-home-details-body">
+        <section className="ov-home-detail-section" aria-labelledby="overview-usage-details-heading">
+          <h3 id="overview-usage-details-heading">Usage details</h3>
+          <dl className="ov-home-token-grid">
+            <UsageMetric label="Input" metric={usage.input} testId="overview-token-input" />
+            <UsageMetric label="Output" metric={usage.output} testId="overview-token-output" />
+            <UsageMetric label="Cache read" metric={usage.cacheRead} testId="overview-token-cache-read" />
+            <UsageMetric label="Cache write" metric={usage.cacheWrite} testId="overview-token-cache-write" />
+            <div className={`ov-home-token-metric ov-home-token-${reasoning.state}`} data-testid="overview-token-reasoning" data-state={reasoning.state}>
+              <dt>Reasoning</dt>
+              <dd><strong>{reasoning.value}</strong><small>{reasoning.detail}</small></dd>
+            </div>
+          </dl>
+          <p className="ov-home-detail-note">{usage.evidenceNote}</p>
+        </section>
+
+        <section className="ov-home-detail-section" aria-labelledby="overview-cost-details-heading">
+          <h3 id="overview-cost-details-heading">Cost details</h3>
+          <div className="ov-home-cost-list">
+            <div className="ov-home-cost-row"><span>Current cost</span><strong>{formatUsd(current.cost)}</strong></div>
+            <div className={`ov-home-cost-row ov-home-cost-${pricing.state}`}>
+              <span>Pricing coverage</span>
+              <strong>{pricing.label}</strong>
+              <small>{pricing.detail}</small>
+            </div>
+          </div>
+          <p className="ov-home-detail-note">This view explains measured usage and current pricing coverage. Historical price records and exact applied pricing context are not available in the Overview payload yet.</p>
+        </section>
+      </div>
+    </details>
+  )
+}
+
 export function OverviewHomeSummary({
   current,
   decision,
@@ -81,7 +192,6 @@ export function OverviewHomeSummary({
   animateKey: string
   onNavigate?: (target: OverviewDecisionTarget) => void
 }) {
-  const hasQualityWarning = decision.quality.tone === 'warn'
   // pricing coverage used to occupy both the Data quality fact and the Material
   // warning slot. Keep one compact diagnostic fact, never duplicate the same
   // issue as a headline warning.
@@ -95,8 +205,17 @@ export function OverviewHomeSummary({
           <span className="ov-streak"><b>{streak}</b>-day streak</span>
         </div>
         <CountUp value={current.cost} animateKey={animateKey} />
-        <div className="ov-hero-sub">{current.calls.toLocaleString('en-US')} calls · {current.sessions.toLocaleString('en-US')} sessions</div>
+        <div className="ov-home-primary-meta">
+          <div className="ov-home-usage-summary" aria-label="Usage summary">
+            <span className="ov-label">Usage</span>
+            <strong>{current.calls.toLocaleString('en-US')} calls</strong>
+            <span aria-hidden="true">·</span>
+            <strong>{current.sessions.toLocaleString('en-US')} sessions</strong>
+          </div>
+          <CostQualityIndicator current={current} />
+        </div>
         <p className="ov-home-primary-copy">Current cost and activity for the selected scope.</p>
+        <CostDetails current={current} />
         {(saved > 0 || localSaved > 0) && (
           <div className="ov-home-savings">
             {saved > 0 ? (
@@ -113,7 +232,6 @@ export function OverviewHomeSummary({
         <div className="ov-home-facts">
           <DecisionFact fact={decision.comparison} />
           <DecisionFact fact={decision.driver} onNavigate={onNavigate} />
-          {hasQualityWarning ? <DecisionFact fact={decision.quality} /> : null}
         </div>
         {materialWarning ? (
           <div className={`ov-home-warning ov-home-${decision.warning.tone}`}>

--- a/app/renderer/sections/overviewUsage.ts
+++ b/app/renderer/sections/overviewUsage.ts
@@ -1,0 +1,188 @@
+import type { DurableModelAccountingRow, MenubarPayload, ReasoningTokenSemantics } from '../lib/types'
+
+export type OverviewEvidenceState = 'available' | 'partial' | 'unavailable'
+
+export type OverviewTokenMetric = {
+  value: number | null
+  state: OverviewEvidenceState
+}
+
+export type OverviewReasoning = {
+  observedTokens: number | null
+  semantics: ReasoningTokenSemantics
+  state: OverviewEvidenceState
+}
+
+export type OverviewUsageDetails = {
+  input: OverviewTokenMetric
+  output: OverviewTokenMetric
+  cacheRead: OverviewTokenMetric
+  cacheWrite: OverviewTokenMetric
+  reasoning: OverviewReasoning
+  evidenceNote: string
+}
+
+export type OverviewPricingDetails = {
+  label: string
+  detail: string
+  state: 'complete' | 'partial' | 'unavailable' | 'estimated'
+}
+
+export type OverviewCurrent = MenubarPayload['current'] & {
+  estimatedCostUSD?: number
+  projectDetailCoverage?: {
+    models: 'complete' | 'partial' | 'unavailable'
+    tokens: 'complete' | 'partial' | 'unavailable'
+    categories: 'complete' | 'partial' | 'unavailable'
+    historical: boolean
+  }
+}
+
+export function asOverviewCurrent(current: MenubarPayload['current']): OverviewCurrent {
+  return current as OverviewCurrent
+}
+
+function tokenMetric(value: number | null, state: OverviewEvidenceState): OverviewTokenMetric {
+  return { value, state }
+}
+
+function combineReasoningSemantics(rows: DurableModelAccountingRow[]): ReasoningTokenSemantics {
+  const semantics = rows.map(row => row.reasoningSemantics ?? 'unavailable')
+  if (semantics.length === 0 || semantics.every(value => value === 'unavailable')) return 'unavailable'
+  const first = semantics[0]
+  return semantics.every(value => value === first) ? first : 'mixed'
+}
+
+function reasoningForRows(rows: DurableModelAccountingRow[]): OverviewReasoning {
+  const semantics = combineReasoningSemantics(rows)
+  if (semantics === 'unavailable') {
+    return { observedTokens: null, semantics, state: 'unavailable' }
+  }
+
+  const observedTokens = rows.reduce((total, row) => {
+    if ((row.reasoningSemantics ?? 'unavailable') === 'unavailable') return total
+    return total + (row.reasoningTokens ?? 0)
+  }, 0)
+
+  return {
+    observedTokens,
+    semantics,
+    state: semantics === 'mixed' ? 'partial' : 'available',
+  }
+}
+
+function unavailableUsage(evidenceNote: string): OverviewUsageDetails {
+  return {
+    input: tokenMetric(null, 'unavailable'),
+    output: tokenMetric(null, 'unavailable'),
+    cacheRead: tokenMetric(null, 'unavailable'),
+    cacheWrite: tokenMetric(null, 'unavailable'),
+    reasoning: { observedTokens: null, semantics: 'unavailable', state: 'unavailable' },
+    evidenceNote,
+  }
+}
+
+function reasoningFromAccounting(current: MenubarPayload['current']): OverviewReasoning {
+  const detailedRows = current.modelAccounting?.rows.filter(row => row.tokenDetail) ?? []
+  return reasoningForRows(detailedRows)
+}
+
+function projectTokenUsage(current: OverviewCurrent): OverviewUsageDetails | null {
+  const coverage = current.projectDetailCoverage?.tokens
+  if (!coverage) return null
+
+  const reasoning = reasoningFromAccounting(current)
+  if (coverage === 'unavailable') {
+    return {
+      ...unavailableUsage('Token totals are unavailable for this Project scope; missing values are not shown as zero.'),
+      reasoning,
+    }
+  }
+
+  const state: OverviewEvidenceState = coverage === 'complete' ? 'available' : 'partial'
+  return {
+    input: tokenMetric(current.inputTokens, state),
+    output: tokenMetric(current.outputTokens, state),
+    cacheRead: tokenMetric(current.cacheReadTokens, state),
+    cacheWrite: tokenMetric(current.cacheWriteTokens, state),
+    reasoning,
+    evidenceNote: coverage === 'complete'
+      ? 'Period token totals are complete for this Project scope; model identity detail is tracked separately.'
+      : 'Period token totals remain factual for this Project scope, but the supporting detail is partial.',
+  }
+}
+
+/**
+ * Derives Overview-only display facts. It does not aggregate accounting data
+ * for any other surface and never turns an absent token field into zero.
+ */
+export function deriveOverviewUsage(current: MenubarPayload['current']): OverviewUsageDetails {
+  const overviewCurrent = asOverviewCurrent(current)
+  const projectUsage = projectTokenUsage(overviewCurrent)
+  if (projectUsage) return projectUsage
+
+  const values = [overviewCurrent.inputTokens, overviewCurrent.outputTokens, overviewCurrent.cacheReadTokens, overviewCurrent.cacheWriteTokens]
+  const hasAccountingTokenEvidence = overviewCurrent.modelAccounting?.rows.some(row => row.tokenDetail) ?? false
+  const hasLegacyEvidence = overviewCurrent.calls === 0 || values.some(value => value > 0) || hasAccountingTokenEvidence
+  if (!hasLegacyEvidence) {
+    return unavailableUsage('This payload does not include token-level evidence for the selected scope.')
+  }
+
+  const reasoning = reasoningFromAccounting(overviewCurrent)
+  return {
+    input: tokenMetric(overviewCurrent.inputTokens, 'available'),
+    output: tokenMetric(overviewCurrent.outputTokens, 'available'),
+    cacheRead: tokenMetric(overviewCurrent.cacheReadTokens, 'available'),
+    cacheWrite: tokenMetric(overviewCurrent.cacheWriteTokens, 'available'),
+    reasoning,
+    evidenceNote: reasoning.state === 'unavailable'
+      ? 'Usage totals are reported by this Overview payload; reasoning detail is unavailable here.'
+      : 'Usage totals are reported by this Overview payload; reasoning detail comes from model accounting evidence.',
+  }
+}
+
+/**
+ * Keeps pricing coverage language factual and intentionally separate from the
+ * cost calculation. Historical price records and route-level provenance are
+ * not part of the Overview payload, so this is not a "Why this cost?" answer.
+ */
+export function deriveOverviewPricing(current: MenubarPayload['current']): OverviewPricingDetails {
+  const overviewCurrent = asOverviewCurrent(current)
+  const coverage = overviewCurrent.pricingCoverage
+  const estimatedCostUSD = overviewCurrent.estimatedCostUSD ?? 0
+  const hasEstimatedRows = overviewCurrent.modelAccounting?.rows.some(row => row.costIsEstimated === true || (row.estimatedCostUSD ?? 0) > 0) ?? false
+  const hasUnpricedModels = (overviewCurrent.unpricedModels?.length ?? 0) > 0
+
+  if (typeof coverage !== 'number') {
+    return {
+      label: hasEstimatedRows || estimatedCostUSD > 0 ? 'Coverage unavailable · some estimated' : 'Coverage unavailable',
+      detail: hasEstimatedRows || estimatedCostUSD > 0
+        ? 'Pricing coverage is not reported, and part of the cost uses estimated usage.'
+        : 'This payload does not report pricing coverage, so cost completeness is not asserted.',
+      state: hasEstimatedRows || estimatedCostUSD > 0 ? 'estimated' : 'unavailable',
+    }
+  }
+
+  if (coverage < 1 || hasUnpricedModels) {
+    const percent = Math.max(0, Math.min(99, Math.round(coverage * 100)))
+    return {
+      label: `${percent}% priced`,
+      detail: 'Some usage could not be priced; cost is partially calculated.',
+      state: 'partial',
+    }
+  }
+
+  if (estimatedCostUSD > 0 || hasEstimatedRows) {
+    return {
+      label: 'Fully priced · some estimated',
+      detail: 'Pricing is present, but part of the cost uses estimated usage.',
+      state: 'estimated',
+    }
+  }
+
+  return {
+    label: 'Fully priced',
+    detail: 'All cost-bearing usage in this scope resolved a price.',
+    state: 'complete',
+  }
+}

--- a/app/renderer/styles/overview-home.css
+++ b/app/renderer/styles/overview-home.css
@@ -14,12 +14,45 @@
 .ov-home-shell > .ov-heatmap-bare { grid-area: history; display: flex; flex-direction: column; justify-content: space-between; gap: 8px; }
 .ov-home-shell > .ov-efficiency { grid-area: efficiency; border-left: 1px solid var(--line2); }
 
-.ov-home-primary-copy { max-width: 54ch; margin: 4px 0 0; color: var(--mut2); font-size: 10.5px; line-height: 1.45; }
+.ov-home-primary-meta { display: flex; width: 100%; flex-wrap: wrap; align-items: baseline; justify-content: space-between; gap: 6px 14px; }
+.ov-home-usage-summary { display: flex; flex-wrap: wrap; align-items: baseline; gap: 5px; margin-top: 1px; color: var(--mut); font-size: 11.5px; font-variant-numeric: tabular-nums; }
+.ov-home-usage-summary .ov-label { margin-right: 2px; color: var(--mut2); font-size: 9.5px; font-weight: 620; letter-spacing: .045em; text-transform: uppercase; }
+.ov-home-usage-summary strong { color: var(--ink); font-size: 11.5px; font-weight: 620; }
+.ov-home-cost-quality { display: flex; min-width: 0; flex-wrap: wrap; align-items: baseline; gap: 5px; margin-top: 1px; font-size: 10.5px; }
+.ov-home-cost-quality .ov-label { color: var(--mut2); font-size: 9.5px; font-weight: 620; letter-spacing: .045em; text-transform: uppercase; }
+.ov-home-cost-quality strong { color: var(--warn); font-size: 10.5px; font-weight: 650; }
+.ov-home-cost-quality-unavailable strong { color: var(--mut); }
+.ov-home-primary-copy { max-width: 54ch; margin: 2px 0 0; color: var(--mut2); font-size: 10.5px; line-height: 1.45; }
+.ov-home-details { width: 100%; margin-top: 5px; border-top: 1px solid var(--line2); color: var(--mut); }
+.ov-home-details > summary { display: flex; align-items: baseline; gap: 12px; padding: 9px 0 3px; color: var(--ink); font-size: 11px; font-weight: 620; cursor: pointer; list-style-position: outside; user-select: none; }
+.ov-home-details > summary:hover { color: var(--accent-text); }
+.ov-home-details > summary:focus-visible { border-radius: 4px; outline: 1px solid var(--accent); outline-offset: 2px; }
+.ov-home-details-hint { margin-left: auto; color: var(--mut2); font-size: 10px; font-weight: 500; }
+.ov-home-details-body { display: grid; gap: 12px; padding: 7px 0 1px; }
+.ov-home-detail-section + .ov-home-detail-section { padding-top: 11px; border-top: 1px solid var(--line2); }
+.ov-home-detail-section h3 { margin: 0 0 8px; color: var(--mut2); font-size: 9.5px; font-weight: 620; letter-spacing: .045em; text-transform: uppercase; }
+.ov-home-token-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 8px 14px; margin: 0; }
+.ov-home-token-metric { min-width: 0; }
+.ov-home-token-metric dt { color: var(--mut2); font-size: 10.5px; }
+.ov-home-token-metric dd { display: flex; min-width: 0; flex-direction: column; gap: 2px; margin: 2px 0 0; }
+.ov-home-token-metric strong { overflow: hidden; color: var(--ink); font-family: var(--mono); font-size: 12px; font-weight: 620; font-variant-numeric: tabular-nums; text-overflow: ellipsis; white-space: nowrap; }
+.ov-home-token-metric small { color: var(--mut); font-size: 9.5px; line-height: 1.35; }
+.ov-home-token-partial strong, .ov-home-token-partial small { color: var(--warn); }
+.ov-home-token-unavailable strong { color: var(--mut); font-family: inherit; font-size: 11px; font-weight: 560; }
+.ov-home-detail-note { margin: 9px 0 0; color: var(--mut2); font-size: 10px; line-height: 1.4; }
+.ov-home-cost-list { display: grid; gap: 8px; }
+.ov-home-cost-row { display: grid; grid-template-columns: minmax(0, 1fr) auto; align-items: baseline; gap: 3px 10px; font-size: 10.5px; }
+.ov-home-cost-row > span { color: var(--mut2); }
+.ov-home-cost-row > strong { color: var(--ink); font-family: var(--mono); font-size: 11.5px; font-weight: 620; font-variant-numeric: tabular-nums; text-align: right; }
+.ov-home-cost-row > small { grid-column: 1 / -1; color: var(--mut); font-size: 9.5px; line-height: 1.35; }
+.ov-home-cost-partial > strong { color: var(--warn); }
+.ov-home-cost-unavailable > strong { color: var(--mut); font-family: inherit; font-size: 11px; font-weight: 560; }
+.ov-home-cost-estimated > strong { color: var(--warn); }
 .ov-home-savings { width: 100%; margin-top: auto; }
 .ov-home-savings:empty { display: none; }
 .ov-home-savings .ov-saved-line + .ov-saved-line { margin-top: 0; }
 
-.ov-home-facts { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); }
+.ov-home-facts { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); }
 .ov-home-fact {
   position: relative; display: flex; min-width: 0; flex-direction: column; align-items: flex-start;
   gap: 3px; min-height: 82px; padding: 12px 13px; border: 0; border-right: 1px solid var(--line2);
@@ -65,5 +98,6 @@
 @media (max-width: 620px) {
   .ov-home-facts { grid-template-columns: 1fr; }
   .ov-home-fact { min-height: 0; border-right: 0; }
+  .ov-home-token-grid { grid-template-columns: 1fr; }
   .ov-home-next-action { align-items: flex-start; flex-direction: column; }
 }


### PR DESCRIPTION
## Summary

Simplifies the Desktop Overview/Home measurement presentation with progressive disclosure while preserving Metrora's accounting and evidence semantics. This is the first bounded UI slice for #203; the umbrella issue remains open.

## Final authority

- Re-aligned base: `f795a4010fbcf228cfc125f43c0dc4cf9f289f15`
- Final HEAD: `e66af9910c4efd3f21e9946999eebea026fcd898`
- Merge commit: `fbc597faa99e82873264b99c49d7d293f0544d94`

The change was re-aligned on current `main` after #208 without replaying unrelated history or accounting changes.

## Overview hierarchy

The default Home emphasizes:

1. Cost and activity.
2. Compact Usage summary with calls and sessions.
3. Material cost-quality status when pricing is partial, unavailable, or estimated.
4. Existing comparison/driver facts and navigation actions.

Specialist detail remains behind a collapsed native `Cost details` disclosure.

## Disclosure behavior

Expanding `Cost details` shows factual Input, Output, Cache read/write, Reasoning, current cost and pricing coverage/estimation state. The interaction uses semantic `<details>/<summary>`, is keyboard-focusable, and preserves existing reduced-motion behavior.

## Truthfulness rules

- Period-level `current.*` token totals remain the primary Overview authority.
- Project token coverage controls complete/partial/unavailable presentation independently from model-detail coverage.
- Explicit factual zero remains `0`; missing evidence is `Unavailable`; factual partial subtotals remain numeric and marked `Partial`.
- Reasoning evidence remains independent from input-token coverage.
- Aggregate-output reasoning is shown as included in output and is never counted again.
- Partial/unavailable/estimated cost quality remains visible even while the detail disclosure is collapsed.
- Fully settled pricing does not add unnecessary warning clutter.

## Why this cost?

A full `Why this cost?` explanation remains deferred because Overview does not yet carry the exact historical applied price record plus canonical route/context/source evidence required to explain each cost-bearing row without approximation. This PR therefore uses the truthful `Cost details` label and does not add backend/pricing authority.

## Files

- `app/renderer/sections/OverviewHomeSummary.tsx`
- `app/renderer/sections/overviewUsage.ts`
- `app/renderer/styles/overview-home.css`
- `app/renderer/sections/Overview.test.tsx`

## Validation

- Focused Overview: 50 passed.
- Desktop renderer: 595 passed.
- Root Vitest: 3,237 passed, 5 skipped.
- Typechecks, renderer build, CLI build, source-size ratchet and `git diff --check` passed.
- Final re-aligned CI: Metrora CI #1150 passed; Architecture, Public Identity and Brand Boundary passed; Windows Candidate skipped.

No accounting, pricing/history, cache authority, parser/collector, mobile/companion, quota, or unrelated surface behavior is changed.