### PR TITLE
feat(capacity): converge provider quota authority

### DIFF
--- a/app/electron/main.test.ts
+++ b/app/electron/main.test.ts
@@ -191,9 +191,25 @@ describe('createBridgeHandlers (IPC wiring)', () => {
   const withQuota = <T extends object>(value: T) => ({ ...value, getQuota: vi.fn(async () => []) })
   it('returns normalized quota through its own IPC channel and sanitizes unexpected failures', async () => {
     const base = { spawnCli: vi.fn(), spawnCliAction: vi.fn(), resolveMetroraPath: () => null }
-    const value = [{ provider: 'claude' as const, connection: 'connected' as const, primary: null, details: [], planLabel: 'Pro', footerLines: [] }]
+    const value = [{
+      schemaVersion: 1 as const,
+      provider: 'claude' as const,
+      authority: 'provider-reported' as const,
+      availability: 'available' as const,
+      connection: 'connected' as const,
+      freshness: 'fresh' as const,
+      observedAt: '2026-07-12T00:00:00.000Z',
+      planLabel: 'Pro',
+      windows: [{ id: 'seven_day', label: 'Weekly', usedFraction: 0.1, resetsAt: null, windowSeconds: null }],
+      credits: null,
+      rateLimit: { state: 'clear' as const, retryAt: null },
+    }]
     const ok = createBridgeHandlers({ ...base, getQuota: vi.fn(async () => value) })
     expect(await ok['metrora:getQuota']!()).toEqual({ ok: true, value })
+
+    const unsafe = createBridgeHandlers({ ...base, getQuota: vi.fn(async () => [{ ...value[0], tokens: { access_token: 'secret' }, accountId: 'acct_secret', credentialPath: '/Users/me/.codex/auth.json' } as never]) })
+    const safe = await unsafe['metrora:getQuota']!()
+    expect(JSON.stringify(safe)).not.toMatch(/secret|acct_secret|auth\.json|tokens/)
 
     const failed = createBridgeHandlers({ ...base, getQuota: vi.fn(async () => { throw new Error('Bearer secret sk-ant-leak') }) })
     const result = await failed['metrora:getQuota']!()

--- a/app/electron/main.test.ts
+++ b/app/electron/main.test.ts
@@ -220,7 +220,7 @@ describe('createBridgeHandlers (IPC wiring)', () => {
     const invalidFresh = createBridgeHandlers({ ...base, getQuota: vi.fn(async () => [{ ...value[0], observedAt: null }]) })
     expect(await invalidFresh['metrora:getQuota']!()).toMatchObject({
       ok: true,
-      value: [{ connection: 'connected', availability: 'unavailable', freshness: 'unavailable', observedAt: null, windows: [{ id: 'seven_day' }] }],
+      value: [{ connection: 'connected', availability: 'unavailable', freshness: 'unavailable', observedAt: null, windows: [], credits: null, planLabel: null }],
     })
 
     const failed = createBridgeHandlers({ ...base, getQuota: vi.fn(async () => { throw new Error('Bearer secret sk-ant-leak') }) })

--- a/app/electron/main.test.ts
+++ b/app/electron/main.test.ts
@@ -211,6 +211,18 @@ describe('createBridgeHandlers (IPC wiring)', () => {
     const safe = await unsafe['metrora:getQuota']!()
     expect(JSON.stringify(safe)).not.toMatch(/secret|acct_secret|auth\.json|tokens/)
 
+    const emptyClaim = createBridgeHandlers({ ...base, getQuota: vi.fn(async () => [{ ...value[0], observedAt: null, windows: [], credits: null, planLabel: null }]) })
+    expect(await emptyClaim['metrora:getQuota']!()).toMatchObject({
+      ok: true,
+      value: [{ connection: 'connected', availability: 'unavailable', freshness: 'unavailable', observedAt: null }],
+    })
+
+    const invalidFresh = createBridgeHandlers({ ...base, getQuota: vi.fn(async () => [{ ...value[0], observedAt: null }]) })
+    expect(await invalidFresh['metrora:getQuota']!()).toMatchObject({
+      ok: true,
+      value: [{ connection: 'connected', availability: 'unavailable', freshness: 'unavailable', observedAt: null, windows: [{ id: 'seven_day' }] }],
+    })
+
     const failed = createBridgeHandlers({ ...base, getQuota: vi.fn(async () => { throw new Error('Bearer secret sk-ant-leak') }) })
     const result = await failed['metrora:getQuota']!()
     expect(result).toMatchObject({ ok: false, error: { kind: 'nonzero' } })

--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -4,6 +4,7 @@ import path from 'node:path'
 import { CliError, killAll, resolveMetroraPath, spawnCli, spawnCliAction, type ActionResult, type SpawnPriority } from './cli'
 import { createApplicationMenuTemplate } from './menu'
 import { getQuota, sanitizeError } from './quota'
+import { sanitizeQuotaProviders } from './quota/types'
 import { createShareBridgeHandlers } from './share-bridge'
 import { initializeDesktopShareRuntime, stopDesktopShareRuntime, type DesktopShareRuntime } from './share-runtime'
 import { Telemetry } from './telemetry'
@@ -321,7 +322,7 @@ export function createBridgeHandlers(deps: Deps = { spawnCli, spawnCliAction, re
 
   return {
     'metrora:getQuota': async (force?: boolean) => {
-      try { return { ok: true, value: await deps.getQuota({ force: Boolean(force) }) } }
+      try { return { ok: true, value: sanitizeQuotaProviders(await deps.getQuota({ force: Boolean(force) })) } }
       catch (error) { return { ok: false, error: { kind: 'nonzero', message: sanitizeError(error) } } }
     },
     'metrora:getOverview': getOverview,

--- a/app/electron/quota/claude.test.ts
+++ b/app/electron/quota/claude.test.ts
@@ -28,9 +28,10 @@ describe('Claude quota', () => {
 
     expect(quota.connection).toBe('connected')
     expect(quota.planLabel).toBe('Max 20x')
-    expect(quota.primary?.label).toBe('Weekly')
-    expect(quota.details.map(row => row.label)).toEqual(['5-hour', 'Weekly', 'Weekly · Opus', 'Weekly · Sonnet', 'Weekly · Haiku'])
-    expect(quota.details.map(row => row.percent)).toEqual([0.25, 0.5, 0.75, 0.9, 0.1])
+    expect(quota.windows.map(row => row.label)).toEqual(['5-hour', 'Weekly', 'Weekly · Opus', 'Weekly · Sonnet', 'Weekly · Haiku'])
+    expect(quota.windows.map(row => row.id)).toEqual(['five_hour', 'seven_day', 'seven_day_opus', 'seven_day_sonnet', 'weekly_scoped:Haiku'])
+    expect(quota.windows.map(row => row.usedFraction)).toEqual([0.25, 0.5, 0.75, 0.9, 0.1])
+    expect(quota.credits).toBeNull()
   })
 
   it('returns disconnected without credentials and never fetches', async () => {

--- a/app/electron/quota/claude.test.ts
+++ b/app/electron/quota/claude.test.ts
@@ -34,6 +34,25 @@ describe('Claude quota', () => {
     expect(quota.credits).toBeNull()
   })
 
+  it.each([
+    [undefined, null],
+    ['', null],
+    ['ultra_custom', 'Ultra Custom'],
+  ])('does not fabricate a generic plan for tier %s', (tier, expected) => {
+    const quota = decodeClaudeUsage({}, { accessToken: 'hidden', rateLimitTier: tier as string | undefined })
+    expect(quota.planLabel).toBe(expected)
+  })
+
+  it('does not treat an empty successful response with no tier as fresh quota', async () => {
+    const emptyCredential = JSON.stringify({ claudeAiOauth: { accessToken: 'sk-ant-empty', rateLimitTier: '' } })
+    const fetchMock = vi.fn(async () => new Response('{}', { status: 200 }))
+    const result = await fetchClaudeQuota({ fetch: fetchMock, readFile: vi.fn(async () => emptyCredential), now: () => Date.parse('2026-07-12T00:00:00Z') })
+    expect(result.quota).toMatchObject({
+      connection: 'connected', availability: 'unavailable', freshness: 'unavailable', observedAt: null,
+      windows: [], credits: null, planLabel: null,
+    })
+  })
+
   it('returns disconnected without credentials and never fetches', async () => {
     const fetchMock = vi.fn()
     const result = await fetchClaudeQuota({ fetch: fetchMock, readFile: vi.fn(async () => null) })

--- a/app/electron/quota/claude.ts
+++ b/app/electron/quota/claude.ts
@@ -99,14 +99,16 @@ function windowOf(id: string, label: string, value: unknown): QuotaWindow | null
   }
 }
 
-function tierLabel(raw: string | undefined): string {
-  const value = raw?.toLowerCase() ?? ''
-  if (value.includes('max_20x') || value.includes('max20x') || value.includes('max-20x')) return 'Max 20x'
-  if (value.includes('max_5x') || value.includes('max5x') || value.includes('max-5x') || value.includes('max')) return 'Max 5x'
-  if (value.includes('pro')) return 'Pro'
-  if (value.includes('team')) return 'Team'
-  if (value.includes('enterprise')) return 'Enterprise'
-  return 'Subscription'
+function tierLabel(raw: string | undefined): string | null {
+  const value = raw?.trim() ?? ''
+  if (!value) return null
+  const normalized = value.toLowerCase()
+  if (normalized === 'max_20x' || normalized === 'max20x' || normalized === 'max-20x') return 'Max 20x'
+  if (normalized === 'max_5x' || normalized === 'max5x' || normalized === 'max-5x' || normalized === 'max') return 'Max 5x'
+  if (normalized === 'pro') return 'Pro'
+  if (normalized === 'team') return 'Team'
+  if (normalized === 'enterprise') return 'Enterprise'
+  return value.replace(/(^|[_-])\w/g, match => match.replace(/[_-]/, ' ').toUpperCase())
 }
 
 function stableScopedIdentity(row: Record<string, any>, display: string): string {

--- a/app/electron/quota/claude.ts
+++ b/app/electron/quota/claude.ts
@@ -1,9 +1,9 @@
 import os from 'node:os'
 import path from 'node:path'
 
+import { emptyQuota, markObserved, type QuotaProvider, type QuotaWindow } from './types'
 import { fraction, quotaRequestSignal, readKeychainPassword, readSecureFile, sanitizeError } from './security'
 import type { KeychainOutcome } from './security'
-import type { QuotaProvider, QuotaWindow } from './types'
 
 const ENDPOINT = 'https://api.anthropic.com/api/oauth/usage'
 const KEYCHAIN_SERVICE = 'Claude Code-credentials'
@@ -25,7 +25,7 @@ const defaults: ClaudeDeps = {
 }
 
 function empty(connection: QuotaProvider['connection']): QuotaProvider {
-  return { provider: 'claude', connection, primary: null, details: [], planLabel: null, footerLines: [] }
+  return emptyQuota('claude', connection)
 }
 
 function parseCredential(raw: string): ClaudeCredential | null {
@@ -52,14 +52,51 @@ export async function readClaudeKeychain(): Promise<KeychainOutcome> {
   return readKeychainPassword(KEYCHAIN_SERVICE, user ? [user, null] : [null])
 }
 
-function windowOf(label: string, value: unknown): QuotaWindow | null {
+type CredentialSource = {
+  credential: ClaudeCredential
+  reread: () => Promise<ClaudeCredential | null>
+}
+
+async function discoverCredential(deps: ClaudeDeps, allowKeychain: boolean): Promise<CredentialSource | null | 'accessDenied'> {
+  const fromFile = await credentialFromFile(deps)
+  if (fromFile) return { credential: fromFile, reread: () => credentialFromFile(deps) }
+  if (!allowKeychain || process.platform !== 'darwin') return null
+  const outcome = await (deps.keychain ?? readClaudeKeychain)()
+  if (outcome.status === 'accessDenied') return 'accessDenied'
+  if (outcome.status !== 'found') return null
+  const credential = parseCredential(outcome.value)
+  if (!credential) return null
+  return {
+    credential,
+    reread: async () => {
+      const next = await (deps.keychain ?? readClaudeKeychain)()
+      return next.status === 'found' ? parseCredential(next.value) : null
+    },
+  }
+}
+
+function resetAt(value: unknown): string | null {
+  if (typeof value !== 'string' || !Number.isFinite(Date.parse(value))) return null
+  return new Date(value).toISOString()
+}
+
+function evidenceWindowSeconds(row: Record<string, unknown>): number | null {
+  const raw = row.window_seconds ?? row.limit_window_seconds
+  return typeof raw === 'number' && Number.isFinite(raw) && raw > 0 ? Math.trunc(raw) : null
+}
+
+function windowOf(id: string, label: string, value: unknown): QuotaWindow | null {
   if (!value || typeof value !== 'object') return null
   const row = value as Record<string, unknown>
-  const percent = fraction(row.utilization)
-  if (percent === null) return null
-  const resetsAt = typeof row.resets_at === 'string' && !Number.isNaN(Date.parse(row.resets_at))
-    ? new Date(row.resets_at).toISOString() : null
-  return { label, percent, resetsAt }
+  const usedFraction = fraction(row.utilization ?? row.percent)
+  if (usedFraction === null) return null
+  return {
+    id,
+    label,
+    usedFraction,
+    resetsAt: resetAt(row.resets_at),
+    windowSeconds: evidenceWindowSeconds(row),
+  }
 }
 
 function tierLabel(raw: string | undefined): string {
@@ -72,29 +109,48 @@ function tierLabel(raw: string | undefined): string {
   return 'Subscription'
 }
 
+function stableScopedIdentity(row: Record<string, any>, display: string): string {
+  const candidates = [
+    row.id,
+    row.limit_id,
+    row.scope_id,
+    row.scope?.id,
+    row.scope?.model?.id,
+    row.scope?.model?.name,
+    display,
+  ]
+  const identity = candidates.find(candidate => typeof candidate === 'string' && candidate.trim())
+  return `weekly_scoped:${typeof identity === 'string' ? identity.trim() : display}`
+}
+
 export function decodeClaudeUsage(body: unknown, credential: ClaudeCredential): QuotaProvider {
   const data = body && typeof body === 'object' ? body as Record<string, unknown> : {}
-  const five = windowOf('5-hour', data.five_hour)
-  const weekly = windowOf('Weekly', data.seven_day)
-  const opus = windowOf('Weekly · Opus', data.seven_day_opus)
-  const sonnet = windowOf('Weekly · Sonnet', data.seven_day_sonnet)
-  const scoped: QuotaWindow[] = []
+  const windows: QuotaWindow[] = []
+  const five = windowOf('five_hour', '5-hour', data.five_hour)
+  const weekly = windowOf('seven_day', 'Weekly', data.seven_day)
+  const opus = windowOf('seven_day_opus', 'Weekly · Opus', data.seven_day_opus)
+  const sonnet = windowOf('seven_day_sonnet', 'Weekly · Sonnet', data.seven_day_sonnet)
+  for (const row of [five, weekly, opus, sonnet]) if (row) windows.push(row)
+
   if (Array.isArray(data.limits)) {
     for (const item of data.limits) {
       if (!item || typeof item !== 'object') continue
       const row = item as Record<string, any>
       const display = row.scope?.model?.display_name
-      const percent = fraction(row.percent)
-      if (row.kind !== 'weekly_scoped' || typeof display !== 'string' || percent === null) continue
-      const resetsAt = typeof row.resets_at === 'string' && !Number.isNaN(Date.parse(row.resets_at))
-        ? new Date(row.resets_at).toISOString() : null
-      scoped.push({ label: `Weekly · ${display}`, percent, resetsAt })
+      const candidate = fraction(row.percent)
+      if (row.kind !== 'weekly_scoped' || typeof display !== 'string' || !display.trim() || candidate === null) continue
+      const scoped = windowOf(stableScopedIdentity(row, display), `Weekly · ${display}`, row)
+      if (scoped) windows.push(scoped)
     }
   }
+
+  const decoded = emptyQuota('claude', 'connected')
   return {
-    provider: 'claude', connection: 'connected', primary: weekly,
-    details: [five, weekly, opus, sonnet].filter((row): row is QuotaWindow => row !== null).concat(scoped),
-    planLabel: tierLabel(credential.rateLimitTier), footerLines: [],
+    ...decoded,
+    planLabel: tierLabel(credential.rateLimitTier),
+    windows,
+    // Anthropic's usage response does not report an equivalent credits balance.
+    credits: null,
   }
 }
 
@@ -115,26 +171,27 @@ export type ClaudeResult = { quota: QuotaProvider; retryAfterSeconds?: number }
 export async function fetchClaudeQuota(options: Partial<ClaudeDeps> & { signal?: AbortSignal; allowKeychain?: boolean } = {}): Promise<ClaudeResult> {
   const deps = { ...defaults, ...options }
   try {
-    let credential = await credentialFromFile(deps)
-    if (!credential && options.allowKeychain && process.platform === 'darwin') {
-      const outcome = await (deps.keychain ?? readClaudeKeychain)()
-      if (outcome.status === 'accessDenied') return { quota: empty('accessDenied') }
-      credential = outcome.status === 'found' ? parseCredential(outcome.value) : null
-    }
-    if (!credential) return { quota: empty('disconnected') }
+    const discovered = await discoverCredential(deps, Boolean(options.allowKeychain))
+    if (discovered === 'accessDenied') return { quota: empty('accessDenied') }
+    if (!discovered) return { quota: empty('disconnected') }
+    const source = discovered
+    let credential = source.credential
 
-    let response: Response
+    // Claude's CLI owns token rotation. A near-expiry credential gets one
+    // bounded reread; Metrora never calls a provider refresh endpoint.
     if (credential.expiresAt !== undefined && credential.expiresAt - deps.now() <= 5 * 60_000) {
-      const reread = await credentialFromFile(deps)
+      const reread = await source.reread()
       if (!reread || reread.accessToken === credential.accessToken) return { quota: empty('transientFailure') }
       credential = reread
     }
-    response = await request(credential.accessToken, deps, options.signal)
+
+    let response = await request(credential.accessToken, deps, options.signal)
     if (response.status === 401) {
-      const reread = await credentialFromFile(deps)
+      const reread = await source.reread()
       if (!reread || reread.accessToken === credential.accessToken) return { quota: empty('transientFailure') }
       credential = reread
       response = await request(credential.accessToken, deps, options.signal)
+      if (response.status === 401) return { quota: empty('transientFailure') }
     }
     if (response.status === 429) {
       let hint: unknown
@@ -143,9 +200,10 @@ export async function fetchClaudeQuota(options: Partial<ClaudeDeps> & { signal?:
       return { quota: empty('transientFailure'), retryAfterSeconds: Math.max(Number.isFinite(parsed) ? parsed : 300, 60) }
     }
     if (!response.ok) return { quota: empty(response.status >= 400 && response.status < 500 ? 'terminalFailure' : 'transientFailure') }
-    return { quota: decodeClaudeUsage(await response.json(), credential) }
+    return { quota: markObserved(decodeClaudeUsage(await response.json(), credential), deps.now()) }
   } catch (error) {
-    // Deliberately sanitize before the only diagnostic sink. Tokens are never returned.
+    // Deliberately sanitize before the only diagnostic sink. Tokens and
+    // provider response bodies are never returned or logged.
     console.warn(`Claude quota unavailable: ${sanitizeError(error)}`)
     return { quota: empty('transientFailure') }
   }

--- a/app/electron/quota/codex.test.ts
+++ b/app/electron/quota/codex.test.ts
@@ -27,15 +27,21 @@ describe('Codex quota', () => {
       credits: { balance: '3.5' },
     })
     expect(quota.planLabel).toBe('Plus')
-    expect(quota.primary?.label).toBe('5-hour')
-    expect(quota.details.map(row => row.label)).toEqual(['5-hour', 'Weekly', 'GPT-5 · Hour'])
-    expect(quota.footerLines).toEqual(['Credits remaining · $3.50'])
+    expect(quota.windows.map(row => row.label)).toEqual(['5-hour', 'Weekly', 'GPT-5 · Hour', 'GPT-5 · Daily'])
+    expect(quota.windows.map(row => row.id)).toEqual(['primary', 'secondary', 'additional:GPT-5:primary', 'additional:GPT-5:secondary'])
+    expect(quota.windows[0]).toMatchObject({ usedFraction: 0.2, resetsAt: '2027-01-15T08:00:00.000Z', windowSeconds: 18_000 })
+    expect(quota.credits).toEqual({ balance: 3.5, currency: 'USD' })
   })
 
   it('promotes secondary when primary is absent', () => {
     const quota = decodeCodexUsage({ rate_limit: { secondary_window: { used_percent: 9, reset_at: 1_800_000_000, limit_window_seconds: 604_800 } } })
-    expect(quota.primary?.label).toBe('Weekly')
-    expect(quota.details).toHaveLength(1)
+    expect(quota.windows[0]).toMatchObject({ id: 'secondary', label: 'Weekly' })
+    expect(quota.windows).toHaveLength(1)
+  })
+
+  it('preserves an explicit zero credit balance and keeps absent credits unavailable', () => {
+    expect(decodeCodexUsage({ credits: { balance: 0 } }).credits).toEqual({ balance: 0, currency: 'USD' })
+    expect(decodeCodexUsage({}).credits).toBeNull()
   })
 
   it('returns disconnected without credentials', async () => {
@@ -53,17 +59,36 @@ describe('Codex quota', () => {
     expect(usageInit.headers).toMatchObject({ 'ChatGPT-Account-Id': 'acct_1', 'User-Agent': 'Metrora' })
   })
 
-  it('refreshes after eight days and preserves unrelated auth keys on write-back', async () => {
+  it('never refreshes or writes a stale provider-owned auth document', async () => {
     const stale = { ...auth, last_refresh: '2026-07-01T00:00:00Z' }
-    const fetchMock = vi.fn(async (url: string) => url.includes('/oauth/token')
-      ? new Response(JSON.stringify({ access_token: 'new-access', refresh_token: 'new-refresh', id_token: 'new-id' }), { status: 200 })
-      : new Response(JSON.stringify({ plan_type: 'pro', rate_limit: {} }), { status: 200 }))
-    const writeFile = vi.fn(async () => undefined)
-    await fetchCodexQuota({ fetch: fetchMock as typeof fetch, readFile: vi.fn(async () => JSON.stringify(stale)), writeFile, now: () => now })
-    const saved = JSON.parse((writeFile.mock.calls[0]! as unknown as [string, string])[1])
-    expect(saved.OPENAI_API_KEY).toBe('preserve-me')
-    expect(saved.tokens).toMatchObject({ access_token: 'new-access', refresh_token: 'new-refresh', id_token: 'new-id', account_id: 'acct_1' })
-    expect((fetchMock.mock.calls[0]! as unknown as [string, RequestInit])[1].method).toBe('POST')
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify({ plan_type: 'pro', rate_limit: {} }), { status: 200 }))
+    const result = await fetchCodexQuota({ fetch: fetchMock as typeof fetch, readFile: vi.fn(async () => JSON.stringify(stale)), now: () => now })
+    expect(result.quota.connection).toBe('connected')
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(fetchMock).toHaveBeenCalledWith('https://chatgpt.com/backend-api/wham/usage', expect.anything())
+  })
+
+  it('re-reads once after 401 and retries when Codex owner rotated the token', async () => {
+    const rotated = { ...auth, tokens: { ...auth.tokens, access_token: 'eyJrotated.access.sig' } }
+    let reads = 0
+    const readFile = vi.fn(async () => JSON.stringify(reads++ === 0 ? auth : rotated))
+    const fetchMock = vi.fn(async (_url: string, init?: RequestInit) =>
+      (init?.headers as Record<string, string>).Authorization === 'Bearer eyJrotated.access.sig'
+        ? new Response(JSON.stringify({ rate_limit: {} }), { status: 200 })
+        : new Response('', { status: 401 }))
+    const result = await fetchCodexQuota({ fetch: fetchMock as typeof fetch, readFile })
+    expect(result.quota.connection).toBe('connected')
+    expect(readFile).toHaveBeenCalledTimes(2)
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('returns transient after 401 when the provider-owned token is unchanged', async () => {
+    const readFile = vi.fn(async () => JSON.stringify(auth))
+    const fetchMock = vi.fn(async () => new Response('', { status: 401 }))
+    const result = await fetchCodexQuota({ fetch: fetchMock as typeof fetch, readFile })
+    expect(result.quota.connection).toBe('transientFailure')
+    expect(readFile).toHaveBeenCalledTimes(2)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
   })
 })
 
@@ -80,13 +105,11 @@ describe('Codex menubar keychain source', () => {
   it('resolves quota from the menubar keychain when auth.json is absent, read-only', async () => {
     const fetchMock = vi.fn(async () => new Response(JSON.stringify({ plan_type: 'pro', rate_limit: { primary_window: { used_percent: 10, reset_at: 1_800_000_000, limit_window_seconds: 18_000 } } }), { status: 200 }))
     const keychain = vi.fn(async () => ({ status: 'found' as const, value: menubarRecord }))
-    const writeFile = vi.fn(async () => undefined)
-    const result = await fetchCodexQuota({ fetch: fetchMock as unknown as typeof fetch, readFile: vi.fn(async () => null), writeFile, keychain, allowKeychain: true })
+    const result = await fetchCodexQuota({ fetch: fetchMock as unknown as typeof fetch, readFile: vi.fn(async () => null), keychain, allowKeychain: true })
     expect(result.quota.connection).toBe('connected')
     expect(result.quota.planLabel).toBe('Pro')
     const init = (fetchMock.mock.calls[0]! as unknown as [string, RequestInit])[1]
     expect(init.headers).toMatchObject({ Authorization: 'Bearer eyJmenubar.token.sig', 'ChatGPT-Account-Id': 'acct_mb' })
-    expect(writeFile).not.toHaveBeenCalled()
     expect(keychain).toHaveBeenCalledWith('eu.metrora.menubar.codex.oauth.v1')
   })
 
@@ -97,22 +120,18 @@ describe('Codex menubar keychain source', () => {
     const fetchMock = vi.fn(async (_url: string, init?: RequestInit) => (init?.headers as Record<string, string>).Authorization === 'Bearer eyJrotated.token.sig'
       ? new Response(JSON.stringify({ plan_type: 'pro', rate_limit: {} }), { status: 200 })
       : new Response('', { status: 401 }))
-    const writeFile = vi.fn(async () => undefined)
-    const result = await fetchCodexQuota({ fetch: fetchMock as unknown as typeof fetch, readFile: vi.fn(async () => null), writeFile, keychain, allowKeychain: true })
+    const result = await fetchCodexQuota({ fetch: fetchMock as unknown as typeof fetch, readFile: vi.fn(async () => null), keychain, allowKeychain: true })
     expect(result.quota.connection).toBe('connected')
     expect(fetchMock.mock.calls.every(call => String(call[0]).includes('/wham/usage'))).toBe(true)
     expect(keychain).toHaveBeenCalledTimes(2)
-    expect(writeFile).not.toHaveBeenCalled()
   })
 
   it('returns transientFailure on a keychain 401 with no rotation, never writing back', async () => {
     const keychain = vi.fn(async () => ({ status: 'found' as const, value: menubarRecord }))
     const fetchMock = vi.fn(async (_url: string) => new Response('', { status: 401 }))
-    const writeFile = vi.fn(async () => undefined)
-    const result = await fetchCodexQuota({ fetch: fetchMock as unknown as typeof fetch, readFile: vi.fn(async () => null), writeFile, keychain, allowKeychain: true })
+    const result = await fetchCodexQuota({ fetch: fetchMock as unknown as typeof fetch, readFile: vi.fn(async () => null), keychain, allowKeychain: true })
     expect(result.quota.connection).toBe('transientFailure')
     expect(fetchMock.mock.calls.every(call => String(call[0]).includes('/wham/usage'))).toBe(true)
-    expect(writeFile).not.toHaveBeenCalled()
   })
 
   it('surfaces accessDenied when the menubar keychain is blocked and no file exists', async () => {
@@ -126,12 +145,10 @@ describe('Codex menubar keychain source', () => {
   it('prefers the menubar keychain over ~/.codex/auth.json and keeps it read-only', async () => {
     const keychain = vi.fn(async () => ({ status: 'found' as const, value: menubarRecord }))
     const fetchMock = vi.fn(async () => new Response(JSON.stringify({ plan_type: 'plus', rate_limit: {} }), { status: 200 }))
-    const writeFile = vi.fn(async () => undefined)
-    const result = await fetchCodexQuota({ fetch: fetchMock as unknown as typeof fetch, readFile: vi.fn(async () => JSON.stringify(auth)), writeFile, keychain, allowKeychain: true, now: () => now })
+    const result = await fetchCodexQuota({ fetch: fetchMock as unknown as typeof fetch, readFile: vi.fn(async () => JSON.stringify(auth)), keychain, allowKeychain: true, now: () => now })
     expect(result.quota.connection).toBe('connected')
     const init = (fetchMock.mock.calls[0]! as unknown as [string, RequestInit])[1]
     expect(init.headers).toMatchObject({ Authorization: 'Bearer eyJmenubar.token.sig' })
-    expect(writeFile).not.toHaveBeenCalled()
   })
 
   it('falls through to ~/.codex/auth.json when the keychain has no menubar item', async () => {

--- a/app/electron/quota/codex.test.ts
+++ b/app/electron/quota/codex.test.ts
@@ -44,6 +44,38 @@ describe('Codex quota', () => {
     expect(decodeCodexUsage({}).credits).toBeNull()
   })
 
+  it('does not treat an empty successful response as fresh quota', async () => {
+    const fetchMock = vi.fn(async () => new Response('{}', { status: 200 }))
+    const result = await fetchCodexQuota({ fetch: fetchMock, readFile: vi.fn(async () => JSON.stringify(auth)), now: () => now })
+    expect(result.quota).toMatchObject({
+      connection: 'connected', availability: 'unavailable', freshness: 'unavailable', observedAt: null,
+      windows: [], credits: null, planLabel: null,
+    })
+  })
+
+  it('treats plan-only provider data as a fresh factual snapshot', async () => {
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify({ plan_type: 'pro' }), { status: 200 }))
+    const result = await fetchCodexQuota({ fetch: fetchMock, readFile: vi.fn(async () => JSON.stringify(auth)), now: () => now })
+    expect(result.quota).toMatchObject({ connection: 'connected', availability: 'available', freshness: 'fresh', planLabel: 'Pro', windows: [], credits: null })
+    expect(result.quota.observedAt).toBe(new Date(now).toISOString())
+  })
+
+  it('treats credits-only responses as factual, including explicit zero', async () => {
+    const readFile = vi.fn(async () => JSON.stringify(auth))
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify({ credits: { balance: 3.5 } }), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ credits: { balance: 0 } }), { status: 200 }))
+
+    const positive = await fetchCodexQuota({ fetch: fetchMock, readFile, now: () => now })
+    const zero = await fetchCodexQuota({ fetch: fetchMock, readFile, now: () => now })
+    for (const result of [positive, zero]) {
+      expect(result.quota).toMatchObject({ connection: 'connected', availability: 'available', freshness: 'fresh', windows: [] })
+      expect(result.quota.observedAt).toBe(new Date(now).toISOString())
+    }
+    expect(positive.quota.credits).toEqual({ balance: 3.5, currency: 'USD' })
+    expect(zero.quota.credits).toEqual({ balance: 0, currency: 'USD' })
+  })
+
   it('returns disconnected without credentials', async () => {
     const fetchMock = vi.fn()
     const result = await fetchCodexQuota({ fetch: fetchMock, readFile: vi.fn(async () => null) })

--- a/app/electron/quota/codex.ts
+++ b/app/electron/quota/codex.ts
@@ -1,18 +1,15 @@
 import os from 'node:os'
 import path from 'node:path'
 
-import { atomicWriteSecureFile, fraction, quotaRequestSignal, readKeychainPassword, readSecureFile, sanitizeError } from './security'
+import { emptyQuota, markObserved, type QuotaProvider, type QuotaWindow } from './types'
+import { fraction, quotaRequestSignal, readKeychainPassword, readSecureFile, sanitizeError } from './security'
 import type { KeychainOutcome } from './security'
-import type { QuotaProvider, QuotaWindow } from './types'
 
 const USAGE_ENDPOINT = 'https://chatgpt.com/backend-api/wham/usage'
-const TOKEN_ENDPOINT = 'https://auth.openai.com/oauth/token'
-const CLIENT_ID = 'app_EMoamEEZ73f0CkXaXp7hrann'
-const EIGHT_DAYS = 8 * 24 * 60 * 60_000
 // The Metrora menubar caches its ChatGPT-mode Codex OAuth here as a
 // `CredentialRecord` JSON blob (accessToken/refreshToken/idToken/accountId/…),
 // account "default". Same brand, same machine, already consented — preferred
-// over any OpenAI-owned storage.
+// over any OpenAI-owned storage. It remains read-only to this quota path.
 const MENUBAR_KEYCHAIN_SERVICE = 'eu.metrora.menubar.codex.oauth.v1'
 
 type AuthDoc = Record<string, any> & {
@@ -25,8 +22,8 @@ export type CodexDeps = {
   fetch: typeof fetch
   authPath: string
   openaiAuthPath: string
+  /** Read-only credential source. Codex owns rotation of this document. */
   readFile: typeof readSecureFile
-  writeFile: typeof atomicWriteSecureFile
   keychain: (service: string) => Promise<KeychainOutcome>
   now: () => number
 }
@@ -36,23 +33,19 @@ const defaults: CodexDeps = {
   authPath: path.join(os.homedir(), '.codex', 'auth.json'),
   openaiAuthPath: path.join(os.homedir(), 'Library', 'Application Support', 'com.openai.codex', 'auth.json'),
   readFile: readSecureFile,
-  writeFile: atomicWriteSecureFile,
   keychain: service => readKeychainPassword(service, ['default', null]),
   now: Date.now,
 }
 
-/** A resolved Codex credential plus how much of its lifecycle we own. Only the
- * Codex CLI's own auth.json is `writable` (we may rotate + write it back); the
- * menubar keychain and OpenAI app-support copies are read-only. */
+/** Every Codex credential source is provider-owned and read-only here. */
 type CodexSource = {
   name: 'menubarKeychain' | 'authFile' | 'openaiAppSupport'
   auth: AuthDoc
-  writable: boolean
   reread: () => Promise<AuthDoc | null>
 }
 
 function empty(connection: QuotaProvider['connection']): QuotaProvider {
-  return { provider: 'codex', connection, primary: null, details: [], planLabel: null, footerLines: [] }
+  return emptyQuota('codex', connection)
 }
 
 async function readAuth(deps: CodexDeps, filePath: string = deps.authPath): Promise<AuthDoc | null> {
@@ -82,7 +75,7 @@ function authFromMenubarRecord(raw: string): AuthDoc | null {
 async function discoverSource(deps: CodexDeps, allowKeychain: boolean): Promise<CodexSource | 'accessDenied' | null> {
   let denied = false
   // (a) Metrora menubar's own cached Codex OAuth. Read-only: the menubar owns
-  // rotation, so we never write it back and never proactively refresh it.
+  // rotation, so this path never writes it back or proactively refreshes it.
   if (allowKeychain && process.platform === 'darwin') {
     const outcome = await deps.keychain(MENUBAR_KEYCHAIN_SERVICE)
     if (outcome.status === 'accessDenied') denied = true
@@ -90,7 +83,7 @@ async function discoverSource(deps: CodexDeps, allowKeychain: boolean): Promise<
       const auth = authFromMenubarRecord(outcome.value)
       if (auth) {
         return {
-          name: 'menubarKeychain', auth, writable: false,
+          name: 'menubarKeychain', auth,
           reread: async () => {
             const next = await deps.keychain(MENUBAR_KEYCHAIN_SERVICE)
             return next.status === 'found' ? authFromMenubarRecord(next.value) : null
@@ -99,21 +92,27 @@ async function discoverSource(deps: CodexDeps, allowKeychain: boolean): Promise<
       }
     }
   }
-  // (b) The Codex CLI's own ~/.codex/auth.json. We own rotation + write-back.
+  // (b) The Codex CLI's own ~/.codex/auth.json. Read-only: Codex owns refresh
+  // token rotation and Metrora must never write this provider-owned file.
   const fileAuth = await readAuth(deps)
-  if (fileAuth) return { name: 'authFile', auth: fileAuth, writable: true, reread: () => readAuth(deps) }
+  if (fileAuth) return { name: 'authFile', auth: fileAuth, reread: () => readAuth(deps) }
   // (c) com.openai.codex App Support, only if it holds a plaintext auth JSON
   // with a usable token. Tokens encrypted via "Codex Safe Storage" have no
   // plaintext access_token here, so they fall through — we never decrypt.
   const openaiAuth = await readAuth(deps, deps.openaiAuthPath).catch(() => null)
   if (openaiAuth?.tokens?.access_token) {
-    return { name: 'openaiAppSupport', auth: openaiAuth, writable: false, reread: () => readAuth(deps, deps.openaiAuthPath).catch(() => null) }
+    return { name: 'openaiAppSupport', auth: openaiAuth, reread: () => readAuth(deps, deps.openaiAuthPath).catch(() => null) }
   }
   return denied ? 'accessDenied' : null
 }
 
-function labelForSeconds(value: unknown): string {
-  const seconds = typeof value === 'number' ? Math.max(0, Math.trunc(value)) : 0
+function windowSeconds(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0 ? Math.trunc(value) : null
+}
+
+function labelForSeconds(value: number | null): string {
+  const seconds = value ?? 0
+  if (seconds <= 0) return 'Quota window'
   if (seconds < 3600) return 'Hourly'
   if (seconds < 7200) return 'Hour'
   if (seconds >= 18_000 && seconds < 19_000) return '5-hour'
@@ -123,14 +122,28 @@ function labelForSeconds(value: unknown): string {
   return hours < 24 ? `${hours}-hour` : `${Math.floor(hours / 24)}-day`
 }
 
-function windowOf(value: unknown, override?: string): QuotaWindow | null {
+function resetAt(value: unknown): string | null {
+  const date = typeof value === 'number' && Number.isFinite(value)
+    ? new Date(value * 1000)
+    : typeof value === 'string' && Number.isFinite(Date.parse(value))
+      ? new Date(value)
+      : null
+  return date && Number.isFinite(date.getTime()) ? date.toISOString() : null
+}
+
+function windowOf(value: unknown, id: string, override?: string): QuotaWindow | null {
   if (!value || typeof value !== 'object') return null
   const row = value as Record<string, unknown>
-  const percent = fraction(row.used_percent)
-  if (percent === null) return null
-  const reset = typeof row.reset_at === 'number' && Number.isFinite(row.reset_at)
-    ? new Date(row.reset_at * 1000).toISOString() : null
-  return { label: override ?? labelForSeconds(row.limit_window_seconds), percent, resetsAt: reset }
+  const usedFraction = fraction(row.used_percent)
+  if (usedFraction === null) return null
+  const seconds = windowSeconds(row.limit_window_seconds)
+  return {
+    id,
+    label: override ?? labelForSeconds(seconds),
+    usedFraction,
+    resetsAt: resetAt(row.reset_at),
+    windowSeconds: seconds,
+  }
 }
 
 function planLabel(value: unknown): string | null {
@@ -146,56 +159,43 @@ function planLabel(value: unknown): string | null {
   return known[lower] ?? lower.replace(/(^|[_-])\w/g, match => match.replace(/[_-]/, ' ').toUpperCase())
 }
 
-export function decodeCodexUsage(body: unknown): QuotaProvider {
-  const data = body && typeof body === 'object' ? body as Record<string, any> : {}
-  const primaryRaw = windowOf(data.rate_limit?.primary_window)
-  const secondaryRaw = windowOf(data.rate_limit?.secondary_window)
-  const primary = primaryRaw ?? secondaryRaw
-  const details: QuotaWindow[] = []
-  if (primaryRaw) details.push(primaryRaw)
-  if (secondaryRaw && secondaryRaw !== primary) details.push(secondaryRaw)
-  else if (!primaryRaw && secondaryRaw) details.push(secondaryRaw)
-  if (Array.isArray(data.additional_rate_limits)) {
-    for (const additional of data.additional_rate_limits) {
-      if (!additional || typeof additional !== 'object' || typeof additional.limit_name !== 'string') continue
-      for (const key of ['primary_window', 'secondary_window'] as const) {
-        const raw = additional.rate_limit?.[key]
-        const base = windowOf(raw)
-        if (base && base.percent > 0) details.push({ ...base, label: `${additional.limit_name} · ${base.label}` })
-      }
-    }
-  }
-  const rawBalance = data.credits?.balance
-  const balance = typeof rawBalance === 'number' ? rawBalance : typeof rawBalance === 'string' ? Number(rawBalance) : NaN
-  return {
-    provider: 'codex', connection: 'connected', primary, details,
-    planLabel: planLabel(data.plan_type),
-    footerLines: Number.isFinite(balance) && balance > 0 ? [`Credits remaining · $${balance.toFixed(2)}`] : [],
-  }
+function credits(value: unknown): QuotaProvider['credits'] {
+  if (!value || typeof value !== 'object') return null
+  const raw = (value as Record<string, unknown>).balance
+  const balance = typeof raw === 'number'
+    ? raw
+    : typeof raw === 'string' && raw.trim()
+      ? Number(raw)
+      : NaN
+  return Number.isFinite(balance) ? { balance, currency: 'USD' } : null
 }
 
-async function refresh(auth: AuthDoc, deps: CodexDeps, signal?: AbortSignal): Promise<AuthDoc | null> {
-  const refreshToken = auth.tokens?.refresh_token
-  if (!refreshToken) return null
-  const response = await deps.fetch(TOKEN_ENDPOINT, {
-    method: 'POST', signal: quotaRequestSignal(signal),
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ client_id: CLIENT_ID, grant_type: 'refresh_token', refresh_token: refreshToken, scope: 'openid profile email' }),
-  })
-  if (!response.ok) return null
-  const next = await response.json() as Record<string, unknown>
-  if (typeof next.access_token !== 'string' || !next.access_token) return null
-  const latest = await readAuth(deps)
-  if (!latest || latest.auth_mode !== 'chatgpt') return null
-  latest.tokens = {
-    ...latest.tokens,
-    access_token: next.access_token,
-    ...(typeof next.refresh_token === 'string' ? { refresh_token: next.refresh_token } : {}),
-    ...(typeof next.id_token === 'string' ? { id_token: next.id_token } : {}),
+export function decodeCodexUsage(body: unknown): QuotaProvider {
+  const data = body && typeof body === 'object' ? body as Record<string, any> : {}
+  const windows: QuotaWindow[] = []
+  const primary = windowOf(data.rate_limit?.primary_window, 'primary')
+  const secondary = windowOf(data.rate_limit?.secondary_window, 'secondary')
+  if (primary) windows.push(primary)
+  if (secondary) windows.push(secondary)
+
+  if (Array.isArray(data.additional_rate_limits)) {
+    for (const additional of data.additional_rate_limits) {
+      if (!additional || typeof additional !== 'object' || typeof additional.limit_name !== 'string' || !additional.limit_name.trim()) continue
+      const name = additional.limit_name.trim()
+      const primaryAdditional = windowOf(additional.rate_limit?.primary_window, `additional:${name}:primary`, `${name} · ${labelForSeconds(windowSeconds(additional.rate_limit?.primary_window?.limit_window_seconds))}`)
+      const secondaryAdditional = windowOf(additional.rate_limit?.secondary_window, `additional:${name}:secondary`, `${name} · ${labelForSeconds(windowSeconds(additional.rate_limit?.secondary_window?.limit_window_seconds))}`)
+      if (primaryAdditional) windows.push(primaryAdditional)
+      if (secondaryAdditional) windows.push(secondaryAdditional)
+    }
   }
-  latest.last_refresh = new Date(deps.now()).toISOString()
-  await deps.writeFile(deps.authPath, `${JSON.stringify(latest, null, 2)}\n`)
-  return latest
+
+  const decoded = emptyQuota('codex', 'connected')
+  return {
+    ...decoded,
+    planLabel: planLabel(data.plan_type),
+    windows,
+    credits: credits(data.credits),
+  }
 }
 
 async function usage(auth: AuthDoc, deps: CodexDeps, signal?: AbortSignal): Promise<Response | null> {
@@ -219,31 +219,22 @@ export async function fetchCodexQuota(options: Partial<CodexDeps> & { signal?: A
     if (auth.auth_mode !== 'chatgpt') return { quota: empty('terminalFailure') }
     if (!auth.tokens?.access_token) return { quota: empty('disconnected') }
 
-    // Proactive staleness refresh only for the source whose rotation we own.
-    if (source.writable) {
-      const refreshedAt = typeof auth.last_refresh === 'string' ? Date.parse(auth.last_refresh) : NaN
-      if (!Number.isFinite(refreshedAt) || deps.now() - refreshedAt > EIGHT_DAYS) {
-        const next = await refresh(auth, deps, options.signal)
-        if (next) auth = next
-      }
-    }
+    // Provider-owned Codex OAuth is observationally read-only. In particular,
+    // a stale refresh_token in auth.json is never spent by this code.
     let response = await usage(auth, deps, options.signal)
     if (!response) return { quota: empty('disconnected') }
     if (response.status === 401) {
+      // One bounded reread lets the owner win a concurrent rotation. If the
+      // access token did not change, truthfully wait rather than refreshing or
+      // mutating the provider-owned credential source.
       const reread = await source.reread()
-      if (reread?.tokens?.access_token && reread.tokens.access_token !== auth.tokens?.access_token) {
-        auth = reread
-      } else if (source.writable) {
-        const next = await refresh(reread ?? auth, deps, options.signal)
-        if (!next) return { quota: empty('transientFailure') }
-        auth = next
-      } else {
-        // Read-only source: the owner (menubar) rotates tokens on its own
-        // cadence, so re-read once and otherwise wait for the next poll.
-        return { quota: empty('transientFailure') }
-      }
+      const nextToken = reread?.tokens?.access_token
+      if (!nextToken || nextToken === auth.tokens?.access_token) return { quota: empty('transientFailure') }
+      if (reread?.auth_mode !== 'chatgpt') return { quota: empty('terminalFailure') }
+      auth = reread
       response = await usage(auth, deps, options.signal)
       if (!response) return { quota: empty('transientFailure') }
+      if (response.status === 401) return { quota: empty('transientFailure') }
     }
     if (response.status === 429) {
       const raw = response.headers.get('Retry-After')
@@ -252,7 +243,7 @@ export async function fetchCodexQuota(options: Partial<CodexDeps> & { signal?: A
       return { quota: empty('transientFailure'), retryAfterSeconds: Math.max(Number.isFinite(seconds) ? Math.ceil(seconds) : 300, 60) }
     }
     if (!response.ok) return { quota: empty(response.status >= 400 && response.status < 500 ? 'terminalFailure' : 'transientFailure') }
-    return { quota: decodeCodexUsage(await response.json()) }
+    return { quota: markObserved(decodeCodexUsage(await response.json()), deps.now()) }
   } catch (error) {
     console.warn(`Codex quota unavailable: ${sanitizeError(error)}`)
     return { quota: empty('transientFailure') }

--- a/app/electron/quota/index.test.ts
+++ b/app/electron/quota/index.test.ts
@@ -105,5 +105,23 @@ describe('QuotaService', () => {
     expect(value[0]!.observedAt).toBeNull()
     expect(value[0]!.freshness).toBe('unavailable')
   })
+
+  it('does not retain an empty successful response as a stale factual snapshot', async () => {
+    let healthy = true
+    const claude = vi.fn(async () => healthy
+      ? { quota: quota('claude') }
+      : { quota: quota('claude', { connection: 'transientFailure', availability: 'unavailable', freshness: 'unavailable', observedAt: null }) })
+    const service = new QuotaService({
+      claude,
+      codex: vi.fn(async () => ({ quota: quota('codex') })),
+      readFile: vi.fn(async () => null), writeFile: vi.fn(async () => undefined),
+    })
+
+    const first = await service.getQuota({ force: true })
+    expect(first[0]).toMatchObject({ connection: 'connected', availability: 'unavailable', freshness: 'unavailable', observedAt: null, windows: [] })
+    healthy = false
+    const second = await service.getQuota({ force: true })
+    expect(second[0]).toMatchObject({ connection: 'transientFailure', availability: 'unavailable', freshness: 'unavailable', observedAt: null, windows: [] })
+  })
 })
 

--- a/app/electron/quota/index.test.ts
+++ b/app/electron/quota/index.test.ts
@@ -3,8 +3,19 @@ import { describe, expect, it, vi } from 'vitest'
 import { QuotaService } from './index'
 import type { QuotaProvider } from './types'
 
-const quota = (provider: 'claude' | 'codex'): QuotaProvider => ({
-  provider, connection: 'connected', primary: null, details: [], planLabel: null, footerLines: [],
+const quota = (provider: 'claude' | 'codex', overrides: Partial<QuotaProvider> = {}): QuotaProvider => ({
+  schemaVersion: 1,
+  provider,
+  authority: 'provider-reported',
+  availability: 'available',
+  connection: 'connected',
+  freshness: 'fresh',
+  observedAt: '2026-07-12T00:00:00.000Z',
+  planLabel: null,
+  windows: [],
+  credits: null,
+  rateLimit: { state: 'clear', retryAt: null },
+  ...overrides,
 })
 
 describe('QuotaService', () => {
@@ -21,6 +32,9 @@ describe('QuotaService', () => {
     await service.getQuota({ force: true })
     const saved = JSON.parse(writes[0]!)
     expect(saved.claude).toBe('2026-07-12T00:01:00.000Z')
+    const first = await service.getQuota()
+    expect(first[0]!.freshness).toBe('unavailable')
+    expect(first[0]!.windows).toEqual([])
     await service.getQuota({ force: true })
     expect(claude).toHaveBeenCalledTimes(1)
     expect(codex).toHaveBeenCalledTimes(2)
@@ -53,6 +67,43 @@ describe('QuotaService', () => {
     release()
     expect(await first).toEqual(await second)
     expect(claude).toHaveBeenCalledTimes(1)
+  })
+
+  it('retains the last factual snapshot with stale freshness and original observation time', async () => {
+    let healthy = true
+    const factual = quota('claude', {
+      observedAt: '2026-07-11T23:00:00.000Z',
+      windows: [{ id: 'seven_day', label: 'Weekly', usedFraction: 0.25, resetsAt: '2026-07-19T00:00:00.000Z', windowSeconds: null }],
+    })
+    const claude = vi.fn(async () => ({ quota: healthy ? factual : quota('claude', { connection: 'transientFailure', availability: 'unavailable', freshness: 'unavailable', observedAt: null }) }))
+    let now = Date.parse('2026-07-12T00:00:00Z')
+    const service = new QuotaService({
+      claude, codex: vi.fn(async () => ({ quota: quota('codex') })), now: () => now,
+      readFile: vi.fn(async () => null), writeFile: vi.fn(async () => undefined),
+    })
+
+    const first = await service.getQuota({ force: true })
+    expect(first[0]!.freshness).toBe('fresh')
+    healthy = false
+    now += 5 * 60_000
+    const second = await service.getQuota({ force: true })
+    expect(second[0]).toMatchObject({
+      connection: 'transientFailure', availability: 'unavailable', freshness: 'stale',
+      observedAt: '2026-07-11T23:00:00.000Z',
+    })
+    expect(second[0]!.windows).toEqual(factual.windows)
+  })
+
+  it('does not fabricate windows when there is no previous factual snapshot', async () => {
+    const service = new QuotaService({
+      claude: vi.fn(async () => ({ quota: quota('claude', { connection: 'transientFailure', availability: 'unavailable', freshness: 'unavailable', observedAt: null }) })),
+      codex: vi.fn(async () => ({ quota: quota('codex') })),
+      readFile: vi.fn(async () => null), writeFile: vi.fn(async () => undefined),
+    })
+    const value = await service.getQuota({ force: true })
+    expect(value[0]!.windows).toEqual([])
+    expect(value[0]!.observedAt).toBeNull()
+    expect(value[0]!.freshness).toBe('unavailable')
   })
 })
 

--- a/app/electron/quota/index.ts
+++ b/app/electron/quota/index.ts
@@ -6,6 +6,7 @@ import { fetchCodexQuota } from './codex'
 import { atomicWriteSecureFile, readSecureFile, sanitizeError } from './security'
 import {
   emptyQuota,
+  hasProviderQuotaFacts,
   markStale,
   sanitizeQuotaProvider,
   type ProviderNameFromQuota,
@@ -24,6 +25,7 @@ export type {
   QuotaConnection,
   QuotaFreshness,
 } from './types'
+export { hasProviderQuotaFacts } from './types'
 export { sanitizeError } from './security'
 
 type Blocked = Partial<Record<ProviderNameFromQuota, string>>
@@ -55,7 +57,12 @@ function backoffRateLimit(retryAt: string): QuotaProvider['rateLimit'] {
 }
 
 function isFactualSnapshot(quota: QuotaProvider): boolean {
-  return quota.connection === 'connected' && quota.freshness === 'fresh' && quota.authority === 'provider-reported'
+  return quota.connection === 'connected'
+    && quota.freshness === 'fresh'
+    && quota.authority === 'provider-reported'
+    && hasProviderQuotaFacts(quota)
+    && quota.observedAt !== null
+    && Number.isFinite(Date.parse(quota.observedAt))
 }
 
 export class QuotaService {
@@ -108,7 +115,13 @@ export class QuotaService {
     const blocked = await this.readBlocked()
     const run = async (provider: ProviderNameFromQuota): Promise<QuotaProvider> => {
       const retainOnFailure = (next: QuotaProvider): QuotaProvider => {
-        const previous = this.lastGood[provider] ?? prior.find(item => item.provider === provider)
+        const candidate = this.lastGood[provider] ?? prior.find(item => item.provider === provider)
+        const previous = candidate
+          && hasProviderQuotaFacts(candidate)
+          && candidate.observedAt !== null
+          && Number.isFinite(Date.parse(candidate.observedAt))
+          ? candidate
+          : undefined
         if (!previous) return next
 
         // Background polls deliberately skip keychain reads. Keep the previous

--- a/app/electron/quota/index.ts
+++ b/app/electron/quota/index.ts
@@ -4,12 +4,29 @@ import path from 'node:path'
 import { fetchClaudeQuota } from './claude'
 import { fetchCodexQuota } from './codex'
 import { atomicWriteSecureFile, readSecureFile, sanitizeError } from './security'
-import type { ProviderName, QuotaProvider } from './types'
+import {
+  emptyQuota,
+  markStale,
+  sanitizeQuotaProvider,
+  type ProviderNameFromQuota,
+  type QuotaProvider,
+} from './types'
 
 export type { QuotaProvider, QuotaWindow } from './types'
+export type {
+  ProviderName,
+  ProviderQuotaCredits,
+  ProviderQuotaRateLimit,
+  ProviderQuotaSnapshot,
+  ProviderQuotaWindow,
+  QuotaAvailability,
+  QuotaAuthority,
+  QuotaConnection,
+  QuotaFreshness,
+} from './types'
 export { sanitizeError } from './security'
 
-type Blocked = Partial<Record<ProviderName, string>>
+type Blocked = Partial<Record<ProviderNameFromQuota, string>>
 type FetchResult = { quota: QuotaProvider; retryAfterSeconds?: number }
 type QuotaDeps = {
   claude: (options: { signal: AbortSignal; allowKeychain: boolean }) => Promise<FetchResult>
@@ -33,21 +50,27 @@ const defaultDeps: QuotaDeps = {
   refreshMs: 5 * 60_000,
 }
 
-function unavailable(provider: ProviderName, connection: QuotaProvider['connection']): QuotaProvider {
-  return { provider, connection, primary: null, details: [], planLabel: null, footerLines: [] }
+function backoffRateLimit(retryAt: string): QuotaProvider['rateLimit'] {
+  return { state: 'backoff', retryAt }
+}
+
+function isFactualSnapshot(quota: QuotaProvider): boolean {
+  return quota.connection === 'connected' && quota.freshness === 'fresh' && quota.authority === 'provider-reported'
 }
 
 export class QuotaService {
   private readonly deps: QuotaDeps
   private cache: { at: number; value: QuotaProvider[] } | null = null
+  /** Last factual value survives cache invalidation so force failures can be honest. */
+  private readonly lastGood: Partial<Record<ProviderNameFromQuota, QuotaProvider>> = {}
   private flight: Promise<QuotaProvider[]> | null = null
-  private generations: Record<ProviderName, number> = { claude: 0, codex: 0 }
-  private controllers: Partial<Record<ProviderName, AbortController>> = {}
+  private generations: Record<ProviderNameFromQuota, number> = { claude: 0, codex: 0 }
+  private controllers: Partial<Record<ProviderNameFromQuota, AbortController>> = {}
 
   constructor(deps: Partial<QuotaDeps> = {}) { this.deps = { ...defaultDeps, ...deps } }
 
-  invalidate(provider?: ProviderName): void {
-    const providers: ProviderName[] = provider ? [provider] : ['claude', 'codex']
+  invalidate(provider?: ProviderNameFromQuota): void {
+    const providers: ProviderNameFromQuota[] = provider ? [provider] : ['claude', 'codex']
     for (const p of providers) {
       this.generations[p] += 1
       this.controllers[p]?.abort()
@@ -83,38 +106,65 @@ export class QuotaService {
     const startingGenerations = { ...this.generations }
     const prior = this.cache?.value ?? []
     const blocked = await this.readBlocked()
-    const run = async (provider: ProviderName): Promise<QuotaProvider> => {
+    const run = async (provider: ProviderNameFromQuota): Promise<QuotaProvider> => {
       const retainOnFailure = (next: QuotaProvider): QuotaProvider => {
-        const previous = prior.find(item => item.provider === provider)
-        if (previous?.connection !== 'connected') return next
-        // Keychain-only credentials are invisible to a background (keychain-less)
-        // poll; keep showing the live connection rather than flapping to
-        // disconnected. A forced refresh re-reads the keychain and reveals truth.
-        if (!allowKeychain && (next.connection === 'disconnected' || next.connection === 'accessDenied')) return previous
-        if (next.connection === 'transientFailure') return { ...previous, connection: 'transientFailure', rateLimited: next.rateLimited }
-        return next
+        const previous = this.lastGood[provider] ?? prior.find(item => item.provider === provider)
+        if (!previous) return next
+
+        // Background polls deliberately skip keychain reads. Keep the previous
+        // factual value, but make the unavailable/stale state explicit. A
+        // force refresh does not get this exception for missing credentials.
+        const backgroundCredentialMiss = !allowKeychain && (next.connection === 'disconnected' || next.connection === 'accessDenied')
+        const transient = next.connection === 'transientFailure' || next.connection === 'stale' || backgroundCredentialMiss
+        if (!transient) return next
+        return markStale(previous, next.connection === 'stale' ? 'stale' : 'transientFailure', next.rateLimit)
       }
+
       const until = blocked[provider] ? Date.parse(blocked[provider]!) : NaN
-      if (Number.isFinite(until) && until > this.deps.now()) return retainOnFailure({ ...unavailable(provider, 'transientFailure'), rateLimited: true })
+      if (Number.isFinite(until) && until > this.deps.now()) {
+        return retainOnFailure({
+          ...emptyQuota(provider, 'transientFailure', backoffRateLimit(new Date(until).toISOString())),
+        })
+      }
+
       const generation = this.generations[provider]
       const controller = new AbortController()
       this.controllers[provider] = controller
-      const result = provider === 'claude'
-        ? await this.deps.claude({ signal: controller.signal, allowKeychain })
-        : await this.deps.codex({ signal: controller.signal, allowKeychain })
-      if (generation !== this.generations[provider] || controller.signal.aborted) return unavailable(provider, 'disconnected')
-      if (result.retryAfterSeconds !== undefined) {
-        blocked[provider] = new Date(this.deps.now() + result.retryAfterSeconds * 1000).toISOString()
-        await this.writeBlocked(blocked)
+      try {
+        const result = provider === 'claude'
+          ? await this.deps.claude({ signal: controller.signal, allowKeychain })
+          : await this.deps.codex({ signal: controller.signal, allowKeychain })
+        if (generation !== this.generations[provider] || controller.signal.aborted) return emptyQuota(provider, 'disconnected')
+
+        const quota = sanitizeQuotaProvider(result.quota) ?? emptyQuota(provider, 'transientFailure')
+        if (result.retryAfterSeconds !== undefined) {
+          const seconds = Number.isFinite(result.retryAfterSeconds) ? Math.max(60, Math.ceil(result.retryAfterSeconds)) : 300
+          const retryAt = new Date(this.deps.now() + seconds * 1000).toISOString()
+          blocked[provider] = retryAt
+          await this.writeBlocked(blocked)
+          // A 429 response contains no new quota fact. Do not let an adapter
+          // accidentally mark its placeholder as fresh; only a prior factual
+          // snapshot may supply windows while this backoff is active.
+          return retainOnFailure(emptyQuota(provider, 'transientFailure', backoffRateLimit(retryAt)))
+        }
+
+        if (blocked[provider]) {
+          delete blocked[provider]
+          await this.writeBlocked(blocked)
+        }
+        if (isFactualSnapshot(quota)) this.lastGood[provider] = quota
+        return retainOnFailure(quota)
+      } catch (error) {
+        // Provider adapters normally convert failures to a snapshot. Keep this
+        // final guard so a test/transport adapter cannot turn one provider's
+        // outage into a rejected all-provider request.
+        console.warn(`${provider} quota unavailable: ${sanitizeError(error)}`)
+        return retainOnFailure(emptyQuota(provider, 'transientFailure'))
+      } finally {
         if (this.controllers[provider] === controller) this.controllers[provider] = undefined
-        return retainOnFailure({ ...result.quota, rateLimited: true })
-      } else if (blocked[provider]) {
-        delete blocked[provider]
-        await this.writeBlocked(blocked)
       }
-      if (this.controllers[provider] === controller) this.controllers[provider] = undefined
-      return retainOnFailure(result.quota)
     }
+
     const value = await Promise.all([run('claude'), run('codex')])
     if (startingGenerations.claude === this.generations.claude && startingGenerations.codex === this.generations.codex) {
       this.cache = { at: this.deps.now(), value }
@@ -124,6 +174,7 @@ export class QuotaService {
 }
 
 export const quotaService = new QuotaService()
+
 // Keychain reads can raise a one-time macOS permission dialog, so only attempt
 // them on a user-initiated forced refresh (the Connect / Refresh affordance).
 // Background polls skip the keychain and lean on retainOnFailure to hold a

--- a/app/electron/quota/types.test.ts
+++ b/app/electron/quota/types.test.ts
@@ -45,13 +45,32 @@ describe('provider quota contract', () => {
     const safe = sanitizeQuotaProvider(quota({
       observedAt: null,
       windows: [{ id: 'primary', label: '5-hour', usedFraction: 0.25, resetsAt: null, windowSeconds: null }],
+      credits: { balance: 3.5, currency: 'USD' },
+      planLabel: 'Plus',
     }))!
     expect(safe).toMatchObject({
       availability: 'unavailable',
       freshness: 'unavailable',
       observedAt: null,
-      windows: [{ id: 'primary', usedFraction: 0.25 }],
+      windows: [],
+      credits: null,
+      planLabel: null,
     })
+  })
+
+  it('clears credits and plan facts when the observation time is invalid', () => {
+    const credits = sanitizeQuotaProvider(quota({ observedAt: 'not-a-date', credits: { balance: 3.5, currency: 'USD' } }))!
+    const plan = sanitizeQuotaProvider(quota({ observedAt: 'not-a-date', planLabel: 'Plus' }))!
+
+    expect(credits).toMatchObject({ availability: 'unavailable', freshness: 'unavailable', observedAt: null, credits: null, planLabel: null, windows: [] })
+    expect(plan).toMatchObject({ availability: 'unavailable', freshness: 'unavailable', observedAt: null, credits: null, planLabel: null, windows: [] })
+  })
+
+  it('preserves valid fresh credits-only facts, including explicit zero', () => {
+    for (const balance of [3.5, 0]) {
+      const input = quota({ credits: { balance, currency: 'USD' } })
+      expect(sanitizeQuotaProvider(input)).toEqual(input)
+    }
   })
 
   it('preserves a valid fresh factual snapshot semantically', () => {
@@ -75,6 +94,11 @@ describe('provider quota contract', () => {
     expect(sanitizeQuotaProvider(input)).toEqual(input)
 
     const invalid = sanitizeQuotaProvider({ ...input, observedAt: 'not-a-date' })!
-    expect(invalid).toMatchObject({ availability: 'unavailable', freshness: 'unavailable', observedAt: null, credits: input.credits })
+    expect(invalid).toMatchObject({ availability: 'unavailable', freshness: 'unavailable', observedAt: null, windows: [], credits: null, planLabel: null })
+  })
+
+  it('fails closed when stale facts do not carry a transient connection', () => {
+    const safe = sanitizeQuotaProvider(quota({ freshness: 'stale', availability: 'unavailable', connection: 'connected', credits: { balance: 3.5, currency: 'USD' } }))!
+    expect(safe).toMatchObject({ availability: 'unavailable', freshness: 'unavailable', observedAt: null, windows: [], credits: null, planLabel: null })
   })
 })

--- a/app/electron/quota/types.test.ts
+++ b/app/electron/quota/types.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest'
+
+import { hasProviderQuotaFacts, sanitizeQuotaProvider } from './types'
+import type { QuotaProvider } from './types'
+
+function quota(overrides: Partial<QuotaProvider> = {}): QuotaProvider {
+  return {
+    schemaVersion: 1,
+    provider: 'codex',
+    authority: 'provider-reported',
+    availability: 'available',
+    connection: 'connected',
+    freshness: 'fresh',
+    observedAt: '2026-07-12T00:00:00.000Z',
+    planLabel: null,
+    windows: [],
+    credits: null,
+    rateLimit: { state: 'clear', retryAt: null },
+    ...overrides,
+  }
+}
+
+describe('provider quota contract', () => {
+  it('recognizes independent provider facts, including explicit zero credits', () => {
+    expect(hasProviderQuotaFacts(quota())).toBe(false)
+    expect(hasProviderQuotaFacts(quota({ planLabel: 'Pro' }))).toBe(true)
+    expect(hasProviderQuotaFacts(quota({ credits: { balance: 0, currency: 'USD' } }))).toBe(true)
+    expect(hasProviderQuotaFacts(quota({ windows: [{ id: 'primary', label: '5-hour', usedFraction: 0, resetsAt: null, windowSeconds: null }] }))).toBe(true)
+  })
+
+  it('fails closed when connected fresh input has no factual provider data', () => {
+    const safe = sanitizeQuotaProvider(quota({ observedAt: '2026-07-12T00:00:00.000Z' }))!
+    expect(safe).toMatchObject({
+      connection: 'connected',
+      availability: 'unavailable',
+      freshness: 'unavailable',
+      observedAt: null,
+      windows: [],
+      credits: null,
+      planLabel: null,
+    })
+  })
+
+  it('does not preserve fresh when factual data has no valid observation time', () => {
+    const safe = sanitizeQuotaProvider(quota({
+      observedAt: null,
+      windows: [{ id: 'primary', label: '5-hour', usedFraction: 0.25, resetsAt: null, windowSeconds: null }],
+    }))!
+    expect(safe).toMatchObject({
+      availability: 'unavailable',
+      freshness: 'unavailable',
+      observedAt: null,
+      windows: [{ id: 'primary', usedFraction: 0.25 }],
+    })
+  })
+
+  it('preserves a valid fresh factual snapshot semantically', () => {
+    const input = quota({
+      planLabel: 'Plus',
+      windows: [{ id: 'primary', label: '5-hour', usedFraction: 0.25, resetsAt: null, windowSeconds: 18_000 }],
+      credits: { balance: 0, currency: 'USD' },
+    })
+    expect(sanitizeQuotaProvider(input)).toEqual(input)
+  })
+
+  it('retains factual data as stale only with the original valid observation time', () => {
+    const input = quota({
+      availability: 'unavailable',
+      connection: 'transientFailure',
+      freshness: 'stale',
+      planLabel: 'Plus',
+      windows: [],
+      credits: { balance: 3.5, currency: 'USD' },
+    })
+    expect(sanitizeQuotaProvider(input)).toEqual(input)
+
+    const invalid = sanitizeQuotaProvider({ ...input, observedAt: 'not-a-date' })!
+    expect(invalid).toMatchObject({ availability: 'unavailable', freshness: 'unavailable', observedAt: null, credits: input.credits })
+  })
+})

--- a/app/electron/quota/types.ts
+++ b/app/electron/quota/types.ts
@@ -65,24 +65,30 @@ export type ProviderQuotaSnapshot = {
 export type QuotaProvider = ProviderQuotaSnapshot
 export type QuotaWindow = ProviderQuotaWindow
 
+/** At least one provider-reported dimension is required before quota is factual. */
+export function hasProviderQuotaFacts(quota: Pick<QuotaProvider, 'windows' | 'credits' | 'planLabel'>): boolean {
+  return quota.windows.length > 0
+    || quota.credits !== null
+    || (typeof quota.planLabel === 'string' && quota.planLabel.trim().length > 0)
+}
+
 export const CONNECTIONS: readonly QuotaConnection[] = [
   'connected', 'disconnected', 'accessDenied', 'loading', 'stale', 'transientFailure', 'terminalFailure',
 ]
 
+/** Empty snapshots never claim quota evidence, even when transport connected. */
 export function emptyQuota(
   provider: ProviderName,
   connection: QuotaConnection,
   rateLimit: ProviderQuotaRateLimit = { state: 'clear', retryAt: null },
 ): QuotaProvider {
-  const availability: QuotaAvailability = connection === 'connected' ? 'available' : 'unavailable'
-  const freshness: QuotaFreshness = connection === 'connected' ? 'fresh' : 'unavailable'
   return {
     schemaVersion: PROVIDER_QUOTA_SCHEMA_VERSION,
     provider,
     authority: 'provider-reported',
-    availability,
+    availability: 'unavailable',
     connection,
-    freshness,
+    freshness: 'unavailable',
     observedAt: null,
     planLabel: null,
     windows: [],
@@ -92,29 +98,36 @@ export function emptyQuota(
 }
 
 export function markObserved(quota: QuotaProvider, now: number): QuotaProvider {
-  const observedAt = Number.isFinite(now) ? new Date(now).toISOString() : null
+  const factual = hasProviderQuotaFacts(quota)
+  const observedAt = factual ? observationTime(now) : null
   return {
     ...quota,
     schemaVersion: PROVIDER_QUOTA_SCHEMA_VERSION,
     authority: 'provider-reported',
-    availability: 'available',
+    availability: factual && observedAt ? 'available' : 'unavailable',
     connection: 'connected',
-    freshness: 'fresh',
-    observedAt,
+    freshness: factual && observedAt ? 'fresh' : 'unavailable',
+    observedAt: factual && observedAt ? observedAt : null,
+    windows: factual ? quota.windows : [],
+    credits: factual ? quota.credits : null,
+    planLabel: factual ? quota.planLabel : null,
     rateLimit: { state: 'clear', retryAt: null },
   }
 }
 
 /** Retain factual values while making the failed refresh explicit. */
 export function markStale(previous: QuotaProvider, connection: QuotaConnection, rateLimit: ProviderQuotaRateLimit): QuotaProvider {
+  const observedAt = isoOrNull(previous.observedAt)
+  const factual = hasProviderQuotaFacts(previous) && observedAt !== null
   return {
     ...previous,
     schemaVersion: PROVIDER_QUOTA_SCHEMA_VERSION,
     authority: 'provider-reported',
     availability: 'unavailable',
     connection,
-    freshness: 'stale',
+    freshness: factual ? 'stale' : 'unavailable',
     // observedAt intentionally remains the previous provider observation.
+    observedAt: factual ? observedAt : null,
     rateLimit,
   }
 }
@@ -135,14 +148,16 @@ function isFreshness(value: unknown): value is QuotaFreshness {
   return value === 'fresh' || value === 'stale' || value === 'unavailable'
 }
 
-function isAvailability(value: unknown): value is QuotaAvailability {
-  return value === 'available' || value === 'unavailable'
-}
-
 function isoOrNull(value: unknown): string | null {
   if (value === null || value === undefined) return null
   if (typeof value !== 'string' || !Number.isFinite(Date.parse(value))) return null
   return new Date(value).toISOString()
+}
+
+function observationTime(value: number): string | null {
+  if (!Number.isFinite(value)) return null
+  const date = new Date(value)
+  return Number.isFinite(date.getTime()) ? date.toISOString() : null
 }
 
 function finiteOrNull(value: unknown, minimum = 0): number | null {
@@ -188,21 +203,34 @@ export function sanitizeQuotaProvider(value: unknown): QuotaProvider | null {
     state: rateState,
     retryAt: rateState === 'backoff' ? isoOrNull(rawRate.retryAt) : null,
   } as ProviderQuotaRateLimit
-  const fallbackFreshness: QuotaFreshness = connection === 'connected' ? 'fresh' : 'unavailable'
-  const fallbackAvailability: QuotaAvailability = connection === 'connected' ? 'available' : 'unavailable'
-  return {
+  const sanitized: QuotaProvider = {
     schemaVersion: PROVIDER_QUOTA_SCHEMA_VERSION,
     provider: value.provider,
     authority: 'provider-reported',
-    availability: isAvailability(value.availability) ? value.availability : fallbackAvailability,
+    availability: 'unavailable',
     connection,
-    freshness: isFreshness(value.freshness) ? value.freshness : fallbackFreshness,
+    freshness: isFreshness(value.freshness) ? value.freshness : 'unavailable',
     observedAt: isoOrNull(value.observedAt),
     planLabel: typeof value.planLabel === 'string' && value.planLabel.trim() ? value.planLabel : null,
     windows,
     credits,
     rateLimit,
   }
+
+  const factual = hasProviderQuotaFacts(sanitized)
+  if (!factual) {
+    return { ...sanitized, availability: 'unavailable', freshness: 'unavailable', observedAt: null, windows: [], credits: null, planLabel: null }
+  }
+
+  if (sanitized.freshness === 'fresh' && sanitized.connection === 'connected' && sanitized.observedAt !== null) {
+    return { ...sanitized, availability: 'available', freshness: 'fresh' }
+  }
+
+  if (sanitized.freshness === 'stale' && sanitized.observedAt !== null) {
+    return { ...sanitized, availability: 'unavailable', freshness: 'stale' }
+  }
+
+  return { ...sanitized, availability: 'unavailable', freshness: 'unavailable', observedAt: null }
 }
 
 export function sanitizeQuotaProviders(value: unknown): QuotaProvider[] {

--- a/app/electron/quota/types.ts
+++ b/app/electron/quota/types.ts
@@ -226,11 +226,20 @@ export function sanitizeQuotaProvider(value: unknown): QuotaProvider | null {
     return { ...sanitized, availability: 'available', freshness: 'fresh' }
   }
 
-  if (sanitized.freshness === 'stale' && sanitized.observedAt !== null) {
+  const staleConnection = sanitized.connection === 'stale' || sanitized.connection === 'transientFailure'
+  if (sanitized.freshness === 'stale' && staleConnection && sanitized.observedAt !== null) {
     return { ...sanitized, availability: 'unavailable', freshness: 'stale' }
   }
 
-  return { ...sanitized, availability: 'unavailable', freshness: 'unavailable', observedAt: null }
+  return {
+    ...sanitized,
+    availability: 'unavailable',
+    freshness: 'unavailable',
+    observedAt: null,
+    windows: [],
+    credits: null,
+    planLabel: null,
+  }
 }
 
 export function sanitizeQuotaProviders(value: unknown): QuotaProvider[] {

--- a/app/electron/quota/types.ts
+++ b/app/electron/quota/types.ts
@@ -1,21 +1,212 @@
-export type QuotaWindow = {
+/**
+ * Canonical provider-quota contract for the Electron live-quota path.
+ *
+ * This module is intentionally JSON-safe and contains provider facts only.
+ * Renderer code type-imports this same module; measured usage and local budget
+ * plans remain separate contracts.
+ */
+
+export const PROVIDER_QUOTA_SCHEMA_VERSION = 1 as const
+
+export type ProviderName = 'claude' | 'codex'
+export type QuotaAuthority = 'provider-reported'
+export type QuotaConnection =
+  | 'connected'
+  | 'disconnected'
+  | 'accessDenied'
+  | 'loading'
+  | 'stale'
+  | 'transientFailure'
+  | 'terminalFailure'
+export type QuotaAvailability = 'available' | 'unavailable'
+export type QuotaFreshness = 'fresh' | 'stale' | 'unavailable'
+
+export type ProviderQuotaWindow = {
+  /** Stable producer identity; display labels are not row identity. */
+  id: string
+  /** Human-readable provider label, suitable for presentation. */
   label: string
-  percent: number
+  /** Normalized provider-reported utilization, always 0..1. */
+  usedFraction: number
+  /** Provider reset boundary in ISO-8601 form, when supplied. */
   resetsAt: string | null
+  /** Provider evidence for the window duration, when supplied. */
+  windowSeconds: number | null
 }
 
-export type QuotaProvider = {
-  provider: 'claude' | 'codex'
-  connection: 'connected' | 'disconnected' | 'accessDenied' | 'loading' | 'stale' | 'transientFailure' | 'terminalFailure'
-  primary: QuotaWindow | null
-  details: QuotaWindow[]
+export type ProviderQuotaCredits = {
+  /** Explicit provider-reported balance. Zero is meaningful. */
+  balance: number
+  currency: 'USD'
+}
+
+export type ProviderQuotaRateLimit = {
+  state: 'clear' | 'backoff'
+  /** Persisted/provider Retry-After boundary when state is backoff. */
+  retryAt: string | null
+}
+
+/** JSON-safe factual provider quota snapshot crossing the Electron bridge. */
+export type ProviderQuotaSnapshot = {
+  schemaVersion: typeof PROVIDER_QUOTA_SCHEMA_VERSION
+  provider: ProviderName
+  authority: QuotaAuthority
+  availability: QuotaAvailability
+  connection: QuotaConnection
+  freshness: QuotaFreshness
+  /** Time the provider response was observed, not the time stale data was reused. */
+  observedAt: string | null
   planLabel: string | null
-  footerLines: string[]
-  /** Set when the provider is in a 429 backoff window (rate limited by the
-   *  upstream quota endpoint), so the UI can say so honestly instead of the
-   *  generic "waiting" copy. */
-  rateLimited?: boolean
+  windows: ProviderQuotaWindow[]
+  credits: ProviderQuotaCredits | null
+  rateLimit: ProviderQuotaRateLimit
 }
 
-export type ProviderName = QuotaProvider['provider']
+export type QuotaProvider = ProviderQuotaSnapshot
+export type QuotaWindow = ProviderQuotaWindow
 
+export const CONNECTIONS: readonly QuotaConnection[] = [
+  'connected', 'disconnected', 'accessDenied', 'loading', 'stale', 'transientFailure', 'terminalFailure',
+]
+
+export function emptyQuota(
+  provider: ProviderName,
+  connection: QuotaConnection,
+  rateLimit: ProviderQuotaRateLimit = { state: 'clear', retryAt: null },
+): QuotaProvider {
+  const availability: QuotaAvailability = connection === 'connected' ? 'available' : 'unavailable'
+  const freshness: QuotaFreshness = connection === 'connected' ? 'fresh' : 'unavailable'
+  return {
+    schemaVersion: PROVIDER_QUOTA_SCHEMA_VERSION,
+    provider,
+    authority: 'provider-reported',
+    availability,
+    connection,
+    freshness,
+    observedAt: null,
+    planLabel: null,
+    windows: [],
+    credits: null,
+    rateLimit,
+  }
+}
+
+export function markObserved(quota: QuotaProvider, now: number): QuotaProvider {
+  const observedAt = Number.isFinite(now) ? new Date(now).toISOString() : null
+  return {
+    ...quota,
+    schemaVersion: PROVIDER_QUOTA_SCHEMA_VERSION,
+    authority: 'provider-reported',
+    availability: 'available',
+    connection: 'connected',
+    freshness: 'fresh',
+    observedAt,
+    rateLimit: { state: 'clear', retryAt: null },
+  }
+}
+
+/** Retain factual values while making the failed refresh explicit. */
+export function markStale(previous: QuotaProvider, connection: QuotaConnection, rateLimit: ProviderQuotaRateLimit): QuotaProvider {
+  return {
+    ...previous,
+    schemaVersion: PROVIDER_QUOTA_SCHEMA_VERSION,
+    authority: 'provider-reported',
+    availability: 'unavailable',
+    connection,
+    freshness: 'stale',
+    // observedAt intentionally remains the previous provider observation.
+    rateLimit,
+  }
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object'
+}
+
+function isProvider(value: unknown): value is ProviderName {
+  return value === 'claude' || value === 'codex'
+}
+
+function isConnection(value: unknown): value is QuotaConnection {
+  return typeof value === 'string' && (CONNECTIONS as readonly string[]).includes(value)
+}
+
+function isFreshness(value: unknown): value is QuotaFreshness {
+  return value === 'fresh' || value === 'stale' || value === 'unavailable'
+}
+
+function isAvailability(value: unknown): value is QuotaAvailability {
+  return value === 'available' || value === 'unavailable'
+}
+
+function isoOrNull(value: unknown): string | null {
+  if (value === null || value === undefined) return null
+  if (typeof value !== 'string' || !Number.isFinite(Date.parse(value))) return null
+  return new Date(value).toISOString()
+}
+
+function finiteOrNull(value: unknown, minimum = 0): number | null {
+  return typeof value === 'number' && Number.isFinite(value) && value >= minimum ? value : null
+}
+
+function finiteNumber(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null
+}
+
+/**
+ * Last-mile allowlist for the renderer bridge. Even an injected/test provider
+ * result can only cross with product-safe fields; credentials and account
+ * identifiers are never copied through.
+ */
+export function sanitizeQuotaProvider(value: unknown): QuotaProvider | null {
+  if (!isObject(value) || !isProvider(value.provider)) return null
+  const connection = isConnection(value.connection) ? value.connection : 'transientFailure'
+  const windows = Array.isArray(value.windows)
+    ? value.windows.flatMap(row => {
+        if (!isObject(row) || typeof row.id !== 'string' || !row.id || typeof row.label !== 'string' || !row.label) return []
+        const rawUsedFraction = finiteNumber(row.usedFraction)
+        if (rawUsedFraction === null) return []
+        const windowSeconds = finiteOrNull(row.windowSeconds, Number.MIN_VALUE)
+        return [{
+          id: row.id,
+          label: row.label,
+          usedFraction: Math.min(1, Math.max(0, rawUsedFraction)),
+          resetsAt: isoOrNull(row.resetsAt),
+          windowSeconds,
+        }]
+      })
+    : []
+  const credits = isObject(value.credits)
+    ? (() => {
+        const balance = finiteNumber(value.credits.balance)
+        return balance === null ? null : { balance, currency: 'USD' as const }
+      })()
+    : null
+  const rawRate = isObject(value.rateLimit) ? value.rateLimit : {}
+  const rateState = rawRate.state === 'backoff' ? 'backoff' : 'clear'
+  const rateLimit = {
+    state: rateState,
+    retryAt: rateState === 'backoff' ? isoOrNull(rawRate.retryAt) : null,
+  } as ProviderQuotaRateLimit
+  const fallbackFreshness: QuotaFreshness = connection === 'connected' ? 'fresh' : 'unavailable'
+  const fallbackAvailability: QuotaAvailability = connection === 'connected' ? 'available' : 'unavailable'
+  return {
+    schemaVersion: PROVIDER_QUOTA_SCHEMA_VERSION,
+    provider: value.provider,
+    authority: 'provider-reported',
+    availability: isAvailability(value.availability) ? value.availability : fallbackAvailability,
+    connection,
+    freshness: isFreshness(value.freshness) ? value.freshness : fallbackFreshness,
+    observedAt: isoOrNull(value.observedAt),
+    planLabel: typeof value.planLabel === 'string' && value.planLabel.trim() ? value.planLabel : null,
+    windows,
+    credits,
+    rateLimit,
+  }
+}
+
+export function sanitizeQuotaProviders(value: unknown): QuotaProvider[] {
+  return Array.isArray(value) ? value.flatMap(item => { const safe = sanitizeQuotaProvider(item); return safe ? [safe] : [] }) : []
+}
+
+export type ProviderNameFromQuota = QuotaProvider['provider']

--- a/app/renderer/App.test.tsx
+++ b/app/renderer/App.test.tsx
@@ -134,8 +134,8 @@ function installDefaultMocks() {
   mocks.getSessions.mockResolvedValue([])
   mocks.getCompareModels.mockResolvedValue([])
   mocks.getQuota.mockResolvedValue([
-    { provider: 'claude', connection: 'disconnected', primary: null, details: [], planLabel: null, footerLines: [] },
-    { provider: 'codex', connection: 'disconnected', primary: null, details: [], planLabel: null, footerLines: [] },
+    { schemaVersion: 1, provider: 'claude', authority: 'provider-reported', availability: 'unavailable', connection: 'disconnected', freshness: 'unavailable', observedAt: null, planLabel: null, windows: [], credits: null, rateLimit: { state: 'clear', retryAt: null } },
+    { schemaVersion: 1, provider: 'codex', authority: 'provider-reported', availability: 'unavailable', connection: 'disconnected', freshness: 'unavailable', observedAt: null, planLabel: null, windows: [], credits: null, rateLimit: { state: 'clear', retryAt: null } },
   ])
   mocks.getPlans.mockResolvedValue({})
   mocks.getActReport.mockResolvedValue({ totals: { realizedCostUSD: 0, measuredActions: 0 } })

--- a/app/renderer/lib/types.ts
+++ b/app/renderer/lib/types.ts
@@ -8,6 +8,7 @@ import type { ModelAccounting, ModelPresentation } from './model-projection-type
 import type { ModelReportRow } from './model-report-types'
 import type { ProjectScopePayload } from './project-bridge-types'
 import type { ModelStats, SessionRow } from './usage-projection-types'
+import type { ProviderQuotaSnapshot, ProviderQuotaWindow } from '../../electron/quota/types'
 export type { ProjectScopePayload } from './project-bridge-types'
 
 export type {
@@ -36,22 +37,9 @@ export interface CliError {
 export type AliasRow = { from: string; to: string }
 export type ActionResult = { ok: boolean; stdout: string; stderr: string; code: number | null }
 
-export type QuotaWindow = {
-  label: string
-  percent: number
-  resetsAt: string | null
-}
-
-export type QuotaProvider = {
-  provider: 'claude' | 'codex'
-  connection: 'connected' | 'disconnected' | 'accessDenied' | 'loading' | 'stale' | 'transientFailure' | 'terminalFailure'
-  primary: QuotaWindow | null
-  details: QuotaWindow[]
-  planLabel: string | null
-  footerLines: string[]
-  /** True when the provider is in a 429 backoff window (upstream rate limit). */
-  rateLimited?: boolean
-}
+/** The renderer consumes the same JSON-safe snapshot as Electron. */
+export type QuotaWindow = ProviderQuotaWindow
+export type QuotaProvider = ProviderQuotaSnapshot
 
 // ————— src/menubar-json.ts —————
 

--- a/app/renderer/sections/Plans.test.tsx
+++ b/app/renderer/sections/Plans.test.tsx
@@ -170,6 +170,26 @@ describe('Plans', () => {
     expect(screen.getByText('Credits remaining · $3.50')).toBeInTheDocument()
   })
 
+  it('does not render injected provider facts when freshness is unavailable', async () => {
+    getPlans.mockResolvedValue(baseStatus)
+    getQuota.mockResolvedValue([quota('codex', {
+      availability: 'unavailable',
+      freshness: 'unavailable',
+      observedAt: null,
+      planLabel: 'Injected Plan',
+      windows: [{ id: 'primary', label: 'Injected window', usedFraction: 0.25, resetsAt: null, windowSeconds: null }],
+      credits: { balance: 3.5, currency: 'USD' },
+    })])
+
+    const { container } = render(<Plans period="30days" />)
+
+    expect(await screen.findByText('The provider did not report quota evidence.')).toBeInTheDocument()
+    expect(screen.queryByText('Injected Plan')).not.toBeInTheDocument()
+    expect(screen.queryByText('Credits remaining · $3.50')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('quota-track-primary')).not.toBeInTheDocument()
+    expect(container.querySelector('.quota-windows')).not.toBeInTheDocument()
+  })
+
   it('keeps manual budget overage and clamped-track behavior', async () => {
     getPlans.mockResolvedValue({
       ...baseStatus,

--- a/app/renderer/sections/Plans.test.tsx
+++ b/app/renderer/sections/Plans.test.tsx
@@ -135,6 +135,41 @@ describe('Plans', () => {
     expect(screen.queryByText('API usage')).not.toBeInTheDocument()
   })
 
+  it('renders provider credits when no quota windows are present', async () => {
+    getPlans.mockResolvedValue(baseStatus)
+    getQuota.mockResolvedValue([quota('codex', { planLabel: 'Plus', credits: { balance: 3.5, currency: 'USD' } })])
+
+    render(<Plans period="30days" />)
+
+    expect(await screen.findByText('The provider did not report quota windows.')).toBeInTheDocument()
+    expect(screen.getByText('Credits remaining · $3.50')).toBeInTheDocument()
+  })
+
+  it('renders an explicit zero credit balance when no quota windows are present', async () => {
+    getPlans.mockResolvedValue(baseStatus)
+    getQuota.mockResolvedValue([quota('codex', { credits: { balance: 0, currency: 'USD' } })])
+
+    render(<Plans period="30days" />)
+
+    expect(await screen.findByText('Credits remaining · $0.00')).toBeInTheDocument()
+  })
+
+  it('renders stale credits-only last-good data with its original observation note', async () => {
+    getPlans.mockResolvedValue(baseStatus)
+    getQuota.mockResolvedValue([quota('codex', {
+      connection: 'transientFailure',
+      availability: 'unavailable',
+      freshness: 'stale',
+      observedAt: '2026-07-12T00:00:00.000Z',
+      credits: { balance: 3.5, currency: 'USD' },
+    })])
+
+    render(<Plans period="30days" />)
+
+    expect(await screen.findByText(/Showing last provider-reported quota from/)).toBeInTheDocument()
+    expect(screen.getByText('Credits remaining · $3.50')).toBeInTheDocument()
+  })
+
   it('keeps manual budget overage and clamped-track behavior', async () => {
     getPlans.mockResolvedValue({
       ...baseStatus,

--- a/app/renderer/sections/Plans.test.tsx
+++ b/app/renderer/sections/Plans.test.tsx
@@ -75,26 +75,32 @@ const statusWithPlans: StatusJson = {
 function quotaProviders(): QuotaProvider[] {
   const now = Date.now()
   return [
-    {
-      provider: 'claude',
-      connection: 'connected',
-      primary: { label: 'Weekly', percent: 0.92, resetsAt: new Date(now + (3 * 24 + 14) * 60 * 60_000 + 30 * 60_000).toISOString() },
-      details: [
-        { label: '5-hour', percent: 0.25, resetsAt: new Date(now + 2 * 60 * 60_000 + 30 * 60_000).toISOString() },
-        { label: 'Weekly', percent: 0.92, resetsAt: new Date(now + (3 * 24 + 14) * 60 * 60_000 + 30 * 60_000).toISOString() },
-      ],
+    quota('claude', {
       planLabel: 'Max 20x',
-      footerLines: [],
-    },
-    {
-      provider: 'codex',
-      connection: 'disconnected',
-      primary: null,
-      details: [],
-      planLabel: null,
-      footerLines: [],
-    },
+      windows: [
+        { id: 'five_hour', label: '5-hour', usedFraction: 0.25, resetsAt: new Date(now + 2 * 60 * 60_000 + 30 * 60_000).toISOString(), windowSeconds: null },
+        { id: 'seven_day', label: 'Weekly', usedFraction: 0.92, resetsAt: new Date(now + (3 * 24 + 14) * 60 * 60_000 + 30 * 60_000).toISOString(), windowSeconds: null },
+      ],
+    }),
+    quota('codex', { connection: 'disconnected', availability: 'unavailable', freshness: 'unavailable', observedAt: null }),
   ]
+}
+
+function quota(provider: 'claude' | 'codex', overrides: Partial<QuotaProvider> = {}): QuotaProvider {
+  return {
+    schemaVersion: 1,
+    provider,
+    authority: 'provider-reported',
+    availability: 'available',
+    connection: 'connected',
+    freshness: 'fresh',
+    observedAt: '2026-07-12T00:00:00.000Z',
+    planLabel: null,
+    windows: [],
+    credits: null,
+    rateLimit: { state: 'clear', retryAt: null },
+    ...overrides,
+  }
 }
 
 describe('Plans', () => {
@@ -113,8 +119,8 @@ describe('Plans', () => {
     expect(await screen.findByText('Max 20x')).toBeInTheDocument()
     expect(screen.getByText('25% used · resets in 2h 29m')).toBeInTheDocument()
     expect(screen.getByText('92% used · resets in 3d 14h')).toBeInTheDocument()
-    expect(container.querySelector('[data-testid="quota-track-5-hour"] i')).toHaveClass('accent')
-    expect(container.querySelector('[data-testid="quota-track-Weekly"] i')).toHaveClass('bad')
+    expect(container.querySelector('[data-testid="quota-track-five_hour"] i')).toHaveClass('accent')
+    expect(container.querySelector('[data-testid="quota-track-seven_day"] i')).toHaveClass('bad')
     expect(screen.getByText('Not connected. Log in with the Codex CLI.')).toBeInTheDocument()
 
     expect(screen.getByRole('heading', { name: 'Budget plans' })).toBeInTheDocument()
@@ -261,8 +267,8 @@ describe('Plans', () => {
   it('renders the honest rate-limited note on a 429 backoff, per provider owner', async () => {
     getPlans.mockResolvedValue(baseStatus)
     getQuota.mockResolvedValue([
-      { provider: 'claude', connection: 'transientFailure', rateLimited: true, primary: null, details: [], planLabel: null, footerLines: [] },
-      { provider: 'codex', connection: 'stale', rateLimited: true, primary: null, details: [], planLabel: null, footerLines: [] },
+      quota('claude', { connection: 'transientFailure', availability: 'unavailable', freshness: 'unavailable', observedAt: null, rateLimit: { state: 'backoff', retryAt: '2026-07-12T00:05:00.000Z' } }),
+      quota('codex', { connection: 'stale', availability: 'unavailable', freshness: 'stale', rateLimit: { state: 'backoff', retryAt: '2026-07-12T00:05:00.000Z' } }),
     ])
 
     render(<Plans period="30days" />)
@@ -276,20 +282,20 @@ describe('Plans', () => {
   it('falls back to the generic waiting note when a transient failure is not rate limited', async () => {
     getPlans.mockResolvedValue(baseStatus)
     getQuota.mockResolvedValue([
-      { provider: 'claude', connection: 'transientFailure', rateLimited: false, primary: null, details: [], planLabel: null, footerLines: [] },
+      quota('claude', { connection: 'transientFailure', availability: 'unavailable', freshness: 'unavailable', observedAt: null }),
     ])
 
     render(<Plans period="30days" />)
 
-    expect(await screen.findByText('waiting on the CLI…')).toBeInTheDocument()
+    expect(await screen.findByText('Provider quota is temporarily unavailable.')).toBeInTheDocument()
     expect(screen.queryByText(/rate limited the quota endpoint/)).not.toBeInTheDocument()
   })
 
   it('renders the keychain access-denied state with recovery copy and a locked indicator', async () => {
     getPlans.mockResolvedValue(statusWithPlans)
     getQuota.mockResolvedValue([
-      { provider: 'claude', connection: 'accessDenied', primary: null, details: [], planLabel: null, footerLines: [] },
-      { provider: 'codex', connection: 'connected', primary: { label: 'Weekly', percent: 0.1, resetsAt: null }, details: [{ label: 'Weekly', percent: 0.1, resetsAt: null }], planLabel: 'Plus', footerLines: [] },
+      quota('claude', { connection: 'accessDenied', availability: 'unavailable', freshness: 'unavailable', observedAt: null }),
+      quota('codex', { planLabel: 'Plus', windows: [{ id: 'secondary', label: 'Weekly', usedFraction: 0.1, resetsAt: null, windowSeconds: 604800 }] }),
     ])
 
     render(<Plans period="30days" />)

--- a/app/renderer/sections/Plans.tsx
+++ b/app/renderer/sections/Plans.tsx
@@ -151,10 +151,11 @@ function renderBudgetPlans(data: StatusJson | null, error: ReturnType<typeof use
 
 function QuotaPanel({ quota, onReconnect }: { quota: QuotaProvider; onReconnect: () => void }) {
   const providerName = quota.provider === 'claude' ? 'Claude' : 'Codex'
+  const planLabel = quota.freshness === 'unavailable' ? null : quota.planLabel
   return (
     <Panel
       className="quota-card"
-      title={<span className="quota-title">{providerName}{quota.planLabel ? <small>{quota.planLabel}</small> : null}</span>}
+      title={<span className="quota-title">{providerName}{planLabel ? <small>{planLabel}</small> : null}</span>}
       right={<ConnectionIndicator connection={quota.connection} />}
     >
       <QuotaContent quota={quota} onReconnect={onReconnect} />
@@ -178,14 +179,19 @@ function QuotaContent({ quota, onReconnect }: { quota: QuotaProvider; onReconnec
   if (quota.connection === 'terminalFailure') {
     return <p className="quota-connection-note quota-terminal">Quota is currently unavailable.</p>
   }
-
-  const hasWindows = quota.windows.length > 0
   const stale = quota.freshness === 'stale' || quota.connection === 'stale' || quota.connection === 'transientFailure'
   const note = isRateLimited(quota)
     ? rateLimitedNote(quota.provider)
     : stale
       ? staleQuotaNote(quota)
       : null
+  if (quota.freshness === 'unavailable') {
+    return note
+      ? <p className="quota-connection-note">{note}</p>
+      : <p className="quota-connection-note">The provider did not report quota evidence.</p>
+  }
+
+  const hasWindows = quota.windows.length > 0
 
   return (
     <>

--- a/app/renderer/sections/Plans.tsx
+++ b/app/renderer/sections/Plans.tsx
@@ -37,6 +37,10 @@ export function rateLimitedNote(provider: QuotaProvider['provider']): string {
   return `${owner} rate limited the quota endpoint, retrying in a few minutes`
 }
 
+function isRateLimited(quota: QuotaProvider): boolean {
+  return quota.rateLimit.state === 'backoff'
+}
+
 function cycleEndDate(plan: JsonPlanSummary): Date | null {
   const date = new Date(plan.periodEnd)
   if (Number.isNaN(date.getTime())) return null
@@ -171,29 +175,40 @@ function QuotaContent({ quota, onReconnect }: { quota: QuotaProvider; onReconnec
     return <ConnectAffordance provider={quota.provider} connection={quota.connection} onRefresh={onReconnect} />
   }
   if (quota.connection === 'loading') return <p className="quota-connection-note">Loading quota…</p>
-  if (quota.connection === 'stale' || quota.connection === 'transientFailure') {
-    if (quota.rateLimited) return <p className="quota-connection-note">{rateLimitedNote(quota.provider)}</p>
-    return <p className="quota-connection-note">waiting on the CLI…</p>
-  }
   if (quota.connection === 'terminalFailure') {
     return <p className="quota-connection-note quota-terminal">Quota is currently unavailable.</p>
   }
 
+  const hasWindows = quota.windows.length > 0
+  const stale = quota.freshness === 'stale' || quota.connection === 'stale' || quota.connection === 'transientFailure'
+  const note = isRateLimited(quota)
+    ? rateLimitedNote(quota.provider)
+    : stale
+      ? staleQuotaNote(quota)
+      : null
+  if (!hasWindows) {
+    return <p className="quota-connection-note">{note ?? 'The provider did not report quota windows.'}</p>
+  }
+
   return (
     <>
-      <div className="quota-windows">
-        {quota.details.map((window, index) => <QuotaMeter key={`${window.label}-${index}`} window={window} />)}
-      </div>
-      {quota.footerLines.length > 0 ? (
-        <div className="quota-footer">{quota.footerLines.map((line, index) => <span key={`${line}-${index}`}>{line}</span>)}</div>
-      ) : null}
+      {note ? <p className="quota-connection-note">{note}</p> : null}
+      <div className="quota-windows">{quota.windows.map(window => <QuotaMeter key={window.id} window={window} />)}</div>
+      {quota.credits ? <div className="quota-footer"><span>Credits remaining · ${quota.credits.balance.toFixed(2)}</span></div> : null}
     </>
   )
 }
 
+function staleQuotaNote(quota: QuotaProvider): string {
+  if (!quota.observedAt) return 'Provider quota is temporarily unavailable.'
+  const observed = new Date(quota.observedAt)
+  if (Number.isNaN(observed.getTime())) return 'Provider quota is temporarily unavailable.'
+  return `Showing last provider-reported quota from ${new Intl.DateTimeFormat('en-US', { dateStyle: 'medium', timeStyle: 'short' }).format(observed)}.`
+}
+
 function QuotaMeter({ window }: { window: QuotaWindow }) {
-  const percent = Math.round(window.percent * 100)
-  const severity = window.percent >= 0.9 ? 'bad' : window.percent >= 0.7 ? 'warn' : 'accent'
+  const percent = Math.round(window.usedFraction * 100)
+  const severity = window.usedFraction >= 0.9 ? 'bad' : window.usedFraction >= 0.7 ? 'warn' : 'accent'
   const reset = formatResetTime(window.resetsAt)
   return (
     <div className="quota-window">
@@ -201,7 +216,7 @@ function QuotaMeter({ window }: { window: QuotaWindow }) {
         <span>{window.label}</span>
         <span>{percent}% used{reset ? ` · resets ${reset}` : ''}</span>
       </div>
-      <div className="track" data-testid={`quota-track-${window.label}`}>
+      <div className="track" data-testid={`quota-track-${window.id}`}>
         <i className={severity} style={{ width: `${Math.min(100, Math.max(0, percent))}%` }} />
       </div>
     </div>

--- a/app/renderer/sections/Plans.tsx
+++ b/app/renderer/sections/Plans.tsx
@@ -186,15 +186,14 @@ function QuotaContent({ quota, onReconnect }: { quota: QuotaProvider; onReconnec
     : stale
       ? staleQuotaNote(quota)
       : null
-  if (!hasWindows) {
-    return <p className="quota-connection-note">{note ?? 'The provider did not report quota windows.'}</p>
-  }
 
   return (
     <>
       {note ? <p className="quota-connection-note">{note}</p> : null}
-      <div className="quota-windows">{quota.windows.map(window => <QuotaMeter key={window.id} window={window} />)}</div>
-      {quota.credits ? <div className="quota-footer"><span>Credits remaining · ${quota.credits.balance.toFixed(2)}</span></div> : null}
+      {hasWindows
+        ? <div className="quota-windows">{quota.windows.map(window => <QuotaMeter key={window.id} window={window} />)}</div>
+        : <p className="quota-connection-note">The provider did not report quota windows.</p>}
+      {quota.credits !== null ? <div className="quota-footer"><span>Credits remaining · ${quota.credits.balance.toFixed(2)}</span></div> : null}
     </>
   )
 }

--- a/app/renderer/sections/Settings.test.tsx
+++ b/app/renderer/sections/Settings.test.tsx
@@ -48,8 +48,8 @@ const devices: CombinedUsage = {
 const scan: DeviceScanResult = { found: [{ name: 'Mac Studio', host: 'mac-studio.local', port: 9732, fingerprint: '7F:2A:19:88:55:44:33:C4', code: 'pair-1', paired: false }] }
 const overview = { current: { providers: { claude: 12.34, codex: 4.5 } } } as unknown as MenubarPayload
 const quotaProviders: QuotaProvider[] = [
-  { provider: 'claude', connection: 'connected', primary: null, details: [], planLabel: 'Max 20x', footerLines: [] },
-  { provider: 'codex', connection: 'disconnected', primary: null, details: [], planLabel: null, footerLines: [] },
+  { schemaVersion: 1, provider: 'claude', authority: 'provider-reported', availability: 'available', connection: 'connected', freshness: 'fresh', observedAt: '2026-07-12T00:00:00.000Z', windows: [], credits: null, planLabel: 'Max 20x', rateLimit: { state: 'clear', retryAt: null } },
+  { schemaVersion: 1, provider: 'codex', authority: 'provider-reported', availability: 'unavailable', connection: 'disconnected', freshness: 'unavailable', observedAt: null, windows: [], credits: null, planLabel: null, rateLimit: { state: 'clear', retryAt: null } },
 ]
 const stored = new Map<string, string>()
 vi.stubGlobal('localStorage', {

--- a/app/renderer/sections/Settings.tsx
+++ b/app/renderer/sections/Settings.tsx
@@ -342,7 +342,7 @@ function DetectedRow({ quota, onReconnect }: { quota: QuotaProvider; onReconnect
     <span className="tx">{name}</span>
     {quota.connection === 'disconnected' || quota.connection === 'accessDenied'
       ? <div className="r set-status"><ConnectAffordance provider={quota.provider} connection={quota.connection} onRefresh={onReconnect} /></div>
-      : quota.rateLimited
+      : quota.rateLimit.state === 'backoff'
       ? <span className="r set-status"><span className="set-dot" />{rateLimitedNote(quota.provider)}</span>
       : <span className="r set-status"><span className="set-dot ok" />{quota.planLabel ?? 'Connected'}</span>}
   </div>

--- a/docs/provider-quota-authority.md
+++ b/docs/provider-quota-authority.md
@@ -1,0 +1,9 @@
+# Provider quota authority
+
+Metrora treats provider-reported quota, Metrora-measured usage, and user-configured budget plans as three different concepts. A provider quota window is a fact from the provider endpoint; local token, call, and cost history cannot fabricate or backfill it. A missing provider response is shown as unavailable or stale, never as a zero-valued quota.
+
+The Electron live-quota path exposes one JSON-safe `ProviderQuotaSnapshot` contract. It records `authority: "provider-reported"`, connection and freshness state, the original `observedAt`, stable window IDs, normalized `usedFraction` values, provider reset boundaries, structured Codex credits, and rate-limit backoff state. Pace is a separate interpretation of a known provider window and is fail-closed when its timing evidence is missing or malformed.
+
+Codex and Claude quota reads are observational. Electron reads provider-owned credentials, retries one time after a 401 only when the owner has rotated the access token, and never refreshes or writes provider credential files. Metrora-owned backoff state may still be persisted. Renderer IPC applies a product-field allowlist so tokens, account identifiers, credential JSON, and credential paths cannot cross the bridge.
+
+This first convergence covers Codex and Claude only. It does not add quota to Companion/mobile payloads, invent quota for unsupported providers, redesign Plans navigation, change usage accounting or pricing, or rewrite the native macOS services. The current macOS Codex credential lifecycle and its legacy quota presentation require a parity follow-up before the platforms can share this contract completely.

--- a/src/quota.ts
+++ b/src/quota.ts
@@ -1,15 +1,11 @@
-// Provider-agnostic quota model (#725 Part 1). Pure and side-effect free:
-// callers hand in window readings from whatever source they have — the live
-// quota endpoints the menubar already fetches, or windows derived from local
-// token history — and get back one merged, provenance-tagged view with pace.
-//
-// Provenance is load-bearing: a derived window is an estimate and every
-// surface must be able to render it as one. Same discipline as
-// costIsEstimated — a guess never renders as a measurement.
-
-export type QuotaWindowKind = 'five_hour' | 'weekly' | 'monthly' | 'credits' | { custom: string }
-
-export type QuotaSource = 'live' | 'derived'
+/**
+ * Provider-window pace interpretation for the CLI/library boundary.
+ *
+ * The Electron live path's canonical JSON contract lives in
+ * app/electron/quota/types.ts because that module is shared directly with the
+ * renderer bridge. This file intentionally contains no live-quota authority,
+ * no local-history capacity estimate, and no live/derived merge behavior.
+ */
 
 export type QuotaPace = {
   /** Elapsed fraction of the window, 0..1. */
@@ -18,112 +14,66 @@ export type QuotaPace = {
   deltaFraction: number
   /** Linear projection of usedFraction at the reset boundary. */
   projectedAtReset: number
-  /**
-   * When the window hits 100% at the current pace. Absent when the pace
-   * doesn't overflow, or on short windows where a whole-window linear ETA
-   * isn't defensible (one burst on a 5h window reads as "runs out in 40min",
-   * then recovers). Deficit still reports there.
-   */
+  /** Conservative exhaustion ETA for sufficiently long windows only. */
   exhaustsAt?: Date
 }
 
-export type QuotaWindow = {
-  kind: QuotaWindowKind
-  /** Display label; provider-supplied when live. */
-  label: string
-  /** 0..1. Callers clamp out-of-range provider values before storing. */
+/** Input accepted by computePace. Date is retained for pure math callers. */
+export type QuotaPaceWindow = {
   usedFraction: number
-  resetsAt?: Date
-  windowSeconds?: number
-  source: QuotaSource
-  /** Computed via computePace/withPace, never persisted. */
-  pace?: QuotaPace
+  resetsAt?: string | Date | null
+  windowSeconds?: number | null
 }
 
-export type PlanQuota = {
-  provider: string
-  /** e.g. "pro", "max_20x" when known. */
-  plan?: string
-  windows: QuotaWindow[]
-  asOf: Date
-}
-
-/** No pace until this fraction of the window has elapsed — projecting a week
- * off the first few minutes is noise, not signal. */
+/** No pace until this fraction of the window has elapsed. */
 export const QUOTA_PACE_MIN_ELAPSED_FRACTION = 0.03
 
 /** Windows at or under this length report deficit but no exhaustion ETA. */
 export const QUOTA_PACE_ETA_MAX_WINDOW_SECONDS = 6 * 3600
 
-/** Stable identity for merging: live and derived readings of the same window
- * kind describe the same underlying quota. */
-export function quotaWindowKey(kind: QuotaWindowKind): string {
-  return typeof kind === 'string' ? kind : `custom:${kind.custom}`
+function validDate(value: string | Date | null | undefined): Date | undefined {
+  if (value instanceof Date) return Number.isFinite(value.getTime()) ? value : undefined
+  if (typeof value !== 'string' || !value) return undefined
+  const parsed = new Date(value)
+  return Number.isFinite(parsed.getTime()) ? parsed : undefined
 }
 
 /**
- * Whole-window linear pace with the guards that keep it honest. Returns
- * undefined — never a fabricated value — when the window lacks the inputs,
- * hasn't elapsed enough to say anything, is exhausted (the bar already says
- * it), or its reset time is skewed (in the past, or further out than one
- * window length).
+ * Whole-window linear pace with guards that keep it honest. Returns undefined
+ * when the provider window lacks inputs, has not elapsed enough to say
+ * anything, is exhausted, or has a skewed reset boundary.
  */
-export function computePace(window: QuotaWindow, now: Date = new Date()): QuotaPace | undefined {
-  const { resetsAt, windowSeconds } = window
-  if (!resetsAt || !windowSeconds || windowSeconds <= 0) return undefined
-  const remainingSeconds = (resetsAt.getTime() - now.getTime()) / 1000
-  if (remainingSeconds <= 0 || remainingSeconds > windowSeconds) return undefined
+export function computePace(window: QuotaPaceWindow, now: Date = new Date()): QuotaPace | undefined {
+  const resetsAt = validDate(window.resetsAt)
+  const windowSeconds = window.windowSeconds
+  const nowMs = now.getTime()
+  if (!resetsAt || !Number.isFinite(nowMs) || typeof windowSeconds !== 'number' || !Number.isFinite(windowSeconds) || windowSeconds <= 0) return undefined
+
+  const remainingSeconds = (resetsAt.getTime() - nowMs) / 1000
+  if (!Number.isFinite(remainingSeconds) || remainingSeconds <= 0 || remainingSeconds > windowSeconds) return undefined
+
   const elapsedSeconds = windowSeconds - remainingSeconds
   const expectedFraction = elapsedSeconds / windowSeconds
-  if (expectedFraction < QUOTA_PACE_MIN_ELAPSED_FRACTION) return undefined
-  // A NaN usedFraction (e.g. derived from used/limit with limit 0) would sail
-  // through the clamp below (min/max propagate NaN) and poison every pace
-  // field. Unknown usage means no pace, not a NaN pace.
+  if (!Number.isFinite(expectedFraction) || expectedFraction < QUOTA_PACE_MIN_ELAPSED_FRACTION) return undefined
   if (!Number.isFinite(window.usedFraction)) return undefined
+
   const used = Math.min(Math.max(window.usedFraction, 0), 1)
-  if (used >= 1) return undefined
+  if (!Number.isFinite(used) || used >= 1) return undefined
 
   const projectedAtReset = used / expectedFraction
+  if (!Number.isFinite(projectedAtReset)) return undefined
   const pace: QuotaPace = {
     expectedFraction,
     deltaFraction: used - expectedFraction,
     projectedAtReset,
   }
+
   if (projectedAtReset > 1 && windowSeconds > QUOTA_PACE_ETA_MAX_WINDOW_SECONDS) {
     const usedPerSecond = used / elapsedSeconds
-    if (usedPerSecond > 0) {
-      pace.exhaustsAt = new Date(now.getTime() + ((1 - used) / usedPerSecond) * 1000)
+    if (Number.isFinite(usedPerSecond) && usedPerSecond > 0) {
+      const eta = nowMs + ((1 - used) / usedPerSecond) * 1000
+      if (Number.isFinite(eta) && eta < resetsAt.getTime()) pace.exhaustsAt = new Date(eta)
     }
   }
   return pace
-}
-
-/**
- * Merge live and derived readings of a provider's windows. Live wins per
- * window kind; derived fills the gaps. Provenance stays on each surviving
- * window. Order: live windows first (in given order), then unmatched derived.
- */
-export function mergeQuotaWindows(live: QuotaWindow[], derived: QuotaWindow[]): QuotaWindow[] {
-  const liveKeys = new Set(live.map(w => quotaWindowKey(w.kind)))
-  return [...live, ...derived.filter(w => !liveKeys.has(quotaWindowKey(w.kind)))]
-}
-
-/**
- * Assemble a plan's merged quota view with pace attached. A provider with no
- * readings from either source yields an empty windows list — absent data is
- * absent, never zeros.
- */
-export function buildPlanQuota(input: {
-  provider: string
-  plan?: string
-  live?: QuotaWindow[]
-  derived?: QuotaWindow[]
-  now?: Date
-}): PlanQuota {
-  const now = input.now ?? new Date()
-  const windows = mergeQuotaWindows(input.live ?? [], input.derived ?? []).map(w => {
-    const pace = computePace(w, now)
-    return pace ? { ...w, pace } : { ...w, pace: undefined }
-  })
-  return { provider: input.provider, plan: input.plan, windows, asOf: now }
 }

--- a/tests/quota.test.ts
+++ b/tests/quota.test.ts
@@ -3,25 +3,19 @@ import { describe, expect, it } from 'vitest'
 import {
   QUOTA_PACE_ETA_MAX_WINDOW_SECONDS,
   QUOTA_PACE_MIN_ELAPSED_FRACTION,
-  buildPlanQuota,
   computePace,
-  mergeQuotaWindows,
-  quotaWindowKey,
-  type QuotaWindow,
+  type QuotaPaceWindow,
 } from '../src/quota.js'
 
 const NOW = new Date('2026-07-18T12:00:00Z')
 const WEEK = 7 * 24 * 3600
 const FIVE_HOURS = 5 * 3600
 
-function window(overrides: Partial<QuotaWindow> = {}): QuotaWindow {
+function window(overrides: Partial<QuotaPaceWindow> = {}): QuotaPaceWindow {
   return {
-    kind: 'weekly',
-    label: 'Weekly',
     usedFraction: 0.5,
     windowSeconds: WEEK,
     resetsAt: resetsAfterElapsedFraction(0.5, WEEK),
-    source: 'live',
     ...overrides,
   }
 }
@@ -30,14 +24,6 @@ function window(overrides: Partial<QuotaWindow> = {}): QuotaWindow {
 function resetsAfterElapsedFraction(fraction: number, windowSeconds: number): Date {
   return new Date(NOW.getTime() + windowSeconds * (1 - fraction) * 1000)
 }
-
-describe('quotaWindowKey', () => {
-  it('distinguishes named kinds and custom kinds', () => {
-    expect(quotaWindowKey('weekly')).toBe('weekly')
-    expect(quotaWindowKey({ custom: 'Codex-Spark' })).toBe('custom:Codex-Spark')
-    expect(quotaWindowKey({ custom: 'weekly' })).not.toBe(quotaWindowKey('weekly'))
-  })
-})
 
 describe('computePace', () => {
   it('reports on-pace at the window midpoint', () => {
@@ -53,7 +39,6 @@ describe('computePace', () => {
     const pace = computePace(window({ usedFraction: 0.8, resetsAt }), NOW)
     expect(pace?.deltaFraction).toBeCloseTo(0.3, 6)
     expect(pace?.projectedAtReset).toBeCloseTo(1.6, 6)
-    // 80% in 3.5 days → 100% at 4.375 days elapsed.
     const expectedHit = NOW.getTime() + WEEK * (0.5 * (1 / 0.8) - 0.5) * 1000
     expect(pace?.exhaustsAt?.getTime()).toBeCloseTo(expectedHit, -3)
     expect(pace!.exhaustsAt!.getTime()).toBeLessThan(resetsAt.getTime())
@@ -67,14 +52,7 @@ describe('computePace', () => {
   })
 
   it('suppresses the ETA on short windows but keeps the deficit', () => {
-    const pace = computePace(
-      window({
-        usedFraction: 0.9,
-        windowSeconds: FIVE_HOURS,
-        resetsAt: resetsAfterElapsedFraction(0.5, FIVE_HOURS),
-      }),
-      NOW
-    )
+    const pace = computePace(window({ usedFraction: 0.9, windowSeconds: FIVE_HOURS, resetsAt: resetsAfterElapsedFraction(0.5, FIVE_HOURS) }), NOW)
     expect(pace?.deltaFraction).toBeCloseTo(0.4, 6)
     expect(pace?.projectedAtReset).toBeGreaterThan(1)
     expect(pace?.exhaustsAt).toBeUndefined()
@@ -88,12 +66,11 @@ describe('computePace', () => {
 
   it('says nothing on skewed or missing inputs', () => {
     expect(computePace(window({ resetsAt: new Date(NOW.getTime() - 60_000) }), NOW)).toBeUndefined()
-    expect(
-      computePace(window({ resetsAt: new Date(NOW.getTime() + (WEEK + 3600) * 1000) }), NOW)
-    ).toBeUndefined()
+    expect(computePace(window({ resetsAt: new Date(NOW.getTime() + (WEEK + 3600) * 1000) }), NOW)).toBeUndefined()
     expect(computePace(window({ resetsAt: undefined }), NOW)).toBeUndefined()
     expect(computePace(window({ windowSeconds: undefined }), NOW)).toBeUndefined()
     expect(computePace(window({ windowSeconds: 0 }), NOW)).toBeUndefined()
+    expect(computePace(window({ resetsAt: 'not-a-date' }), NOW)).toBeUndefined()
   })
 
   it('says nothing on an exhausted window, clamping over-range input', () => {
@@ -109,88 +86,14 @@ describe('computePace', () => {
   })
 
   it('keeps the ETA boundary aligned with the exported constant', () => {
-    const boundary = window({
-      usedFraction: 0.9,
-      windowSeconds: QUOTA_PACE_ETA_MAX_WINDOW_SECONDS,
-      resetsAt: resetsAfterElapsedFraction(0.5, QUOTA_PACE_ETA_MAX_WINDOW_SECONDS),
-    })
+    const boundary = window({ usedFraction: 0.9, windowSeconds: QUOTA_PACE_ETA_MAX_WINDOW_SECONDS, resetsAt: resetsAfterElapsedFraction(0.5, QUOTA_PACE_ETA_MAX_WINDOW_SECONDS) })
     expect(computePace(boundary, NOW)?.exhaustsAt).toBeUndefined()
-    const above = window({
-      usedFraction: 0.9,
-      windowSeconds: QUOTA_PACE_ETA_MAX_WINDOW_SECONDS + 3600,
-      resetsAt: resetsAfterElapsedFraction(0.5, QUOTA_PACE_ETA_MAX_WINDOW_SECONDS + 3600),
-    })
+    const above = window({ usedFraction: 0.9, windowSeconds: QUOTA_PACE_ETA_MAX_WINDOW_SECONDS + 3600, resetsAt: resetsAfterElapsedFraction(0.5, QUOTA_PACE_ETA_MAX_WINDOW_SECONDS + 3600) })
     expect(computePace(above, NOW)?.exhaustsAt).toBeInstanceOf(Date)
   })
-})
 
-describe('mergeQuotaWindows', () => {
-  const liveWeekly = window({ source: 'live', label: 'Weekly (live)' })
-  const derivedWeekly = window({ source: 'derived', label: 'Weekly (derived)' })
-  const derivedMonthly = window({ kind: 'monthly', source: 'derived', label: 'Monthly' })
-
-  it('prefers live per window kind and lets derived fill gaps', () => {
-    const merged = mergeQuotaWindows([liveWeekly], [derivedWeekly, derivedMonthly])
-    expect(merged).toHaveLength(2)
-    expect(merged[0]).toBe(liveWeekly)
-    expect(merged[1]).toBe(derivedMonthly)
-  })
-
-  it('keeps distinct custom kinds separate', () => {
-    const spark = window({ kind: { custom: 'Spark' }, source: 'live' })
-    const review = window({ kind: { custom: 'Review' }, source: 'derived' })
-    expect(mergeQuotaWindows([spark], [review])).toHaveLength(2)
-  })
-
-  it('is all-derived when nothing live exists, and empty when nothing exists', () => {
-    expect(mergeQuotaWindows([], [derivedWeekly])).toEqual([derivedWeekly])
-    expect(mergeQuotaWindows([], [])).toEqual([])
-  })
-})
-
-describe('buildPlanQuota', () => {
-  it('merges, attaches pace, and stamps provenance per window', () => {
-    const quota = buildPlanQuota({
-      provider: 'codex',
-      plan: 'pro',
-      live: [window({ usedFraction: 0.8 })],
-      derived: [window({ kind: 'monthly', source: 'derived', usedFraction: 0.2 })],
-      now: NOW,
-    })
-    expect(quota.windows).toHaveLength(2)
-    expect(quota.windows[0].source).toBe('live')
-    expect(quota.windows[0].pace?.deltaFraction).toBeCloseTo(0.3, 6)
-    expect(quota.windows[1].source).toBe('derived')
-    expect(quota.windows[1].pace?.deltaFraction).toBeCloseTo(-0.3, 6)
-    expect(quota.asOf).toBe(NOW)
-  })
-
-  it('yields an empty windows list when no source has readings — never zeros', () => {
-    const quota = buildPlanQuota({ provider: 'claude', now: NOW })
-    expect(quota.windows).toEqual([])
-  })
-
-  it('leaves pace undefined when the guards say nothing', () => {
-    const quota = buildPlanQuota({
-      provider: 'codex',
-      live: [window({ resetsAt: resetsAfterElapsedFraction(0.01, WEEK) })],
-      now: NOW,
-    })
-    expect(quota.windows[0].pace).toBeUndefined()
-  })
-})
-
-describe('computePace NaN guard', () => {
-  it('returns undefined for a non-finite usedFraction instead of a NaN pace', () => {
-    const now = new Date('2026-07-15T00:00:00Z')
-    const win = {
-      kind: 'weekly' as const,
-      usedFraction: NaN,
-      resetsAt: new Date('2026-07-18T12:00:00Z'),
-      windowSeconds: 7 * 24 * 3600,
-      source: 'live' as const,
-    }
-    expect(computePace(win, now)).toBeUndefined()
-    expect(computePace({ ...win, usedFraction: Infinity }, now)).toBeUndefined()
+  it('returns undefined for malformed and non-finite usage instead of a NaN pace', () => {
+    expect(computePace(window({ usedFraction: NaN }), NOW)).toBeUndefined()
+    expect(computePace(window({ usedFraction: Infinity }), NOW)).toBeUndefined()
   })
 })


### PR DESCRIPTION
## Summary

Related to #209, which remains open. This is the bounded provider-quota authority and trust-boundary convergence for the Electron/renderer live-quota path, including the final fail-closed bridge and presentation remediation.

## Base and branch

- Base SHA: fbc597faa99e82873264b99c49d7d293f0544d94
- Branch: feat/provider-quota-authority
- Final reviewed HEAD: 12ba56616b9a265cfdf6f543f2d280719609f2e6

## Canonical quota contract

The Electron live path exposes one JSON-safe `ProviderQuotaSnapshot` contract shared by Electron and renderer types:

- `schemaVersion: 1` and `authority: provider-reported`
- explicit availability, connection, freshness, and original provider `observedAt`
- `planLabel`, stable `windows[]` IDs and labels, normalized `usedFraction` (0..1), `resetsAt`, and evidence-backed `windowSeconds`
- structured provider credits with explicit zero preserved, or `null` when absent
- structured rate-limit backoff state

Local measured usage remains usage history. User-configured budgets and plan pacing remain separate. No local tokens, calls, cost, or history are used to fabricate or backfill provider quota.

## Final bridge trust boundary

- Fresh presentation requires factual provider data, connected state, a valid `observedAt`, `freshness=fresh`, and `availability=available`.
- Stale presentation requires factual data, the original valid `observedAt`, `freshness=stale`, `availability=unavailable`, and a transient/stale connection.
- Every other bridge state is unavailable with `observedAt=null`, `windows=[]`, `credits=null`, and `planLabel=null`.
- Plans hard-gates `freshness=unavailable` before rendering provider windows, credits, or plan labels.
- Valid partial fresh data remains factual: credits-only, plan-only, windows-only, and combinations all survive; explicit credits balance `0` remains factual.

## Provider behavior and credential proof

### Codex

- Stable IDs: `primary`, `secondary`, and `additional:<limit>:<primary|secondary>`.
- Reads supported provider-owned credential sources observationally; product snapshots and IPC exclude credentials and account IDs.
- On 401, re-reads once and retries once only when the owner rotated the access token. It never invokes OAuth refresh and never writes `~/.codex/auth.json`.
- Preserves provider-reported credits, including balance `0`.

### Claude

- Preserves secure credential reads, provider usage requests, bounded credential re-read behavior, 429 handling, and sanitized diagnostics.
- Uses stable IDs for five-hour, weekly, model-scoped weekly, and provider-scoped limits.
- Performs no provider credential mutation and does not invent credits.

## Freshness, polling, and separation

- Last factual snapshots remain visible during transient failures as stale, with their original `observedAt` preserved.
- Without a previous factual snapshot, unavailable quota has empty windows and is never rendered as zero or as injected facts.
- The five-minute politeness floor, in-flight deduplication, abort/invalidation behavior, persisted Retry-After backoff, and forced-refresh/keychain behavior remain bounded.
- Pace behavior and budget-plan rendering remain separate from provider-reported quota; pricing, usage accounting, and history are unchanged.

## Files changed

- `app/electron/quota/types.ts`: canonical snapshot, stale/observed helpers, and final bridge allowlist/fail-closed normalization.
- `app/electron/quota/index.ts`: last-good, freshness, 429/backoff, and polling semantics.
- `app/electron/quota/codex.ts` and `claude.ts`: provider mappings and observational credential reads.
- `app/electron/main.ts` and renderer quota types/Plans/Settings: sanitized bridge and canonical presentation.
- `src/quota.ts`: pace-only, fail-closed interpretation; removed live/derived quota merge authority.
- Focused tests plus `docs/provider-quota-authority.md`.

## Validation

- Focused app quota/bridge/Plans/Codex/Claude/security suite: 7 files, 158 tests passed.
- Root quota focused suite: 10 tests passed.
- Full app suite: 77 files, 620 tests passed.
- Full root local validation: 3,250 tests passed, 5 skipped.
- App typecheck and root TypeScript check passed.
- Electron/renderer build passed.
- `npm run build:cli` passed.
- Source-size ratchet and `git diff --check` passed.
- GitHub Metrora CI #1155 initially hit an unrelated timing-sensitive cache-refresh-lock assertion in the complete core fallback. The isolated file rerun passed locally; the targeted GitHub job was rerun without code changes and completed successfully, including the complete core fallback.
- Architecture Boundaries, Brand Boundary, Public Identity, Version authority, Security rules, and targeted Desktop validation passed; Windows candidate/package checks were skipped as expected for this change surface.

## macOS parity

`MAC_PARITY_FOLLOWUP_REQUIRED`

Native Codex still owns a refresh-and-write lifecycle for provider-owned `~/.codex/auth.json`; this Electron path is read-only. Native services still expose the legacy quota shape rather than the canonical schema, authority, freshness, observation timestamp, stable windows, and structured credits. Native Codex reset-credit fields and Swift Claude credential semantics remain platform-specific. No broad Swift/macOS rewrite is included here.

## Non-goals

No Android credential access or quota authority; no Companion/mobile quota payload; no guessed quota for unsupported providers; no broad Plans/navigation redesign; no pricing, usage accounting, or history changes; and no cross-platform native rewrite. #209 remains open for the native parity follow-up.

## Review state

Final independent review: PASS. Ready for guarded merge at HEAD `12ba56616b9a265cfdf6f543f2d280719609f2e6`.