### PR TITLE
fix(macOS): align provider quota semantics

### DIFF
--- a/mac/Sources/MetroraMenubar/AppStore.swift
+++ b/mac/Sources/MetroraMenubar/AppStore.swift
@@ -965,7 +965,7 @@ final class AppStore {
         } catch let err as ClaudeSubscriptionService.FetchError {
             applyFetchError(err)
         } catch {
-            subscriptionError = String(describing: error)
+            subscriptionError = sanitizeForUI(String(describing: error))
             subscriptionLoadState = .failed
         }
     }
@@ -1217,22 +1217,7 @@ final class AppStore {
     /// envelopes don't typically echo tokens, but we also surface this in
     /// unified-log paths readable by other local users via `log stream`.
     private func sanitizeForUI(_ s: String?) -> String? {
-        guard let s, !s.isEmpty else { return nil }
-        var cleaned = s.replacingOccurrences(of: "\u{0000}", with: "")
-        // Token-shaped redaction. Apply to all known auth-token formats so
-        // an error body that quotes the request/response token is masked.
-        let patterns: [(pattern: String, replacement: String)] = [
-            (#"sk-ant-[A-Za-z0-9_-]+"#, "sk-ant-***"),
-            (#"sk-[A-Za-z0-9_-]{16,}"#, "sk-***"),
-            (#"eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+"#, "eyJ***"),
-            (#"(?i)Bearer\s+\S+"#, "Bearer ***"),
-        ]
-        for entry in patterns {
-            cleaned = cleaned.replacingOccurrences(of: entry.pattern, with: entry.replacement, options: .regularExpression)
-        }
-        // Cap length so a runaway server body cannot fill stderr.
-        if cleaned.count > 240 { cleaned = String(cleaned.prefix(240)) + "…" }
-        return cleaned
+        ProviderQuotaDiagnostics.sanitize(s)
     }
 
     /// Snapshot of live quota state for a given provider. Returns nil when the user
@@ -1282,6 +1267,23 @@ final class AppStore {
         case .loading, .loaded, .failed, .terminalFailure, .transientFailure:
             return true
         }
+    }
+
+    /// Canonical native quota snapshots for the providers supported by the
+    /// Electron authority. This is a read-only projection of already-fetched
+    /// service values; credentials and account identifiers never cross this
+    /// boundary. Kimi remains outside the shared contract until it has an
+    /// approved provider authority.
+    var providerQuotaSnapshots: [ProviderQuotaSnapshot] {
+        [
+            ProviderQuotaSnapshotAdapter.claude(usage: subscription, state: subscriptionLoadState),
+            ProviderQuotaSnapshotAdapter.codex(usage: codexUsage, state: codexLoadState),
+        ]
+    }
+
+    func providerQuotaSnapshot(for provider: ProviderQuotaSnapshot.Provider) -> ProviderQuotaSnapshot {
+        providerQuotaSnapshots.first { $0.provider == provider }
+            ?? .empty(provider: provider, connection: .disconnected)
     }
 
     func quotaSummary(for filter: ProviderFilter) -> QuotaSummary? {
@@ -1381,7 +1383,7 @@ final class AppStore {
         }
         let plan = codexUsage?.plan.displayName
         var footerLines: [String] = []
-        if let balance = codexUsage?.creditsBalance, balance > 0 {
+        if let balance = codexUsage?.creditsBalance, balance.isFinite {
             // Format as plain dollars; ChatGPT settles in USD regardless of
             // the user's display-currency preference.
             let formatter = NumberFormatter()

--- a/mac/Sources/MetroraMenubar/Data/ClaudeSubscriptionService.swift
+++ b/mac/Sources/MetroraMenubar/Data/ClaudeSubscriptionService.swift
@@ -30,7 +30,7 @@ enum ClaudeSubscriptionService {
                 f.unitsStyle = .short
                 return "Anthropic rate-limited the quota endpoint. Retrying \(f.localizedString(for: retryAt, relativeTo: Date()))."
             case let .usageHTTPError(code, body):
-                return "Quota fetch failed (HTTP \(code))\(body.map { ": \($0)" } ?? "")"
+                return "Quota fetch failed (HTTP \(code))\(body.flatMap { ProviderQuotaDiagnostics.sanitize($0) }.map { ": \($0)" } ?? "")"
             case .usageDecodeFailed:
                 return "Quota response was malformed."
             case let .network(err):

--- a/mac/Sources/MetroraMenubar/Data/CodexCredentialStore.swift
+++ b/mac/Sources/MetroraMenubar/Data/CodexCredentialStore.swift
@@ -63,7 +63,7 @@ enum CodexCredentialStore {
             case let .fileWriteFailed(message):
                 return "Could not write to local cache: \(message)"
             case let .refreshHTTPError(code, body):
-                return "Codex token refresh failed (HTTP \(code))\(body.map { ": \($0)" } ?? "")"
+                return "Codex token refresh failed (HTTP \(code))\(body.flatMap { ProviderQuotaDiagnostics.sanitize($0) }.map { ": \($0)" } ?? "")"
             case let .refreshNetworkError(err):
                 return "Codex token refresh network error: \(err.localizedDescription)"
             case .refreshDecodeFailed:

--- a/mac/Sources/MetroraMenubar/Data/CodexSubscriptionService.swift
+++ b/mac/Sources/MetroraMenubar/Data/CodexSubscriptionService.swift
@@ -28,7 +28,7 @@ enum CodexSubscriptionService {
                 f.unitsStyle = .short
                 return "ChatGPT rate-limited the quota endpoint. Retrying \(f.localizedString(for: retryAt, relativeTo: Date()))."
             case let .usageHTTPError(code, body):
-                return "Codex quota fetch failed (HTTP \(code))\(body.map { ": \($0)" } ?? "")"
+                return "Codex quota fetch failed (HTTP \(code))\(body.flatMap { ProviderQuotaDiagnostics.sanitize($0) }.map { ": \($0)" } ?? "")"
             case .usageDecodeFailed: return "Codex quota response was malformed."
             case let .network(err): return "Network error: \(err.localizedDescription)"
             case let .credential(err): return err.errorDescription

--- a/mac/Sources/MetroraMenubar/Data/KimiSubscriptionService.swift
+++ b/mac/Sources/MetroraMenubar/Data/KimiSubscriptionService.swift
@@ -59,7 +59,7 @@ enum KimiSubscriptionService {
                 f.unitsStyle = .short
                 return "Kimi rate-limited the quota endpoint. Retrying \(f.localizedString(for: retryAt, relativeTo: Date()))."
             case let .usageHTTPError(code, body):
-                return "Kimi quota fetch failed (HTTP \(code))\(body.map { ": \($0)" } ?? "")"
+                return "Kimi quota fetch failed (HTTP \(code))\(body.flatMap { ProviderQuotaDiagnostics.sanitize($0) }.map { ": \($0)" } ?? "")"
             case .usageDecodeFailed: return "Kimi quota response was malformed."
             case let .network(err): return "Network error: \(err.localizedDescription)"
             }

--- a/mac/Sources/MetroraMenubar/Data/ProviderQuotaDiagnostics.swift
+++ b/mac/Sources/MetroraMenubar/Data/ProviderQuotaDiagnostics.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+/// Sanitizes provider diagnostics before they reach SwiftUI or unified logging.
+/// Quota payloads never carry these fields; this helper also protects legacy
+/// error paths that still contain an upstream response excerpt.
+enum ProviderQuotaDiagnostics {
+    static func sanitize(_ value: String?) -> String? {
+        guard let value, !value.isEmpty else { return nil }
+        var cleaned = value.replacingOccurrences(of: "\u{0000}", with: "")
+        let patterns: [(String, String)] = [
+            (#"(?i)Bearer\s+\S+"#, "Bearer [REDACTED]"),
+            (#"sk-ant-[A-Za-z0-9_-]+"#, "[REDACTED_TOKEN]"),
+            (#"sk-[A-Za-z0-9_-]{16,}"#, "[REDACTED_TOKEN]"),
+            (#"eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+"#, "[REDACTED_TOKEN]"),
+            (#"(?i)"?(?:access[_-]?token|refresh[_-]?token|id[_-]?token|account[_-]?id|authorization|chatgpt-account-id)"?\s*[:=]\s*"?[^",}\s]+"?"#, "[REDACTED_CREDENTIAL_FIELD]"),
+            (#"(?i)(?:token|api[_-]?key|apikey)=[^&\s]+"#, "[REDACTED_QUERY]"),
+            (#"(?i)(?:/Users/|[A-Za-z]:\\Users\\)[^ \t\r\n]+"#, "[REDACTED_PATH]"),
+        ]
+        for (pattern, replacement) in patterns {
+            cleaned = cleaned.replacingOccurrences(of: pattern, with: replacement, options: .regularExpression)
+        }
+        if cleaned.count > 240 {
+            cleaned = String(cleaned.prefix(240)) + "…"
+        }
+        return cleaned.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}

--- a/mac/Sources/MetroraMenubar/Data/ProviderQuotaSnapshot.swift
+++ b/mac/Sources/MetroraMenubar/Data/ProviderQuotaSnapshot.swift
@@ -190,9 +190,12 @@ enum ProviderQuotaSnapshotAdapter {
             }
             return rows
         } ?? []
-        // rawTier nil means Claude did not report a plan. Do not turn the
-        // UI fallback label Subscription into a provider fact.
-        let plan = usage?.rawTier == nil ? nil : usage?.tier.displayName
+        // A missing or blank rawTier means Claude did not report a plan. Do
+        // not turn the UI fallback label Subscription into a provider fact.
+        let rawTier = usage?.rawTier?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .flatMap { $0.isEmpty ? nil : $0 }
+        let plan = rawTier == nil ? nil : usage?.tier.displayName
         return ProviderQuotaSnapshot(
             provider: .claude,
             connection: connection,

--- a/mac/Sources/MetroraMenubar/Data/ProviderQuotaSnapshot.swift
+++ b/mac/Sources/MetroraMenubar/Data/ProviderQuotaSnapshot.swift
@@ -1,0 +1,292 @@
+import Foundation
+
+/// Native counterpart of the Electron ProviderQuotaSnapshot contract.
+///
+/// This is deliberately a product-only payload: provider credentials,
+/// account identifiers, source paths and raw response bodies cannot be
+/// represented by this type. Provider quota, local usage and local budgets
+/// remain separate authorities.
+struct ProviderQuotaSnapshot: Codable, Sendable, Equatable {
+    static let currentSchemaVersion = 1
+
+    enum Provider: String, Codable, Sendable, Equatable {
+        case claude
+        case codex
+    }
+
+    enum Authority: String, Codable, Sendable, Equatable {
+        case providerReported = "provider-reported"
+    }
+
+    enum Connection: String, Codable, Sendable, Equatable {
+        case connected
+        case disconnected
+        case accessDenied
+        case loading
+        case stale
+        case transientFailure
+        case terminalFailure
+    }
+
+    enum Availability: String, Codable, Sendable, Equatable {
+        case available
+        case unavailable
+    }
+
+    enum Freshness: String, Codable, Sendable, Equatable {
+        case fresh
+        case stale
+        case unavailable
+    }
+
+    struct Window: Codable, Sendable, Equatable {
+        let id: String
+        let label: String
+        let usedFraction: Double
+        let resetsAt: Date?
+        let windowSeconds: Int?
+    }
+
+    struct Credits: Codable, Sendable, Equatable {
+        let balance: Double
+        let currency: String
+
+        init(balance: Double, currency: String = "USD") {
+            self.balance = balance
+            self.currency = currency
+        }
+    }
+
+    struct RateLimit: Codable, Sendable, Equatable {
+        enum State: String, Codable, Sendable, Equatable {
+            case clear
+            case backoff
+        }
+
+        let state: State
+        let retryAt: Date?
+
+        static let clear = RateLimit(state: .clear, retryAt: nil)
+
+        static func backoff(until: Date?) -> RateLimit {
+            RateLimit(state: .backoff, retryAt: until)
+        }
+    }
+
+    let schemaVersion: Int
+    let provider: Provider
+    let authority: Authority
+    let availability: Availability
+    let connection: Connection
+    let freshness: Freshness
+    /// The provider response observation time. A failed refresh never moves
+    /// this timestamp forward; stale snapshots retain the original value.
+    let observedAt: Date?
+    let planLabel: String?
+    let windows: [Window]
+    /// A provider-reported balance. Zero is factual and must not be treated as
+    /// missing; nil means the provider did not report a balance.
+    let credits: Credits?
+    let rateLimit: RateLimit
+
+    /// Builds a product-safe snapshot and fail-closes malformed or
+    /// non-factual values. Connection is supplied by the adapter from the
+    /// native refresh state; this initializer decides whether the facts are
+    /// fresh, stale or unavailable.
+    init(
+        provider: Provider,
+        connection: Connection,
+        observedAt: Date?,
+        planLabel: String?,
+        windows: [Window],
+        credits: Credits?,
+        rateLimit: RateLimit = .clear
+    ) {
+        let safeWindows = windows.compactMap { row -> Window? in
+            guard !row.id.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+                  !row.label.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+                  row.usedFraction.isFinite
+            else { return nil }
+            return Window(
+                id: row.id,
+                label: row.label,
+                usedFraction: min(1, max(0, row.usedFraction)),
+                resetsAt: row.resetsAt,
+                windowSeconds: row.windowSeconds.flatMap { $0 > 0 ? $0 : nil }
+            )
+        }
+        let safePlan = planLabel?.trimmingCharacters(in: .whitespacesAndNewlines)
+            .flatMap { $0.isEmpty ? nil : $0 }
+        let safeCredits = credits.flatMap { $0.balance.isFinite ? Credits(balance: $0.balance) : nil }
+        let factual = !safeWindows.isEmpty || safeCredits != nil || safePlan != nil
+        let hasObservation = factual && observedAt != nil
+        let isFresh = connection == .connected && hasObservation
+        let isStale = (connection == .stale || connection == .transientFailure) && hasObservation
+
+        schemaVersion = Self.currentSchemaVersion
+        self.provider = provider
+        authority = .providerReported
+        self.connection = connection
+        availability = isFresh ? .available : .unavailable
+        freshness = isFresh ? .fresh : (isStale ? .stale : .unavailable)
+        // Terminal/loading/disconnected snapshots do not claim provider facts.
+        // A stale/transient snapshot retains the provider original time.
+        self.observedAt = (isFresh || isStale) ? observedAt : nil
+        self.planLabel = (isFresh || isStale) ? safePlan : nil
+        self.windows = (isFresh || isStale) ? safeWindows : []
+        self.credits = (isFresh || isStale) ? safeCredits : nil
+        self.rateLimit = Self.sanitizeRateLimit(rateLimit)
+    }
+
+    static func empty(provider: Provider, connection: Connection, rateLimit: RateLimit = .clear) -> ProviderQuotaSnapshot {
+        ProviderQuotaSnapshot(
+            provider: provider,
+            connection: connection,
+            observedAt: nil,
+            planLabel: nil,
+            windows: [],
+            credits: nil,
+            rateLimit: rateLimit
+        )
+    }
+
+    var hasProviderFacts: Bool {
+        !windows.isEmpty || credits != nil || planLabel != nil
+    }
+
+    private static func sanitizeRateLimit(_ value: RateLimit) -> RateLimit {
+        switch value.state {
+        case .clear:
+            return .clear
+        case .backoff:
+            return .backoff(until: value.retryAt)
+        }
+    }
+}
+
+/// Maps already-decoded native service values into the shared conceptual
+/// provider-quota model. The adapter is observational only: it never reads,
+/// refreshes or writes provider credentials.
+enum ProviderQuotaSnapshotAdapter {
+    static func claude(
+        usage: SubscriptionUsage?,
+        state: SubscriptionLoadState
+    ) -> ProviderQuotaSnapshot {
+        let connection = connection(for: state, hasUsage: usage != nil)
+        let windows: [ProviderQuotaSnapshot.Window] = usage.map { value in
+            var rows: [ProviderQuotaSnapshot.Window] = []
+            append(&rows, id: "five_hour", label: "5-hour", percent: value.fiveHourPercent, resetsAt: value.fiveHourResetsAt)
+            append(&rows, id: "seven_day", label: "Weekly", percent: value.sevenDayPercent, resetsAt: value.sevenDayResetsAt)
+            append(&rows, id: "seven_day_opus", label: "Weekly · Opus", percent: value.sevenDayOpusPercent, resetsAt: value.sevenDayOpusResetsAt)
+            append(&rows, id: "seven_day_sonnet", label: "Weekly · Sonnet", percent: value.sevenDaySonnetPercent, resetsAt: value.sevenDaySonnetResetsAt)
+            for scoped in value.scopedWeekly {
+                append(
+                    &rows,
+                    id: "weekly_scoped:\(scoped.label)",
+                    label: "Weekly · \(scoped.label)",
+                    percent: scoped.percent,
+                    resetsAt: scoped.resetsAt
+                )
+            }
+            return rows
+        } ?? []
+        // rawTier nil means Claude did not report a plan. Do not turn the
+        // UI fallback label Subscription into a provider fact.
+        let plan = usage?.rawTier == nil ? nil : usage?.tier.displayName
+        return ProviderQuotaSnapshot(
+            provider: .claude,
+            connection: connection,
+            observedAt: usage?.fetchedAt,
+            planLabel: plan,
+            windows: windows,
+            credits: nil,
+            rateLimit: rateLimit(for: state)
+        )
+    }
+
+    static func codex(
+        usage: CodexUsage?,
+        state: SubscriptionLoadState
+    ) -> ProviderQuotaSnapshot {
+        let connection = connection(for: state, hasUsage: usage != nil)
+        let windows: [ProviderQuotaSnapshot.Window] = usage.map { value in
+            var rows: [ProviderQuotaSnapshot.Window] = []
+            append(&rows, id: "primary", window: value.primary)
+            append(&rows, id: "secondary", window: value.secondary)
+            for extra in value.additionalLimits {
+                append(&rows, id: "additional:\(extra.name):primary", window: extra.primary, labelPrefix: extra.name)
+                append(&rows, id: "additional:\(extra.name):secondary", window: extra.secondary, labelPrefix: extra.name)
+            }
+            return rows
+        } ?? []
+        let plan: String? = {
+            guard let usage else { return nil }
+            if case let .unknown(raw) = usage.plan, raw.isEmpty { return nil }
+            return usage.plan.displayName
+        }()
+        let credits = usage?.creditsBalance.flatMap { $0.isFinite ? ProviderQuotaSnapshot.Credits(balance: $0) : nil }
+        return ProviderQuotaSnapshot(
+            provider: .codex,
+            connection: connection,
+            observedAt: usage?.fetchedAt,
+            planLabel: plan,
+            windows: windows,
+            credits: credits,
+            rateLimit: rateLimit(for: state)
+        )
+    }
+
+    private static func connection(for state: SubscriptionLoadState, hasUsage: Bool) -> ProviderQuotaSnapshot.Connection {
+        switch state {
+        case .notBootstrapped, .noCredentials:
+            return .disconnected
+        case .dormant, .bootstrapping:
+            return .loading
+        case .loading:
+            return hasUsage ? .stale : .loading
+        case .loaded:
+            return .connected
+        case .failed:
+            return .transientFailure
+        case .terminalFailure:
+            return .terminalFailure
+        case .transientFailure:
+            return .transientFailure
+        }
+    }
+
+    private static func rateLimit(for state: SubscriptionLoadState) -> ProviderQuotaSnapshot.RateLimit {
+        if case let .transientFailure(retryAt) = state {
+            return .backoff(until: retryAt)
+        }
+        return .clear
+    }
+
+    private static func append(
+        _ rows: inout [ProviderQuotaSnapshot.Window],
+        id: String,
+        label: String,
+        percent: Double?,
+        resetsAt: Date?
+    ) {
+        guard let percent, percent.isFinite else { return }
+        rows.append(.init(id: id, label: label, usedFraction: percent / 100, resetsAt: resetsAt, windowSeconds: nil))
+    }
+
+    private static func append(
+        _ rows: inout [ProviderQuotaSnapshot.Window],
+        id: String,
+        window: CodexUsage.Window?,
+        labelPrefix: String? = nil
+    ) {
+        guard let window else { return }
+        let label = labelPrefix.map { "\($0) · \(window.windowLabel)" } ?? window.windowLabel
+        rows.append(.init(
+            id: id,
+            label: label,
+            usedFraction: window.usedPercent / 100,
+            resetsAt: window.resetsAt,
+            windowSeconds: window.limitWindowSeconds > 0 ? window.limitWindowSeconds : nil
+        ))
+    }
+}

--- a/mac/Tests/MetroraMenubarTests/ProviderQuotaSnapshotTests.swift
+++ b/mac/Tests/MetroraMenubarTests/ProviderQuotaSnapshotTests.swift
@@ -78,8 +78,19 @@ struct ProviderQuotaSnapshotTests {
         #expect(snapshot.availability == .unavailable)
         #expect(snapshot.freshness == .unavailable)
         #expect(snapshot.observedAt == nil)
+        #expect(snapshot.planLabel == nil)
         #expect(snapshot.windows.isEmpty)
         #expect(snapshot.credits == nil)
+    }
+
+    @Test("an empty Claude raw tier without quota facts is unavailable")
+    func emptyClaudeRawTierIsNotAProviderFact() {
+        assertBlankClaudeRawTierIsUnavailable("")
+    }
+
+    @Test("a whitespace Claude raw tier without quota facts is unavailable")
+    func whitespaceClaudeRawTierIsNotAProviderFact() {
+        assertBlankClaudeRawTierIsUnavailable(" \t\n ")
     }
 
     @Test("native payload has no credential or account fields")
@@ -114,5 +125,31 @@ struct ProviderQuotaSnapshotTests {
         #expect(!sanitized.contains("refresh-secret"))
         #expect(!sanitized.contains("/Users/alice"))
         #expect(sanitized.contains("[REDACTED]"))
+    }
+
+    private func assertBlankClaudeRawTierIsUnavailable(_ rawTier: String) {
+        let usage = SubscriptionUsage(
+            tier: .unknown,
+            rawTier: rawTier,
+            fiveHourPercent: nil,
+            fiveHourResetsAt: nil,
+            sevenDayPercent: nil,
+            sevenDayResetsAt: nil,
+            sevenDayOpusPercent: nil,
+            sevenDayOpusResetsAt: nil,
+            sevenDaySonnetPercent: nil,
+            sevenDaySonnetResetsAt: nil,
+            scopedWeekly: [],
+            fetchedAt: observedAt
+        )
+
+        let snapshot = ProviderQuotaSnapshotAdapter.claude(usage: usage, state: .loaded)
+
+        #expect(snapshot.availability == .unavailable)
+        #expect(snapshot.freshness == .unavailable)
+        #expect(snapshot.observedAt == nil)
+        #expect(snapshot.planLabel == nil)
+        #expect(snapshot.windows.isEmpty)
+        #expect(snapshot.credits == nil)
     }
 }

--- a/mac/Tests/MetroraMenubarTests/ProviderQuotaSnapshotTests.swift
+++ b/mac/Tests/MetroraMenubarTests/ProviderQuotaSnapshotTests.swift
@@ -93,6 +93,31 @@ struct ProviderQuotaSnapshotTests {
         assertBlankClaudeRawTierIsUnavailable(" \t\n ")
     }
 
+    @Test("a padded nonblank Claude raw tier preserves its canonical plan")
+    func paddedClaudeRawTierPreservesPlan() {
+        let usage = claudeUsage(tier: .pro, rawTier: "  pro \n")
+
+        let snapshot = ProviderQuotaSnapshotAdapter.claude(usage: usage, state: .loaded)
+
+        #expect(snapshot.availability == .available)
+        #expect(snapshot.freshness == .fresh)
+        #expect(snapshot.observedAt == observedAt)
+        #expect(snapshot.planLabel == "Pro")
+    }
+
+    @Test("a blank Claude raw tier never becomes a plan when a window is factual")
+    func blankClaudeRawTierDoesNotOverrideWindowFact() {
+        let usage = claudeUsage(rawTier: " \t\n ", fiveHourPercent: 25)
+
+        let snapshot = ProviderQuotaSnapshotAdapter.claude(usage: usage, state: .loaded)
+
+        #expect(snapshot.availability == .available)
+        #expect(snapshot.freshness == .fresh)
+        #expect(snapshot.observedAt == observedAt)
+        #expect(snapshot.planLabel == nil)
+        #expect(snapshot.windows.map(\.usedFraction) == [0.25])
+    }
+
     @Test("native payload has no credential or account fields")
     func payloadAllowlistExcludesSecrets() throws {
         let usage = CodexUsage(
@@ -128,10 +153,27 @@ struct ProviderQuotaSnapshotTests {
     }
 
     private func assertBlankClaudeRawTierIsUnavailable(_ rawTier: String) {
-        let usage = SubscriptionUsage(
-            tier: .unknown,
+        let usage = claudeUsage(rawTier: rawTier)
+
+        let snapshot = ProviderQuotaSnapshotAdapter.claude(usage: usage, state: .loaded)
+
+        #expect(snapshot.availability == .unavailable)
+        #expect(snapshot.freshness == .unavailable)
+        #expect(snapshot.observedAt == nil)
+        #expect(snapshot.planLabel == nil)
+        #expect(snapshot.windows.isEmpty)
+        #expect(snapshot.credits == nil)
+    }
+
+    private func claudeUsage(
+        tier: SubscriptionUsage.Tier = .unknown,
+        rawTier: String?,
+        fiveHourPercent: Double? = nil
+    ) -> SubscriptionUsage {
+        SubscriptionUsage(
+            tier: tier,
             rawTier: rawTier,
-            fiveHourPercent: nil,
+            fiveHourPercent: fiveHourPercent,
             fiveHourResetsAt: nil,
             sevenDayPercent: nil,
             sevenDayResetsAt: nil,
@@ -142,14 +184,5 @@ struct ProviderQuotaSnapshotTests {
             scopedWeekly: [],
             fetchedAt: observedAt
         )
-
-        let snapshot = ProviderQuotaSnapshotAdapter.claude(usage: usage, state: .loaded)
-
-        #expect(snapshot.availability == .unavailable)
-        #expect(snapshot.freshness == .unavailable)
-        #expect(snapshot.observedAt == nil)
-        #expect(snapshot.planLabel == nil)
-        #expect(snapshot.windows.isEmpty)
-        #expect(snapshot.credits == nil)
     }
 }

--- a/mac/Tests/MetroraMenubarTests/ProviderQuotaSnapshotTests.swift
+++ b/mac/Tests/MetroraMenubarTests/ProviderQuotaSnapshotTests.swift
@@ -1,0 +1,118 @@
+import Foundation
+import Testing
+@testable import MetroraMenubar
+
+@Suite("Native provider quota parity")
+struct ProviderQuotaSnapshotTests {
+    private let observedAt = Date(timeIntervalSince1970: 1_800_000_000)
+
+    @Test("Codex preserves a factual zero credit balance")
+    func zeroCreditsRemainFactual() throws {
+        let usage = CodexUsage(
+            plan: .plus,
+            primary: .init(usedPercent: 0, resetsAt: observedAt.addingTimeInterval(3600), limitWindowSeconds: 18_000),
+            secondary: nil,
+            additionalLimits: [],
+            creditsBalance: 0,
+            resetCredits: nil,
+            fetchedAt: observedAt
+        )
+
+        let snapshot = ProviderQuotaSnapshotAdapter.codex(usage: usage, state: .loaded)
+
+        #expect(snapshot.availability == .available)
+        #expect(snapshot.freshness == .fresh)
+        #expect(snapshot.observedAt == observedAt)
+        #expect(snapshot.credits?.balance == 0)
+        #expect(snapshot.windows.first?.usedFraction == 0)
+        #expect(snapshot.windows.first?.windowSeconds == 18_000)
+    }
+
+    @Test("failed refresh retains the provider observation but is unavailable")
+    func staleObservationIsExplicit() {
+        let usage = CodexUsage(
+            plan: .plus,
+            primary: .init(usedPercent: 42, resetsAt: observedAt.addingTimeInterval(3600), limitWindowSeconds: 18_000),
+            secondary: nil,
+            additionalLimits: [],
+            creditsBalance: 0,
+            resetCredits: nil,
+            fetchedAt: observedAt
+        )
+        let retryAt = observedAt.addingTimeInterval(300)
+
+        let snapshot = ProviderQuotaSnapshotAdapter.codex(
+            usage: usage,
+            state: .transientFailure(retryAt: retryAt)
+        )
+
+        #expect(snapshot.availability == .unavailable)
+        #expect(snapshot.freshness == .stale)
+        #expect(snapshot.connection == .transientFailure)
+        #expect(snapshot.observedAt == observedAt)
+        #expect(snapshot.windows.first?.usedFraction == 0.42)
+        #expect(snapshot.credits?.balance == 0)
+        #expect(snapshot.rateLimit.state == .backoff)
+        #expect(snapshot.rateLimit.retryAt == retryAt)
+    }
+
+    @Test("a connected response without provider facts is unavailable, never zero")
+    func noFactsAreNotZero() {
+        let usage = SubscriptionUsage(
+            tier: .unknown,
+            rawTier: nil,
+            fiveHourPercent: nil,
+            fiveHourResetsAt: nil,
+            sevenDayPercent: nil,
+            sevenDayResetsAt: nil,
+            sevenDayOpusPercent: nil,
+            sevenDayOpusResetsAt: nil,
+            sevenDaySonnetPercent: nil,
+            sevenDaySonnetResetsAt: nil,
+            scopedWeekly: [],
+            fetchedAt: observedAt
+        )
+
+        let snapshot = ProviderQuotaSnapshotAdapter.claude(usage: usage, state: .loaded)
+
+        #expect(snapshot.availability == .unavailable)
+        #expect(snapshot.freshness == .unavailable)
+        #expect(snapshot.observedAt == nil)
+        #expect(snapshot.windows.isEmpty)
+        #expect(snapshot.credits == nil)
+    }
+
+    @Test("native payload has no credential or account fields")
+    func payloadAllowlistExcludesSecrets() throws {
+        let usage = CodexUsage(
+            plan: .plus,
+            primary: .init(usedPercent: 10, resetsAt: nil, limitWindowSeconds: 18_000),
+            secondary: nil,
+            additionalLimits: [],
+            creditsBalance: 0,
+            resetCredits: nil,
+            fetchedAt: observedAt
+        )
+        let snapshot = ProviderQuotaSnapshotAdapter.codex(usage: usage, state: .loaded)
+        let data = try JSONEncoder().encode(snapshot)
+        let json = String(decoding: data, as: UTF8.self)
+
+        #expect(!json.contains("accessToken"))
+        #expect(!json.contains("refreshToken"))
+        #expect(!json.contains("accountId"))
+        #expect(!json.contains("account_id"))
+        #expect(!json.contains("credential"))
+    }
+
+    @Test("diagnostics redact token, account and local path material")
+    func diagnosticsAreSanitized() {
+        let raw = #"HTTP 401 Bearer super-secret-token {"account_id":"acct_123","refresh_token":"refresh-secret"} /Users/alice/.codex/auth.json"#
+        let sanitized = ProviderQuotaDiagnostics.sanitize(raw) ?? ""
+
+        #expect(!sanitized.contains("super-secret-token"))
+        #expect(!sanitized.contains("acct_123"))
+        #expect(!sanitized.contains("refresh-secret"))
+        #expect(!sanitized.contains("/Users/alice"))
+        #expect(sanitized.contains("[REDACTED]"))
+    }
+}


### PR DESCRIPTION
## Current-main forensic status — 2026-08-29

Source-level revalidated against current `main` `8db16e19a898366647aa6088a07fa32a08db73b4`; PR head remains `8d1b5566cef7c2887ae977c418322840944b9cc4`.

**Do not merge or rebase this branch as-is.** The original macOS parity gap was real, but the branch predates later Capacity authority work, especially #230 / PR #236.

### Still-valid intent

- Preserve an explicit Codex credit balance of `0` instead of treating it as unavailable/absent in macOS presentation.
- Keep provider diagnostics sanitized before UI/log exposure, including credential/account material.
- Keep provider-reported quota distinct from Metrora-measured usage and local budget plans.

### Superseded / incompatible portions

- The added native `ProviderQuotaSnapshot` is a two-provider (`claude`/`codex`) parallel contract. Current canonical Desktop Capacity covers Claude, Codex, Copilot, Kimi Code and Antigravity through one authority/projection; the branch comment that Kimi remains outside the approved contract is stale.
- The branch treats retained native usage plus `loading`/`transientFailure` as stale factual quota. After #230, stale retention is valid only when bound to the same retention-safe provider credential identity. #211 has no such identity boundary, so this logic must not be carried forward.
- The branch intentionally leaves provider authentication lifecycle unchanged. Native Codex still has refresh-and-write behavior for provider-owned `~/.codex/auth.json`, while current Capacity authority requires quota observation to be read-only/observational.

### Recommended disposition

`REPLACE_WITH_SMALLER_PR`

Build any replacement from current `main` and salvage only still-valid behavior after re-deriving it from current Capacity authority. Do not transplant the old two-provider snapshot/adapters or their stale-retention tests unchanged.

This revalidation did **not** perform native macOS runtime/toolchain validation and made no runtime code changes, merge, release, rebase, push, or PR state change.