### PR TITLE
feat(history): persist Project model and category detail

### DIFF
--- a/src/daily-cache-category-detail.ts
+++ b/src/daily-cache-category-detail.ts
@@ -49,3 +49,41 @@ export function sanitizeCategories(raw: unknown): DailyEntry['categories'] {
   }
   return out
 }
+
+export type SanitizedCategories = {
+  rows: DailyEntry['categories']
+  sanitizationIsLossless: boolean
+}
+
+const REQUIRED_CATEGORY_NUMERICS = ['turns', 'cost', 'savingsUSD', 'editTurns', 'oneShotTurns'] as const
+
+function hasRequiredCategoryStats(category: Record<string, unknown>): boolean {
+  return REQUIRED_CATEGORY_NUMERICS.every(field =>
+    Object.hasOwn(category, field) && typeof category[field] === 'number' && Number.isFinite(category[field]),
+  )
+}
+
+/**
+ * Sanitize Project category detail while retaining whether any serialized row
+ * was rejected or had its required numeric structure altered.
+ */
+export function sanitizeCategoriesWithIntegrity(raw: unknown): SanitizedCategories {
+  if (!isRecord(raw)) return { rows: {}, sanitizationIsLossless: false }
+
+  const rows: DailyEntry['categories'] = {}
+  let sanitizationIsLossless = true
+  for (const [name, category] of Object.entries(raw)) {
+    if (name in Object.prototype || !isRecord(category) || !hasRequiredCategoryStats(category)) {
+      sanitizationIsLossless = false
+      continue
+    }
+    setOwn(rows, name, {
+      turns: category.turns as number,
+      cost: category.cost as number,
+      savingsUSD: category.savingsUSD as number,
+      editTurns: category.editTurns as number,
+      oneShotTurns: category.oneShotTurns as number,
+    })
+  }
+  return { rows, sanitizationIsLossless }
+}

--- a/src/daily-cache-category-detail.ts
+++ b/src/daily-cache-category-detail.ts
@@ -1,0 +1,51 @@
+import type { CategoryDayStats, DailyEntry } from './daily-cache-types.js'
+
+function finiteNumber(value: unknown): number {
+  return typeof value === 'number' && Number.isFinite(value) ? value : 0
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value)
+}
+
+export function setOwn<T>(target: Record<string, T>, key: string, value: T): void {
+  Object.defineProperty(target, key, { value, enumerable: true, writable: true, configurable: true })
+}
+
+export function emptyCategoryStats(): CategoryDayStats {
+  return { turns: 0, cost: 0, savingsUSD: 0, editTurns: 0, oneShotTurns: 0 }
+}
+
+export function cloneCategoryStats(stats: CategoryDayStats): CategoryDayStats {
+  return {
+    turns: finiteNumber(stats.turns),
+    cost: finiteNumber(stats.cost),
+    savingsUSD: finiteNumber(stats.savingsUSD),
+    editTurns: finiteNumber(stats.editTurns),
+    oneShotTurns: finiteNumber(stats.oneShotTurns),
+  }
+}
+
+export function mergeCategoryStats(target: CategoryDayStats, source: CategoryDayStats): void {
+  target.turns += source.turns
+  target.cost += source.cost
+  target.savingsUSD += source.savingsUSD ?? 0
+  target.editTurns += source.editTurns
+  target.oneShotTurns += source.oneShotTurns
+}
+
+export function sanitizeCategories(raw: unknown): DailyEntry['categories'] {
+  if (!isRecord(raw)) return {}
+  const out: DailyEntry['categories'] = {}
+  for (const [name, category] of Object.entries(raw)) {
+    if (name in Object.prototype || !isRecord(category)) continue
+    setOwn(out, name, {
+      turns: finiteNumber(category.turns),
+      cost: finiteNumber(category.cost),
+      savingsUSD: finiteNumber(category.savingsUSD),
+      editTurns: finiteNumber(category.editTurns),
+      oneShotTurns: finiteNumber(category.oneShotTurns),
+    })
+  }
+  return out
+}

--- a/src/daily-cache-core.ts
+++ b/src/daily-cache-core.ts
@@ -5,9 +5,14 @@ import { join } from 'path'
 import type { DateRange, ProjectSummary } from './types.js'
 import { getMetroraCacheDir } from './product-paths.js'
 import { sanitizeModels } from './daily-cache-model-detail.js'
+import { sanitizeCategories } from './daily-cache-category-detail.js'
+import { sanitizeProjectDetails } from './daily-cache-project-detail.js'
 import type { CategoryDayStats, DailyCache, DailyEntry, ModelDayStats, ProjectDayStats, ProviderDaySlice } from './daily-cache-types.js'
 import { mergeDayEntries, setOwn } from './daily-cache-merge.js'
 import { writeDailyCacheGenerationFromPayloadV1 } from './cache-generation.js'
+// v20: Source Project daily rollups add factual model/category detail alongside
+// the existing token evidence. v19 history is adopted losslessly, re-derived
+// where sources survive, and carried otherwise.
 // v19: Source Project daily rollups add factual token evidence. v18 history is
 // adopted losslessly, re-derived where sources survive, and carried otherwise.
 // v18: Copilot accounting changed; v17 history is adopted untrusted, re-derived where sources survive, and carried otherwise.
@@ -67,15 +72,15 @@ import { writeDailyCacheGenerationFromPayloadV1 } from './cache-generation.js'
 // that older binaries skipped. v8 added local-model savings to the daily
 // rollup; the `savingsConfigHash` field is invalidated separately when the
 // user changes their `localModelSavings` mapping.
-export const DAILY_CACHE_VERSION = 19
-const MIN_SUPPORTED_VERSION = 15
+export const DAILY_CACHE_VERSION = 20
+export const MIN_SUPPORTED_VERSION = 15
 // A durable source is allowed to outlive the bounded detailed session cache.
 // This marker makes the first run after that contract change an explicit,
 // one-time reconciliation rather than relying on the ordinary 365-day poll.
 // The Codex session-meta model authority change also advances this marker so
 // surviving Codex sources anywhere in the 10-year retained history are
 // re-derived; sourceless provider slices remain carried by NEVER-LOSE merge.
-export const DURABLE_HISTORY_AUTHORITY = 'materialize-before-evict-v2-project-tokens-codex-session-meta-model-v1'
+export const DURABLE_HISTORY_AUTHORITY = 'materialize-before-evict-v2-project-tokens-codex-session-meta-model-v1-project-model-category-v1'
 // Version-suffixed so different binaries each own a distinct file and never
 // clobber an incompatible schema. Bumping the version mints a fresh filename;
 // adoptOlderDailyCaches then unions days out of every previous file (including
@@ -84,7 +89,17 @@ export const DURABLE_HISTORY_AUTHORITY = 'materialize-before-evict-v2-project-to
 const DAILY_CACHE_FILENAME = `daily-cache.v${DAILY_CACHE_VERSION}.json`
 
 
-export type { CategoryDayStats, DailyCache, DailyEntry, ModelDayStats, ProjectDayStats, ProviderDaySlice } from './daily-cache-types.js'
+export type {
+  CategoryDayStats,
+  DailyCache,
+  DailyEntry,
+  DurableProjectDetailCoverage,
+  ModelDayStats,
+  ProjectCategoryDetail,
+  ProjectDayStats,
+  ProjectModelDetail,
+  ProviderDaySlice,
+} from './daily-cache-types.js'
 export { emptyDailyEntry } from './daily-cache-reconciliation.js'
 export { mergeDayEntries } from './daily-cache-merge.js'
 
@@ -135,22 +150,6 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === 'object' && !Array.isArray(value)
 }
 
-function sanitizeCategories(raw: unknown): DailyEntry['categories'] {
-  if (!isRecord(raw)) return {}
-  const out: DailyEntry['categories'] = {}
-  for (const [name, c] of Object.entries(raw)) {
-    if (name in Object.prototype || !isRecord(c)) continue
-    setOwn(out, name, {
-      turns: num(c.turns),
-      cost: num(c.cost),
-      savingsUSD: num(c.savingsUSD),
-      editTurns: num(c.editTurns),
-      oneShotTurns: num(c.oneShotTurns),
-    })
-  }
-  return out
-}
-
 const OPTIONAL_SLICE_NUMERICS = ['sessions', 'inputTokens', 'outputTokens', 'reasoningTokens', 'additiveReasoningTokens', 'cacheReadTokens', 'cacheWriteTokens', 'editTurns', 'oneShotTurns'] as const
 
 /// Same junk-tolerance as sanitizeProjects, one level up: a foreign cache can
@@ -194,6 +193,7 @@ function sanitizeProjects(raw: unknown): { projects?: DailyEntry['projects'] } {
     for (const field of ['inputTokens', 'outputTokens', 'reasoningTokens', 'additiveReasoningTokens', 'cacheReadTokens', 'cacheWriteTokens'] as const) {
       if (typeof p[field] === 'number' && Number.isFinite(p[field])) clean[field] = Math.max(0, p[field])
     }
+    Object.assign(clean, sanitizeProjectDetails(p))
     setOwn(out, name, clean)
   }
   return Object.keys(out).length > 0 ? { projects: out } : {}

--- a/src/daily-cache-core.ts
+++ b/src/daily-cache-core.ts
@@ -193,7 +193,7 @@ function sanitizeProjects(raw: unknown): { projects?: DailyEntry['projects'] } {
     for (const field of ['inputTokens', 'outputTokens', 'reasoningTokens', 'additiveReasoningTokens', 'cacheReadTokens', 'cacheWriteTokens'] as const) {
       if (typeof p[field] === 'number' && Number.isFinite(p[field])) clean[field] = Math.max(0, p[field])
     }
-    Object.assign(clean, sanitizeProjectDetails(p))
+    Object.assign(clean, sanitizeProjectDetails(p, clean))
     setOwn(out, name, clean)
   }
   return Object.keys(out).length > 0 ? { projects: out } : {}

--- a/src/daily-cache-merge.ts
+++ b/src/daily-cache-merge.ts
@@ -1,4 +1,5 @@
 import { emptyModelStats, mergeModelStats } from './daily-cache-model-detail.js'
+import { cloneProjectStats, cloneProjectStatsMap, hasProjectUsage, mergeProjectDetails } from './daily-cache-project-detail.js'
 import type { DailyEntry, ProjectDayStats, ProviderDaySlice } from './daily-cache-types.js'
 
 const PROJECT_TOKEN_FIELDS = ['inputTokens', 'outputTokens', 'reasoningTokens', 'additiveReasoningTokens', 'cacheReadTokens', 'cacheWriteTokens'] as const
@@ -13,10 +14,6 @@ function hasSliceData(slice: ProviderDaySlice): boolean {
     || (slice.reasoningTokens ?? 0) > 0 || (slice.cacheReadTokens ?? 0) > 0
     || (slice.additiveReasoningTokens ?? 0) > 0
     || (slice.cacheWriteTokens ?? 0) > 0
-}
-
-function hasProjectUsage(stats: ProjectDayStats): boolean {
-  return stats.cost > 0 || stats.calls > 0 || stats.savingsUSD > 0
 }
 
 function addProjectTokenEvidence(target: ProjectDayStats, source: ProjectDayStats, targetHadUsage: boolean): void {
@@ -49,7 +46,12 @@ function addSliceIntoDay(day: DailyEntry, provider: string, slice: ProviderDaySl
   // it pollutes every object in the process.
   const placeholder = Object.hasOwn(day.providers, provider) ? day.providers[provider] : undefined
   const placeholderSessions = placeholder?.sessions ?? 0
-  const merged = structuredClone(slice)
+  const merged: ProviderDaySlice = {
+    ...slice,
+    ...(slice.models ? { models: structuredClone(slice.models) } : {}),
+    ...(slice.categories ? { categories: structuredClone(slice.categories) } : {}),
+    ...(slice.projects ? { projects: cloneProjectStatsMap(slice.projects) } : {}),
+  }
   if (placeholderSessions > (merged.sessions ?? 0)) merged.sessions = placeholderSessions
   setOwn(day.providers, provider, merged)
   day.cost += slice.cost
@@ -91,6 +93,7 @@ function addSliceIntoDay(day: DailyEntry, provider: string, slice: ProviderDaySl
     const placeholderProjectSessions = Object.hasOwn(placeholderProjects, name) ? num(placeholderProjects[name]?.sessions) : 0
     acc.sessions += Math.max(0, num(p.sessions) - placeholderProjectSessions)
     addProjectTokenEvidence(acc, p, targetHadUsage)
+    mergeProjectDetails(acc, p, targetHadUsage)
     setOwn(dayProjects, name, acc)
   }
   // Placeholder-only projects survive on the merged slice rather than being
@@ -102,11 +105,11 @@ function addSliceIntoDay(day: DailyEntry, provider: string, slice: ProviderDaySl
       if (Object.hasOwn(mergedProjects, name)) {
         if (num(p.sessions) > num(mergedProjects[name]!.sessions)) mergedProjects[name]!.sessions = num(p.sessions)
       } else {
-        setOwn(mergedProjects, name, { cost: 0, calls: 0, savingsUSD: 0, sessions: num(p.sessions) })
+        setOwn(mergedProjects, name, cloneProjectStats({ cost: 0, calls: 0, savingsUSD: 0, sessions: num(p.sessions) }))
       }
     }
   } else if (placeholder?.projects) {
-    merged.projects = structuredClone(placeholder.projects)
+    merged.projects = cloneProjectStatsMap(placeholder.projects)
   }
 }
 

--- a/src/daily-cache-model-detail.ts
+++ b/src/daily-cache-model-detail.ts
@@ -1,4 +1,4 @@
-import type { DailyEntry, ModelDayStats } from './daily-cache-core.js'
+import type { DailyEntry, ModelDayStats } from './daily-cache-types.js'
 import { combineReasoningSemantics, type ReasoningTokenSemantics } from './token-semantics.js'
 
 function finiteNumber(value: unknown): number {
@@ -19,6 +19,8 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 function setOwn<T>(target: Record<string, T>, key: string, value: T): void {
   Object.defineProperty(target, key, { value, enumerable: true, writable: true, configurable: true })
 }
+
+export { setOwn }
 
 export function sanitizeModels(raw: unknown): DailyEntry['models'] {
   if (!isRecord(raw)) return {}
@@ -55,6 +57,23 @@ export function sanitizeModels(raw: unknown): DailyEntry['models'] {
 
 export function emptyModelStats(): ModelDayStats {
   return { calls: 0, cost: 0, savingsUSD: 0, inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0 }
+}
+
+export function cloneModelStats(stats: ModelDayStats): ModelDayStats {
+  return {
+    calls: finiteNumber(stats.calls),
+    cost: finiteNumber(stats.cost),
+    savingsUSD: finiteNumber(stats.savingsUSD),
+    inputTokens: finiteNumber(stats.inputTokens),
+    outputTokens: finiteNumber(stats.outputTokens),
+    ...(stats.reasoningTokens !== undefined ? { reasoningTokens: finiteNumber(stats.reasoningTokens) } : {}),
+    ...(stats.additiveReasoningTokens !== undefined ? { additiveReasoningTokens: finiteNumber(stats.additiveReasoningTokens) } : {}),
+    ...(stats.reasoningSemantics ? { reasoningSemantics: stats.reasoningSemantics } : {}),
+    cacheReadTokens: finiteNumber(stats.cacheReadTokens),
+    cacheWriteTokens: finiteNumber(stats.cacheWriteTokens),
+    ...(stats.modelProvider ? { modelProvider: stats.modelProvider } : {}),
+    ...(stats.sourceProviders?.length ? { sourceProviders: [...stats.sourceProviders] } : {}),
+  }
 }
 
 export function mergeModelStats(target: ModelDayStats, source: ModelDayStats): void {

--- a/src/daily-cache-project-detail.ts
+++ b/src/daily-cache-project-detail.ts
@@ -1,0 +1,144 @@
+import type {
+  CategoryDayStats,
+  DurableProjectDetailCoverage,
+  ModelDayStats,
+  ProjectCategoryDetail,
+  ProjectDayStats,
+  ProjectModelDetail,
+} from './daily-cache-types.js'
+import { cloneCategoryStats, mergeCategoryStats, sanitizeCategories, setOwn } from './daily-cache-category-detail.js'
+import { cloneModelStats, mergeModelStats, sanitizeModels } from './daily-cache-model-detail.js'
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value)
+}
+
+function isCoverage(value: unknown): value is DurableProjectDetailCoverage {
+  return value === 'complete' || value === 'partial'
+}
+
+export function cloneModelDetail(detail: ProjectModelDetail): ProjectModelDetail {
+  const rows: ProjectModelDetail['rows'] = {}
+  for (const [name, stats] of Object.entries(detail.rows)) setOwn(rows, name, cloneModelStats(stats))
+  return { coverage: detail.coverage, rows }
+}
+
+export function cloneCategoryDetail(detail: ProjectCategoryDetail): ProjectCategoryDetail {
+  const rows: ProjectCategoryDetail['rows'] = {}
+  for (const [name, stats] of Object.entries(detail.rows)) setOwn(rows, name, cloneCategoryStats(stats))
+  return { coverage: detail.coverage, rows }
+}
+
+export function cloneProjectStats(stats: ProjectDayStats): ProjectDayStats {
+  return {
+    cost: stats.cost,
+    calls: stats.calls,
+    savingsUSD: stats.savingsUSD,
+    sessions: stats.sessions,
+    ...(stats.inputTokens !== undefined ? { inputTokens: stats.inputTokens } : {}),
+    ...(stats.outputTokens !== undefined ? { outputTokens: stats.outputTokens } : {}),
+    ...(stats.reasoningTokens !== undefined ? { reasoningTokens: stats.reasoningTokens } : {}),
+    ...(stats.additiveReasoningTokens !== undefined ? { additiveReasoningTokens: stats.additiveReasoningTokens } : {}),
+    ...(stats.cacheReadTokens !== undefined ? { cacheReadTokens: stats.cacheReadTokens } : {}),
+    ...(stats.cacheWriteTokens !== undefined ? { cacheWriteTokens: stats.cacheWriteTokens } : {}),
+    ...(stats.path !== undefined ? { path: stats.path } : {}),
+    ...(stats.modelDetail ? { modelDetail: cloneModelDetail(stats.modelDetail) } : {}),
+    ...(stats.categoryDetail ? { categoryDetail: cloneCategoryDetail(stats.categoryDetail) } : {}),
+  }
+}
+
+export function cloneProjectStatsMap(
+  projects: Record<string, ProjectDayStats> | undefined,
+): Record<string, ProjectDayStats> | undefined {
+  if (!projects) return undefined
+  const out: Record<string, ProjectDayStats> = {}
+  for (const [name, stats] of Object.entries(projects)) {
+    if (!isRecord(stats)) continue
+    setOwn(out, name, cloneProjectStats(stats as ProjectDayStats))
+  }
+  return out
+}
+
+export function hasProjectUsage(stats: ProjectDayStats): boolean {
+  return stats.cost > 0 || stats.calls > 0 || stats.savingsUSD > 0
+}
+
+type DetailBlock<T> = {
+  coverage: DurableProjectDetailCoverage
+  rows: Record<string, T>
+}
+
+function mergeDetailBlock<T>(
+  targetDetail: DetailBlock<T> | undefined,
+  sourceDetail: DetailBlock<T> | undefined,
+  targetHadUsage: boolean,
+  cloneRow: (row: T) => T,
+  mergeRow: (target: T, source: T) => void,
+): DetailBlock<T> | undefined {
+  if (!sourceDetail) {
+    if (targetDetail && targetHadUsage) targetDetail.coverage = 'partial'
+    return targetDetail
+  }
+
+  if (!targetDetail) {
+    const copy: DetailBlock<T> = {
+      coverage: targetHadUsage || sourceDetail.coverage === 'partial' ? 'partial' : 'complete',
+      rows: {},
+    }
+    for (const [name, row] of Object.entries(sourceDetail.rows)) setOwn(copy.rows, name, cloneRow(row))
+    return copy
+  }
+
+  for (const [name, row] of Object.entries(sourceDetail.rows)) {
+    const existing = Object.hasOwn(targetDetail.rows, name) ? targetDetail.rows[name] : undefined
+    if (existing) mergeRow(existing, row)
+    else setOwn(targetDetail.rows, name, cloneRow(row))
+  }
+  if (targetDetail.coverage === 'partial' || sourceDetail.coverage === 'partial') targetDetail.coverage = 'partial'
+  return targetDetail
+}
+
+export function mergeProjectDetails(target: ProjectDayStats, source: ProjectDayStats, targetHadUsage: boolean): void {
+  if (!hasProjectUsage(source)) return
+  target.modelDetail = mergeDetailBlock(
+    target.modelDetail,
+    source.modelDetail,
+    targetHadUsage,
+    cloneModelStats,
+    mergeModelStats,
+  )
+  target.categoryDetail = mergeDetailBlock(
+    target.categoryDetail,
+    source.categoryDetail,
+    targetHadUsage,
+    cloneCategoryStats,
+    mergeCategoryStats,
+  )
+}
+
+export function addModelDetail(target: ProjectDayStats, key: string, stats: ModelDayStats): void {
+  if (!target.modelDetail) target.modelDetail = { coverage: 'complete', rows: {} }
+  const existing = Object.hasOwn(target.modelDetail.rows, key) ? target.modelDetail.rows[key] : undefined
+  if (existing) mergeModelStats(existing, stats)
+  else setOwn(target.modelDetail.rows, key, cloneModelStats(stats))
+}
+
+export function addCategoryDetail(target: ProjectDayStats, key: string, stats: CategoryDayStats): void {
+  if (!target.categoryDetail) target.categoryDetail = { coverage: 'complete', rows: {} }
+  const existing = Object.hasOwn(target.categoryDetail.rows, key) ? target.categoryDetail.rows[key] : undefined
+  if (existing) mergeCategoryStats(existing, stats)
+  else setOwn(target.categoryDetail.rows, key, cloneCategoryStats(stats))
+}
+
+export function sanitizeProjectDetails(raw: Record<string, unknown>): Pick<ProjectDayStats, 'modelDetail' | 'categoryDetail'> {
+  const result: Pick<ProjectDayStats, 'modelDetail' | 'categoryDetail'> = {}
+  const model = raw.modelDetail
+  if (isRecord(model) && isCoverage(model.coverage) && isRecord(model.rows)) {
+    result.modelDetail = { coverage: model.coverage, rows: sanitizeModels(model.rows) }
+  }
+  const category = raw.categoryDetail
+  if (isRecord(category) && isCoverage(category.coverage) && isRecord(category.rows)) {
+    result.categoryDetail = { coverage: category.coverage, rows: sanitizeCategories(category.rows) }
+  }
+  return result
+}

--- a/src/daily-cache-project-detail.ts
+++ b/src/daily-cache-project-detail.ts
@@ -6,7 +6,7 @@ import type {
   ProjectDayStats,
   ProjectModelDetail,
 } from './daily-cache-types.js'
-import { cloneCategoryStats, mergeCategoryStats, sanitizeCategories, setOwn } from './daily-cache-category-detail.js'
+import { cloneCategoryStats, mergeCategoryStats, sanitizeCategoriesWithIntegrity, setOwn } from './daily-cache-category-detail.js'
 import { cloneModelStats, mergeModelStats, sanitizeModels } from './daily-cache-model-detail.js'
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -135,15 +135,17 @@ function normalizeCategoryDetail(
   coverage: DurableProjectDetailCoverage,
   rows: Record<string, CategoryDayStats>,
   project: ProjectDayStats,
+  sanitizationIsLossless: boolean,
 ): ProjectCategoryDetail | undefined {
   const hasUsage = hasFactualProjectUsage(project)
   const hasRows = Object.values(rows).some(hasFactualCategoryRow)
 
   if (!hasUsage) {
-    return coverage === 'complete' && !hasRows ? { coverage: 'complete', rows: {} } : undefined
+    return coverage === 'complete' && sanitizationIsLossless && !hasRows ? { coverage: 'complete', rows: {} } : undefined
   }
   if (!hasRows) return undefined
   if (coverage === 'partial') return { coverage: 'partial', rows }
+  if (!sanitizationIsLossless) return { coverage: 'partial', rows }
   return { coverage: categoryRowsReconcile(project, rows) ? 'complete' : 'partial', rows }
 }
 
@@ -273,8 +275,8 @@ export function sanitizeProjectDetails(
   }
   const category = raw.categoryDetail
   if (isRecord(category) && isCoverage(category.coverage) && isRecord(category.rows)) {
-    const rows = sanitizeCategories(category.rows)
-    const normalized = normalizeCategoryDetail(category.coverage, rows, project)
+    const sanitized = sanitizeCategoriesWithIntegrity(category.rows)
+    const normalized = normalizeCategoryDetail(category.coverage, sanitized.rows, project, sanitized.sanitizationIsLossless)
     if (normalized) result.categoryDetail = normalized
   }
   return result

--- a/src/daily-cache-project-detail.ts
+++ b/src/daily-cache-project-detail.ts
@@ -17,6 +17,136 @@ function isCoverage(value: unknown): value is DurableProjectDetailCoverage {
   return value === 'complete' || value === 'partial'
 }
 
+const DETAIL_EPSILON = 1e-9
+const PROJECT_DETAIL_NUMERICS = [
+  'cost',
+  'calls',
+  'savingsUSD',
+  'inputTokens',
+  'outputTokens',
+  'reasoningTokens',
+  'additiveReasoningTokens',
+  'cacheReadTokens',
+  'cacheWriteTokens',
+] as const
+
+function hasMagnitude(value: number | undefined): boolean {
+  return typeof value === 'number' && Number.isFinite(value) && Math.abs(value) > DETAIL_EPSILON
+}
+
+function approximatelyEqual(actual: number, expected: number): boolean {
+  const tolerance = Math.max(DETAIL_EPSILON, Math.abs(expected) * DETAIL_EPSILON)
+  return Math.abs(actual - expected) <= tolerance
+}
+
+function hasFactualProjectUsage(project: ProjectDayStats): boolean {
+  return PROJECT_DETAIL_NUMERICS.some(field => hasMagnitude(project[field]))
+}
+
+function hasFactualModelRow(row: ModelDayStats): boolean {
+  return PROJECT_DETAIL_NUMERICS.some(field => hasMagnitude(row[field]))
+}
+
+function hasFactualCategoryRow(row: CategoryDayStats): boolean {
+  return hasMagnitude(row.turns)
+    || hasMagnitude(row.cost)
+    || hasMagnitude(row.savingsUSD)
+}
+
+type ModelDetailTotals = {
+  calls: number
+  cost: number
+  savingsUSD: number
+  inputTokens: number
+  outputTokens: number
+  reasoningTokens: number
+  additiveReasoningTokens: number
+  cacheReadTokens: number
+  cacheWriteTokens: number
+}
+
+function modelDetailTotals(rows: Record<string, ModelDayStats>): ModelDetailTotals {
+  const totals: ModelDetailTotals = {
+    calls: 0,
+    cost: 0,
+    savingsUSD: 0,
+    inputTokens: 0,
+    outputTokens: 0,
+    reasoningTokens: 0,
+    additiveReasoningTokens: 0,
+    cacheReadTokens: 0,
+    cacheWriteTokens: 0,
+  }
+  for (const row of Object.values(rows)) {
+    totals.calls += row.calls
+    totals.cost += row.cost
+    totals.savingsUSD += row.savingsUSD
+    totals.inputTokens += row.inputTokens
+    totals.outputTokens += row.outputTokens
+    totals.reasoningTokens += row.reasoningTokens ?? 0
+    totals.additiveReasoningTokens += row.additiveReasoningTokens ?? 0
+    totals.cacheReadTokens += row.cacheReadTokens
+    totals.cacheWriteTokens += row.cacheWriteTokens
+  }
+  return totals
+}
+
+function modelRowsReconcile(project: ProjectDayStats, rows: Record<string, ModelDayStats>): boolean {
+  const totals = modelDetailTotals(rows)
+  if (!approximatelyEqual(totals.calls, project.calls)) return false
+  if (!approximatelyEqual(totals.cost, project.cost)) return false
+  if (!approximatelyEqual(totals.savingsUSD, project.savingsUSD)) return false
+  for (const field of ['inputTokens', 'outputTokens', 'reasoningTokens', 'additiveReasoningTokens', 'cacheReadTokens', 'cacheWriteTokens'] as const) {
+    if (project[field] !== undefined && !approximatelyEqual(totals[field], project[field])) return false
+  }
+  return true
+}
+
+function categoryRowsReconcile(project: ProjectDayStats, rows: Record<string, CategoryDayStats>): boolean {
+  let cost = 0
+  let savingsUSD = 0
+  for (const row of Object.values(rows)) {
+    cost += row.cost
+    savingsUSD += row.savingsUSD
+  }
+  return approximatelyEqual(cost, project.cost)
+    && approximatelyEqual(savingsUSD, project.savingsUSD)
+}
+
+function normalizeModelDetail(
+  coverage: DurableProjectDetailCoverage,
+  rows: Record<string, ModelDayStats>,
+  project: ProjectDayStats,
+): ProjectModelDetail | undefined {
+  const hasUsage = hasFactualProjectUsage(project)
+  const hasRows = Object.values(rows).some(hasFactualModelRow)
+
+  if (!hasUsage) {
+    // Complete-empty is authoritative only for a genuinely sessions-only
+    // project. A partial claim cannot be upgraded during sanitization.
+    return coverage === 'complete' && !hasRows ? { coverage: 'complete', rows: {} } : undefined
+  }
+  if (!hasRows) return undefined
+  if (coverage === 'partial') return { coverage: 'partial', rows }
+  return { coverage: modelRowsReconcile(project, rows) ? 'complete' : 'partial', rows }
+}
+
+function normalizeCategoryDetail(
+  coverage: DurableProjectDetailCoverage,
+  rows: Record<string, CategoryDayStats>,
+  project: ProjectDayStats,
+): ProjectCategoryDetail | undefined {
+  const hasUsage = hasFactualProjectUsage(project)
+  const hasRows = Object.values(rows).some(hasFactualCategoryRow)
+
+  if (!hasUsage) {
+    return coverage === 'complete' && !hasRows ? { coverage: 'complete', rows: {} } : undefined
+  }
+  if (!hasRows) return undefined
+  if (coverage === 'partial') return { coverage: 'partial', rows }
+  return { coverage: categoryRowsReconcile(project, rows) ? 'complete' : 'partial', rows }
+}
+
 export function cloneModelDetail(detail: ProjectModelDetail): ProjectModelDetail {
   const rows: ProjectModelDetail['rows'] = {}
   for (const [name, stats] of Object.entries(detail.rows)) setOwn(rows, name, cloneModelStats(stats))
@@ -130,15 +260,22 @@ export function addCategoryDetail(target: ProjectDayStats, key: string, stats: C
   else setOwn(target.categoryDetail.rows, key, cloneCategoryStats(stats))
 }
 
-export function sanitizeProjectDetails(raw: Record<string, unknown>): Pick<ProjectDayStats, 'modelDetail' | 'categoryDetail'> {
+export function sanitizeProjectDetails(
+  raw: Record<string, unknown>,
+  project: ProjectDayStats = { cost: 0, calls: 0, savingsUSD: 0, sessions: 0 },
+): Pick<ProjectDayStats, 'modelDetail' | 'categoryDetail'> {
   const result: Pick<ProjectDayStats, 'modelDetail' | 'categoryDetail'> = {}
   const model = raw.modelDetail
   if (isRecord(model) && isCoverage(model.coverage) && isRecord(model.rows)) {
-    result.modelDetail = { coverage: model.coverage, rows: sanitizeModels(model.rows) }
+    const rows = sanitizeModels(model.rows)
+    const normalized = normalizeModelDetail(model.coverage, rows, project)
+    if (normalized) result.modelDetail = normalized
   }
   const category = raw.categoryDetail
   if (isRecord(category) && isCoverage(category.coverage) && isRecord(category.rows)) {
-    result.categoryDetail = { coverage: category.coverage, rows: sanitizeCategories(category.rows) }
+    const rows = sanitizeCategories(category.rows)
+    const normalized = normalizeCategoryDetail(category.coverage, rows, project)
+    if (normalized) result.categoryDetail = normalized
   }
   return result
 }

--- a/src/daily-cache-types.ts
+++ b/src/daily-cache-types.ts
@@ -23,6 +23,18 @@ export type ModelDayStats = {
 
 export type CategoryDayStats = { turns: number; cost: number; savingsUSD: number; editTurns: number; oneShotTurns: number }
 
+export type DurableProjectDetailCoverage = 'complete' | 'partial'
+
+export type ProjectModelDetail = {
+  coverage: DurableProjectDetailCoverage
+  rows: Record<string, ModelDayStats>
+}
+
+export type ProjectCategoryDetail = {
+  coverage: DurableProjectDetailCoverage
+  rows: Record<string, CategoryDayStats>
+}
+
 /// `path` is the project's filesystem path when known — it is what display
 /// layers derive a friendly name from once the sessions that carried the
 /// mapping are gone. Token fields are optional because pre-v19 days never
@@ -41,6 +53,10 @@ export type ProjectDayStats = {
   cacheReadTokens?: number
   cacheWriteTokens?: number
   path?: string
+  /// Model/category detail is source-backed aggregate authority. An absent
+  /// block is unavailable; an explicit complete empty block is authoritative.
+  modelDetail?: ProjectModelDetail
+  categoryDetail?: ProjectCategoryDetail
 }
 
 export type ProviderDaySlice = {

--- a/src/daily-cache-tz-reconcile.ts
+++ b/src/daily-cache-tz-reconcile.ts
@@ -6,6 +6,9 @@ import {
   type ProjectDayStats,
   type ProviderDaySlice,
 } from './daily-cache-core.js'
+import { cloneCategoryStats } from './daily-cache-category-detail.js'
+import { cloneModelStats } from './daily-cache-model-detail.js'
+import { cloneProjectStats } from './daily-cache-project-detail.js'
 
 function num(value: number | undefined): number {
   return typeof value === 'number' && Number.isFinite(value) ? value : 0
@@ -83,7 +86,7 @@ function subtractModels(
   if (!base) return undefined
   const out: Record<string, ModelDayStats> = {}
   for (const [name, stats] of Object.entries(base)) {
-    const reduced = sub && Object.hasOwn(sub, name) ? subtractModelStats(stats, sub[name]!) : structuredClone(stats)
+    const reduced = sub && Object.hasOwn(sub, name) ? subtractModelStats(stats, sub[name]!) : cloneModelStats(stats)
     if (reduced) setOwn(out, name, reduced)
   }
   return Object.keys(out).length > 0 ? out : undefined
@@ -106,10 +109,50 @@ function subtractCategories(
   if (!base) return undefined
   const out: Record<string, CategoryDayStats> = {}
   for (const [name, stats] of Object.entries(base)) {
-    const reduced = sub && Object.hasOwn(sub, name) ? subtractCategoryStats(stats, sub[name]!) : structuredClone(stats)
+    const reduced = sub && Object.hasOwn(sub, name) ? subtractCategoryStats(stats, sub[name]!) : cloneCategoryStats(stats)
     if (reduced) setOwn(out, name, reduced)
   }
   return Object.keys(out).length > 0 ? out : undefined
+}
+
+function detailCoverage(
+  base: 'complete' | 'partial',
+  sub: 'complete' | 'partial' | undefined,
+  missingSubIsPartial: boolean,
+): 'complete' | 'partial' {
+  return base === 'partial' || sub === 'partial' || (missingSubIsPartial && sub === undefined) ? 'partial' : 'complete'
+}
+
+function subtractModelDetail(
+  base: NonNullable<ProjectDayStats['modelDetail']>,
+  sub: NonNullable<ProjectDayStats['modelDetail']> | undefined,
+  missingSubIsPartial: boolean,
+): NonNullable<ProjectDayStats['modelDetail']> {
+  const rows: NonNullable<ProjectDayStats['modelDetail']>['rows'] = {}
+  for (const [name, stats] of Object.entries(base.rows)) {
+    const reduced = sub && Object.hasOwn(sub.rows, name) ? subtractModelStats(stats, sub.rows[name]!) : cloneModelStats(stats)
+    if (reduced) setOwn(rows, name, reduced)
+  }
+  return {
+    coverage: detailCoverage(base.coverage, sub?.coverage, missingSubIsPartial),
+    rows,
+  }
+}
+
+function subtractCategoryDetail(
+  base: NonNullable<ProjectDayStats['categoryDetail']>,
+  sub: NonNullable<ProjectDayStats['categoryDetail']> | undefined,
+  missingSubIsPartial: boolean,
+): NonNullable<ProjectDayStats['categoryDetail']> {
+  const rows: NonNullable<ProjectDayStats['categoryDetail']>['rows'] = {}
+  for (const [name, stats] of Object.entries(base.rows)) {
+    const reduced = sub && Object.hasOwn(sub.rows, name) ? subtractCategoryStats(stats, sub.rows[name]!) : cloneCategoryStats(stats)
+    if (reduced) setOwn(rows, name, reduced)
+  }
+  return {
+    coverage: detailCoverage(base.coverage, sub?.coverage, missingSubIsPartial),
+    rows,
+  }
 }
 
 function subtractProjectStats(base: ProjectDayStats, sub: ProjectDayStats): ProjectDayStats | null {
@@ -129,6 +172,12 @@ function subtractProjectStats(base: ProjectDayStats, sub: ProjectDayStats): Proj
       out[field] = Math.max(0, base[field] - num(sub[field]))
     }
   }
+  if (base.modelDetail) {
+    out.modelDetail = subtractModelDetail(base.modelDetail, sub.modelDetail, subHasUsage)
+  }
+  if (base.categoryDetail) {
+    out.categoryDetail = subtractCategoryDetail(base.categoryDetail, sub.categoryDetail, subHasUsage)
+  }
   if (cost === 0 && calls === 0 && savingsUSD === 0 && sessions === 0
     && (out.inputTokens ?? 0) === 0 && (out.outputTokens ?? 0) === 0
     && (out.reasoningTokens ?? 0) === 0 && (out.cacheReadTokens ?? 0) === 0
@@ -144,7 +193,7 @@ function subtractProjects(
   if (!base) return undefined
   const out: Record<string, ProjectDayStats> = {}
   for (const [name, stats] of Object.entries(base)) {
-    const reduced = sub && Object.hasOwn(sub, name) ? subtractProjectStats(stats, sub[name]!) : structuredClone(stats)
+    const reduced = sub && Object.hasOwn(sub, name) ? subtractProjectStats(stats, sub[name]!) : cloneProjectStats(stats)
     if (reduced) setOwn(out, name, reduced)
   }
   return Object.keys(out).length > 0 ? out : undefined
@@ -232,6 +281,12 @@ function projectDelta(base: ProjectDayStats, reduced: ProjectDayStats | undefine
     } else {
       out[field] = Math.max(0, base[field] - num(reduced?.[field]))
     }
+  }
+  if (base.modelDetail) {
+    out.modelDetail = subtractModelDetail(base.modelDetail, reduced?.modelDetail, reduced !== undefined)
+  }
+  if (base.categoryDetail) {
+    out.categoryDetail = subtractCategoryDetail(base.categoryDetail, reduced?.categoryDetail, reduced !== undefined)
   }
   return out
 }

--- a/src/daily-cache.ts
+++ b/src/daily-cache.ts
@@ -45,8 +45,8 @@ async function readTrust(path: string): Promise<{ version: number; trusted: bool
 
 function supportsActiveTrust(version: number): boolean {
   // The immediately previous envelope is an adoptable baseline, not active
-  // authority: v18 carried no durable Source Project token split and must
-  // re-derive surviving sources before its watermark becomes trusted again.
+  // authority: v19 carried no durable Source Project model/category detail and
+  // must re-derive surviving sources before its watermark becomes trusted again.
   return version === core.DAILY_CACHE_VERSION
 }
 

--- a/src/day-aggregator.ts
+++ b/src/day-aggregator.ts
@@ -1,13 +1,16 @@
-import type { DailyEntry, ProjectDayStats, ProviderDaySlice } from './daily-cache.js'
+import type { CategoryDayStats, DailyEntry, ModelDayStats, ProjectDayStats, ProviderDaySlice } from './daily-cache.js'
 import type { PeriodData } from './menubar-json.js'
 import { CATEGORY_LABELS, type ProjectSummary, type TaskCategory, type TokenUsage } from './types.js'
 import { combineReasoningSemantics, reasoningTokenTotals, type ReasoningTokenSemantics, type ReasoningTokenTotals } from './token-semantics.js'
+import { emptyModelStats, mergeModelStats } from './daily-cache-model-detail.js'
+import { emptyCategoryStats, mergeCategoryStats, setOwn } from './daily-cache-category-detail.js'
+import { addCategoryDetail, addModelDetail } from './daily-cache-project-detail.js'
 
 // Raw model IDs remain human-readable in legacy daily caches. New rows use an
 // additive envelope so a source-recorded route can survive the daily
 // projection without changing the model ID used for pricing.
 const MODEL_KEY_PREFIX = '\u0001metrora-model\u0001'
-function modelStorageKey(model: string, modelProvider?: string): string {
+export function modelStorageKey(model: string, modelProvider?: string): string {
   return modelProvider ? `${MODEL_KEY_PREFIX}${JSON.stringify([modelProvider, model])}` : model
 }
 
@@ -26,10 +29,6 @@ function decodeModelStorageKey(key: string): { name: string; modelProvider?: str
     // dropped from durable accounting.
   }
   return { name: key }
-}
-
-function addSourceProvider(target: { sourceProviders?: string[] }, provider: string): void {
-  target.sourceProviders = [...new Set([...(target.sourceProviders ?? []), provider])].sort()
 }
 
 function addCallReasoningSemantics(
@@ -61,6 +60,31 @@ function addProjectTokenUsage(target: ProjectDayStats, usage: TokenUsage, reason
   target.cacheReadTokens = (target.cacheReadTokens ?? 0) + usage.cacheReadInputTokens
   target.cacheWriteTokens = (target.cacheWriteTokens ?? 0) + usage.cacheCreationInputTokens
   addReasoningTotals(target, reasoning)
+}
+
+function modelStatsForCall(call: {
+  provider: string
+  modelProvider?: string
+  model: string
+  costUSD: number
+  savingsUSD?: number
+  usage: TokenUsage
+  reasoningSemantics?: ReasoningTokenSemantics
+}, reasoning: ReasoningTokenTotals): ModelDayStats {
+  const stats: ModelDayStats = {
+    calls: 1,
+    cost: call.costUSD,
+    savingsUSD: call.savingsUSD ?? 0,
+    inputTokens: call.usage.inputTokens,
+    outputTokens: call.usage.outputTokens,
+    cacheReadTokens: call.usage.cacheReadInputTokens,
+    cacheWriteTokens: call.usage.cacheCreationInputTokens,
+    ...(call.modelProvider ? { modelProvider: call.modelProvider } : {}),
+    sourceProviders: [call.provider],
+  }
+  addReasoningTotals(stats, reasoning)
+  addCallReasoningSemantics(stats, call)
+  return stats
 }
 
 function emptyEntry(date: string): DailyEntry {
@@ -127,8 +151,8 @@ export function aggregateProjectsIntoDays(
     return d
   }
   const ensureSlice = (day: DailyEntry, provider: string): ProviderDaySlice => {
-    let s = day.providers[provider]
-    if (!s) { s = emptySlice(); day.providers[provider] = s }
+    let s = Object.hasOwn(day.providers, provider) ? day.providers[provider] : undefined
+    if (!s) { s = emptySlice(); setOwn(day.providers, provider, s) }
     return s
   }
   const ensureProject = (holder: { projects?: Record<string, ProjectDayStats> }, project: string, path?: string): ProjectDayStats => {
@@ -179,13 +203,21 @@ export function aggregateProjectsIntoDays(
         turnDay.editTurns += editTurns
         turnDay.oneShotTurns += oneShotTurns
 
-        const cat = turnDay.categories[turn.category] ?? { turns: 0, cost: 0, savingsUSD: 0, editTurns: 0, oneShotTurns: 0 }
-        cat.turns += 1
-        cat.cost += turnCost
-        cat.savingsUSD += turnSavings
-        cat.editTurns += editTurns
-        cat.oneShotTurns += oneShotTurns
-        turnDay.categories[turn.category] = cat
+        const categoryContribution: CategoryDayStats = {
+          turns: 1,
+          cost: turnCost,
+          savingsUSD: turnSavings,
+          editTurns,
+          oneShotTurns,
+        }
+        const cat = Object.hasOwn(turnDay.categories, turn.category)
+          ? turnDay.categories[turn.category]!
+          : emptyCategoryStats()
+        mergeCategoryStats(cat, categoryContribution)
+        setOwn(turnDay.categories, turn.category, cat)
+
+        const dayProject = ensureProject(turnDay, session.project, project.projectPath)
+        addCategoryDetail(dayProject, turn.category, categoryContribution)
 
         // Cost stays attributed to every provider actually present in the turn,
         // but turn counts belong to exactly one slice. Otherwise carrying one
@@ -214,18 +246,27 @@ export function aggregateProjectsIntoDays(
           const ownsTurn = prov === primaryProvider
           turnSlice.editTurns! += ownsTurn ? editTurns : 0
           turnSlice.oneShotTurns! += ownsTurn ? oneShotTurns : 0
-          const sliceCat = turnSlice.categories![turn.category] ?? { turns: 0, cost: 0, savingsUSD: 0, editTurns: 0, oneShotTurns: 0 }
-          sliceCat.turns += ownsTurn ? 1 : 0
-          sliceCat.cost += totals.cost
-          sliceCat.savingsUSD += totals.savingsUSD
-          sliceCat.editTurns += ownsTurn ? editTurns : 0
-          sliceCat.oneShotTurns += ownsTurn ? oneShotTurns : 0
-          turnSlice.categories![turn.category] = sliceCat
+          const sliceCategoryContribution: CategoryDayStats = {
+            turns: ownsTurn ? 1 : 0,
+            cost: totals.cost,
+            savingsUSD: totals.savingsUSD,
+            editTurns: ownsTurn ? editTurns : 0,
+            oneShotTurns: ownsTurn ? oneShotTurns : 0,
+          }
+          const sliceCat = Object.hasOwn(turnSlice.categories!, turn.category)
+            ? turnSlice.categories![turn.category]!
+            : emptyCategoryStats()
+          mergeCategoryStats(sliceCat, sliceCategoryContribution)
+          setOwn(turnSlice.categories!, turn.category, sliceCat)
+
+          const sliceProject = ensureProject(turnSlice, session.project, project.projectPath)
+          addCategoryDetail(sliceProject, turn.category, sliceCategoryContribution)
         }
 
         for (const call of turn.assistantCalls) {
           const callSavings = call.savingsUSD ?? 0
           const callReasoning = callReasoningTotals(call)
+          const modelContribution = modelStatsForCall(call, callReasoning)
 
           turnDay.cost += call.costUSD
           turnDay.savingsUSD += callSavings
@@ -236,30 +277,16 @@ export function aggregateProjectsIntoDays(
           turnDay.cacheReadTokens += call.usage.cacheReadInputTokens
           turnDay.cacheWriteTokens += call.usage.cacheCreationInputTokens
 
-          const dayProject = ensureProject(turnDay, session.project, project.projectPath)
           dayProject.cost += call.costUSD
           dayProject.calls += 1
           dayProject.savingsUSD += callSavings
           addProjectTokenUsage(dayProject, call.usage, callReasoning)
 
           const modelKey = modelStorageKey(call.model, call.modelProvider)
-          const model = turnDay.models[modelKey] ?? {
-            calls: 0, cost: 0, savingsUSD: 0,
-            inputTokens: 0, outputTokens: 0,
-            cacheReadTokens: 0, cacheWriteTokens: 0,
-          }
-          model.calls += 1
-          model.cost += call.costUSD
-          model.savingsUSD += callSavings
-          model.inputTokens += call.usage.inputTokens
-          model.outputTokens += call.usage.outputTokens
-          addReasoningTotals(model, callReasoning)
-          model.cacheReadTokens += call.usage.cacheReadInputTokens
-          model.cacheWriteTokens += call.usage.cacheCreationInputTokens
-          if (call.modelProvider) model.modelProvider = call.modelProvider
-          addCallReasoningSemantics(model, call)
-          addSourceProvider(model, call.provider)
-          turnDay.models[modelKey] = model
+          const model = Object.hasOwn(turnDay.models, modelKey) ? turnDay.models[modelKey]! : emptyModelStats()
+          mergeModelStats(model, modelContribution)
+          setOwn(turnDay.models, modelKey, model)
+          addModelDetail(dayProject, modelKey, modelContribution)
 
           const slice = ensureSlice(turnDay, call.provider)
           slice.calls += 1
@@ -277,23 +304,10 @@ export function aggregateProjectsIntoDays(
           sliceProject.savingsUSD += callSavings
           addProjectTokenUsage(sliceProject, call.usage, callReasoning)
 
-          const sliceModel = slice.models![modelKey] ?? {
-            calls: 0, cost: 0, savingsUSD: 0,
-            inputTokens: 0, outputTokens: 0,
-            cacheReadTokens: 0, cacheWriteTokens: 0,
-          }
-          sliceModel.calls += 1
-          sliceModel.cost += call.costUSD
-          sliceModel.savingsUSD += callSavings
-          sliceModel.inputTokens += call.usage.inputTokens
-          sliceModel.outputTokens += call.usage.outputTokens
-          addReasoningTotals(sliceModel, callReasoning)
-          sliceModel.cacheReadTokens += call.usage.cacheReadInputTokens
-          sliceModel.cacheWriteTokens += call.usage.cacheCreationInputTokens
-          if (call.modelProvider) sliceModel.modelProvider = call.modelProvider
-          addSourceProvider(sliceModel, call.provider)
-          addCallReasoningSemantics(sliceModel, call)
-          slice.models![modelKey] = sliceModel
+          const sliceModel = Object.hasOwn(slice.models!, modelKey) ? slice.models![modelKey]! : emptyModelStats()
+          mergeModelStats(sliceModel, modelContribution)
+          setOwn(slice.models!, modelKey, sliceModel)
+          addModelDetail(sliceProject, modelKey, modelContribution)
         }
       }
     }

--- a/src/durable-project-reconciliation.ts
+++ b/src/durable-project-reconciliation.ts
@@ -1,4 +1,7 @@
 import type { DailyEntry, ProjectDayStats, ProviderDaySlice } from './daily-cache.js'
+import { cloneCategoryStats } from './daily-cache-category-detail.js'
+import { cloneModelStats } from './daily-cache-model-detail.js'
+import { cloneProjectStats as cloneDurableProjectStats, cloneProjectStatsMap, hasProjectUsage, mergeProjectDetails } from './daily-cache-project-detail.js'
 
 export const UNATTRIBUTED_PROJECT_KEY = '\u0000metrora:unattributed'
 export const UNATTRIBUTED_PROJECT_LABEL = 'Unattributed'
@@ -11,8 +14,9 @@ export type DurableProjectFilter = {
 export type DurableProjectScopeOptions = {
   /**
    * True only for a day already produced from a project-filtered live parse.
-   * Historical project rollups do not own token/model/category attribution, so
-   * those details must remain empty when a project filter is applied.
+   * Historical project rollups use durable Source Project detail when present;
+   * this flag is reserved for a day already produced from a project-filtered
+   * live parse, whose day-level maps are already authoritative.
    */
   preserveDetailedBreakdown?: boolean
 }
@@ -60,12 +64,13 @@ export function matchesDurableProjectFilter(
 }
 
 function cloneProjectStats(stats: ProjectDayStats): ProjectDayStats {
-  return { ...stats }
+  return cloneDurableProjectStats(stats)
 }
 
 function sumProjects(projects: Record<string, ProjectDayStats>): ProjectDayStats {
   const total: ProjectDayStats = { cost: 0, calls: 0, savingsUSD: 0, sessions: 0 }
   for (const stats of Object.values(projects)) {
+    const targetHadUsage = hasProjectUsage(total)
     total.cost += stats.cost
     total.calls += stats.calls
     total.savingsUSD += stats.savingsUSD
@@ -76,8 +81,21 @@ function sumProjects(projects: Record<string, ProjectDayStats>): ProjectDayStats
     if (stats.additiveReasoningTokens !== undefined) total.additiveReasoningTokens = (total.additiveReasoningTokens ?? 0) + stats.additiveReasoningTokens
     if (stats.cacheReadTokens !== undefined) total.cacheReadTokens = (total.cacheReadTokens ?? 0) + stats.cacheReadTokens
     if (stats.cacheWriteTokens !== undefined) total.cacheWriteTokens = (total.cacheWriteTokens ?? 0) + stats.cacheWriteTokens
+    mergeProjectDetails(total, stats, targetHadUsage)
   }
   return total
+}
+
+function cloneModels(rows: ProviderDaySlice['models'] | undefined): NonNullable<ProviderDaySlice['models']> {
+  const out: NonNullable<ProviderDaySlice['models']> = {}
+  for (const [name, stats] of Object.entries(rows ?? {})) setOwn(out, name, cloneModelStats(stats))
+  return out
+}
+
+function cloneCategories(rows: ProviderDaySlice['categories'] | undefined): NonNullable<ProviderDaySlice['categories']> {
+  const out: NonNullable<ProviderDaySlice['categories']> = {}
+  for (const [name, stats] of Object.entries(rows ?? {})) setOwn(out, name, cloneCategoryStats(stats))
+  return out
 }
 
 function positiveFloatRemainder(total: number, attributed: number): number {
@@ -149,21 +167,19 @@ function projectScopedSlice(
 
   const selected = filterProjects(projects, filter)
   const totals = sumProjects(selected)
+  const { modelDetail, categoryDetail, ...scalarTotals } = totals
   return {
-    calls: totals.calls,
-    cost: totals.cost,
-    savingsUSD: totals.savingsUSD,
-    sessions: totals.sessions,
-    inputTokens: preserveDetailedBreakdown ? (slice.inputTokens ?? 0) : (totals.inputTokens ?? 0),
-    outputTokens: preserveDetailedBreakdown ? (slice.outputTokens ?? 0) : (totals.outputTokens ?? 0),
-    reasoningTokens: preserveDetailedBreakdown ? slice.reasoningTokens : totals.reasoningTokens,
-    additiveReasoningTokens: preserveDetailedBreakdown ? slice.additiveReasoningTokens : totals.additiveReasoningTokens,
-    cacheReadTokens: preserveDetailedBreakdown ? (slice.cacheReadTokens ?? 0) : (totals.cacheReadTokens ?? 0),
-    cacheWriteTokens: preserveDetailedBreakdown ? (slice.cacheWriteTokens ?? 0) : (totals.cacheWriteTokens ?? 0),
+    ...scalarTotals,
+    inputTokens: preserveDetailedBreakdown ? (slice.inputTokens ?? 0) : (scalarTotals.inputTokens ?? 0),
+    outputTokens: preserveDetailedBreakdown ? (slice.outputTokens ?? 0) : (scalarTotals.outputTokens ?? 0),
+    reasoningTokens: preserveDetailedBreakdown ? slice.reasoningTokens : scalarTotals.reasoningTokens,
+    additiveReasoningTokens: preserveDetailedBreakdown ? slice.additiveReasoningTokens : scalarTotals.additiveReasoningTokens,
+    cacheReadTokens: preserveDetailedBreakdown ? (slice.cacheReadTokens ?? 0) : (scalarTotals.cacheReadTokens ?? 0),
+    cacheWriteTokens: preserveDetailedBreakdown ? (slice.cacheWriteTokens ?? 0) : (scalarTotals.cacheWriteTokens ?? 0),
     editTurns: preserveDetailedBreakdown ? (slice.editTurns ?? 0) : 0,
     oneShotTurns: preserveDetailedBreakdown ? (slice.oneShotTurns ?? 0) : 0,
-    models: preserveDetailedBreakdown ? (slice.models ?? {}) : {},
-    categories: preserveDetailedBreakdown ? (slice.categories ?? {}) : {},
+    models: preserveDetailedBreakdown ? cloneModels(slice.models) : cloneModels(modelDetail?.rows),
+    categories: preserveDetailedBreakdown ? cloneCategories(slice.categories) : cloneCategories(categoryDetail?.rows),
     ...(Object.keys(selected).length > 0 ? { projects: selected } : {}),
   }
 }
@@ -191,24 +207,30 @@ export function sliceDayToProvider(day: DailyEntry, provider: string): DailyEntr
   }
 
   const providers = ownRecord<ProviderDaySlice>()
-  setOwn(providers, provider, slice)
+  setOwn(providers, provider, {
+    ...slice,
+    ...(slice.models ? { models: cloneModels(slice.models) } : {}),
+    ...(slice.categories ? { categories: cloneCategories(slice.categories) } : {}),
+    ...(slice.projects ? { projects: cloneProjectStatsMap(slice.projects) } : {}),
+  })
+  const projectedSlice = providers[provider]!
   return {
     date: day.date,
-    cost: slice.cost,
-    savingsUSD: slice.savingsUSD ?? 0,
-    calls: slice.calls,
-    sessions: slice.sessions ?? 0,
-    inputTokens: slice.inputTokens ?? 0,
-    outputTokens: slice.outputTokens ?? 0,
-    additiveReasoningTokens: slice.additiveReasoningTokens,
-    cacheReadTokens: slice.cacheReadTokens ?? 0,
-    cacheWriteTokens: slice.cacheWriteTokens ?? 0,
-    editTurns: slice.editTurns ?? 0,
-    oneShotTurns: slice.oneShotTurns ?? 0,
-    models: slice.models ?? {},
-    categories: slice.categories ?? {},
+    cost: projectedSlice.cost,
+    savingsUSD: projectedSlice.savingsUSD ?? 0,
+    calls: projectedSlice.calls,
+    sessions: projectedSlice.sessions ?? 0,
+    inputTokens: projectedSlice.inputTokens ?? 0,
+    outputTokens: projectedSlice.outputTokens ?? 0,
+    additiveReasoningTokens: projectedSlice.additiveReasoningTokens,
+    cacheReadTokens: projectedSlice.cacheReadTokens ?? 0,
+    cacheWriteTokens: projectedSlice.cacheWriteTokens ?? 0,
+    editTurns: projectedSlice.editTurns ?? 0,
+    oneShotTurns: projectedSlice.oneShotTurns ?? 0,
+    models: projectedSlice.models ?? {},
+    categories: projectedSlice.categories ?? {},
     providers,
-    ...(slice.projects ? { projects: slice.projects } : {}),
+    ...(projectedSlice.projects ? { projects: projectedSlice.projects } : {}),
     ...(day.carried ? { carried: true as const } : {}),
   }
 }
@@ -240,22 +262,20 @@ export function reconcileDurableProjectDay(
 
   const selected = filterProjects(projects, filter)
   const totals = sumProjects(selected)
+  const { modelDetail, categoryDetail, ...scalarTotals } = totals
   return {
     date: day.date,
-    cost: totals.cost,
-    savingsUSD: totals.savingsUSD,
-    calls: totals.calls,
-    sessions: totals.sessions,
-    inputTokens: preserveDetailedBreakdown ? day.inputTokens : (totals.inputTokens ?? 0),
-    outputTokens: preserveDetailedBreakdown ? day.outputTokens : (totals.outputTokens ?? 0),
-    reasoningTokens: preserveDetailedBreakdown ? day.reasoningTokens : totals.reasoningTokens,
-    additiveReasoningTokens: preserveDetailedBreakdown ? day.additiveReasoningTokens : totals.additiveReasoningTokens,
-    cacheReadTokens: preserveDetailedBreakdown ? day.cacheReadTokens : (totals.cacheReadTokens ?? 0),
-    cacheWriteTokens: preserveDetailedBreakdown ? day.cacheWriteTokens : (totals.cacheWriteTokens ?? 0),
+    ...scalarTotals,
+    inputTokens: preserveDetailedBreakdown ? day.inputTokens : (scalarTotals.inputTokens ?? 0),
+    outputTokens: preserveDetailedBreakdown ? day.outputTokens : (scalarTotals.outputTokens ?? 0),
+    reasoningTokens: preserveDetailedBreakdown ? day.reasoningTokens : scalarTotals.reasoningTokens,
+    additiveReasoningTokens: preserveDetailedBreakdown ? day.additiveReasoningTokens : scalarTotals.additiveReasoningTokens,
+    cacheReadTokens: preserveDetailedBreakdown ? day.cacheReadTokens : (scalarTotals.cacheReadTokens ?? 0),
+    cacheWriteTokens: preserveDetailedBreakdown ? day.cacheWriteTokens : (scalarTotals.cacheWriteTokens ?? 0),
     editTurns: preserveDetailedBreakdown ? day.editTurns : 0,
     oneShotTurns: preserveDetailedBreakdown ? day.oneShotTurns : 0,
-    models: preserveDetailedBreakdown ? day.models : {},
-    categories: preserveDetailedBreakdown ? day.categories : {},
+    models: preserveDetailedBreakdown ? cloneModels(day.models) : cloneModels(modelDetail?.rows),
+    categories: preserveDetailedBreakdown ? cloneCategories(day.categories) : cloneCategories(categoryDetail?.rows),
     providers,
     ...(Object.keys(selected).length > 0 ? { projects: selected } : {}),
     ...(day.carried ? { carried: true as const } : {}),

--- a/src/local-state/canonical-history-analytics-publication.test.ts
+++ b/src/local-state/canonical-history-analytics-publication.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
 
-import { currentTzKey, dailyCachePath, emptyCache as emptyDailyCache, loadDailyCache, saveDailyCache, type DailyCache } from '../daily-cache.js'
+import { currentTzKey, dailyCachePath, DAILY_CACHE_VERSION, emptyCache as emptyDailyCache, loadDailyCache, saveDailyCache, type DailyCache } from '../daily-cache.js'
 import { readCurrentDailyCacheGenerationV1, readCurrentSessionCacheGenerationV1 } from '../cache-generation.js'
 import { isSnapshotReadMode } from '../read-lifecycle.js'
 import { CACHE_VERSION, emptyCache as emptySessionCache, loadCache, saveCache, sessionCachePath, type CachedCall, type SessionCache } from '../session-cache.js'
@@ -89,7 +89,7 @@ function sessionCache(calls: CachedCall[] = [call()]): SessionCache {
 
 function dailyCache(): DailyCache {
   const cache = emptyDailyCache('test')
-  cache.version = 19
+  cache.version = DAILY_CACHE_VERSION
   cache.complete = true
   cache.lastComputedDate = '2026-08-12'
   cache.tzKey = 'UTC'

--- a/src/local-state/canonical-history-cli-freshness.test.ts
+++ b/src/local-state/canonical-history-cli-freshness.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
-import { currentTzKey, dailyCachePath, saveDailyCache, type DailyCache } from '../daily-cache.js'
+import { currentTzKey, dailyCachePath, DAILY_CACHE_VERSION, saveDailyCache, type DailyCache } from '../daily-cache.js'
 import {
   readCurrentDailyCacheGenerationV1,
   readCurrentSessionCacheGenerationV1,
@@ -37,7 +37,7 @@ function dateRange(date: string) {
 
 function daily(day: string, timeZone: string): DailyCache {
   return {
-    version: 19,
+    version: DAILY_CACHE_VERSION,
     savingsConfigHash: '',
     tzKey: timeZone,
     lastComputedDate: day,

--- a/src/project-coverage.ts
+++ b/src/project-coverage.ts
@@ -21,16 +21,48 @@ function hasProjectUsage(stats: NonNullable<DailyEntry['projects']>[string]): bo
   return stats.cost > 0 || stats.calls > 0 || stats.savingsUSD > 0
 }
 
+function hasDayUsage(day: DailyEntry): boolean {
+  return day.cost !== 0 || day.calls > 0 || day.savingsUSD !== 0
+}
+
+function hasModelRows(project: NonNullable<DailyEntry['projects']>[string]): boolean {
+  return Object.values(project.modelDetail?.rows ?? {}).some(row =>
+    row.calls > 0
+    || row.cost > 0
+    || row.savingsUSD > 0
+    || row.inputTokens > 0
+    || row.outputTokens > 0
+    || (row.reasoningTokens ?? 0) > 0
+    || (row.additiveReasoningTokens ?? 0) > 0
+    || row.cacheReadTokens > 0
+    || row.cacheWriteTokens > 0,
+  )
+}
+
+function hasCategoryRows(project: NonNullable<DailyEntry['projects']>[string]): boolean {
+  return Object.values(project.categoryDetail?.rows ?? {}).some(row =>
+    row.turns > 0 || row.cost > 0 || row.savingsUSD > 0,
+  )
+}
+
 function projectDetailCoverage(
   days: DailyEntry[],
   kind: 'modelDetail' | 'categoryDetail',
 ): DetailCoverageState[] {
   return days.map(day => {
     const projects = Object.values(day.projects ?? {}).filter(hasProjectUsage)
-    if (projects.length === 0) return 'unavailable'
-    const blocks = projects.map(project => project[kind])
-    if (blocks.every(block => block !== undefined && block.coverage === 'complete')) return 'complete'
-    if (blocks.some(block => block !== undefined)) return 'partial'
+    // A sessions-only shell has no model/category usage to cover. Treat it as
+    // neutral complete-empty evidence; a cost/call-bearing day with no
+    // attributed project usage remains unavailable.
+    if (projects.length === 0) return hasDayUsage(day) ? 'unavailable' : 'complete'
+    const states = projects.map(project => {
+      const block = project[kind]
+      const hasRows = kind === 'modelDetail' ? hasModelRows(project) : hasCategoryRows(project)
+      if (!block || !hasRows) return 'unavailable' as const
+      return block.coverage
+    })
+    if (states.every(state => state === 'complete')) return 'complete'
+    if (states.some(state => state === 'complete' || state === 'partial')) return 'partial'
     return 'unavailable'
   })
 }

--- a/src/project-coverage.ts
+++ b/src/project-coverage.ts
@@ -17,6 +17,24 @@ function hasProjectTokenEvidence(stats: NonNullable<DailyEntry['projects']>[stri
     && stats.cacheWriteTokens !== undefined
 }
 
+function hasProjectUsage(stats: NonNullable<DailyEntry['projects']>[string]): boolean {
+  return stats.cost > 0 || stats.calls > 0 || stats.savingsUSD > 0
+}
+
+function projectDetailCoverage(
+  days: DailyEntry[],
+  kind: 'modelDetail' | 'categoryDetail',
+): DetailCoverageState[] {
+  return days.map(day => {
+    const projects = Object.values(day.projects ?? {}).filter(hasProjectUsage)
+    if (projects.length === 0) return 'unavailable'
+    const blocks = projects.map(project => project[kind])
+    if (blocks.every(block => block !== undefined && block.coverage === 'complete')) return 'complete'
+    if (blocks.some(block => block !== undefined)) return 'partial'
+    return 'unavailable'
+  })
+}
+
 function coverageState(values: boolean[], hasData: boolean): DetailCoverageState {
   if (!hasData || values.length === 0) return 'complete'
   if (values.every(Boolean)) return 'complete'
@@ -24,10 +42,17 @@ function coverageState(values: boolean[], hasData: boolean): DetailCoverageState
   return 'unavailable'
 }
 
+function detailCoverageState(values: DetailCoverageState[], hasData: boolean): DetailCoverageState {
+  if (!hasData || values.length === 0) return 'complete'
+  if (values.every(value => value === 'complete')) return 'complete'
+  if (values.some(value => value === 'complete' || value === 'partial')) return 'partial'
+  return 'unavailable'
+}
+
 /**
- * A Project-scoped durable day owns cost/calls/sessions, but its model/category
- * split may have been removed with the source session files. Keep that fact as
- * metadata instead of making the missing split look like factual zeroes.
+ * A Project-scoped durable day owns cost/calls/sessions and now carries explicit
+ * Source Project model/category detail blocks. Coverage is derived from those
+ * blocks, never from whether a projected map happens to contain rows.
  */
 export function withProjectDetailCoverage(
   data: PeriodData,
@@ -38,18 +63,18 @@ export function withProjectDetailCoverage(
   if (!projectScopeActive) return data
 
   const dataDays = days.filter(day => day.cost !== 0 || day.calls > 0 || day.sessions > 0)
-  const modelDetail = dataDays.map(day => Object.keys(day.models).length > 0)
+  const modelDetail = projectDetailCoverage(dataDays, 'modelDetail')
   const projectTokenDetail = dataDays.map(day => {
     const projects = Object.values(day.projects ?? {}).filter(value => value.cost !== 0 || value.calls > 0 || value.sessions > 0)
     return projects.length > 0 && projects.every(hasProjectTokenEvidence)
   })
-  const categoryDetail = dataDays.map(day => Object.keys(day.categories).length > 0)
+  const categoryDetail = projectDetailCoverage(dataDays, 'categoryDetail')
   return {
     ...data,
     projectDetailCoverage: {
-      models: coverageState(modelDetail, dataDays.length > 0),
+      models: detailCoverageState(modelDetail, dataDays.length > 0),
       tokens: coverageState(projectTokenDetail, dataDays.length > 0),
-      categories: coverageState(categoryDetail, dataDays.length > 0),
+      categories: detailCoverageState(categoryDetail, dataDays.length > 0),
       historical: dataDays.some(day => day.date !== liveDate),
     },
   }

--- a/src/project-scope.ts
+++ b/src/project-scope.ts
@@ -1,6 +1,9 @@
 import { createHash } from 'node:crypto'
 
 import type { DailyEntry, ProjectDayStats, ProviderDaySlice } from './daily-cache.js'
+import { cloneCategoryStats, setOwn } from './daily-cache-category-detail.js'
+import { cloneModelStats } from './daily-cache-model-detail.js'
+import { cloneProjectStats, hasProjectUsage, mergeProjectDetails } from './daily-cache-project-detail.js'
 import { durableProjectDisplayName } from './durable-project-reconciliation.js'
 import { normalizeProjectPathKey, projectNameFromPath } from './project-path-utils.js'
 import type { ProjectRegistry, MetroraProject } from './project-registry.js'
@@ -230,7 +233,19 @@ export function filterProjectsByMetroraScope(
 }
 
 function cloneStats(stats: ProjectDayStats): ProjectDayStats {
-  return { ...stats }
+  return cloneProjectStats(stats)
+}
+
+function cloneModelRows(rows: DailyEntry['models'] | undefined): DailyEntry['models'] {
+  const result: DailyEntry['models'] = {}
+  for (const [name, stats] of Object.entries(rows ?? {})) setOwn(result, name, cloneModelStats(stats))
+  return result
+}
+
+function cloneCategoryRows(rows: DailyEntry['categories'] | undefined): DailyEntry['categories'] {
+  const result: DailyEntry['categories'] = {}
+  for (const [name, stats] of Object.entries(rows ?? {})) setOwn(result, name, cloneCategoryStats(stats))
+  return result
 }
 
 function addProjectTokenStats(target: ProjectDayStats, source: ProjectDayStats): void {
@@ -250,7 +265,7 @@ function scopedProjectStats(
   const result: Record<string, ProjectDayStats> = {}
   for (const [name, value] of Object.entries(stats ?? {})) {
     const id = sourceProjectIdForDurableProject(name, value.path)
-    if (includeSource(scopeId, assignedProjectId(registry, id))) result[name] = cloneStats(value)
+    if (includeSource(scopeId, assignedProjectId(registry, id))) setOwn(result, name, cloneStats(value))
   }
   return result
 }
@@ -258,11 +273,13 @@ function scopedProjectStats(
 function sumStats(stats: Record<string, ProjectDayStats>): ProjectDayStats {
   const total: ProjectDayStats = { cost: 0, savingsUSD: 0, calls: 0, sessions: 0 }
   for (const value of Object.values(stats)) {
+    const targetHadUsage = hasProjectUsage(total)
     total.cost += value.cost
     total.savingsUSD += value.savingsUSD
     total.calls += value.calls
     total.sessions += value.sessions
     addProjectTokenStats(total, value)
+    mergeProjectDetails(total, value, targetHadUsage)
   }
   return total
 }
@@ -275,9 +292,10 @@ function scopedProviderSlice(
 ): ProviderDaySlice {
   const projects = scopedProjectStats(slice.projects, registry, scopeId)
   const totals = sumStats(projects)
+  const { modelDetail, categoryDetail, ...scalarTotals } = totals
   return {
     ...slice,
-    ...totals,
+    ...scalarTotals,
     projects,
     ...(preserveDetailedBreakdown ? {
       inputTokens: slice.inputTokens,
@@ -288,11 +306,11 @@ function scopedProviderSlice(
       cacheWriteTokens: slice.cacheWriteTokens,
       editTurns: slice.editTurns,
       oneShotTurns: slice.oneShotTurns,
-      models: slice.models ?? {},
-      categories: slice.categories ?? {},
+      models: cloneModelRows(slice.models),
+      categories: cloneCategoryRows(slice.categories),
     } : {
-      // Daily caches do not retain model/category detail per Source Project.
-      // Empty detail is explicit unavailable data; it is never a factual zero.
+      // Historical project detail is sourced only from the selected Source
+      // Project rows. A missing block remains an unavailable empty projection.
       inputTokens: totals.inputTokens ?? 0,
       outputTokens: totals.outputTokens ?? 0,
       reasoningTokens: totals.reasoningTokens,
@@ -301,13 +319,13 @@ function scopedProviderSlice(
       cacheWriteTokens: totals.cacheWriteTokens ?? 0,
       editTurns: 0,
       oneShotTurns: 0,
-      models: {},
-      categories: {},
+      models: cloneModelRows(modelDetail?.rows),
+      categories: cloneCategoryRows(categoryDetail?.rows),
     }),
   }
 }
 
-/** Project-scoped durable days reuse cached project totals without inventing model detail. */
+/** Project-scoped durable days derive detail only from selected Source Project rows. */
 export function filterDailyEntryByMetroraScope(
   day: DailyEntry,
   registry: ProjectRegistry,
@@ -317,14 +335,15 @@ export function filterDailyEntryByMetroraScope(
   if (!scopeId || scopeId === ALL_PROJECTS_SCOPE_ID) return day
   const projects = scopedProjectStats(day.projects, registry, scopeId)
   const totals = sumStats(projects)
+  const { modelDetail, categoryDetail, ...scalarTotals } = totals
   const providers: Record<string, ProviderDaySlice> = {}
   for (const [provider, slice] of Object.entries(day.providers)) {
     const scoped = scopedProviderSlice(slice, registry, scopeId, options.preserveDetailedBreakdown === true)
-    if (scoped.calls > 0 || (scoped.sessions ?? 0) > 0 || scoped.cost !== 0 || Object.keys(scoped.projects ?? {}).length > 0) providers[provider] = scoped
+    if (scoped.calls > 0 || (scoped.sessions ?? 0) > 0 || scoped.cost !== 0 || Object.keys(scoped.projects ?? {}).length > 0) setOwn(providers, provider, scoped)
   }
   return {
     ...day,
-    ...totals,
+    ...scalarTotals,
     projects,
     providers,
     ...(options.preserveDetailedBreakdown ? {
@@ -336,8 +355,8 @@ export function filterDailyEntryByMetroraScope(
       cacheWriteTokens: day.cacheWriteTokens,
       editTurns: day.editTurns,
       oneShotTurns: day.oneShotTurns,
-      models: day.models,
-      categories: day.categories,
+      models: cloneModelRows(day.models),
+      categories: cloneCategoryRows(day.categories),
     } : {
       inputTokens: totals.inputTokens ?? 0,
       outputTokens: totals.outputTokens ?? 0,
@@ -347,8 +366,8 @@ export function filterDailyEntryByMetroraScope(
       cacheWriteTokens: totals.cacheWriteTokens ?? 0,
       editTurns: 0,
       oneShotTurns: 0,
-      models: {},
-      categories: {},
+      models: cloneModelRows(modelDetail?.rows),
+      categories: cloneCategoryRows(categoryDetail?.rows),
     }),
   }
 }

--- a/src/usage-aggregator.ts
+++ b/src/usage-aggregator.ts
@@ -503,10 +503,10 @@ export async function buildMenubarPayloadForRange(periodInfo: PeriodInfo, opts: 
     )
     dailyHistory = dailyEntriesToHistory(aggregateProjectsIntoDays(historyProjects))
   } else if (projectFilterActive || projectScopeActive) {
-    // Historical project rollups own cost/calls/savings/session splits,
-    // but not token/model/category splits. Keep those unavailable details empty
-    // instead of assigning the whole day to every selected project. Today's
-    // project-filtered live parse can preserve its detailed breakdown safely.
+    // Historical project rollups use durable Source Project detail for token,
+    // model, and category splits where that authority survived. Missing blocks
+    // remain unavailable instead of assigning global rows to every selected
+    // project. Today's project-filtered live parse preserves its detail.
     const historyFromCache = scopedCacheDays.map(day => reconcileDurableProjectDay(
       isAllProviders ? day : sliceDayToProvider(day, pf),
       projectFilter,

--- a/tests/codex-daily-cache-model-migration.test.ts
+++ b/tests/codex-daily-cache-model-migration.test.ts
@@ -87,7 +87,7 @@ async function seedDailyCache(daily: DailyApi, days: DailyEntry[], savingsConfig
 describe('Codex session_meta model attribution and durable daily history', () => {
   it('changes the daily hash and re-derives a surviving source across the 3650-day horizon', async () => {
     const daily = await import('../src/daily-cache.js')
-    expect(daily.DAILY_CACHE_VERSION).toBe(19)
+    expect(daily.DAILY_CACHE_VERSION).toBe(20)
     expect(daily.DURABLE_HISTORY_AUTHORITY).toContain('codex-session-meta-model-v1')
 
     const oldHash = configHashForAuthority(priorCodexAuthority())

--- a/tests/codex-daily-cache-v17-migration.test.ts
+++ b/tests/codex-daily-cache-v17-migration.test.ts
@@ -62,7 +62,7 @@ afterEach(async () => {
 
 describe('daily-cache v19 adoption from v17', () => {
   it('re-derives surviving Codex days and carries sourceless history losslessly and idempotently', async () => {
-    expect(DAILY_CACHE_VERSION).toBe(19)
+    expect(DAILY_CACHE_VERSION).toBe(20)
     await mkdir(cacheDir, { recursive: true })
     const v17 = {
       version: 17,
@@ -101,7 +101,7 @@ describe('daily-cache v19 adoption from v17', () => {
     await writeFile(join(cacheDir, 'daily-cache.v17.json'), JSON.stringify(v17))
 
     const adopted = await loadDailyCache()
-    expect(adopted.version).toBe(19)
+    expect(adopted.version).toBe(20)
     expect(adopted.complete).toBe(false)
     expect(adopted.days).toHaveLength(2)
 
@@ -162,7 +162,7 @@ describe('daily-cache v19 adoption from v17', () => {
     expect(again).toEqual(migrated)
 
     const persisted = JSON.parse(await readFile(dailyCachePath(), 'utf-8'))
-    expect(persisted.version).toBe(19)
+    expect(persisted.version).toBe(20)
     expect(persisted.days.find((entry: DailyEntry) => entry.date === '2026-08-03').cost).toBe(12.345678)
   })
 

--- a/tests/copilot-daily-cache-v18-migration.test.ts
+++ b/tests/copilot-daily-cache-v18-migration.test.ts
@@ -69,7 +69,7 @@ afterEach(async () => {
 
 describe('Copilot daily-cache v19 adoption from v17', () => {
   it('re-derives a surviving Copilot slice and carries an unrelated orphan once', async () => {
-    expect(DAILY_CACHE_VERSION).toBe(19)
+    expect(DAILY_CACHE_VERSION).toBe(20)
     const date = '2026-07-30'
     const staleCopilot = slice(90, 9, { sessions: 1, inputTokens: 900, outputTokens: 90 })
     const orphanClaude = slice(7, 1, { sessions: 1, inputTokens: 70, outputTokens: 7 })
@@ -85,7 +85,7 @@ describe('Copilot daily-cache v19 adoption from v17', () => {
     const migratedDay = migrated.days.find(entry => entry.date === date)!
 
     expect(parses).toBe(1)
-    expect(migrated.version).toBe(19)
+    expect(migrated.version).toBe(20)
     expect(migrated.complete).toBe(true)
     expect(migrated.watermarkTrusted).toBe(true)
     expect(migratedDay.providers.copilot).toEqual(freshCopilot)
@@ -99,7 +99,7 @@ describe('Copilot daily-cache v19 adoption from v17', () => {
     const again = await ensureCacheHydrated(parseSessions, () => [], 'cfg', () => true)
     expect(parses).toBe(1)
     expect(again.days.find(entry => entry.date === date)!.calls).toBe(3)
-    expect(JSON.parse(await readFile(dailyCachePath(), 'utf-8')).version).toBe(19)
+    expect(JSON.parse(await readFile(dailyCachePath(), 'utf-8')).version).toBe(20)
   })
 
   it('carries a sourceless Copilot slice exactly and does not create a historical zero', async () => {

--- a/tests/daily-cache-pricing-mode.test.ts
+++ b/tests/daily-cache-pricing-mode.test.ts
@@ -50,7 +50,7 @@ describe('daily cache historical-pricing boundary', () => {
 
     expect(hash).toContain(`reviewedBook=${fingerprint}`)
     expect(runtimeHistoricalPricingCacheKeyV1()).toContain(`reviewedBook=${fingerprint}`)
-    expect(DAILY_CACHE_VERSION).toBe(19)
+    expect(DAILY_CACHE_VERSION).toBe(20)
 
     const changed = structuredClone(book)
     changed.records[0]!.rates.inputPerToken += 1e-12

--- a/tests/day-aggregator.test.ts
+++ b/tests/day-aggregator.test.ts
@@ -303,9 +303,40 @@ describe('aggregateProjectsIntoDays', () => {
       cost: 10, calls: 2, savingsUSD: 0, sessions: 1,
       inputTokens: 200, outputTokens: 400, cacheReadTokens: 100, cacheWriteTokens: 0,
       path: '/p',
+      modelDetail: {
+        coverage: 'complete',
+        rows: {
+          'Opus 4.7': { calls: 1, cost: 7, savingsUSD: 0, inputTokens: 100, outputTokens: 200, cacheReadTokens: 50, cacheWriteTokens: 0, sourceProviders: ['claude'] },
+          'gpt-5': { calls: 1, cost: 3, savingsUSD: 0, inputTokens: 100, outputTokens: 200, cacheReadTokens: 50, cacheWriteTokens: 0, sourceProviders: ['codex'] },
+        },
+      },
+      categoryDetail: {
+        coverage: 'complete',
+        rows: { coding: { turns: 1, cost: 10, savingsUSD: 0, editTurns: 0, oneShotTurns: 0 } },
+      },
     })
-    expect(day.providers['claude']!.projects!['p']).toMatchObject({ cost: 7, calls: 1, inputTokens: 100, outputTokens: 200, cacheReadTokens: 50, cacheWriteTokens: 0 })
-    expect(day.providers['codex']!.projects!['p']).toMatchObject({ cost: 3, calls: 1, inputTokens: 100, outputTokens: 200, cacheReadTokens: 50, cacheWriteTokens: 0 })
+    expect(day.providers['claude']!.projects!['p']).toMatchObject({
+      cost: 7, calls: 1, inputTokens: 100, outputTokens: 200, cacheReadTokens: 50, cacheWriteTokens: 0,
+      modelDetail: {
+        coverage: 'complete',
+        rows: { 'Opus 4.7': { calls: 1, cost: 7, sourceProviders: ['claude'] } },
+      },
+      categoryDetail: {
+        coverage: 'complete',
+        rows: { coding: { turns: 1, cost: 7 } },
+      },
+    })
+    expect(day.providers['codex']!.projects!['p']).toMatchObject({
+      cost: 3, calls: 1, inputTokens: 100, outputTokens: 200, cacheReadTokens: 50, cacheWriteTokens: 0,
+      modelDetail: {
+        coverage: 'complete',
+        rows: { 'gpt-5': { calls: 1, cost: 3, sourceProviders: ['codex'] } },
+      },
+      categoryDetail: {
+        coverage: 'complete',
+        rows: { coding: { turns: 0, cost: 3 } },
+      },
+    })
   })
 
   it('carries separately observed reasoning tokens through durable day and period models', () => {

--- a/tests/grok-daily-cache-remediation.test.ts
+++ b/tests/grok-daily-cache-remediation.test.ts
@@ -102,7 +102,7 @@ async function authorities() {
 describe('Grok daily-cache authority', () => {
   it('re-derives retained Grok source evidence without a global daily-version bump', async () => {
     const { daily, currentHash, oldHash } = await authorities()
-    expect(daily.DAILY_CACHE_VERSION).toBe(19)
+    expect(daily.DAILY_CACHE_VERSION).toBe(20)
     expect(daily.DURABLE_HISTORY_AUTHORITY).toContain('codex-session-meta-model-v1')
     expect(currentHash).not.toBe(oldHash)
     expect(currentHash).toContain(`grokCollector=${sessionCacheApi.PROVIDER_PARSE_VERSIONS.grok}`)

--- a/tests/project-coverage.test.ts
+++ b/tests/project-coverage.test.ts
@@ -30,6 +30,8 @@ function day(
       metrora: {
         cost: 10, calls: 4, sessions: 1, savingsUSD: 0, path: '/work/metrora',
         ...(tokens ? { inputTokens: 100, outputTokens: 50, cacheReadTokens: 0, cacheWriteTokens: 0 } : {}),
+        ...(models ? { modelDetail: { coverage: 'complete' as const, rows: { 'claude-opus-4-6': { calls: 4, cost: 10, savingsUSD: 0, inputTokens: 100, outputTokens: 50, cacheReadTokens: 0, cacheWriteTokens: 0 } } } } : {}),
+        ...(categories ? { categoryDetail: { coverage: 'complete' as const, rows: { build: { turns: 4, cost: 10, savingsUSD: 0, editTurns: 0, oneShotTurns: 0 } } } } : {}),
       },
     },
   }

--- a/tests/project-model-category-authority-v20.test.ts
+++ b/tests/project-model-category-authority-v20.test.ts
@@ -176,6 +176,26 @@ function v19Envelope(days: DailyEntry[], authority = 'materialize-before-evict-v
   }
 }
 
+function foreignDay(project: Record<string, unknown>): Record<string, unknown> {
+  return {
+    date: '2026-08-02',
+    cost: project.cost ?? 0,
+    savingsUSD: project.savingsUSD ?? 0,
+    calls: project.calls ?? 0,
+    sessions: project.sessions ?? 0,
+    inputTokens: 0,
+    outputTokens: 0,
+    cacheReadTokens: 0,
+    cacheWriteTokens: 0,
+    editTurns: 0,
+    oneShotTurns: 0,
+    models: {},
+    categories: {},
+    providers: {},
+    projects: { A: project },
+  }
+}
+
 beforeEach(async () => {
   vi.useFakeTimers()
   vi.setSystemTime(new Date('2026-08-03T12:00:00.000Z'))
@@ -308,7 +328,7 @@ describe('v20 durable Source Project model/category authority', () => {
     expect(accounting.rows[0]).not.toHaveProperty('tokenDetail', false)
   })
 
-  it('distinguishes explicit complete-empty detail from unavailable detail', () => {
+  it('fails closed when call-bearing complete-empty detail is serialized', () => {
     const base: DailyEntry = {
       date: '2026-08-02', cost: 1, savingsUSD: 0, calls: 1, sessions: 1,
       inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0,
@@ -317,16 +337,134 @@ describe('v20 durable Source Project model/category authority', () => {
     }
     const missing = { ...base, projects: { A: { cost: 1, calls: 1, savingsUSD: 0, sessions: 1, path: '/source/a' } } }
     const scope = registry({ mp_a: [sourceProjectIdForSummary(projectSummary('A', '/source/a', []))] })
-    const complete = filterDailyEntryByMetroraScope(base, scope, 'mp_a')
+    const normalized = migrateDays([base as unknown as Record<string, unknown>])[0]!
+    const complete = filterDailyEntryByMetroraScope(normalized, scope, 'mp_a')
     const unavailable = filterDailyEntryByMetroraScope(missing, scope, 'mp_a')
+    const unsanitizedCoverage = withProjectDetailCoverage(buildPeriodDataFromDays([base], 'Lifetime'), [base], true, '2026-08-03')
     const completeCoverage = withProjectDetailCoverage(buildPeriodDataFromDays([complete], 'Lifetime'), [complete], true, '2026-08-03')
     const unavailableCoverage = withProjectDetailCoverage(buildPeriodDataFromDays([unavailable], 'Lifetime'), [unavailable], true, '2026-08-03')
 
+    expect(normalized.projects?.A?.modelDetail).toBeUndefined()
+    expect(normalized.projects?.A?.categoryDetail).toBeUndefined()
     expect(complete.models).toEqual({})
-    expect(completeCoverage.projectDetailCoverage?.models).toBe('complete')
-    expect(completeCoverage.projectDetailCoverage?.categories).toBe('complete')
+    expect(unsanitizedCoverage.projectDetailCoverage?.models).toBe('unavailable')
+    expect(unsanitizedCoverage.projectDetailCoverage?.categories).toBe('unavailable')
+    expect(completeCoverage.projectDetailCoverage?.models).toBe('unavailable')
+    expect(completeCoverage.projectDetailCoverage?.categories).toBe('unavailable')
     expect(unavailableCoverage.projectDetailCoverage?.models).toBe('unavailable')
     expect(unavailableCoverage.projectDetailCoverage?.categories).toBe('unavailable')
+  })
+
+  it('preserves complete-empty detail for a genuine sessions-only project', () => {
+    const normalized = migrateDays([foreignDay({
+      cost: 0,
+      calls: 0,
+      savingsUSD: 0,
+      sessions: 1,
+      modelDetail: { coverage: 'complete', rows: {} },
+      categoryDetail: { coverage: 'complete', rows: {} },
+    })])[0]!
+    const scope = registry({ mp_a: [sourceProjectIdForSummary(projectSummary('A', '/source/a', []))] })
+    const scoped = filterDailyEntryByMetroraScope(normalized, scope, 'mp_a')
+    const coverage = withProjectDetailCoverage(buildPeriodDataFromDays([scoped], 'Lifetime'), [scoped], true, '2026-08-03')
+
+    expect(normalized.projects?.A?.modelDetail).toEqual({ coverage: 'complete', rows: {} })
+    expect(normalized.projects?.A?.categoryDetail).toEqual({ coverage: 'complete', rows: {} })
+    expect(coverage.projectDetailCoverage?.models).toBe('complete')
+    expect(coverage.projectDetailCoverage?.categories).toBe('complete')
+  })
+
+  it('downgrades a complete model claim when sanitization drops a malformed row', () => {
+    const normalized = migrateDays([foreignDay({
+      cost: 2,
+      calls: 2,
+      savingsUSD: 0,
+      sessions: 1,
+      modelDetail: {
+        coverage: 'complete',
+        rows: {
+          known: { calls: 1, cost: 1, savingsUSD: 0, inputTokens: 10, outputTokens: 20, cacheReadTokens: 0, cacheWriteTokens: 0 },
+          malformed: 'drop-me',
+        },
+      },
+    })])[0]!
+    const detail = normalized.projects?.A?.modelDetail
+
+    expect(detail?.coverage).toBe('partial')
+    expect(detail?.rows).toHaveProperty('known')
+    expect(detail?.rows).not.toHaveProperty('malformed')
+  })
+
+  it('downgrades a complete category claim when sanitization drops a malformed row', () => {
+    const normalized = migrateDays([foreignDay({
+      cost: 2,
+      calls: 2,
+      savingsUSD: 0,
+      sessions: 1,
+      categoryDetail: {
+        coverage: 'complete',
+        rows: {
+          coding: { turns: 1, cost: 1, savingsUSD: 0, editTurns: 0, oneShotTurns: 0 },
+          malformed: null,
+        },
+      },
+    })])[0]!
+    const detail = normalized.projects?.A?.categoryDetail
+
+    expect(detail?.coverage).toBe('partial')
+    expect(detail?.rows).toHaveProperty('coding')
+    expect(detail?.rows).not.toHaveProperty('malformed')
+  })
+
+  it('removes a partial detail block when sanitization removes every factual row', () => {
+    const normalized = migrateDays([foreignDay({
+      cost: 2,
+      calls: 2,
+      savingsUSD: 0,
+      sessions: 1,
+      modelDetail: { coverage: 'partial', rows: { malformed: [] } },
+      categoryDetail: { coverage: 'partial', rows: { malformed: false } },
+    })])[0]!
+
+    expect(normalized.projects?.A?.modelDetail).toBeUndefined()
+    expect(normalized.projects?.A?.categoryDetail).toBeUndefined()
+  })
+
+  it('keeps valid complete model rows only when they reconcile to Project facts', () => {
+    const normalized = migrateDays([foreignDay({
+      cost: 3,
+      calls: 2,
+      savingsUSD: 0,
+      sessions: 1,
+      inputTokens: 30,
+      outputTokens: 40,
+      cacheReadTokens: 3,
+      cacheWriteTokens: 4,
+      modelDetail: {
+        coverage: 'complete',
+        rows: {
+          first: { calls: 1, cost: 1, savingsUSD: 0, inputTokens: 10, outputTokens: 20, cacheReadTokens: 1, cacheWriteTokens: 2 },
+          second: { calls: 1, cost: 2, savingsUSD: 0, inputTokens: 20, outputTokens: 20, cacheReadTokens: 2, cacheWriteTokens: 2 },
+        },
+      },
+    })])[0]!
+
+    expect(normalized.projects?.A?.modelDetail?.coverage).toBe('complete')
+  })
+
+  it('keeps valid complete category rows when cost and savings reconcile', () => {
+    const normalized = migrateDays([foreignDay({
+      cost: 3,
+      calls: 2,
+      savingsUSD: 0.25,
+      sessions: 1,
+      categoryDetail: {
+        coverage: 'complete',
+        rows: { coding: { turns: 1, cost: 3, savingsUSD: 0.25, editTurns: 0, oneShotTurns: 0 } },
+      },
+    })])[0]!
+
+    expect(normalized.projects?.A?.categoryDetail?.coverage).toBe('complete')
   })
 
   it('preserves separate, aggregate-output, and mixed reasoning algebra in project rows', () => {
@@ -376,8 +514,7 @@ describe('v20 durable Source Project model/category authority', () => {
     const migrated = migrateDays([raw])[0]!
 
     expect(({} as { polluted?: boolean }).polluted).toBeUndefined()
-    expect(migrated.projects?.A?.modelDetail?.rows).not.toHaveProperty('__proto__')
-    expect(migrated.projects?.A?.modelDetail?.rows).not.toHaveProperty('constructor')
+    expect(migrated.projects?.A?.modelDetail).toBeUndefined()
     expect(migrated.projects?.A?.categoryDetail?.rows).toHaveProperty('coding')
   })
 

--- a/tests/project-model-category-authority-v20.test.ts
+++ b/tests/project-model-category-authority-v20.test.ts
@@ -467,6 +467,45 @@ describe('v20 durable Source Project model/category authority', () => {
     expect(normalized.projects?.A?.categoryDetail?.coverage).toBe('complete')
   })
 
+  it('fails closed on a malformed zero-cost category row even when surviving rows reconcile', () => {
+    const normalized = migrateDays([foreignDay({
+      cost: 0,
+      calls: 2,
+      savingsUSD: 0,
+      sessions: 1,
+      categoryDetail: {
+        coverage: 'complete',
+        rows: {
+          coding: { turns: 1, cost: 0, savingsUSD: 0, editTurns: 0, oneShotTurns: 0 },
+          testing: { turns: 'malformed', cost: 0, savingsUSD: 0, editTurns: 0, oneShotTurns: 0 },
+        },
+      },
+    })])[0]!
+    const detail = normalized.projects?.A?.categoryDetail
+
+    expect(detail?.coverage).toBe('partial')
+    expect(detail?.rows).toHaveProperty('coding')
+    expect(detail?.rows).not.toHaveProperty('testing')
+  })
+
+  it('keeps complete zero-cost category detail when every serialized row is valid', () => {
+    const normalized = migrateDays([foreignDay({
+      cost: 0,
+      calls: 2,
+      savingsUSD: 0,
+      sessions: 1,
+      categoryDetail: {
+        coverage: 'complete',
+        rows: {
+          coding: { turns: 1, cost: 0, savingsUSD: 0, editTurns: 0, oneShotTurns: 0 },
+          testing: { turns: 1, cost: 0, savingsUSD: 0, editTurns: 0, oneShotTurns: 0 },
+        },
+      },
+    })])[0]!
+
+    expect(normalized.projects?.A?.categoryDetail?.coverage).toBe('complete')
+  })
+
   it('preserves separate, aggregate-output, and mixed reasoning algebra in project rows', () => {
     const source = projectSummary('A', '/source/a', [
       call({ timestamp: '2026-08-02T10:00:00.000Z', costUSD: 1, provider: 'codex', model: 'reasoning-model', outputTokens: 100, reasoningTokens: 40, reasoningSemantics: 'separate' }),

--- a/tests/project-model-category-authority-v20.test.ts
+++ b/tests/project-model-category-authority-v20.test.ts
@@ -1,0 +1,396 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { existsSync } from 'node:fs'
+import { mkdir, readFile, rm, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+
+import { aggregateProjectsIntoDays, buildPeriodDataFromDays } from '../src/day-aggregator.js'
+import {
+  DAILY_CACHE_VERSION,
+  DURABLE_HISTORY_AUTHORITY,
+  MIN_SUPPORTED_VERSION,
+  currentTzKey,
+  dailyCachePath,
+  ensureCacheHydrated,
+  type DailyEntry,
+} from '../src/daily-cache.js'
+import { migrateDays } from '../src/daily-cache-core.js'
+import { mergeDayEntries } from '../src/daily-cache-merge.js'
+import { buildModelAccounting } from '../src/model-accounting.js'
+import { filterDailyEntryByMetroraScope, sourceProjectIdForSummary } from '../src/project-scope.js'
+import { withProjectDetailCoverage } from '../src/project-coverage.js'
+import { toCompanionUsageV1 } from '../src/sharing/companion-contract.js'
+import type { ProjectRegistry } from '../src/project-registry.js'
+import type { ProjectSummary } from '../src/types.js'
+import type { ReasoningTokenSemantics } from '../src/token-semantics.js'
+
+const ROOT = join(tmpdir(), `metrora-project-authority-v20-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`)
+let previousCacheDir: string | undefined
+
+type CallInput = {
+  timestamp: string
+  costUSD: number
+  provider: string
+  model?: string
+  modelProvider?: string
+  category?: ProjectSummary['sessions'][number]['turns'][number]['category']
+  inputTokens?: number
+  outputTokens?: number
+  cacheReadTokens?: number
+  cacheWriteTokens?: number
+  reasoningTokens?: number
+  reasoningSemantics?: ReasoningTokenSemantics
+}
+
+function call(input: CallInput): any {
+  const cacheReadTokens = input.cacheReadTokens ?? 0
+  const cacheWriteTokens = input.cacheWriteTokens ?? 0
+  return {
+    provider: input.provider,
+    model: input.model ?? 'synthetic-model',
+    ...(input.modelProvider ? { modelProvider: input.modelProvider } : {}),
+    ...(input.reasoningSemantics ? { reasoningSemantics: input.reasoningSemantics } : {}),
+    usage: {
+      inputTokens: input.inputTokens ?? 0,
+      outputTokens: input.outputTokens ?? 0,
+      cacheCreationInputTokens: cacheWriteTokens,
+      cacheReadInputTokens: cacheReadTokens,
+      cachedInputTokens: cacheReadTokens,
+      reasoningTokens: input.reasoningTokens ?? 0,
+      webSearchRequests: 0,
+    },
+    costUSD: input.costUSD,
+    savingsUSD: 0,
+    tools: [],
+    mcpTools: [],
+    skills: [],
+    subagentTypes: [],
+    hasAgentSpawn: false,
+    hasPlanMode: false,
+    speed: 'standard',
+    timestamp: input.timestamp,
+    bashCommands: [],
+    deduplicationKey: `${input.provider}-${input.timestamp}-${input.model ?? 'synthetic-model'}`,
+  }
+}
+
+function projectSummary(name: string, path: string, calls: any[], categories?: string[]): ProjectSummary {
+  const grouped = new Map<string, any[]>()
+  for (const [index, apiCall] of calls.entries()) {
+    const category = categories?.[index] ?? 'coding'
+    const bucket = grouped.get(category) ?? []
+    bucket.push(apiCall)
+    grouped.set(category, bucket)
+  }
+  const total = (selector: (apiCall: any) => number) => calls.reduce((sum, apiCall) => sum + selector(apiCall), 0)
+  const firstTimestamp = calls[0]?.timestamp ?? '2026-08-01T10:00:00.000Z'
+  const lastTimestamp = calls.at(-1)?.timestamp ?? firstTimestamp
+  const turns = [...grouped.entries()].flatMap(([category, categoryCalls]) => categoryCalls.map((apiCall, index) => ({
+    userMessage: `${category}-${index}`,
+    assistantCalls: [apiCall],
+    timestamp: apiCall.timestamp,
+    sessionId: `${name}-session`,
+    category,
+    retries: 0,
+    hasEdits: false,
+  })))
+  return {
+    project: name,
+    projectPath: path,
+    totalCostUSD: total(apiCall => apiCall.costUSD),
+    totalSavingsUSD: 0,
+    totalApiCalls: calls.length,
+    totalProxiedCostUSD: 0,
+    sessions: [{
+      sessionId: `${name}-session`,
+      project: name,
+      firstTimestamp,
+      lastTimestamp,
+      totalCostUSD: total(apiCall => apiCall.costUSD),
+      totalSavingsUSD: 0,
+      totalInputTokens: total(apiCall => apiCall.usage.inputTokens),
+      totalOutputTokens: total(apiCall => apiCall.usage.outputTokens),
+      totalReasoningTokens: total(apiCall => apiCall.usage.reasoningTokens),
+      totalCacheReadTokens: total(apiCall => apiCall.usage.cacheReadInputTokens),
+      totalCacheWriteTokens: total(apiCall => apiCall.usage.cacheCreationInputTokens),
+      apiCalls: calls.length,
+      turns,
+      modelBreakdown: {},
+      toolBreakdown: {},
+      mcpBreakdown: {},
+      bashBreakdown: {},
+      categoryBreakdown: {},
+      skillBreakdown: {},
+      subagentBreakdown: {},
+    }],
+  } as unknown as ProjectSummary
+}
+
+function registry(assignments: Record<string, string[]>): ProjectRegistry {
+  return {
+    kind: 'metrora.project-registry',
+    version: 1,
+    projects: Object.entries(assignments).map(([id, sourceProjectMembership]) => ({
+      id,
+      name: id,
+      icon: 'grid',
+      color: 'cyan',
+      sourceProjectMembership,
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+    })),
+  }
+}
+
+function legacyV19Day(date: string, cost = 5, calls = 2): DailyEntry {
+  const project = { cost, calls, savingsUSD: 0, sessions: 1, path: '/source/a' }
+  return {
+    date,
+    cost,
+    savingsUSD: 0,
+    calls,
+    sessions: 1,
+    inputTokens: cost * 100,
+    outputTokens: cost * 50,
+    cacheReadTokens: cost * 10,
+    cacheWriteTokens: cost * 2,
+    editTurns: 0,
+    oneShotTurns: 0,
+    models: { legacy: { calls, cost, savingsUSD: 0, inputTokens: cost * 100, outputTokens: cost * 50, cacheReadTokens: cost * 10, cacheWriteTokens: cost * 2 } },
+    categories: {},
+    providers: { claude: { calls, cost, savingsUSD: 0, sessions: 1, inputTokens: cost * 100, outputTokens: cost * 50, cacheReadTokens: cost * 10, cacheWriteTokens: cost * 2, projects: { A: project } } },
+    projects: { A: project },
+    carried: true,
+  }
+}
+
+function v19Envelope(days: DailyEntry[], authority = 'materialize-before-evict-v1') {
+  return {
+    version: 19,
+    savingsConfigHash: 'cfg',
+    tzKey: currentTzKey(),
+    durableHistoryAuthority: authority,
+    lastComputedDate: '2026-08-02',
+    complete: true,
+    days,
+  }
+}
+
+beforeEach(async () => {
+  vi.useFakeTimers()
+  vi.setSystemTime(new Date('2026-08-03T12:00:00.000Z'))
+  previousCacheDir = process.env['METRORA_CACHE_DIR']
+  process.env['METRORA_CACHE_DIR'] = ROOT
+  await mkdir(ROOT, { recursive: true })
+})
+
+afterEach(async () => {
+  vi.useRealTimers()
+  if (previousCacheDir === undefined) delete process.env['METRORA_CACHE_DIR']
+  else process.env['METRORA_CACHE_DIR'] = previousCacheDir
+  if (existsSync(ROOT)) await rm(ROOT, { recursive: true, force: true })
+})
+
+describe('v20 durable Source Project model/category authority', () => {
+  it('materializes complete model/category detail and serves it after source deletion', async () => {
+    const source = projectSummary('A', '/source/a', [
+      call({ timestamp: '2026-08-02T10:00:00.000Z', costUSD: 2, provider: 'claude', model: 'model-a', inputTokens: 10, outputTokens: 20 }),
+      call({ timestamp: '2026-08-02T11:00:00.000Z', costUSD: 3, provider: 'codex', model: 'model-b', inputTokens: 30, outputTokens: 40 }),
+    ], ['coding', 'testing'])
+    const first = await ensureCacheHydrated(async () => [source], aggregateProjectsIntoDays, 'cfg', () => true, undefined, { durableHistoryAuthority: DURABLE_HISTORY_AUTHORITY })
+    const firstDay = first.days.find(day => day.date === '2026-08-02')!
+    const sourceId = sourceProjectIdForSummary(source)
+    const scoped = filterDailyEntryByMetroraScope(firstDay, registry({ mp_a: [sourceId] }), 'mp_a')
+    const coverage = withProjectDetailCoverage(buildPeriodDataFromDays([scoped], 'Lifetime'), [scoped], true, '2026-08-03')
+
+    expect(first.version).toBe(20)
+    expect(firstDay.projects?.A?.modelDetail).toMatchObject({ coverage: 'complete' })
+    expect(Object.keys(firstDay.projects?.A?.modelDetail?.rows ?? {})).toHaveLength(2)
+    expect(firstDay.projects?.A?.categoryDetail).toMatchObject({ coverage: 'complete' })
+    expect(Object.keys(firstDay.projects?.A?.categoryDetail?.rows ?? {})).toEqual(expect.arrayContaining(['coding', 'testing']))
+    expect(scoped.models).toEqual(firstDay.projects?.A?.modelDetail?.rows)
+    expect(scoped.categories).toEqual(firstDay.projects?.A?.categoryDetail?.rows)
+    expect(coverage.projectDetailCoverage).toEqual({ models: 'complete', tokens: 'complete', categories: 'complete', historical: true })
+
+    const warm = await ensureCacheHydrated(async () => [], aggregateProjectsIntoDays, 'cfg', () => true, undefined, { durableHistoryAuthority: DURABLE_HISTORY_AUTHORITY })
+    const warmDay = warm.days.find(day => day.date === '2026-08-02')!
+    expect(warmDay.projects?.A?.modelDetail).toEqual(firstDay.projects?.A?.modelDetail)
+    expect(warmDay.projects?.A?.categoryDetail).toEqual(firstDay.projects?.A?.categoryDetail)
+  })
+
+  it('keeps same-display-name model routes distinct in durable project rows and scoped projection', () => {
+    const source = projectSummary('A', '/source/a', [
+      call({ timestamp: '2026-08-02T10:00:00.000Z', costUSD: 2, provider: 'claude', model: 'same-name', modelProvider: 'route-a', inputTokens: 10, outputTokens: 20 }),
+      call({ timestamp: '2026-08-02T11:00:00.000Z', costUSD: 3, provider: 'claude', model: 'same-name', modelProvider: 'route-b', inputTokens: 30, outputTokens: 40 }),
+    ])
+    const day = aggregateProjectsIntoDays([source])[0]!
+    const sourceId = sourceProjectIdForSummary(source)
+    const scoped = filterDailyEntryByMetroraScope(day, registry({ mp_a: [sourceId] }), 'mp_a')
+    const rows = buildPeriodDataFromDays([scoped], 'Lifetime').models
+
+    expect(Object.keys(day.projects?.A?.modelDetail?.rows ?? {})).toHaveLength(2)
+    expect(rows.map(row => row.modelProvider).sort()).toEqual(['route-a', 'route-b'])
+    expect(rows.map(row => row.cost).sort((a, b) => a - b)).toEqual([2, 3])
+  })
+
+  it('moves only the current projection when Source Project membership is regrouped', () => {
+    const source = projectSummary('A', '/source/a', [call({ timestamp: '2026-08-02T10:00:00.000Z', costUSD: 4, provider: 'claude', model: 'model-a' })])
+    const day = aggregateProjectsIntoDays([source])[0]!
+    const sourceId = sourceProjectIdForSummary(source)
+    const before = filterDailyEntryByMetroraScope(day, registry({ mp_a: [sourceId], mp_b: [] }), 'mp_a')
+    const afterA = filterDailyEntryByMetroraScope(day, registry({ mp_a: [], mp_b: [sourceId] }), 'mp_a')
+    const afterB = filterDailyEntryByMetroraScope(day, registry({ mp_a: [], mp_b: [sourceId] }), 'mp_b')
+
+    expect(day.projects?.A?.modelDetail?.coverage).toBe('complete')
+    expect(before.models).toHaveProperty('model-a')
+    expect(afterA.cost).toBe(0)
+    expect(afterA.models).toEqual({})
+    expect(afterB.models).toHaveProperty('model-a')
+    expect(afterB.categories).toHaveProperty('coding')
+  })
+
+  it('adopts v19 with retained source evidence and leaves the v19 file untouched', async () => {
+    const oldPath = join(ROOT, 'daily-cache.v19.json')
+    const oldBytes = JSON.stringify(v19Envelope([legacyV19Day('2026-07-20')]))
+    await writeFile(oldPath, oldBytes, 'utf8')
+    const source = projectSummary('A', '/source/a', [call({ timestamp: '2026-07-20T10:00:00.000Z', costUSD: 5, provider: 'claude', model: 'rehydrated-model' })])
+
+    const migrated = await ensureCacheHydrated(async () => [source], aggregateProjectsIntoDays, 'cfg', () => true, undefined, { durableHistoryAuthority: DURABLE_HISTORY_AUTHORITY })
+    const rehydrated = migrated.days.find(day => day.date === '2026-07-20')!
+
+    expect(DAILY_CACHE_VERSION).toBe(20)
+    expect(MIN_SUPPORTED_VERSION).toBe(15)
+    expect(rehydrated.projects?.A?.modelDetail?.coverage).toBe('complete')
+    expect(rehydrated.projects?.A?.categoryDetail?.coverage).toBe('complete')
+    expect(await readFile(oldPath, 'utf8')).toBe(oldBytes)
+    expect(JSON.parse(await readFile(dailyCachePath(), 'utf8')).version).toBe(20)
+  })
+
+  it('adopts v19 sourceless project facts exactly without fabricating detail', async () => {
+    const oldPath = join(ROOT, 'daily-cache.v19.json')
+    const old = legacyV19Day('2026-07-21', 6, 3)
+    await writeFile(oldPath, JSON.stringify(v19Envelope([old])), 'utf8')
+
+    const migrated = await ensureCacheHydrated(async () => [], aggregateProjectsIntoDays, 'cfg', () => true, undefined, { durableHistoryAuthority: DURABLE_HISTORY_AUTHORITY })
+    const carried = migrated.days.find(day => day.date === '2026-07-21')!
+
+    expect(carried.cost).toBe(old.cost)
+    expect(carried.calls).toBe(old.calls)
+    expect(carried.inputTokens).toBe(old.inputTokens)
+    expect(carried.projects?.A?.modelDetail).toBeUndefined()
+    expect(carried.projects?.A?.categoryDetail).toBeUndefined()
+    expect(carried.models).toEqual(old.models)
+  })
+
+  it('keeps known detail and marks the project partial when a carried provider lacks detail', () => {
+    const detailed = aggregateProjectsIntoDays([projectSummary('A', '/source/a', [call({ timestamp: '2026-08-02T10:00:00.000Z', costUSD: 2, provider: 'claude', model: 'known-model' })])])[0]!
+    const carried: DailyEntry = {
+      ...legacyV19Day('2026-08-02', 3, 1),
+      providers: { legacy: { calls: 1, cost: 3, savingsUSD: 0, sessions: 1, projects: { A: { cost: 3, calls: 1, savingsUSD: 0, sessions: 1, path: '/source/a' } } } },
+      projects: { A: { cost: 3, calls: 1, savingsUSD: 0, sessions: 1, path: '/source/a' } },
+    }
+    const merged = mergeDayEntries([detailed], [carried], true)[0]!
+    const project = merged.projects?.A!
+
+    expect(merged.cost).toBe(5)
+    expect(project.modelDetail?.coverage).toBe('partial')
+    expect(project.categoryDetail?.coverage).toBe('partial')
+    expect(project.modelDetail?.rows).toHaveProperty('known-model')
+    expect(project.categoryDetail?.rows).toHaveProperty('coding')
+  })
+
+  it('keeps Other models as exact cost/call residual without assigning token identity', () => {
+    const accounting = buildModelAccounting([
+      { name: 'known-model', cost: 6, savingsUSD: 0, calls: 7, inputTokens: 10, outputTokens: 20, cacheReadTokens: 0, cacheWriteTokens: 0 },
+    ], 10, 10)
+    expect(accounting.gap).toEqual({ cost: 4, savingsUSD: 0, calls: 3 })
+    expect(accounting.rows[0]).toMatchObject({ name: 'known-model', inputTokens: 10, outputTokens: 20 })
+    expect(accounting.rows[0]).not.toHaveProperty('tokenDetail', false)
+  })
+
+  it('distinguishes explicit complete-empty detail from unavailable detail', () => {
+    const base: DailyEntry = {
+      date: '2026-08-02', cost: 1, savingsUSD: 0, calls: 1, sessions: 1,
+      inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0,
+      editTurns: 0, oneShotTurns: 0, models: {}, categories: {}, providers: {},
+      projects: { A: { cost: 1, calls: 1, savingsUSD: 0, sessions: 1, path: '/source/a', modelDetail: { coverage: 'complete', rows: {} }, categoryDetail: { coverage: 'complete', rows: {} } } },
+    }
+    const missing = { ...base, projects: { A: { cost: 1, calls: 1, savingsUSD: 0, sessions: 1, path: '/source/a' } } }
+    const scope = registry({ mp_a: [sourceProjectIdForSummary(projectSummary('A', '/source/a', []))] })
+    const complete = filterDailyEntryByMetroraScope(base, scope, 'mp_a')
+    const unavailable = filterDailyEntryByMetroraScope(missing, scope, 'mp_a')
+    const completeCoverage = withProjectDetailCoverage(buildPeriodDataFromDays([complete], 'Lifetime'), [complete], true, '2026-08-03')
+    const unavailableCoverage = withProjectDetailCoverage(buildPeriodDataFromDays([unavailable], 'Lifetime'), [unavailable], true, '2026-08-03')
+
+    expect(complete.models).toEqual({})
+    expect(completeCoverage.projectDetailCoverage?.models).toBe('complete')
+    expect(completeCoverage.projectDetailCoverage?.categories).toBe('complete')
+    expect(unavailableCoverage.projectDetailCoverage?.models).toBe('unavailable')
+    expect(unavailableCoverage.projectDetailCoverage?.categories).toBe('unavailable')
+  })
+
+  it('preserves separate, aggregate-output, and mixed reasoning algebra in project rows', () => {
+    const source = projectSummary('A', '/source/a', [
+      call({ timestamp: '2026-08-02T10:00:00.000Z', costUSD: 1, provider: 'codex', model: 'reasoning-model', outputTokens: 100, reasoningTokens: 40, reasoningSemantics: 'separate' }),
+      call({ timestamp: '2026-08-02T11:00:00.000Z', costUSD: 1, provider: 'claude', model: 'reasoning-model', outputTokens: 200, reasoningTokens: 50, reasoningSemantics: 'aggregate-output' }),
+    ])
+    const day = aggregateProjectsIntoDays([source])[0]!
+    const row = day.projects?.A?.modelDetail?.rows['reasoning-model']!
+
+    expect(row.reasoningTokens).toBe(90)
+    expect(row.additiveReasoningTokens).toBe(40)
+    expect(row.reasoningSemantics).toBe('mixed')
+    expect(row.outputTokens + row.additiveReasoningTokens!).toBe(340)
+  })
+
+  it('keeps Desktop/core and Companion model rows and coverage aligned', () => {
+    const source = projectSummary('A', '/source/a', [call({ timestamp: '2026-08-02T10:00:00.000Z', costUSD: 2, provider: 'claude', model: 'model-a', inputTokens: 10, outputTokens: 20 })])
+    const day = aggregateProjectsIntoDays([source])[0]!
+    const scoped = filterDailyEntryByMetroraScope(day, registry({ mp_a: [sourceProjectIdForSummary(source)] }), 'mp_a')
+    const period = withProjectDetailCoverage(buildPeriodDataFromDays([scoped], 'Lifetime'), [scoped], true, '2026-08-03')
+    const companion = toCompanionUsageV1({
+      generated: '2026-08-03T12:00:00.000Z',
+      projectScope: { selectedId: 'mp_a' },
+      current: {
+        label: period.label,
+        cost: period.cost,
+        calls: period.calls,
+        sessions: period.sessions,
+        inputTokens: period.inputTokens,
+        outputTokens: period.outputTokens,
+        cacheReadTokens: period.cacheReadTokens,
+        cacheWriteTokens: period.cacheWriteTokens,
+        cacheHitPercent: 0,
+        topModels: [],
+        modelAccounting: buildModelAccounting(period.models, period.cost, period.calls),
+        projectDetailCoverage: period.projectDetailCoverage,
+      },
+    })
+    expect(companion.quality.projectDetailCoverage).toEqual(period.projectDetailCoverage)
+    expect(companion.models?.[0]?.name).toBe('model-a')
+    expect(companion.totals.tokens.total).toBe(period.inputTokens + period.outputTokens)
+  })
+
+  it('sanitizes hostile nested project detail keys without prototype pollution', () => {
+    const raw = JSON.parse('{"date":"2026-08-02","cost":1,"calls":1,"projects":{"A":{"cost":1,"calls":1,"savingsUSD":0,"sessions":1,"modelDetail":{"coverage":"complete","rows":{"__proto__":{"polluted":true},"constructor":{"calls":1,"cost":1,"savingsUSD":0,"inputTokens":1,"outputTokens":1,"cacheReadTokens":0,"cacheWriteTokens":0}}},"categoryDetail":{"coverage":"complete","rows":{"__proto__":{"polluted":true},"coding":{"turns":1,"cost":1,"savingsUSD":0,"editTurns":0,"oneShotTurns":0}}}}},"models":{},"categories":{},"providers":{},"inputTokens":0,"outputTokens":0,"cacheReadTokens":0,"cacheWriteTokens":0,"sessions":1,"editTurns":0,"oneShotTurns":0}') as Record<string, unknown>
+    const migrated = migrateDays([raw])[0]!
+
+    expect(({} as { polluted?: boolean }).polluted).toBeUndefined()
+    expect(migrated.projects?.A?.modelDetail?.rows).not.toHaveProperty('__proto__')
+    expect(migrated.projects?.A?.modelDetail?.rows).not.toHaveProperty('constructor')
+    expect(migrated.projects?.A?.categoryDetail?.rows).toHaveProperty('coding')
+  })
+
+  it('keeps v19 and v20 files as separate owners', async () => {
+    const oldPath = join(ROOT, 'daily-cache.v19.json')
+    const oldBytes = JSON.stringify(v19Envelope([legacyV19Day('2026-07-22')]))
+    await writeFile(oldPath, oldBytes, 'utf8')
+    const source = projectSummary('A', '/source/a', [call({ timestamp: '2026-07-22T10:00:00.000Z', costUSD: 2, provider: 'claude', model: 'model-a' })])
+    await ensureCacheHydrated(async () => [source], aggregateProjectsIntoDays, 'cfg', () => true, undefined, { durableHistoryAuthority: DURABLE_HISTORY_AUTHORITY })
+
+    expect(existsSync(oldPath)).toBe(true)
+    expect(await readFile(oldPath, 'utf8')).toBe(oldBytes)
+    expect(existsSync(dailyCachePath())).toBe(true)
+    expect(dailyCachePath()).toContain('daily-cache.v20.json')
+  })
+})

--- a/tests/project-token-authority-v19.test.ts
+++ b/tests/project-token-authority-v19.test.ts
@@ -296,8 +296,8 @@ describe('v19 Source Project token authority', () => {
     const rehydrated = migrated.days.find(day => day.date === '2026-07-20')!
     const carried = migrated.days.find(day => day.date === '2026-07-21')!
 
-    expect(DAILY_CACHE_VERSION).toBe(19)
-    expect(migrated.version).toBe(19)
+    expect(DAILY_CACHE_VERSION).toBe(20)
+    expect(migrated.version).toBe(20)
     expect(rehydrated.projects?.A).toMatchObject({ inputTokens: 11, outputTokens: 22, cacheReadTokens: 3, cacheWriteTokens: 4 })
     expect(carried.cost).toBe(6)
     expect(carried.calls).toBe(3)
@@ -306,7 +306,7 @@ describe('v19 Source Project token authority', () => {
     expect(carried.carried).toBe(true)
     expect(await readFile(oldPath, 'utf8')).toBe(oldBytes)
     expect(existsSync(dailyCachePath())).toBe(true)
-    expect(JSON.parse(await readFile(dailyCachePath(), 'utf8')).version).toBe(19)
+    expect(JSON.parse(await readFile(dailyCachePath(), 'utf8')).version).toBe(20)
   })
 
   it('keeps Desktop/core numeric projection identical to Companion tokens for complete Project scope', () => {


### PR DESCRIPTION
## Summary

Completes durable historical model/category authority for Metrora Project scope while preserving existing factual totals and fail-closed coverage semantics. Resolves the implementation targeted by #184.

## Durable authority

- `ProjectDayStats` now carries durable Source Project model and category detail with explicit `complete` / `partial` coverage.
- Project regrouping remains a current membership overlay; historical collector facts are not rewritten.
- Historical Project scoping derives model/category rows only from selected durable Source Project detail.
- `Other models` remains an exact cost/call residual when historical model identity is incomplete; no token identity is fabricated.
- Reasoning semantics remain separate/aggregate-output/mixed/unavailable without double counting.

## Fail-closed persistence

- Serialized `complete` model detail is retained only when surviving rows reconcile with factual Project calls, cost, savings and available token fields.
- Category `complete` requires lossless sanitization plus factual economic reconciliation.
- Lossy or mismatched detail degrades to `partial`; no surviving factual rows becomes unavailable.
- Zero-cost category usage is handled explicitly: valid zero-cost rows can remain complete, while dropped/malformed rows force partial coverage.
- Genuine sessions-only/no-usage Projects may remain complete-empty.
- Hostile/prototype keys and malformed foreign-cache structures are rejected without inventing replacements.

## History and migration

- `DAILY_CACHE_VERSION = 20`.
- `MIN_SUPPORTED_VERSION = 15` remains unchanged.
- Durable history authority advances to `materialize-before-evict-v2-project-tokens-codex-session-meta-model-v1-project-model-category-v1`.
- Retained v19 source evidence can be re-derived into complete v20 detail.
- Sourceless historical totals are carried exactly through NEVER-LOSE with model/category detail unavailable where it cannot be proven.
- v19 and v20 files remain separate owners.

## Validation

- Final v20 authority suite: 20 tests passed.
- Focused cache/project matrix: 22 files, 164 tests passed.
- Full Vitest: 333 files passed, 2 integration files skipped; 3,257 tests passed, 5 skipped.
- TypeScript, CLI build, source-size ratchet and `git diff --check` passed.
- Final CI: Metrora CI #1147 passed; Architecture, Public Identity and Brand Boundary passed; Windows Candidate skipped.

No real user cache/history/session data was touched. No Android accounting engine, provider/parser/pricing change or classifier-versioning system was introduced.

Merged as `f795a4010fbcf228cfc125f43c0dc4cf9f289f15`.