### PR TITLE
feat(advisor): add local conversational foundation

### DIFF
--- a/app/electron/advisor-runtime.test.ts
+++ b/app/electron/advisor-runtime.test.ts
@@ -14,6 +14,9 @@ function streamedResponse(lines: string[]): Response {
   })
   return new Response(body, { status: 200, headers: { 'content-type': 'application/x-ndjson' } })
 }
+function textOnlyResponse(text: string): Response {
+  return { ok: true, body: null, text: async () => text } as unknown as Response
+}
 
 describe('Electron Advisor local runtime', () => {
   it('probes the fixed loopback endpoint and reports discovered models', async () => {
@@ -42,6 +45,36 @@ describe('Electron Advisor local runtime', () => {
     expect(result.streamed).toBe(true)
     expect(result.message.content).toBe('Measured evidence.')
     expect(deltas).toEqual(['Measured ', 'Measured evidence.'])
+  })
+
+  it('fails closed when one valid reader-backed NDJSON record exceeds the content cap', async () => {
+    const response = streamedResponse([JSON.stringify({ message: { content: 'x'.repeat(32_001) } }) + '\n'])
+
+    await expect(chatOllamaMain(async () => response, payload)).rejects.toThrow('content limit')
+  })
+
+  it('fails closed when valid fallback NDJSON records cumulatively exceed the content cap', async () => {
+    const response = textOnlyResponse([
+      JSON.stringify({ message: { content: 'x'.repeat(20_000) } }),
+      JSON.stringify({ message: { content: 'y'.repeat(12_001) } }),
+    ].join('\n'))
+
+    await expect(chatOllamaMain(async () => response, payload)).rejects.toThrow('content limit')
+  })
+
+  it('tolerates malformed NDJSON up to the intended bound, then fails closed', async () => {
+    const valid = JSON.stringify({ message: { content: 'valid' } }) + '\n'
+    const tolerated = streamedResponse([...Array.from({ length: 16 }, () => '{broken\n'), valid])
+    await expect(chatOllamaMain(async () => tolerated, payload)).resolves.toMatchObject({ message: { content: 'valid' } })
+
+    const exceeded = streamedResponse([...Array.from({ length: 17 }, () => '{broken\n'), valid])
+    await expect(chatOllamaMain(async () => exceeded, payload)).rejects.toThrow('malformed chunks')
+  })
+
+  it('enforces the response byte cap on the non-reader fallback path', async () => {
+    const response = textOnlyResponse('x'.repeat(2 * 1024 * 1024 + 1))
+
+    await expect(chatOllamaMain(async () => response, payload)).rejects.toThrow('response exceeded the safety limit')
   })
 
   it('returns a bounded cancellation envelope and never exposes the local endpoint', async () => {

--- a/app/electron/advisor-runtime.test.ts
+++ b/app/electron/advisor-runtime.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { chatOllamaMain, createAdvisorRuntimeHandlers, probeOllamaMain } from './advisor-runtime'
+
+const payload = { model: 'llama3.2', messages: [], tools: [], stream: true }
+
+function streamedResponse(lines: string[]): Response {
+  const encoder = new TextEncoder()
+  const body = new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const line of lines) controller.enqueue(encoder.encode(line))
+      controller.close()
+    },
+  })
+  return new Response(body, { status: 200, headers: { 'content-type': 'application/x-ndjson' } })
+}
+
+describe('Electron Advisor local runtime', () => {
+  it('probes the fixed loopback endpoint and reports discovered models', async () => {
+    const calls: Array<{ url: string; init?: RequestInit }> = []
+    const fetchImpl = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      calls.push({ url: String(input), init })
+      return new Response(JSON.stringify({ models: [{ name: 'llama3.2' }, { name: 'qwen2.5' }] }), { status: 200 })
+    }) as typeof fetch
+
+    await expect(probeOllamaMain(fetchImpl)).resolves.toEqual({
+      available: true,
+      models: ['llama3.2', 'qwen2.5'],
+      detail: 'Local Ollama is reachable.',
+    })
+    expect(calls[0]?.url).toBe('http://127.0.0.1:11434/api/tags')
+  })
+
+  it('reads NDJSON incrementally, caps content, and exposes deltas without waiting for text()', async () => {
+    const fetchImpl = (async () => streamedResponse([
+      '{"message":{"content":"Measured "}}',
+      '\n{"message":{"content":"evidence."},"done":true}\n',
+    ])) as typeof fetch
+    const deltas: string[] = []
+    const result = await chatOllamaMain(fetchImpl, payload, undefined, text => deltas.push(text))
+
+    expect(result.streamed).toBe(true)
+    expect(result.message.content).toBe('Measured evidence.')
+    expect(deltas).toEqual(['Measured ', 'Measured evidence.'])
+  })
+
+  it('returns a bounded cancellation envelope and never exposes the local endpoint', async () => {
+    let rejectRequest: ((error: unknown) => void) | null = null
+    const fetchImpl = (async (_input: RequestInfo | URL, init?: RequestInit) => new Promise<Response>((_resolve, reject) => {
+      rejectRequest = reject
+      init?.signal?.addEventListener('abort', () => reject(new DOMException('The operation was aborted.', 'AbortError')), { once: true })
+    })) as typeof fetch
+    const handlers = createAdvisorRuntimeHandlers(fetchImpl)
+    const pending = handlers['metrora:advisorChat']('request-1', payload)
+    await Promise.resolve()
+    await expect(handlers['metrora:advisorCancel']('request-1')).resolves.toEqual({ ok: true, value: true })
+    const result = await pending
+    expect(result).toEqual({ ok: false, error: { kind: 'cancelled', message: 'Advisor request cancelled.' } })
+    expect(rejectRequest).not.toBeNull()
+  })
+})

--- a/app/electron/advisor-runtime.ts
+++ b/app/electron/advisor-runtime.ts
@@ -1,0 +1,211 @@
+const LOOPBACK_ENDPOINT = 'http://127.0.0.1:11434'
+const PROBE_TIMEOUT_MS = 1500
+const CHAT_TIMEOUT_MS = 120_000
+const MAX_RESPONSE_BYTES = 2 * 1024 * 1024
+const MAX_STREAM_CHUNKS = 512
+const MAX_MALFORMED_CHUNKS = 16
+
+export type AdvisorRuntimeProbe = { available: boolean; models: string[]; detail: string }
+export type AdvisorRuntimeChatPayload = {
+  model: string
+  messages: Array<Record<string, unknown>>
+  tools: Array<Record<string, unknown>>
+  stream: boolean
+}
+export type AdvisorRuntimeChatResult = { message: { content: string; tool_calls?: Array<Record<string, unknown>> }; streamed: boolean }
+type FetchLike = typeof fetch
+
+function boundedError(error: unknown): Error {
+  const raw = error instanceof Error ? error.message : String(error)
+  return new Error(raw.replace(/[\r\n]+/g, ' ').replace(/[A-Za-z]:\\[^ ]+|\/[^ ]+/g, '[local path]').slice(0, 240))
+}
+function validModel(model: string): boolean {
+  return /^[A-Za-z0-9][A-Za-z0-9._:/-]{0,160}$/.test(model)
+}
+function timeoutSignal(parent?: AbortSignal, timeoutMs = CHAT_TIMEOUT_MS): { signal: AbortSignal; dispose: () => void } {
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), timeoutMs)
+  const forward = () => controller.abort()
+  parent?.addEventListener('abort', forward, { once: true })
+  return { signal: controller.signal, dispose: () => { clearTimeout(timer); parent?.removeEventListener('abort', forward) } }
+}
+async function boundedText(response: Response): Promise<string> {
+  const reader = response.body?.getReader()
+  if (!reader) return (await response.text()).slice(0, MAX_RESPONSE_BYTES)
+  const decoder = new TextDecoder()
+  let bytes = 0
+  let text = ''
+  while (true) {
+    const chunk = await reader.read()
+    if (chunk.done) break
+    bytes += chunk.value.byteLength
+    if (bytes > MAX_RESPONSE_BYTES) throw new Error('Local runtime response exceeded the safety limit.')
+    text += decoder.decode(chunk.value, { stream: true })
+  }
+  return text + decoder.decode()
+}
+async function fetchJson(fetchImpl: FetchLike, url: string, init: RequestInit, timeoutMs: number, parent?: AbortSignal): Promise<Record<string, unknown>> {
+  const timed = timeoutSignal(parent, timeoutMs)
+  try {
+    const response = await fetchImpl(url, { ...init, signal: timed.signal })
+    if (!response.ok) throw new Error('Local runtime returned HTTP ' + response.status + '.')
+    const text = await boundedText(response)
+    const value = JSON.parse(text) as unknown
+    if (!value || typeof value !== 'object') throw new Error('Local runtime returned invalid JSON.')
+    return value as Record<string, unknown>
+  } finally { timed.dispose() }
+}
+export async function probeOllamaMain(fetchImpl: FetchLike = fetch, parent?: AbortSignal): Promise<AdvisorRuntimeProbe> {
+  if (!fetchImpl) return { available: false, models: [], detail: 'Node fetch is unavailable.' }
+  try {
+    const payload = await fetchJson(fetchImpl, LOOPBACK_ENDPOINT + '/api/tags', {}, PROBE_TIMEOUT_MS, parent)
+    const rows = Array.isArray(payload.models) ? payload.models : []
+    const models = rows.flatMap(row => row && typeof row === 'object' && typeof (row as { name?: unknown }).name === 'string' ? [(row as { name: string }).name] : [])
+    return models.length ? { available: true, models, detail: 'Local Ollama is reachable.' } : { available: false, models: [], detail: 'Ollama is reachable but has no local models.' }
+  } catch (error) {
+    if (parent?.aborted) throw error
+    return { available: false, models: [], detail: boundedError(error).message }
+  }
+}
+function parseToolCalls(value: unknown): Array<Record<string, unknown>> {
+  if (!Array.isArray(value)) return []
+  return value.filter(row => row && typeof row === 'object').slice(0, 16) as Array<Record<string, unknown>>
+}
+function messageResult(raw: Record<string, unknown>, streamed: boolean): AdvisorRuntimeChatResult {
+  const message = raw.message && typeof raw.message === 'object' ? raw.message as Record<string, unknown> : {}
+  return {
+    message: {
+      content: typeof message.content === 'string' ? message.content.slice(0, 32_000) : '',
+      tool_calls: parseToolCalls(message.tool_calls),
+    },
+    streamed,
+  }
+}
+function parseNdjsonText(text: string, onDelta?: (text: string) => void): AdvisorRuntimeChatResult {
+  let content = ''
+  const toolCalls: Array<Record<string, unknown>> = []
+  let malformed = 0
+  let chunks = 0
+  for (const line of text.split(/\r?\n/).filter(Boolean)) {
+    chunks += 1
+    if (chunks > MAX_STREAM_CHUNKS) throw new Error('Local runtime stream exceeded the chunk limit.')
+    try {
+      const value = JSON.parse(line) as unknown
+      if (!value || typeof value !== 'object') throw new Error('not an object')
+      const message = (value as { message?: unknown }).message
+      if (!message || typeof message !== 'object') continue
+      const row = message as Record<string, unknown>
+      if (typeof row.content === 'string') {
+        content += row.content
+        if (content.length > 32_000) throw new Error('Local runtime message exceeded the content limit.')
+        onDelta?.(content)
+      }
+      const calls = parseToolCalls(row.tool_calls)
+      if (calls.length) toolCalls.push(...calls)
+    } catch {
+      malformed += 1
+      if (malformed > MAX_MALFORMED_CHUNKS) throw new Error('Local runtime stream contained too many malformed chunks.')
+    }
+  }
+  return { message: { content, tool_calls: toolCalls.slice(0, 16) }, streamed: true }
+}
+async function streamNdjsonResponse(response: Response, onDelta?: (text: string) => void): Promise<AdvisorRuntimeChatResult> {
+  const reader = response.body?.getReader()
+  if (!reader) return parseNdjsonText(await boundedText(response), onDelta)
+  const decoder = new TextDecoder()
+  let pending = ''
+  let bytes = 0
+  let chunks = 0
+  let malformed = 0
+  let content = ''
+  const toolCalls: Array<Record<string, unknown>> = []
+  const consume = (line: string) => {
+    if (!line.trim()) return
+    chunks += 1
+    if (chunks > MAX_STREAM_CHUNKS) throw new Error('Local runtime stream exceeded the chunk limit.')
+    try {
+      const value = JSON.parse(line) as unknown
+      if (!value || typeof value !== 'object') throw new Error('not an object')
+      const message = (value as { message?: unknown }).message
+      if (!message || typeof message !== 'object') return
+      const row = message as Record<string, unknown>
+      if (typeof row.content === 'string') {
+        content += row.content
+        if (content.length > 32_000) throw new Error('Local runtime message exceeded the content limit.')
+        onDelta?.(content)
+      }
+      const calls = parseToolCalls(row.tool_calls)
+      if (calls.length) toolCalls.push(...calls)
+    } catch {
+      malformed += 1
+      if (malformed > MAX_MALFORMED_CHUNKS) throw new Error('Local runtime stream contained too many malformed chunks.')
+    }
+  }
+  while (true) {
+    const part = await reader.read()
+    if (part.done) break
+    bytes += part.value.byteLength
+    if (bytes > MAX_RESPONSE_BYTES) throw new Error('Local runtime response exceeded the safety limit.')
+    pending += decoder.decode(part.value, { stream: true })
+    const lines = pending.split(/\r?\n/)
+    pending = lines.pop() ?? ''
+    for (const line of lines) consume(line)
+  }
+  pending += decoder.decode()
+  consume(pending)
+  return { message: { content, tool_calls: toolCalls.slice(0, 16) }, streamed: true }
+}
+async function chatOnce(fetchImpl: FetchLike, payload: AdvisorRuntimeChatPayload, parent?: AbortSignal, onDelta?: (text: string) => void): Promise<AdvisorRuntimeChatResult> {
+  const timed = timeoutSignal(parent, CHAT_TIMEOUT_MS)
+  try {
+    const response = await fetchImpl(LOOPBACK_ENDPOINT + '/api/chat', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+      signal: timed.signal,
+    })
+    if (!response.ok) throw new Error('Local runtime returned HTTP ' + response.status + '.')
+    if (payload.stream) return streamNdjsonResponse(response, onDelta)
+    const text = await boundedText(response)
+    const value = JSON.parse(text) as unknown
+    if (!value || typeof value !== 'object') throw new Error('Local runtime returned invalid JSON.')
+    return messageResult(value as Record<string, unknown>, false)
+  } finally { timed.dispose() }
+}
+export async function chatOllamaMain(fetchImpl: FetchLike, payload: AdvisorRuntimeChatPayload, parent?: AbortSignal, onDelta?: (text: string) => void): Promise<AdvisorRuntimeChatResult> {
+  if (!fetchImpl) throw new Error('Node fetch is unavailable.')
+  if (!payload || !validModel(payload.model)) throw new Error('Local runtime model is invalid.')
+  if (!Array.isArray(payload.messages) || !Array.isArray(payload.tools) || payload.messages.length > 32 || payload.tools.length > 12) throw new Error('Local runtime request exceeded the safety limit.')
+  const encoded = JSON.stringify(payload)
+  if (encoded.length > MAX_RESPONSE_BYTES) throw new Error('Local runtime request exceeded the safety limit.')
+  return chatOnce(fetchImpl, { ...payload, stream: Boolean(payload.stream) }, parent, onDelta)
+}
+function validRequestId(value: unknown): value is string {
+  return typeof value === 'string' && /^[A-Za-z0-9._:-]{1,128}$/.test(value)
+}
+export function createAdvisorRuntimeHandlers(fetchImpl: FetchLike = fetch): Record<string, (...args: any[]) => Promise<{ ok: true; value: unknown } | { ok: false; error: { kind: string; message: string } }>> {
+  const flights = new Map<string, AbortController>()
+  const fail = (error: unknown, kind = 'runtime') => ({ ok: false as const, error: { kind, message: boundedError(error).message } })
+  return {
+    'metrora:advisorProbe': async () => {
+      try { return { ok: true, value: await probeOllamaMain(fetchImpl) } } catch (error) { return fail(error) }
+    },
+    'metrora:advisorChat': async (requestId: string, payload: AdvisorRuntimeChatPayload, onDelta?: (text: string) => void) => {
+      if (!validRequestId(requestId)) return fail(new Error('Advisor request id is invalid.'), 'validation')
+      const controller = new AbortController()
+      flights.set(requestId, controller)
+      try {
+        const value = await chatOllamaMain(fetchImpl, payload, controller.signal, typeof onDelta === 'function' ? onDelta : undefined)
+        return { ok: true, value }
+      } catch (error) {
+        return controller.signal.aborted ? fail(new Error('Advisor request cancelled.'), 'cancelled') : fail(error)
+      } finally { flights.delete(requestId) }
+    },
+    'metrora:advisorCancel': async (requestId: string) => {
+      if (!validRequestId(requestId)) return { ok: false as const, error: { kind: 'validation', message: 'Advisor request id is invalid.' } }
+      const controller = flights.get(requestId)
+      controller?.abort()
+      return { ok: true, value: Boolean(controller) }
+    },
+  }
+}

--- a/app/electron/advisor-runtime.ts
+++ b/app/electron/advisor-runtime.ts
@@ -31,7 +31,11 @@ function timeoutSignal(parent?: AbortSignal, timeoutMs = CHAT_TIMEOUT_MS): { sig
 }
 async function boundedText(response: Response): Promise<string> {
   const reader = response.body?.getReader()
-  if (!reader) return (await response.text()).slice(0, MAX_RESPONSE_BYTES)
+  if (!reader) {
+    const text = await response.text()
+    if (new TextEncoder().encode(text).byteLength > MAX_RESPONSE_BYTES) throw new Error('Local runtime response exceeded the safety limit.')
+    return text
+  }
   const decoder = new TextDecoder()
   let bytes = 0
   let text = ''
@@ -89,23 +93,27 @@ function parseNdjsonText(text: string, onDelta?: (text: string) => void): Adviso
   for (const line of text.split(/\r?\n/).filter(Boolean)) {
     chunks += 1
     if (chunks > MAX_STREAM_CHUNKS) throw new Error('Local runtime stream exceeded the chunk limit.')
-    try {
-      const value = JSON.parse(line) as unknown
-      if (!value || typeof value !== 'object') throw new Error('not an object')
-      const message = (value as { message?: unknown }).message
-      if (!message || typeof message !== 'object') continue
-      const row = message as Record<string, unknown>
-      if (typeof row.content === 'string') {
-        content += row.content
-        if (content.length > 32_000) throw new Error('Local runtime message exceeded the content limit.')
-        onDelta?.(content)
-      }
-      const calls = parseToolCalls(row.tool_calls)
-      if (calls.length) toolCalls.push(...calls)
-    } catch {
+    let value: unknown
+    try { value = JSON.parse(line) as unknown } catch {
       malformed += 1
       if (malformed > MAX_MALFORMED_CHUNKS) throw new Error('Local runtime stream contained too many malformed chunks.')
+      continue
     }
+    if (!value || typeof value !== 'object') {
+      malformed += 1
+      if (malformed > MAX_MALFORMED_CHUNKS) throw new Error('Local runtime stream contained too many malformed chunks.')
+      continue
+    }
+    const message = (value as { message?: unknown }).message
+    if (!message || typeof message !== 'object') continue
+    const row = message as Record<string, unknown>
+    if (typeof row.content === 'string') {
+      content += row.content
+      if (content.length > 32_000) throw new Error('Local runtime message exceeded the content limit.')
+      onDelta?.(content)
+    }
+    const calls = parseToolCalls(row.tool_calls)
+    if (calls.length) toolCalls.push(...calls)
   }
   return { message: { content, tool_calls: toolCalls.slice(0, 16) }, streamed: true }
 }
@@ -123,23 +131,27 @@ async function streamNdjsonResponse(response: Response, onDelta?: (text: string)
     if (!line.trim()) return
     chunks += 1
     if (chunks > MAX_STREAM_CHUNKS) throw new Error('Local runtime stream exceeded the chunk limit.')
-    try {
-      const value = JSON.parse(line) as unknown
-      if (!value || typeof value !== 'object') throw new Error('not an object')
-      const message = (value as { message?: unknown }).message
-      if (!message || typeof message !== 'object') return
-      const row = message as Record<string, unknown>
-      if (typeof row.content === 'string') {
-        content += row.content
-        if (content.length > 32_000) throw new Error('Local runtime message exceeded the content limit.')
-        onDelta?.(content)
-      }
-      const calls = parseToolCalls(row.tool_calls)
-      if (calls.length) toolCalls.push(...calls)
-    } catch {
+    let value: unknown
+    try { value = JSON.parse(line) as unknown } catch {
       malformed += 1
       if (malformed > MAX_MALFORMED_CHUNKS) throw new Error('Local runtime stream contained too many malformed chunks.')
+      return
     }
+    if (!value || typeof value !== 'object') {
+      malformed += 1
+      if (malformed > MAX_MALFORMED_CHUNKS) throw new Error('Local runtime stream contained too many malformed chunks.')
+      return
+    }
+    const message = (value as { message?: unknown }).message
+    if (!message || typeof message !== 'object') return
+    const row = message as Record<string, unknown>
+    if (typeof row.content === 'string') {
+      content += row.content
+      if (content.length > 32_000) throw new Error('Local runtime message exceeded the content limit.')
+      onDelta?.(content)
+    }
+    const calls = parseToolCalls(row.tool_calls)
+    if (calls.length) toolCalls.push(...calls)
   }
   while (true) {
     const part = await reader.read()

--- a/app/electron/main.test.ts
+++ b/app/electron/main.test.ts
@@ -79,6 +79,9 @@ const CHANNELS = [
   'metrora:telemetryOnboarded',
   'metrora:telemetryTrack',
   'metrora:getUpdateStatus',
+  'metrora:advisorProbe',
+  'metrora:advisorChat',
+  'metrora:advisorCancel',
 ] as const
 
 const ARGV_CASES: Array<{ channel: string; args: unknown[]; argv: string[] }> = [

--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -10,6 +10,7 @@ import { initializeDesktopShareRuntime, stopDesktopShareRuntime, type DesktopSha
 import { Telemetry } from './telemetry'
 import { createUpdateChecker, type UpdateChecker, type UpdateStatus } from './updates'
 import { createProjectBridgeHandlers, validateProjectScope } from './project-bridge'
+import { createAdvisorRuntimeHandlers } from './advisor-runtime'
 
 export { createApplicationMenuTemplate } from './menu'
 
@@ -327,6 +328,7 @@ export function createBridgeHandlers(deps: Deps = { spawnCli, spawnCliAction, re
     },
     'metrora:getOverview': getOverview,
     ...createProjectBridgeHandlers({ spawnCli: deps.spawnCli, spawnCliAction: deps.spawnCliAction, snapshotEnv }),
+    ...createAdvisorRuntimeHandlers(),
     'metrora:getPlans': run((period: string) => ['status', '--format', 'json', '--period', vPeriod(period)]),
     'metrora:getActReport': run(() => ['act', 'report', '--json']),
     'metrora:getModels': run((period: string, provider: string, byTask: boolean, range?: DateRange, projectScopeId?: string | null) => [
@@ -426,7 +428,15 @@ function registerHandlers(): void {
   })
   for (const [channel, handler] of Object.entries(handlers)) {
     for (const alias of ipcChannelAliases(channel)) {
-      ipcMain.handle(alias, (_event, ...args) => handler(...args))
+      ipcMain.handle(alias, (event, ...args) => {
+        if (channel === 'metrora:advisorChat') {
+          const requestId = typeof args[0] === 'string' ? args[0] : ''
+          return handler(...args, (text: string) => {
+            try { event.sender.send('metrora:advisorDelta', { requestId, text }) } catch { /* window closed */ }
+          })
+        }
+        return handler(...args)
+      })
     }
   }
   const chooseDirectory = async () => {

--- a/app/electron/preload.ts
+++ b/app/electron/preload.ts
@@ -17,6 +17,9 @@ async function invoke<T>(channel: string, ...args: unknown[]): Promise<T> {
 // immediately, while old windows/integrations can keep using window.metrora.
 const bridge = {
   getQuota: (force?: boolean) => invoke('metrora:getQuota', force),
+  advisorProbe: () => invoke('metrora:advisorProbe'),
+  advisorChat: (requestId: string, payload: Record<string, unknown>) => invoke('metrora:advisorChat', requestId, payload),
+  advisorCancel: (requestId: string) => invoke('metrora:advisorCancel', requestId),
   getOverview: (period: string, provider: string, range?: DateRange, configSource?: string | null, background?: boolean, fresh?: boolean, projectScopeId?: string | null) => invoke('metrora:getOverview', period, provider, range, configSource, background, fresh, projectScopeId),
   getProjects: () => invoke('metrora:getProjects'),
   createProject: (name: string, icon?: string, color?: string) => invoke('metrora:createProject', name, icon, color),
@@ -85,6 +88,11 @@ const bridge = {
     const listener = (_event: unknown, status: unknown) => cb(status)
     ipcRenderer.on('metrora:update', listener)
     return () => { ipcRenderer.removeListener('metrora:update', listener) }
+  },
+  onAdvisorDelta: (cb: (event: { requestId: string; text: string }) => void) => {
+    const listener = (_event: unknown, event: { requestId: string; text: string }) => cb(event)
+    ipcRenderer.on('metrora:advisorDelta', listener)
+    return () => { ipcRenderer.removeListener('metrora:advisorDelta', listener) }
   },
   platform: process.platform,
   arch: process.arch,

--- a/app/renderer/App.tsx
+++ b/app/renderer/App.tsx
@@ -33,6 +33,7 @@ import { Plans } from './sections/Plans'
 import { Settings, type SettingsPane } from './sections/Settings'
 import { SpendContent } from './sections/Spend'
 import { WorkspaceContent } from './sections/Workspace'
+import { Advisor } from './sections/Advisor'
 import type { MenubarPayload } from './lib/types'
 
 export { overviewMemoKey } from './hooks/useProviderPrefetch'
@@ -144,9 +145,11 @@ function AppMain() {
       <div className="ct">
         <div className={overview.switching ? 'switch-line on' : 'switch-line'} aria-hidden="true" />
         <UpdateBanner />
-        <DailyBudgetBanner payload={overview.data ?? null} provider={provider} />
+        {section !== 'advisor' && <DailyBudgetBanner payload={overview.data ?? null} provider={provider} />}
         <ErrorBoundary key={section}>
-        {section === 'plans' ? (
+        {section === 'advisor' ? (
+          <Advisor period={period} provider={provider} projectScopeId={metroraProjectId} range={customRange} overview={overview} detectedProviders={detectedProviders} />
+        ) : section === 'plans' ? (
           <Plans period={period} refreshToken={refreshToken} onNavigate={navigate} ready={ready} />
         ) : section === 'settings' ? (
           <Settings period={period} refreshToken={refreshToken} onNavigate={navigate} initialPane={settingsPane} claudeConfigs={claudeConfigs} claudeConfigSource={claudeConfigSource} onConfigMutated={onConfigMutated} />
@@ -205,7 +208,7 @@ function AppMain() {
           </>
         )}
         </ErrorBoundary>
-        {section !== 'settings' && (
+        {section !== 'settings' && section !== 'advisor' && (
           <Hint
             items={[
               { k: shortcutRangeLabel('1', '8'), label: 'Navigate' },

--- a/app/renderer/advisor/evidence.test.ts
+++ b/app/renderer/advisor/evidence.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import type { MenubarPayload } from '../lib/types'
 import type { QuotaProvider } from '../../electron/quota/types'
-import { buildModelEfficiencyEvidence, buildQuotaEvidence, buildSpendEvidence } from './evidence'
+import { buildModelEfficiencyEvidence, buildQuotaEvidence, buildSpendEvidence, classifyAdvisorQuestion } from './evidence'
 import type { AdvisorScope } from './types'
 
 const scope: AdvisorScope = { period: 'week', range: null, provider: 'all', projectId: 'all', projectName: 'All projects', model: null }
@@ -36,6 +36,29 @@ function quota(provider: 'claude' | 'codex', freshness: 'fresh' | 'stale' | 'una
 }
 
 describe('Advisor evidence truth contract', () => {
+  it.each([
+    'Why did spend increase?',
+    'What caused the spike?',
+    'Which Project drove spend?',
+    'Which sessions were unusually expensive?',
+    'Which model drove the spend increase?',
+    'What changed versus the selected period?',
+  ])('routes spend/change investigation to measured spend evidence: %s', question => {
+    expect(classifyAdvisorQuestion(question)).toBe('spend-change')
+  })
+
+  it.each([
+    'Which model has lower observed cost per call?',
+    'Which model is cheaper per observed call?',
+    'Compare observed model cost efficiency.',
+  ])('routes explicit model efficiency questions to model evidence: %s', question => {
+    expect(classifyAdvisorQuestion(question)).toBe('model-efficiency')
+  })
+
+  it('does not let a generic model mention override a spend/change driver question', () => {
+    expect(classifyAdvisorQuestion('Which model drove the spend increase?')).toBe('spend-change')
+  })
+
   it('keeps missing spend totals unavailable instead of inventing zeroes', () => {
     const evidence = buildSpendEvidence('missing totals', scope, emptyOverview)
     expect(evidence.coverage.level).toBe('unavailable')

--- a/app/renderer/advisor/evidence.test.ts
+++ b/app/renderer/advisor/evidence.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import type { MenubarPayload } from '../lib/types'
 import type { QuotaProvider } from '../../electron/quota/types'
-import { buildQuotaEvidence, buildSpendEvidence } from './evidence'
+import { buildModelEfficiencyEvidence, buildQuotaEvidence, buildSpendEvidence } from './evidence'
 import type { AdvisorScope } from './types'
 
 const scope: AdvisorScope = { period: 'week', range: null, provider: 'all', projectId: 'all', projectName: 'All projects', model: null }
@@ -65,5 +65,36 @@ describe('Advisor evidence truth contract', () => {
     const evidence = buildQuotaEvidence('quota', scope, null, [quota('codex', 'stale', 'available')])
     expect(evidence.coverage.level).toBe('unavailable')
     expect(evidence.quota?.providers[0]).toMatchObject({ planLabel: null, windows: [], creditsUSD: null })
+  })
+
+  it.each(['degraded', 'targeted'] as const)('downgrades otherwise-high spend coverage for %s source reconciliation', reconciliation => {
+    const payload = {
+      ...emptyOverview,
+      freshness: { readMode: 'snapshot', reconciliation, durableThrough: '2026-08-22' },
+      current: { ...emptyOverview.current, cost: 12, calls: 3, sessions: 2, pricingCoverage: 1 },
+    } as unknown as MenubarPayload
+    const evidence = buildSpendEvidence('spend', scope, payload)
+    expect(evidence.coverage.level).toBe('partial')
+    expect(evidence.coverage.label.toLowerCase()).toContain(reconciliation)
+    expect(evidence.unknown.some(item => item.toLowerCase().includes('reconciliation'))).toBe(true)
+  })
+
+  it('does not publish fallback Overview cost-per-call as authoritative model efficiency', () => {
+    const payload = {
+      ...emptyOverview,
+      current: { ...emptyOverview.current, cost: 12, calls: 3, sessions: 2, pricingCoverage: 1, topModels: [{ name: 'fallback-model', cost: 12, calls: 3 }] },
+    } as unknown as MenubarPayload
+    const evidence = buildModelEfficiencyEvidence('model efficiency', scope, payload, [])
+    expect(evidence.coverage.level).toBe('partial')
+    expect(evidence.modelEfficiency?.rows[0]).toMatchObject({ model: 'fallback-model', pricingState: 'unknown', costPerCallUSD: null })
+  })
+
+  it('preserves provider observation timestamps instead of synthesizing newer freshness', () => {
+    const older = quota('codex', 'stale', 'unavailable')
+    older.observedAt = '2026-08-22T08:00:00Z'
+    const newer = quota('claude', 'fresh', 'available')
+    newer.observedAt = '2026-08-23T12:00:00Z'
+    const evidence = buildQuotaEvidence('quota', scope, null, [older, newer])
+    expect(evidence.quota?.providers.map(item => item.observedAt)).toEqual(['2026-08-22T08:00:00Z', '2026-08-23T12:00:00Z'])
   })
 })

--- a/app/renderer/advisor/evidence.test.ts
+++ b/app/renderer/advisor/evidence.test.ts
@@ -97,4 +97,13 @@ describe('Advisor evidence truth contract', () => {
     const evidence = buildQuotaEvidence('quota', scope, null, [older, newer])
     expect(evidence.quota?.providers.map(item => item.observedAt)).toEqual(['2026-08-22T08:00:00Z', '2026-08-23T12:00:00Z'])
   })
+
+  it('does not expose global measured totals as model-scoped quota context', () => {
+    const payload = {
+      ...emptyOverview,
+      current: { ...emptyOverview.current, cost: 99, calls: 77, sessions: 2, pricingCoverage: 1 },
+    } as unknown as MenubarPayload
+    const evidence = buildQuotaEvidence('quota', { ...scope, model: 'gpt-safe' }, payload, [quota('codex', 'fresh', 'available')])
+    expect(evidence.quota).toMatchObject({ measuredSpendUSD: null, measuredCalls: null })
+  })
 })

--- a/app/renderer/advisor/evidence.test.ts
+++ b/app/renderer/advisor/evidence.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest'
+
+import type { MenubarPayload } from '../lib/types'
+import type { QuotaProvider } from '../../electron/quota/types'
+import { buildQuotaEvidence, buildSpendEvidence } from './evidence'
+import type { AdvisorScope } from './types'
+
+const scope: AdvisorScope = { period: 'week', range: null, provider: 'all', projectId: 'all', projectName: 'All projects', model: null }
+const emptyOverview = {
+  current: {
+    cost: undefined,
+    calls: undefined,
+    sessions: undefined,
+    pricingCoverage: undefined,
+    topModels: [],
+    topProjects: [],
+    topSessions: [],
+  },
+  history: { daily: [] },
+} as unknown as MenubarPayload
+
+function quota(provider: 'claude' | 'codex', freshness: 'fresh' | 'stale' | 'unavailable', availability: 'available' | 'unavailable'): QuotaProvider {
+  return {
+    schemaVersion: 1,
+    provider,
+    authority: 'provider-reported',
+    availability,
+    connection: freshness === 'stale' ? 'stale' : availability === 'available' ? 'connected' : 'terminalFailure',
+    freshness,
+    observedAt: '2026-08-23T12:00:00Z',
+    planLabel: 'Pro',
+    windows: [{ id: 'window', label: '5-hour window', usedFraction: 0.2, resetsAt: '2026-08-23T15:00:00Z', windowSeconds: 18_000 }],
+    credits: { balance: 0, currency: 'USD' },
+    rateLimit: { state: 'clear', retryAt: null },
+  }
+}
+
+describe('Advisor evidence truth contract', () => {
+  it('keeps missing spend totals unavailable instead of inventing zeroes', () => {
+    const evidence = buildSpendEvidence('missing totals', scope, emptyOverview)
+    expect(evidence.coverage.level).toBe('unavailable')
+    expect(evidence.spend?.measuredCostUSD).toBeNull()
+    expect(evidence.spend?.calls).toBeNull()
+    expect(evidence.spend?.sessions).toBeNull()
+  })
+
+  it('marks mixed provider freshness partial even when one provider is fresh', () => {
+    const evidence = buildQuotaEvidence('quota', scope, null, [
+      quota('claude', 'fresh', 'available'),
+      quota('codex', 'stale', 'unavailable'),
+    ])
+    expect(evidence.coverage.level).toBe('partial')
+    expect(evidence.coverage.label).toBe('Mixed provider quota freshness')
+    expect(evidence.quota?.providers[1]?.windows).toHaveLength(1)
+    expect(evidence.quota?.providers[1]?.creditsUSD).toBe(0)
+  })
+
+  it('hides plan, windows, and credits when provider availability is unavailable', () => {
+    const evidence = buildQuotaEvidence('quota', scope, null, [quota('codex', 'fresh', 'unavailable')])
+    expect(evidence.coverage.level).toBe('unavailable')
+    expect(evidence.quota?.providers[0]).toMatchObject({ planLabel: null, windows: [], creditsUSD: null })
+  })
+
+  it('does not retain stale facts when availability contradicts the canonical stale state', () => {
+    const evidence = buildQuotaEvidence('quota', scope, null, [quota('codex', 'stale', 'available')])
+    expect(evidence.coverage.level).toBe('unavailable')
+    expect(evidence.quota?.providers[0]).toMatchObject({ planLabel: null, windows: [], creditsUSD: null })
+  })
+})

--- a/app/renderer/advisor/evidence.ts
+++ b/app/renderer/advisor/evidence.ts
@@ -1,0 +1,274 @@
+import { formatUsd } from '../lib/format'
+import type { MenubarPayload, ModelReportRow, Period, QuotaProvider } from '../lib/types'
+import type {
+  AdvisorCoverage,
+  AdvisorEvidence,
+  AdvisorEvidenceRef,
+  AdvisorIntent,
+  AdvisorModelEvidenceRow,
+  AdvisorQuotaProvider,
+  AdvisorQuotaWindow,
+  AdvisorScope,
+  AdvisorSpendDriver,
+  AdvisorTrend,
+} from './types'
+
+const PERIOD_LABELS: Record<Period, string> = {
+  today: 'Today',
+  week: 'Last 7 days',
+  '30days': 'Last 30 days',
+  month: 'This month',
+  all: 'Last 6 months',
+  lifetime: 'Lifetime',
+}
+const USD_CREDITS = new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD', maximumFractionDigits: 2 })
+
+function finite(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value)
+}
+function clamp(value: number): number {
+  return Math.min(1, Math.max(0, value))
+}
+export function formatAdvisorUsd(value: number): string {
+  return finite(value) ? formatUsd(value) : 'unavailable'
+}
+export function formatAdvisorCreditsUsd(value: number): string {
+  return finite(value) ? USD_CREDITS.format(value) : 'unavailable'
+}
+export function formatAdvisorPercent(value: number): string {
+  return finite(value) ? Math.round(value * 100) + '%' : 'unavailable'
+}
+export function periodLabel(scope: Pick<AdvisorScope, 'period' | 'range'>): string {
+  if (!scope.range) return PERIOD_LABELS[scope.period]
+  const from = new Date(scope.range.from + 'T12:00:00')
+  const to = new Date(scope.range.to + 'T12:00:00')
+  if (Number.isNaN(from.getTime()) || Number.isNaN(to.getTime())) return 'Selected date range'
+  const left = from.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
+  const right = to.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: from.getFullYear() === to.getFullYear() ? undefined : 'numeric' })
+  return left === right ? left : left + ' – ' + right
+}
+export function scopeLabel(scope: AdvisorScope): string {
+  const parts = [periodLabel(scope), scope.projectName || 'All projects', scope.provider === 'all' ? 'All providers' : scope.provider]
+  if (scope.model) parts.push(scope.model)
+  return parts.join(' · ')
+}
+function normalize(question: string): string {
+  return question.normalize('NFD').replace(/[\u0300-\u036f]/g, '').toLowerCase().trim()
+}
+export function classifyAdvisorQuestion(question: string): AdvisorIntent {
+  const value = normalize(question)
+  if (/(quota|capacity|limit|reset|remaining|exhaust|rate.?limit|credit|disponibil|limite|esaur)/.test(value)) return 'quota-capacity'
+  if (/(model|efficient|efficien|cheaper|cheap|expensive|cost per|per call|retry|retries|econom|modello)/.test(value)) return 'model-efficiency'
+  if (/(spend|cost|spent|increase|increas|change|changed|spike|driver|cause|why|costo|spesa|aument|picco|perche|perché)/.test(value)) return 'spend-change'
+  return 'unknown'
+}
+function modelDrivers(data: MenubarPayload): AdvisorSpendDriver[] {
+  return data.current.topModels.filter(row => finite(row.cost) && finite(row.calls) && row.name).slice(0, 5).map(row => ({ name: row.name, costUSD: row.cost, calls: row.calls }))
+}
+function projectDrivers(data: MenubarPayload): AdvisorSpendDriver[] {
+  return data.current.topProjects.filter(row => finite(row.cost) && finite(row.sessions) && row.name).slice(0, 5).map(row => ({ name: row.name, costUSD: row.cost, calls: row.sessions }))
+}
+function sessionDrivers(data: MenubarPayload): AdvisorSpendDriver[] {
+  return data.current.topSessions.filter(row => finite(row.cost) && finite(row.calls) && row.cost > 0).slice(0, 5).map((row, index) => ({ name: row.project || 'Session ' + (index + 1), costUSD: row.cost, calls: row.calls }))
+}
+function trendFromHistory(data: MenubarPayload): AdvisorTrend | null {
+  const history = data.history.daily.filter(row => typeof row.date === 'string' && finite(row.cost)).sort((a, b) => a.date.localeCompare(b.date))
+  if (history.length < 2) return null
+  const latest = history[history.length - 1]!
+  const earlier = history.slice(0, -1)
+  const comparisonCostUSD = earlier.reduce((sum, row) => sum + row.cost, 0) / earlier.length
+  const deltaUSD = latest.cost - comparisonCostUSD
+  return {
+    direction: Math.abs(deltaUSD) < 0.005 ? 'flat' : deltaUSD > 0 ? 'up' : 'down',
+    latestCostUSD: latest.cost,
+    comparisonCostUSD,
+    deltaUSD,
+    deltaPercent: comparisonCostUSD > 0 ? deltaUSD / comparisonCostUSD : null,
+    latestDate: latest.date,
+    comparisonLabel: 'average of ' + earlier.length + ' earlier day' + (earlier.length === 1 ? '' : 's'),
+  }
+}
+function spendCoverage(data: MenubarPayload): AdvisorCoverage {
+  const hasCalls = finite(data.current.calls) && data.current.calls > 0
+  const hasCost = finite(data.current.cost) && data.current.cost > 0
+  if (!hasCalls && !hasCost) return { level: 'unavailable', label: 'No measured usage', detail: 'The selected scope has no measured spend or calls.' }
+  const coverage = finite(data.current.pricingCoverage)
+    ? clamp(data.current.pricingCoverage)
+    : data.current.modelAccounting && finite(data.current.modelAccounting.coverage.cost)
+      ? clamp(data.current.modelAccounting.coverage.cost)
+      : null
+  if (coverage === null) return { level: 'partial', label: 'Measured, coverage not reported', detail: 'Metrora reported totals, but complete pricing/accounting coverage is not exposed.' }
+  return coverage >= 0.95
+    ? { level: 'high', label: formatAdvisorPercent(coverage) + ' priced coverage', detail: 'The canonical payload reports near-complete pricing coverage.' }
+    : { level: 'partial', label: formatAdvisorPercent(coverage) + ' priced coverage', detail: 'Some cost-bearing calls lack complete pricing/accounting detail.' }
+}
+export function buildSpendEvidence(question: string, scope: AdvisorScope, data: MenubarPayload): AdvisorEvidence {
+  const models = modelDrivers(data).filter(row => !scope.model || row.name === scope.model)
+  const projects = projectDrivers(data).filter(row => scope.projectId === 'all' || row.name === scope.projectName)
+  const sessions = sessionDrivers(data)
+  const trend = trendFromHistory(data)
+  const refs: AdvisorEvidenceRef[] = [{ id: 'overview.current', label: 'Measured spend and call totals', source: 'overview' }]
+  if (data.history.daily.length) refs.push({ id: 'overview.history.daily', label: 'Daily spend history', source: 'history' })
+  if (models.length) refs.push({ id: 'overview.models', label: 'Top model spend breakdown', source: 'overview' })
+  if (projects.length) refs.push({ id: 'overview.projects', label: 'Top project spend breakdown', source: 'overview' })
+  if (sessions.length) refs.push({ id: 'overview.sessions', label: 'Highest-cost session summaries', source: 'overview' })
+  const coverage = spendCoverage(data)
+  return {
+    intent: 'spend-change',
+    question,
+    scope,
+    refs,
+    coverage,
+    assumptions: [
+      'Spend and calls are Metrora-measured usage, separate from provider quota balances.',
+      'Drivers are descriptive rankings from the canonical payload, not causal proof.',
+    ],
+    unknown: [
+      ...(trend ? [] : ['A reliable latest-day comparison is unavailable in the returned history.']),
+      ...(models.length || projects.length || sessions.length ? [] : ['No driver breakdown is available for this scope.']),
+      ...(coverage.level === 'high' ? [] : ['Some cost-bearing usage may lack complete pricing or model attribution.']),
+    ],
+    nextInvestigations: ['Compare the highest-cost models for the same Project and period.', 'Inspect detailed sessions around the latest high-cost day.'],
+    spend: {
+      measuredCostUSD: finite(data.current.cost) ? data.current.cost : null,
+      calls: finite(data.current.calls) ? data.current.calls : null,
+      sessions: finite(data.current.sessions) ? data.current.sessions : null,
+      models,
+      projects,
+      sessionsByCost: sessions,
+      trend,
+      pricingCoverage: finite(data.current.pricingCoverage) ? clamp(data.current.pricingCoverage) : null,
+    },
+  }
+}
+function pricingState(row: ModelReportRow): AdvisorModelEvidenceRow['pricingState'] {
+  const state = row.pricing?.state
+  if (state === 'priced' || state === 'explicit-zero') return 'priced'
+  if (state === 'partial') return 'partial'
+  if (state === 'unavailable') return 'unavailable'
+  return 'unknown'
+}
+function fallbackModels(data: MenubarPayload, scope: AdvisorScope): AdvisorModelEvidenceRow[] {
+  return data.current.topModels.filter(row => finite(row.cost) && finite(row.calls) && (!scope.model || row.name === scope.model)).map(row => ({
+    model: row.name,
+    provider: scope.provider,
+    calls: row.calls,
+    costUSD: row.cost,
+    outputTokens: null,
+    costPerCallUSD: row.calls > 0 ? row.cost / row.calls : null,
+    pricingState: 'unknown' as const,
+  }))
+}
+export function buildModelEfficiencyEvidence(question: string, scope: AdvisorScope, data: MenubarPayload, rows: ModelReportRow[]): AdvisorEvidence {
+  const filtered = rows.filter(row => !scope.model || row.model === scope.model)
+    .filter(row => scope.provider === 'all' || row.provider === scope.provider || row.providerDisplayName.toLowerCase() === scope.provider.toLowerCase())
+    .filter(row => row.model && finite(row.costUSD) && finite(row.calls))
+  const canonicalRows: AdvisorModelEvidenceRow[] = filtered.length
+    ? filtered.map(row => ({
+        model: row.model,
+        provider: row.provider,
+        calls: row.calls,
+        costUSD: row.costUSD,
+        outputTokens: finite(row.outputTokens) ? row.outputTokens : null,
+        costPerCallUSD: row.calls > 0 ? row.costUSD / row.calls : null,
+        pricingState: pricingState(row),
+      }))
+    : fallbackModels(data, scope)
+  canonicalRows.sort((a, b) => (a.costPerCallUSD ?? Number.POSITIVE_INFINITY) - (b.costPerCallUSD ?? Number.POSITIVE_INFINITY))
+  const rowsLimited = canonicalRows.slice(0, 12)
+  const coverage: AdvisorCoverage = !rowsLimited.length
+    ? { level: 'unavailable', label: 'Model detail unavailable', detail: 'No model rows were returned for this scope.' }
+    : rowsLimited.some(row => row.pricingState !== 'priced')
+      ? { level: 'partial', label: 'Partial model coverage', detail: 'One or more rows lack complete pricing or route detail.' }
+      : { level: 'high', label: 'Model rows available', detail: 'The selected scope returned canonical model usage rows.' }
+  return {
+    intent: 'model-efficiency',
+    question,
+    scope,
+    refs: [{ id: 'models.report', label: filtered.length ? 'Canonical model usage report' : 'Canonical Overview model rollup', source: filtered.length ? 'models' : 'overview' }],
+    coverage,
+    assumptions: [
+      'Efficiency is represented as observed cost per call; comparable work and outcome quality are not available here.',
+      'Rows use canonical Metrora pricing/accounting output and are not recalculated from raw tokens.',
+    ],
+    unknown: [
+      ...(rowsLimited.length > 1 ? ['Calls are not normalized for task complexity, output quality, or prompt size.'] : ['A multi-model comparison is unavailable in this scope.']),
+      ...(coverage.level === 'high' ? [] : ['Some model pricing or attribution is incomplete.']),
+    ],
+    nextInvestigations: ['Compare these models inside the same Project and task mix.', 'Open detailed sessions to inspect retries and one-shot outcomes.'],
+    modelEfficiency: { rows: rowsLimited, selectedModel: scope.model, comparableWorkWarning: rowsLimited.length > 1 },
+  }
+}
+function quotaWindow(window: QuotaProvider['windows'][number]): AdvisorQuotaWindow {
+  const usedPercent = Math.round(clamp(window.usedFraction) * 100)
+  return { id: window.id, label: window.label, usedPercent, remainingPercent: 100 - usedPercent, resetsAt: window.resetsAt }
+}
+function quotaProvider(quota: QuotaProvider): AdvisorQuotaProvider {
+  const observed = typeof quota.observedAt === 'string' && Number.isFinite(Date.parse(quota.observedAt))
+  const freshFactual = quota.freshness === 'fresh' && quota.availability === 'available' && quota.connection === 'connected' && observed
+  const staleFactual = quota.freshness === 'stale'
+    && quota.availability === 'unavailable'
+    && observed
+    && (quota.connection === 'stale' || quota.connection === 'transientFailure')
+  const factual = freshFactual || staleFactual
+  return {
+    provider: quota.provider,
+    planLabel: factual ? quota.planLabel : null,
+    availability: quota.availability,
+    connection: quota.connection,
+    freshness: quota.freshness,
+    observedAt: quota.observedAt,
+    windows: factual ? quota.windows.map(quotaWindow) : [],
+    creditsUSD: factual && quota.credits ? quota.credits.balance : null,
+  }
+}
+function quotaCoverage(providers: AdvisorQuotaProvider[]): AdvisorCoverage {
+  if (!providers.length) return { level: 'unavailable', label: 'Provider quota unavailable', detail: 'No matching provider quota snapshot was returned.' }
+  const hasFacts = (row: AdvisorQuotaProvider) => row.windows.length > 0 || row.planLabel !== null || row.creditsUSD !== null
+  const factual = providers.filter(hasFacts)
+  const fresh = factual.filter(row => row.freshness === 'fresh' && row.availability === 'available' && typeof row.observedAt === 'string' && Number.isFinite(Date.parse(row.observedAt))).length
+  const stale = factual.filter(row => row.freshness === 'stale' && typeof row.observedAt === 'string' && Number.isFinite(Date.parse(row.observedAt))).length
+  if (factual.length === providers.length && fresh === providers.length) return { level: 'high', label: 'Fresh provider-reported quota', detail: 'Every matching provider returned a fresh factual snapshot.' }
+  if (fresh || stale) return { level: 'partial', label: fresh ? 'Mixed provider quota freshness' : 'Last provider snapshot is stale', detail: fresh ? 'Some matching providers are fresh while another is stale or unavailable.' : 'Values are retained from the last observation; the refresh did not produce a fresh provider response.' }
+  return { level: 'unavailable', label: 'Provider quota unavailable', detail: 'The provider did not return usable quota facts.' }
+}
+export function buildQuotaEvidence(question: string, scope: AdvisorScope, data: MenubarPayload | null, quota: QuotaProvider[]): AdvisorEvidence {
+  const matching = scope.provider === 'all' ? quota : quota.filter(row => row.provider === scope.provider)
+  const providers = matching.map(quotaProvider)
+  const refs: AdvisorEvidenceRef[] = providers.map(row => ({ id: 'quota.' + row.provider, label: (row.provider === 'claude' ? 'Claude' : 'Codex') + ' provider quota snapshot', source: 'quota' }))
+  if (data) refs.push({ id: 'overview.current', label: 'Metrora-measured usage context', source: 'overview' })
+  const coverage = quotaCoverage(providers)
+  return {
+    intent: 'quota-capacity',
+    question,
+    scope,
+    refs,
+    coverage,
+    assumptions: [
+      'Quota percentages, reset timestamps, and credits are shown only when the provider reports them.',
+      'A stale snapshot keeps its last observed values and is labeled stale; unavailable snapshots show no quota numbers.',
+    ],
+    unknown: [
+      ...(coverage.level === 'high' ? [] : ['A fresh provider quota response is unavailable for every matching provider.']),
+      'Metrora usage and provider quota use different authorities and are not combined into a burn-rate forecast.',
+    ],
+    nextInvestigations: ['Refresh the provider connection if the snapshot is stale or unavailable.', 'Review Metrora usage separately in Spend before drawing capacity conclusions.'],
+    quota: {
+      providers,
+      measuredSpendUSD: data && finite(data.current.cost) ? data.current.cost : null,
+      measuredCalls: data && finite(data.current.calls) ? data.current.calls : null,
+    },
+  }
+}
+export function buildUnknownEvidence(question: string, scope: AdvisorScope): AdvisorEvidence {
+  return {
+    intent: 'unknown',
+    question,
+    scope,
+    refs: [],
+    coverage: { level: 'unavailable', label: 'Question outside this foundation', detail: 'Advisor currently answers spend, model efficiency, and provider quota questions.' },
+    assumptions: [],
+    unknown: ['No deterministic Metrora evidence tool is mapped to this question yet.'],
+    nextInvestigations: ['Ask about a spend change or cost driver.', 'Ask which model has the lowest observed cost per call.', 'Ask what provider quota remains or when it resets.'],
+  }
+}

--- a/app/renderer/advisor/evidence.ts
+++ b/app/renderer/advisor/evidence.ts
@@ -102,17 +102,49 @@ function spendCoverage(data: MenubarPayload): AdvisorCoverage {
     ? { level: 'high', label: formatAdvisorPercent(coverage) + ' priced coverage', detail: 'The canonical payload reports near-complete pricing coverage.' }
     : { level: 'partial', label: formatAdvisorPercent(coverage) + ' priced coverage', detail: 'Some cost-bearing calls lack complete pricing/accounting detail.' }
 }
+function reconciliationCoverage(data: MenubarPayload, coverage: AdvisorCoverage): AdvisorCoverage {
+  const state = data.freshness?.reconciliation
+  if ((state !== 'degraded' && state !== 'targeted') || coverage.level !== 'high') return coverage
+  return {
+    level: 'partial',
+    label: state === 'degraded' ? 'Degraded source reconciliation' : 'Targeted source reconciliation',
+    detail: state === 'degraded'
+      ? 'Canonical last-good data is usable, but source reconciliation is incomplete.'
+      : 'Only the requested reconciliation slice is current; evidence outside that slice may be incomplete.',
+  }
+}
+function reconciliationUnknown(data: MenubarPayload): string[] {
+  if (data.freshness?.reconciliation === 'degraded') return ['Source reconciliation is degraded; newly changed source data may be missing.']
+  if (data.freshness?.reconciliation === 'targeted') return ['Source reconciliation was targeted; data outside the requested slice may be incomplete.']
+  return []
+}
 export function buildSpendEvidence(question: string, scope: AdvisorScope, data: MenubarPayload): AdvisorEvidence {
-  const models = modelDrivers(data).filter(row => !scope.model || row.name === scope.model)
-  const projects = projectDrivers(data).filter(row => scope.projectId === 'all' || row.name === scope.projectName)
-  const sessions = sessionDrivers(data)
-  const trend = trendFromHistory(data)
-  const refs: AdvisorEvidenceRef[] = [{ id: 'overview.current', label: 'Measured spend and call totals', source: 'overview' }]
-  if (data.history.daily.length) refs.push({ id: 'overview.history.daily', label: 'Daily spend history', source: 'history' })
-  if (models.length) refs.push({ id: 'overview.models', label: 'Top model spend breakdown', source: 'overview' })
+  const modelScoped = Boolean(scope.model)
+  const accountingRows = modelScoped
+    ? (data.current.modelAccounting?.rows ?? []).filter(row => row.name === scope.model && finite(row.cost) && finite(row.calls))
+    : []
+  const selectedModel = accountingRows.length ? {
+    name: scope.model!,
+    costUSD: accountingRows.reduce((sum, row) => sum + row.cost, 0),
+    calls: accountingRows.reduce((sum, row) => sum + row.calls, 0),
+  } : null
+  const models = modelScoped ? (selectedModel ? [selectedModel] : []) : modelDrivers(data)
+  const projects = modelScoped ? [] : projectDrivers(data).filter(row => scope.projectId === 'all' || row.name === scope.projectName)
+  const sessions = modelScoped ? [] : sessionDrivers(data)
+  const trend = modelScoped ? null : trendFromHistory(data)
+  const refs: AdvisorEvidenceRef[] = modelScoped
+    ? (selectedModel ? [{ id: 'overview.modelAccounting', label: 'Canonical model accounting row', source: 'overview' }] : [])
+    : [{ id: 'overview.current', label: 'Measured spend and call totals', source: 'overview' }]
+  if (!modelScoped && data.history.daily.length) refs.push({ id: 'overview.history.daily', label: 'Daily spend history', source: 'history' })
+  if (!modelScoped && models.length) refs.push({ id: 'overview.models', label: 'Top model spend breakdown', source: 'overview' })
   if (projects.length) refs.push({ id: 'overview.projects', label: 'Top project spend breakdown', source: 'overview' })
   if (sessions.length) refs.push({ id: 'overview.sessions', label: 'Highest-cost session summaries', source: 'overview' })
-  const coverage = spendCoverage(data)
+  const baseCoverage: AdvisorCoverage = modelScoped
+    ? selectedModel
+      ? { level: 'partial', label: 'Model-scoped accounting available', detail: 'Canonical model cost and calls are available; model-specific sessions and daily history are not.' }
+      : { level: 'unavailable', label: 'Model-scoped spend unavailable', detail: 'The Overview payload has no canonical accounting row for the requested model.' }
+    : spendCoverage(data)
+  const coverage = reconciliationCoverage(data, baseCoverage)
   return {
     intent: 'spend-change',
     question,
@@ -124,20 +156,21 @@ export function buildSpendEvidence(question: string, scope: AdvisorScope, data: 
       'Drivers are descriptive rankings from the canonical payload, not causal proof.',
     ],
     unknown: [
-      ...(trend ? [] : ['A reliable latest-day comparison is unavailable in the returned history.']),
+      ...reconciliationUnknown(data),
+      ...(trend ? [] : [modelScoped ? 'Model-specific daily history is unavailable in the returned payload.' : 'A reliable latest-day comparison is unavailable in the returned history.']),
       ...(models.length || projects.length || sessions.length ? [] : ['No driver breakdown is available for this scope.']),
       ...(coverage.level === 'high' ? [] : ['Some cost-bearing usage may lack complete pricing or model attribution.']),
     ],
     nextInvestigations: ['Compare the highest-cost models for the same Project and period.', 'Inspect detailed sessions around the latest high-cost day.'],
     spend: {
-      measuredCostUSD: finite(data.current.cost) ? data.current.cost : null,
-      calls: finite(data.current.calls) ? data.current.calls : null,
-      sessions: finite(data.current.sessions) ? data.current.sessions : null,
+      measuredCostUSD: modelScoped ? selectedModel?.costUSD ?? null : finite(data.current.cost) ? data.current.cost : null,
+      calls: modelScoped ? selectedModel?.calls ?? null : finite(data.current.calls) ? data.current.calls : null,
+      sessions: modelScoped ? null : finite(data.current.sessions) ? data.current.sessions : null,
       models,
       projects,
       sessionsByCost: sessions,
       trend,
-      pricingCoverage: finite(data.current.pricingCoverage) ? clamp(data.current.pricingCoverage) : null,
+      pricingCoverage: modelScoped ? null : finite(data.current.pricingCoverage) ? clamp(data.current.pricingCoverage) : null,
     },
   }
 }
@@ -155,7 +188,7 @@ function fallbackModels(data: MenubarPayload, scope: AdvisorScope): AdvisorModel
     calls: row.calls,
     costUSD: row.cost,
     outputTokens: null,
-    costPerCallUSD: row.calls > 0 ? row.cost / row.calls : null,
+    costPerCallUSD: null,
     pricingState: 'unknown' as const,
   }))
 }
@@ -170,17 +203,18 @@ export function buildModelEfficiencyEvidence(question: string, scope: AdvisorSco
         calls: row.calls,
         costUSD: row.costUSD,
         outputTokens: finite(row.outputTokens) ? row.outputTokens : null,
-        costPerCallUSD: row.calls > 0 ? row.costUSD / row.calls : null,
+        costPerCallUSD: pricingState(row) === 'priced' && row.calls > 0 ? row.costUSD / row.calls : null,
         pricingState: pricingState(row),
       }))
     : fallbackModels(data, scope)
   canonicalRows.sort((a, b) => (a.costPerCallUSD ?? Number.POSITIVE_INFINITY) - (b.costPerCallUSD ?? Number.POSITIVE_INFINITY))
   const rowsLimited = canonicalRows.slice(0, 12)
-  const coverage: AdvisorCoverage = !rowsLimited.length
+  const modelCoverage: AdvisorCoverage = !rowsLimited.length
     ? { level: 'unavailable', label: 'Model detail unavailable', detail: 'No model rows were returned for this scope.' }
     : rowsLimited.some(row => row.pricingState !== 'priced')
       ? { level: 'partial', label: 'Partial model coverage', detail: 'One or more rows lack complete pricing or route detail.' }
       : { level: 'high', label: 'Model rows available', detail: 'The selected scope returned canonical model usage rows.' }
+  const coverage = reconciliationCoverage(data, modelCoverage)
   return {
     intent: 'model-efficiency',
     question,
@@ -192,6 +226,7 @@ export function buildModelEfficiencyEvidence(question: string, scope: AdvisorSco
       'Rows use canonical Metrora pricing/accounting output and are not recalculated from raw tokens.',
     ],
     unknown: [
+      ...reconciliationUnknown(data),
       ...(rowsLimited.length > 1 ? ['Calls are not normalized for task complexity, output quality, or prompt size.'] : ['A multi-model comparison is unavailable in this scope.']),
       ...(coverage.level === 'high' ? [] : ['Some model pricing or attribution is incomplete.']),
     ],
@@ -249,6 +284,7 @@ export function buildQuotaEvidence(question: string, scope: AdvisorScope, data: 
       'A stale snapshot keeps its last observed values and is labeled stale; unavailable snapshots show no quota numbers.',
     ],
     unknown: [
+      ...(data ? reconciliationUnknown(data) : []),
       ...(coverage.level === 'high' ? [] : ['A fresh provider quota response is unavailable for every matching provider.']),
       'Metrora usage and provider quota use different authorities and are not combined into a burn-rate forecast.',
     ],

--- a/app/renderer/advisor/evidence.ts
+++ b/app/renderer/advisor/evidence.ts
@@ -291,8 +291,8 @@ export function buildQuotaEvidence(question: string, scope: AdvisorScope, data: 
     nextInvestigations: ['Refresh the provider connection if the snapshot is stale or unavailable.', 'Review Metrora usage separately in Spend before drawing capacity conclusions.'],
     quota: {
       providers,
-      measuredSpendUSD: data && finite(data.current.cost) ? data.current.cost : null,
-      measuredCalls: data && finite(data.current.calls) ? data.current.calls : null,
+      measuredSpendUSD: !scope.model && data && finite(data.current.cost) ? data.current.cost : null,
+      measuredCalls: !scope.model && data && finite(data.current.calls) ? data.current.calls : null,
     },
   }
 }

--- a/app/renderer/advisor/evidence.ts
+++ b/app/renderer/advisor/evidence.ts
@@ -58,8 +58,8 @@ function normalize(question: string): string {
 export function classifyAdvisorQuestion(question: string): AdvisorIntent {
   const value = normalize(question)
   if (/(quota|capacity|limit|reset|remaining|exhaust|rate.?limit|credit|disponibil|limite|esaur)/.test(value)) return 'quota-capacity'
-  if (/(model|efficient|efficien|cheaper|cheap|expensive|cost per|per call|retry|retries|econom|modello)/.test(value)) return 'model-efficiency'
-  if (/(spend|cost|spent|increase|increas|change|changed|spike|driver|cause|why|costo|spesa|aument|picco|perche|perché)/.test(value)) return 'spend-change'
+  if (/(why did|what caused|cause|driver|drove|spend|spent|increase|increas|change|changed|spike|which project|which sessions?|unusually expensive|expensive sessions?|versus|vs\b|costo|spesa|aument|picco|perche|perché)/.test(value)) return 'spend-change'
+  if (/(model efficiency|lower observed cost per call|cheaper per observed call|cost per call|per observed call|which model.*(?:lower|cheaper)|compare.*model.*(?:cost|efficien)|efficien|efficient|econom|modello)/.test(value)) return 'model-efficiency'
   return 'unknown'
 }
 function modelDrivers(data: MenubarPayload): AdvisorSpendDriver[] {

--- a/app/renderer/advisor/kernel.test.ts
+++ b/app/renderer/advisor/kernel.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import type { MenubarPayload } from '../lib/types'
+import { createAdvisorKernel } from './kernel'
+import { DeterministicAdvisorRuntime } from './runtime'
+import type { AdvisorDataSource, AdvisorModelRuntime, AdvisorRuntimeInput, AdvisorScope } from './types'
+
+const scope: AdvisorScope = { period: 'week', range: null, provider: 'all', projectId: 'all', projectName: 'All projects', model: null }
+const measured = {
+  current: { cost: 12, calls: 3, sessions: 2, pricingCoverage: 1, topModels: [], topProjects: [], topSessions: [] },
+  history: { daily: [] },
+} as unknown as MenubarPayload
+
+function source(): AdvisorDataSource {
+  return { getOverview: vi.fn(async () => measured), getModels: vi.fn(async () => []), getQuota: vi.fn(async () => []) }
+}
+function capturingRuntime(inputs: AdvisorRuntimeInput[]): AdvisorModelRuntime {
+  return {
+    id: 'capture', label: 'capture', mode: 'ollama-local', providerSupport: [],
+    generate: async input => {
+      inputs.push(input)
+      return new DeterministicAdvisorRuntime().generate(input)
+    },
+  }
+}
+
+describe('Advisor evidence prefetch', () => {
+  it('prefetches deterministic evidence for a recognized intent before an Ollama runtime can return without tools', async () => {
+    const data = source()
+    const inputs: AdvisorRuntimeInput[] = []
+    await createAdvisorKernel(data, capturingRuntime(inputs)).investigate({ question: 'What changed in spend?', scope })
+
+    expect(data.getOverview).toHaveBeenCalledWith(scope)
+    expect(inputs[0]?.evidence).toMatchObject({ intent: 'spend-change', coverage: { level: 'high' }, spend: { measuredCostUSD: 12 } })
+  })
+
+  it('does not fetch or manufacture evidence for an unrecognized no-tool question', async () => {
+    const data = source()
+    const inputs: AdvisorRuntimeInput[] = []
+    await createAdvisorKernel(data, capturingRuntime(inputs)).investigate({ question: 'Tell me a joke', scope })
+
+    expect(data.getOverview).not.toHaveBeenCalled()
+    expect(inputs[0]?.evidence).toMatchObject({ intent: 'unknown', coverage: { level: 'unavailable' }, refs: [] })
+  })
+})

--- a/app/renderer/advisor/kernel.ts
+++ b/app/renderer/advisor/kernel.ts
@@ -30,15 +30,14 @@ export function createAdvisorKernel(source: AdvisorDataSource, runtime: AdvisorM
     async investigate({ question, scope, overview: suppliedOverview = null, conversation = [], signal, onToolEvent, onDelta }) {
       throwIfAborted(signal)
       const toolRegistry = createAdvisorToolRegistry(source, scope, suppliedOverview)
-      if (runtime.mode !== 'ollama-local') {
-        const intent = classifyAdvisorQuestion(question)
-        if (intent === 'unknown') return runtime.generate({ question, evidence: buildUnknownEvidence(question, scope), conversation, tools: toolRegistry.definitions, executeTool: toolRegistry.execute, onToolEvent, onDelta }, signal)
+      const intent = classifyAdvisorQuestion(question)
+      let evidence = buildUnknownEvidence(question, scope)
+      if (intent !== 'unknown') {
         const overview = suppliedOverview ?? await source.getOverview(scope)
         throwIfAborted(signal)
-        const evidence = await deterministicEvidence(source, intent, question, scope, overview, signal)
-        return runtime.generate({ question, evidence, conversation, tools: toolRegistry.definitions, executeTool: toolRegistry.execute, onToolEvent, onDelta }, signal)
+        evidence = await deterministicEvidence(source, intent, question, scope, overview, signal)
       }
-      return runtime.generate({ question, evidence: buildUnknownEvidence(question, scope), conversation, tools: toolRegistry.definitions, executeTool: toolRegistry.execute, onToolEvent, onDelta }, signal)
+      return runtime.generate({ question, evidence, conversation, tools: toolRegistry.definitions, executeTool: toolRegistry.execute, onToolEvent, onDelta }, signal)
     },
   }
 }

--- a/app/renderer/advisor/kernel.ts
+++ b/app/renderer/advisor/kernel.ts
@@ -1,0 +1,44 @@
+import { buildModelEfficiencyEvidence, buildQuotaEvidence, buildSpendEvidence, buildUnknownEvidence, classifyAdvisorQuestion } from './evidence'
+import { createAdvisorToolRegistry } from './tools'
+import type { MenubarPayload, ModelReportRow, QuotaProvider } from '../lib/types'
+import type { AdvisorAnswer, AdvisorConversationTurn, AdvisorDataSource, AdvisorEvidence, AdvisorModelRuntime, AdvisorScope } from './types'
+
+export class AdvisorCancelledError extends Error {
+  constructor() { super('Advisor investigation cancelled'); this.name = 'AdvisorCancelledError' }
+}
+function throwIfAborted(signal?: AbortSignal): void {
+  if (signal?.aborted) throw new AdvisorCancelledError()
+}
+export type AdvisorKernel = {
+  investigate(input: { question: string; scope: AdvisorScope; overview?: MenubarPayload | null; conversation?: AdvisorConversationTurn[]; signal?: AbortSignal; onToolEvent?: (event: { name: string; status: 'started' | 'completed' }) => void; onDelta?: (text: string) => void }): Promise<AdvisorAnswer>
+}
+async function deterministicEvidence(source: AdvisorDataSource, intent: ReturnType<typeof classifyAdvisorQuestion>, question: string, scope: AdvisorScope, overview: MenubarPayload, signal?: AbortSignal): Promise<AdvisorEvidence> {
+  if (intent === 'spend-change') return buildSpendEvidence(question, scope, overview)
+  if (intent === 'model-efficiency') {
+    let rows: ModelReportRow[] = []
+    try { rows = await source.getModels(scope) } catch { /* Overview fallback. */ }
+    throwIfAborted(signal)
+    return buildModelEfficiencyEvidence(question, scope, overview, rows)
+  }
+  let quota: QuotaProvider[] = []
+  try { quota = await source.getQuota() } catch { /* unavailable != zero */ }
+  throwIfAborted(signal)
+  return buildQuotaEvidence(question, scope, overview, quota)
+}
+export function createAdvisorKernel(source: AdvisorDataSource, runtime: AdvisorModelRuntime): AdvisorKernel {
+  return {
+    async investigate({ question, scope, overview: suppliedOverview = null, conversation = [], signal, onToolEvent, onDelta }) {
+      throwIfAborted(signal)
+      const toolRegistry = createAdvisorToolRegistry(source, scope, suppliedOverview)
+      if (runtime.mode !== 'ollama-local') {
+        const intent = classifyAdvisorQuestion(question)
+        if (intent === 'unknown') return runtime.generate({ question, evidence: buildUnknownEvidence(question, scope), conversation, tools: toolRegistry.definitions, executeTool: toolRegistry.execute, onToolEvent, onDelta }, signal)
+        const overview = suppliedOverview ?? await source.getOverview(scope)
+        throwIfAborted(signal)
+        const evidence = await deterministicEvidence(source, intent, question, scope, overview, signal)
+        return runtime.generate({ question, evidence, conversation, tools: toolRegistry.definitions, executeTool: toolRegistry.execute, onToolEvent, onDelta }, signal)
+      }
+      return runtime.generate({ question, evidence: buildUnknownEvidence(question, scope), conversation, tools: toolRegistry.definitions, executeTool: toolRegistry.execute, onToolEvent, onDelta }, signal)
+    },
+  }
+}

--- a/app/renderer/advisor/ollama.test.ts
+++ b/app/renderer/advisor/ollama.test.ts
@@ -1,0 +1,126 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest'
+
+import { OllamaAdvisorRuntime, type OllamaTransport } from './ollama'
+import type { AdvisorEvidence, AdvisorScope } from './types'
+
+const scope: AdvisorScope = {
+  period: 'week',
+  range: null,
+  provider: 'all',
+  projectId: 'all',
+  projectName: 'All projects',
+  model: null,
+}
+const spendEvidence: AdvisorEvidence = {
+  intent: 'spend-change',
+  question: 'spend',
+  scope,
+  refs: [{ id: 'spend', label: 'Measured spend and call totals', source: 'overview' }],
+  coverage: { level: 'high', label: 'High coverage', detail: 'Measured.' },
+  assumptions: [],
+  unknown: [],
+  nextInvestigations: [],
+  spend: {
+    measuredCostUSD: 12,
+    calls: 3,
+    sessions: 2,
+    models: [{ name: 'GPT-5.6', costUSD: 12, calls: 3 }],
+    projects: [],
+    sessionsByCost: [],
+    trend: null,
+    pricingCoverage: 1,
+  },
+}
+const quotaEvidence: AdvisorEvidence = {
+  intent: 'quota-capacity',
+  question: 'quota',
+  scope,
+  refs: [{ id: 'quota', label: 'Provider-reported quota snapshot', source: 'quota' }],
+  coverage: { level: 'high', label: 'High coverage', detail: 'Provider reported.' },
+  assumptions: [],
+  unknown: [],
+  nextInvestigations: [],
+  quota: {
+    providers: [{
+      provider: 'claude',
+      planLabel: 'Pro',
+      availability: 'available',
+      connection: 'connected',
+      freshness: 'fresh',
+      observedAt: '2026-08-23T12:00:00Z',
+      windows: [{ id: 'w1', label: '5-hour window', usedPercent: 20, remainingPercent: 80, resetsAt: '2026-08-23T15:00:00Z' }],
+      creditsUSD: 0,
+    }],
+    measuredSpendUSD: 12,
+    measuredCalls: 3,
+  },
+}
+function transportFor(events: string[], calls: Array<Record<string, unknown>[]>): OllamaTransport {
+  let listener: ((event: { requestId: string; text: string }) => void) | null = null
+  let index = 0
+  return {
+    probe: async () => ({ available: true, models: ['llama3.2'], detail: 'Local Ollama is reachable.' }),
+    cancel: async () => true,
+    onDelta: callback => {
+      listener = callback
+      return () => { listener = null }
+    },
+    chat: async (requestId, payload) => {
+      const current = index++
+      if (current === 0) {
+        listener?.({ requestId, text: 'Planning 99 calls' })
+        return { streamed: false, message: { content: '', tool_calls: calls[0] } }
+      }
+      listener?.({ requestId, text: 'The observed pattern is worth investigating further.' })
+      events.push(JSON.stringify({ model: payload.model, tools: payload.tools, stream: payload.stream }))
+      return { streamed: true, message: { content: 'The observed pattern is worth investigating further.' } }
+    },
+  }
+}
+describe('Ollama Advisor renderer state machine', () => {
+  it('runs one tool-planning request, one streamed final request, and retains all evidence domains', async () => {
+    const events: string[] = []
+    const transport = transportFor(events, [[
+      { function: { name: 'get_spend_snapshot', arguments: '{}' } },
+      { function: { name: 'get_quota_snapshot', arguments: '{}' } },
+    ]])
+    const runtime = new OllamaAdvisorRuntime({ model: 'llama3.2', transport })
+    const deltas: string[] = []
+    const answer = await runtime.generate({
+      question: 'What changed and what quota remains?',
+      evidence: spendEvidence,
+      tools: [{
+        type: 'function',
+        function: { name: 'get_spend_snapshot', description: 'spend', parameters: { type: 'object' } },
+      }, {
+        type: 'function',
+        function: { name: 'get_quota_snapshot', description: 'quota', parameters: { type: 'object' } },
+      }],
+      executeTool: async name => ({ content: name === 'get_spend_snapshot' ? 'spend' : 'quota', evidence: name === 'get_spend_snapshot' ? spendEvidence : quotaEvidence }),
+      onDelta: text => deltas.push(text),
+    })
+
+    expect(JSON.parse(events[0]!).stream).toBe(true)
+    expect(JSON.parse(events[0]!).tools).toEqual([])
+    expect(answer.generatedByModel).toBe(true)
+    expect(answer.streamed).toBe(true)
+    expect(answer.evidence.map(ref => ref.id)).toEqual(['spend', 'quota'])
+    expect(answer.details.some(detail => detail.includes('provider credits remaining'))).toBe(true)
+    expect(answer.conclusion).toContain('Metrora measured')
+    expect(answer.conclusion).not.toContain('99 calls')
+    expect(answer.conclusion).toContain('Local model context')
+    expect(deltas).toEqual(['The observed pattern is worth investigating further.'])
+  })
+
+  it('keeps model identifiers while rejecting an unverified numeric model claim', async () => {
+    const transport = transportFor([], [[]])
+    const answer = await new OllamaAdvisorRuntime({ model: 'llama3.2', transport }).generate({
+      question: 'Which model should I inspect?',
+      evidence: spendEvidence,
+      tools: [],
+      onDelta: () => {},
+    })
+    expect(answer.conclusion).toContain('GPT-5.6')
+  })
+})

--- a/app/renderer/advisor/ollama.test.ts
+++ b/app/renderer/advisor/ollama.test.ts
@@ -2,7 +2,7 @@
 import { describe, expect, it } from 'vitest'
 
 import { OllamaAdvisorRuntime, type OllamaTransport } from './ollama'
-import type { AdvisorEvidence, AdvisorScope } from './types'
+import { advisorScopeFingerprint, type AdvisorEvidence, type AdvisorScope } from './types'
 
 const scope: AdvisorScope = {
   period: 'week',
@@ -87,6 +87,38 @@ function noToolTransport(content: string): OllamaTransport {
   }
 }
 describe('Ollama Advisor renderer state machine', () => {
+  it('sends only same-scope conversation context to the local model', async () => {
+    const requests: Array<Record<string, unknown>> = []
+    const currentFingerprint = advisorScopeFingerprint(scope)
+    const otherFingerprint = advisorScopeFingerprint({ ...scope, provider: 'codex' })
+    const transport: OllamaTransport = {
+      probe: async () => ({ available: true, models: ['llama3.2'], detail: 'ready' }),
+      cancel: async () => true,
+      onDelta: () => () => {},
+      chat: async (_requestId, payload) => {
+        requests.push(payload)
+        return { streamed: false, message: { content: 'done', tool_calls: [] } }
+      },
+    }
+
+    await new OllamaAdvisorRuntime({ model: 'llama3.2', transport }).generate({
+      question: 'Follow up',
+      evidence: spendEvidence,
+      conversation: [
+        { role: 'user', content: 'same scope', scopeFingerprint: currentFingerprint },
+        { role: 'assistant', content: 'same factual answer', scopeFingerprint: currentFingerprint },
+        { role: 'assistant', content: 'different factual answer', scopeFingerprint: otherFingerprint },
+      ],
+      tools: [],
+    })
+
+    const contents = (requests[0]?.messages as Array<{ content: string }>).map(message => message.content)
+    expect(contents).toContain('same factual answer')
+    expect(contents).toContain('Follow up')
+    expect(contents.some(content => content.includes('same scope'))).toBe(true)
+    expect(contents).not.toContain('different factual answer')
+  })
+
   it('runs one tool-planning request, one streamed final request, and retains all evidence domains', async () => {
     const events: string[] = []
     const transport = transportFor(events, [[

--- a/app/renderer/advisor/ollama.test.ts
+++ b/app/renderer/advisor/ollama.test.ts
@@ -56,7 +56,7 @@ const quotaEvidence: AdvisorEvidence = {
     measuredCalls: 3,
   },
 }
-function transportFor(events: string[], calls: Array<Record<string, unknown>[]>): OllamaTransport {
+function transportFor(events: string[], calls: Array<Record<string, unknown>[]>, finalContent = 'The observed pattern is worth investigating further.', finalDelta = finalContent): OllamaTransport {
   let listener: ((event: { requestId: string; text: string }) => void) | null = null
   let index = 0
   return {
@@ -72,10 +72,18 @@ function transportFor(events: string[], calls: Array<Record<string, unknown>[]>)
         listener?.({ requestId, text: 'Planning 99 calls' })
         return { streamed: false, message: { content: '', tool_calls: calls[0] } }
       }
-      listener?.({ requestId, text: 'The observed pattern is worth investigating further.' })
+      listener?.({ requestId, text: finalDelta })
       events.push(JSON.stringify({ model: payload.model, tools: payload.tools, stream: payload.stream }))
-      return { streamed: true, message: { content: 'The observed pattern is worth investigating further.' } }
+      return { streamed: true, message: { content: finalContent } }
     },
+  }
+}
+function noToolTransport(content: string): OllamaTransport {
+  return {
+    probe: async () => ({ available: true, models: ['llama3.2'], detail: 'ready' }),
+    cancel: async () => true,
+    onDelta: () => () => {},
+    chat: async () => ({ streamed: false, message: { content, tool_calls: [] } }),
   }
 }
 describe('Ollama Advisor renderer state machine', () => {
@@ -122,5 +130,90 @@ describe('Ollama Advisor renderer state machine', () => {
       onDelta: () => {},
     })
     expect(answer.conclusion).toContain('GPT-5.6')
+  })
+
+  it.each(['Spend rose by 12.', 'The scope contains 12 calls.'])(
+    'suppresses the entire model narrative when it contains an unverified numeric token: %s',
+    async narrative => {
+      const transport = transportFor([], [[{ function: { name: 'get_spend_snapshot', arguments: '{}' } }]], narrative, narrative)
+      const answer = await new OllamaAdvisorRuntime({ model: 'llama3.2', transport }).generate({
+        question: 'What changed in spend?',
+        evidence: spendEvidence,
+        tools: [{ type: 'function', function: { name: 'get_spend_snapshot', description: 'spend', parameters: { type: 'object' } } }],
+        executeTool: async () => ({ content: 'spend', evidence: spendEvidence }),
+      })
+      expect(answer.conclusion).not.toContain('Local model context')
+      expect(answer.conclusion).not.toContain(narrative)
+    },
+  )
+
+  it('suppresses qualitative no-tool context even when recognized evidence was prefetched', async () => {
+    const narrative = 'The observed pattern deserves a closer look.'
+    const answer = await new OllamaAdvisorRuntime({ model: 'llama3.2', transport: noToolTransport(narrative) }).generate({
+      question: 'What changed in spend?', evidence: spendEvidence, tools: [],
+    })
+    expect(answer.conclusion).not.toContain(narrative)
+    expect(answer.conclusion).not.toContain('Local model context')
+  })
+
+  it('does not expose numeric streamed deltas before final narrative validation', async () => {
+    const deltas: string[] = []
+    const transport = transportFor([], [[{ function: { name: 'get_spend_snapshot', arguments: '{}' } }]], 'A qualitative observation.', 'Planning found 99 calls.')
+    await new OllamaAdvisorRuntime({ model: 'llama3.2', transport }).generate({
+      question: 'What changed in spend?', evidence: spendEvidence,
+      tools: [{ type: 'function', function: { name: 'get_spend_snapshot', description: 'spend', parameters: { type: 'object' } } }],
+      executeTool: async () => ({ content: 'spend', evidence: spendEvidence }),
+      onDelta: text => deltas.push(text),
+    })
+    expect(deltas).toEqual([])
+  })
+
+  it('suppresses no-tool model narrative when the question has no valid mapped evidence', async () => {
+    const unknown: AdvisorEvidence = {
+      ...spendEvidence,
+      intent: 'unknown',
+      refs: [],
+      coverage: { level: 'unavailable', label: 'Unavailable', detail: 'No mapped evidence.' },
+      spend: undefined,
+    }
+    const narrative = 'Trust me, this is definitely the cause.'
+    const answer = await new OllamaAdvisorRuntime({ model: 'llama3.2', transport: noToolTransport(narrative) }).generate({
+      question: 'Tell me a joke', evidence: unknown, tools: [],
+    })
+    expect(answer.conclusion).not.toContain(narrative)
+    expect(answer.conclusion).not.toContain('Local model context')
+  })
+
+  it.each([
+    ['claude', 'codex'],
+    ['codex', 'claude'],
+  ])('rejects mixed-scope tool evidence without cross-scope contamination (%s then %s)', async (first, second) => {
+    const finalRequests: string[] = []
+    const transport = transportFor(finalRequests, [[
+      { function: { name: 'get_spend_snapshot', arguments: { provider: first } } },
+      { function: { name: 'get_spend_snapshot', arguments: { provider: second } } },
+    ]])
+    const answer = await new OllamaAdvisorRuntime({ model: 'llama3.2', transport }).generate({
+      question: 'Compare spend',
+      evidence: spendEvidence,
+      tools: [{ type: 'function', function: { name: 'get_spend_snapshot', description: 'spend', parameters: { type: 'object' } } }],
+      executeTool: async (_name, args) => {
+        const provider = String(args.provider)
+        const evidence: AdvisorEvidence = {
+          ...spendEvidence,
+          scope: { ...scope, provider },
+          refs: [{ id: 'spend-' + provider, label: provider + ' spend', source: 'overview' }],
+          spend: { ...spendEvidence.spend!, measuredCostUSD: provider === 'claude' ? 41 : 73 },
+        }
+        return { content: provider, evidence }
+      },
+    })
+
+    expect(answer.coverage).toMatchObject({ level: 'unavailable', label: 'Conflicting evidence scopes' })
+    expect(answer.evidence).toEqual([])
+    expect(answer.scopeLabel).toContain('All providers')
+    expect(answer.conclusion).not.toMatch(/41|73|claude spend|codex spend/i)
+    expect(answer.details.join(' ')).not.toMatch(/41|73|claude spend|codex spend/i)
+    expect(finalRequests).toEqual([])
   })
 })

--- a/app/renderer/advisor/ollama.ts
+++ b/app/renderer/advisor/ollama.ts
@@ -49,12 +49,8 @@ function extractNarrative(value: string): string {
 }
 function sanitizeNarrative(value: string): string {
   const original = extractNarrative(value)
-  const text = original
-    .replace(/(?:[$€£]\s*)\d[\d,.]*(?:\s*(?:USD|EUR|GBP))?/gi, 'the verified amount')
-    .replace(/\b\d[\d,.]*\s*%/g, 'the verified share')
-    .replace(/\b\d{4}-\d{2}-\d{2}(?:T[0-9:.+-]+Z?)?\b/g, 'the verified date')
-    .trim()
-  if (/\b(?:calls?|sessions?|projects?|models?|credits?|tokens?|remaining|used|cost|spend|quota)\b/i.test(original) && /(?:^|[\s,(])(?:[$€£]\s*)?\d[\d,.]*(?:\s*(?:%|USD|EUR|GBP|calls?|sessions?|projects?|models?|credits?|tokens?))?\b/i.test(original)) return ''
+  if (/\d/.test(original)) return ''
+  const text = original.trim()
   return text.length > 800 ? text.slice(0, 797) + '…' : text
 }
 function systemPrompt(): string {
@@ -67,7 +63,31 @@ function systemPrompt(): string {
     'If the question is outside Metrora, explain the boundary briefly and suggest a supported investigation.',
   ].join(' ')
 }
-function mergeEvidence(items: AdvisorEvidence[]): AdvisorEvidence {
+function sameEvidenceScope(left: AdvisorEvidence['scope'], right: AdvisorEvidence['scope']): boolean {
+  return left.period === right.period
+    && left.provider === right.provider
+    && left.projectId === right.projectId
+    && left.projectName === right.projectName
+    && left.model === right.model
+    && left.range?.from === right.range?.from
+    && left.range?.to === right.range?.to
+}
+function hasMixedEvidenceScopes(items: AdvisorEvidence[]): boolean {
+  return items.length > 1 && items.some(item => !sameEvidenceScope(item.scope, items[0]!.scope))
+}
+function mergeEvidence(items: AdvisorEvidence[], fallback: AdvisorEvidence): AdvisorEvidence {
+  if (hasMixedEvidenceScopes(items)) {
+    return {
+      intent: 'unknown',
+      question: fallback.question,
+      scope: fallback.scope,
+      refs: [],
+      coverage: { level: 'unavailable', label: 'Conflicting evidence scopes', detail: 'Tool evidence from different scopes was rejected instead of being combined.' },
+      assumptions: [],
+      unknown: ['The local model requested evidence from different scopes; no cross-scope facts were combined.'],
+      nextInvestigations: ['Repeat the investigation with one explicit period, Project, provider, and model scope.'],
+    }
+  }
   const last = items[items.length - 1]!
   const usable = items.filter(item => item.coverage.level !== 'unavailable')
   const level: AdvisorCoverageLevel = items.length > 0 && items.every(item => item.coverage.level === 'high')
@@ -147,9 +167,9 @@ export class OllamaAdvisorRuntime implements AdvisorModelRuntime {
     const evidences: AdvisorEvidence[] = []
     let finalContent = ''
     let streamed = false
-    let allowDelta = !(input.tools && input.tools.length)
+    let allowDelta = false
     const offDelta = this.transport.onDelta(event => {
-      if (event.requestId === requestId && allowDelta) {
+      if (event.requestId === requestId && allowDelta && !/\d/.test(event.text)) {
         streamed = true
         input.onDelta?.(event.text)
       }
@@ -165,7 +185,6 @@ export class OllamaAdvisorRuntime implements AdvisorModelRuntime {
         tools: definitions,
         stream: definitions.length === 0,
       })
-      streamed = streamed || Boolean(planning.streamed && definitions.length === 0)
       const planningMessage = planning.message ?? {}
       const calls = Array.isArray(planningMessage.tool_calls) ? planningMessage.tool_calls.slice(0, 8) : []
       messages.push({ role: 'assistant', content: typeof planningMessage.content === 'string' ? planningMessage.content : '', tool_calls: calls })
@@ -184,32 +203,40 @@ export class OllamaAdvisorRuntime implements AdvisorModelRuntime {
           messages.push({ role: 'tool', content: result.content.slice(0, 32_000), tool_name: name })
           input.onToolEvent?.({ name, status: 'completed' })
         }
+        const validToolEvidence = !hasMixedEvidenceScopes(evidences)
+          && evidences.some(item => item.intent !== 'unknown' && item.coverage.level !== 'unavailable' && item.refs.length > 0)
         if (signal?.aborted) throw new DOMException('Advisor request cancelled', 'AbortError')
-        allowDelta = true
-        const finalResponse = await this.transport.chat(requestId, {
-          model: this.model,
-          messages,
-          tools: [],
-          stream: true,
-        })
-        streamed = streamed || Boolean(finalResponse.streamed)
-        finalContent = typeof finalResponse.message?.content === 'string' ? finalResponse.message.content : ''
+        if (validToolEvidence) {
+          allowDelta = true
+          const finalResponse = await this.transport.chat(requestId, {
+            model: this.model,
+            messages,
+            tools: [],
+            stream: true,
+          })
+          streamed = streamed || Boolean(finalResponse.streamed)
+          finalContent = typeof finalResponse.message?.content === 'string' ? finalResponse.message.content : ''
+        }
       }
     } finally {
       signal?.removeEventListener('abort', cancel)
       offDelta()
     }
-    const evidence = mergeEvidence(evidences.length ? evidences : [input.evidence])
-    const deterministicAnswers = await Promise.all((evidences.length ? evidences : [input.evidence]).map(item => new DeterministicAdvisorRuntime().generate({ question: input.question, evidence: item }, signal)))
+    const evidenceItems = evidences.length ? evidences : [input.evidence]
+    const evidence = mergeEvidence(evidenceItems, input.evidence)
+    const homogeneous = !hasMixedEvidenceScopes(evidenceItems)
+    const deterministicItems = homogeneous ? evidenceItems : [evidence]
+    const deterministicAnswers = await Promise.all(deterministicItems.map(item => new DeterministicAdvisorRuntime().generate({ question: input.question, evidence: item }, signal)))
     const fallback = await new DeterministicAdvisorRuntime().generate({ question: input.question, evidence }, signal)
     const verifiedConclusions = Array.from(new Set(deterministicAnswers.map(answer => answer.conclusion).filter(Boolean)))
     const verifiedConclusion = verifiedConclusions.length ? verifiedConclusions.join(' ') : fallback.conclusion
-    const insight = sanitizeNarrative(finalContent)
+    const hasValidEvidence = evidences.length > 0 && homogeneous && evidences.some(item => item.intent !== 'unknown' && item.coverage.level !== 'unavailable' && item.refs.length > 0)
+    const insight = hasValidEvidence ? sanitizeNarrative(finalContent) : ''
     const conclusion = verifiedConclusion + (insight ? ' Local model context: ' + insight : '')
     const details = Array.from(new Set([
       ...deterministicAnswers.flatMap(answer => answer.details),
       ...fallback.details,
-      ...evidences.flatMap(item => item.refs.map(ref => 'Evidence · ' + ref.label)),
+      ...(homogeneous ? evidences.flatMap(item => item.refs.map(ref => 'Evidence · ' + ref.label)) : []),
     ]))
     return {
       ...fallback,

--- a/app/renderer/advisor/ollama.ts
+++ b/app/renderer/advisor/ollama.ts
@@ -1,6 +1,6 @@
 import { metrora } from '../lib/ipc'
 import { DeterministicAdvisorRuntime } from './runtime'
-import type { AdvisorAnswer, AdvisorCoverageLevel, AdvisorEvidence, AdvisorModelRuntime, AdvisorRuntimeInput, AdvisorToolExecution } from './types'
+import { advisorScopeFingerprint, type AdvisorAnswer, type AdvisorCoverageLevel, type AdvisorEvidence, type AdvisorModelRuntime, type AdvisorRuntimeInput, type AdvisorToolExecution } from './types'
 
 type OllamaToolCall = { function?: { name?: string; arguments?: Record<string, unknown> | string } }
 type OllamaChatMessage = { role: 'system' | 'user' | 'assistant' | 'tool'; content: string; tool_calls?: OllamaToolCall[]; tool_name?: string }
@@ -139,7 +139,8 @@ function toolCallArgs(call: OllamaToolCall): Record<string, unknown> {
   return parseArguments(call.function?.arguments)
 }
 function safeConversation(input: AdvisorRuntimeInput): OllamaChatMessage[] {
-  return (input.conversation ?? []).slice(-12).flatMap(turn => {
+  const currentScopeFingerprint = advisorScopeFingerprint(input.evidence.scope)
+  return (input.conversation ?? []).filter(turn => turn.scopeFingerprint === currentScopeFingerprint).slice(-12).flatMap(turn => {
     const content = turn.content.trim().slice(0, 4000)
     return content ? [{ role: turn.role, content }] : []
   })

--- a/app/renderer/advisor/ollama.ts
+++ b/app/renderer/advisor/ollama.ts
@@ -1,0 +1,223 @@
+import { metrora } from '../lib/ipc'
+import { DeterministicAdvisorRuntime } from './runtime'
+import type { AdvisorAnswer, AdvisorCoverageLevel, AdvisorEvidence, AdvisorModelRuntime, AdvisorRuntimeInput, AdvisorToolExecution } from './types'
+
+type OllamaToolCall = { function?: { name?: string; arguments?: Record<string, unknown> | string } }
+type OllamaChatMessage = { role: 'system' | 'user' | 'assistant' | 'tool'; content: string; tool_calls?: OllamaToolCall[]; tool_name?: string }
+type OllamaResponse = { message?: { content?: string; tool_calls?: OllamaToolCall[] }; streamed?: boolean }
+export type OllamaProbeResult = { available: boolean; models: string[]; detail: string }
+export type OllamaTransport = {
+  probe: (signal?: AbortSignal) => Promise<OllamaProbeResult>
+  chat: (requestId: string, payload: Record<string, unknown>) => Promise<OllamaResponse>
+  cancel: (requestId: string) => Promise<boolean>
+  onDelta: (callback: (event: { requestId: string; text: string }) => void) => () => void
+}
+const bridgeTransport: OllamaTransport = {
+  probe: signal => {
+    if (signal?.aborted) return Promise.reject(new DOMException('Advisor request cancelled', 'AbortError'))
+    return metrora.advisorProbe()
+  },
+  chat: (requestId, payload) => metrora.advisorChat(requestId, payload),
+  cancel: requestId => metrora.advisorCancel(requestId),
+  onDelta: callback => metrora.onAdvisorDelta(callback),
+}
+export async function probeOllama(signal?: AbortSignal, transport: OllamaTransport = bridgeTransport): Promise<OllamaProbeResult> {
+  try {
+    return await transport.probe(signal)
+  } catch (error) {
+    if (signal?.aborted) throw error
+    return { available: false, models: [], detail: 'Local Ollama is unavailable.' }
+  }
+}
+function parseArguments(value: unknown): Record<string, unknown> {
+  if (value && typeof value === 'object') return value as Record<string, unknown>
+  if (typeof value === 'string') {
+    try {
+      const parsed = JSON.parse(value)
+      return parsed && typeof parsed === 'object' ? parsed as Record<string, unknown> : {}
+    } catch { return {} }
+  }
+  return {}
+}
+function extractNarrative(value: string): string {
+  const trimmed = value.trim().replace(/^\s*\x60\x60\x60(?:json|text)?\s*/i, '').replace(/\s*\x60\x60\x60$/, '').trim()
+  try {
+    const parsed = JSON.parse(trimmed) as Record<string, unknown>
+    for (const key of ['conclusion', 'answer', 'message']) if (typeof parsed[key] === 'string') return parsed[key] as string
+  } catch { /* Plain text is valid. */ }
+  return trimmed
+}
+function sanitizeNarrative(value: string): string {
+  const original = extractNarrative(value)
+  const text = original
+    .replace(/(?:[$€£]\s*)\d[\d,.]*(?:\s*(?:USD|EUR|GBP))?/gi, 'the verified amount')
+    .replace(/\b\d[\d,.]*\s*%/g, 'the verified share')
+    .replace(/\b\d{4}-\d{2}-\d{2}(?:T[0-9:.+-]+Z?)?\b/g, 'the verified date')
+    .trim()
+  if (/\b(?:calls?|sessions?|projects?|models?|credits?|tokens?|remaining|used|cost|spend|quota)\b/i.test(original) && /(?:^|[\s,(])(?:[$€£]\s*)?\d[\d,.]*(?:\s*(?:%|USD|EUR|GBP|calls?|sessions?|projects?|models?|credits?|tokens?))?\b/i.test(original)) return ''
+  return text.length > 800 ? text.slice(0, 797) + '…' : text
+}
+function systemPrompt(): string {
+  return [
+    'You are Metrora Advisor, a read-only conversational investigator for local Metrora data.',
+    'Answer natural-language questions freely inside Metrora usage, Projects, models, sessions, spend, pricing coverage, and provider quota.',
+    'Use the supplied evidence tools before factual claims. You may call more than one tool and refine the investigation.',
+    'Never invent arithmetic, prices, Project membership, history, quota, permissions, or causal certainty.',
+    'Keep the narrative plain-language and qualitative; do not write numeric factual claims, dates, paths, secrets, prompts, or hidden reasoning. Verified tool facts render separately.',
+    'If the question is outside Metrora, explain the boundary briefly and suggest a supported investigation.',
+  ].join(' ')
+}
+function mergeEvidence(items: AdvisorEvidence[]): AdvisorEvidence {
+  const last = items[items.length - 1]!
+  const usable = items.filter(item => item.coverage.level !== 'unavailable')
+  const level: AdvisorCoverageLevel = items.length > 0 && items.every(item => item.coverage.level === 'high')
+    ? 'high'
+    : usable.length
+      ? 'partial'
+      : 'unavailable'
+  const coverage = level === 'high'
+    ? { level: 'high' as const, label: 'High coverage', detail: 'All requested evidence tools returned usable canonical records.' }
+    : level === 'partial'
+      ? { level: 'partial' as const, label: 'Partial coverage', detail: 'Some requested evidence is usable; other dimensions remain limited or unavailable.' }
+      : { level: 'unavailable' as const, label: 'Unavailable', detail: 'The requested canonical evidence was not available.' }
+  const unique = <T>(values: T[]) => Array.from(new Set(values))
+  const refs = Array.from(new Map(items.flatMap(item => item.refs).map(ref => [ref.id + '|' + ref.label, ref])).values())
+  const spendRows = items.flatMap(item => item.spend ? [item.spend] : [])
+  const modelRows = items.flatMap(item => item.modelEfficiency ? [item.modelEfficiency] : [])
+  const quotaRows = items.flatMap(item => item.quota ? [item.quota] : [])
+  const spend = spendRows[0] ? {
+    ...spendRows[0],
+    models: unique(spendRows.flatMap(item => item.models.map(row => row.name + '|' + row.calls + '|' + row.costUSD)).map(key => spendRows.flatMap(item => item.models).find(row => row.name + '|' + row.calls + '|' + row.costUSD === key)!)),
+    projects: unique(spendRows.flatMap(item => item.projects.map(row => row.name + '|' + row.calls + '|' + row.costUSD)).map(key => spendRows.flatMap(item => item.projects).find(row => row.name + '|' + row.calls + '|' + row.costUSD === key)!)),
+    sessionsByCost: unique(spendRows.flatMap(item => item.sessionsByCost.map(row => row.name + '|' + row.calls + '|' + row.costUSD)).map(key => spendRows.flatMap(item => item.sessionsByCost).find(row => row.name + '|' + row.calls + '|' + row.costUSD === key)!)),
+  } : undefined
+  const modelEfficiency = modelRows[0] ? {
+    ...modelRows[modelRows.length - 1],
+    rows: unique(modelRows.flatMap(item => item.rows.map(row => row.provider + '|' + row.model)).map(key => modelRows.flatMap(item => item.rows).find(row => row.provider + '|' + row.model === key)!)),
+    comparableWorkWarning: modelRows.some(item => item.comparableWorkWarning),
+  } : undefined
+  const quota = quotaRows[0] ? {
+    ...quotaRows[quotaRows.length - 1],
+    providers: unique(quotaRows.flatMap(item => item.providers.map(row => row.provider)).map(provider => quotaRows.flatMap(item => item.providers).find(row => row.provider === provider)!)),
+  } : undefined
+  return {
+    ...last,
+    refs,
+    coverage,
+    assumptions: unique(items.flatMap(item => item.assumptions)),
+    unknown: unique(items.flatMap(item => item.unknown)),
+    nextInvestigations: unique(items.flatMap(item => item.nextInvestigations)),
+    ...(spend ? { spend } : {}),
+    ...(modelEfficiency ? { modelEfficiency } : {}),
+    ...(quota ? { quota } : {}),
+  }
+}
+function toolCallName(call: OllamaToolCall): string {
+  return typeof call.function?.name === 'string' ? call.function.name : ''
+}
+function toolCallArgs(call: OllamaToolCall): Record<string, unknown> {
+  return parseArguments(call.function?.arguments)
+}
+function safeConversation(input: AdvisorRuntimeInput): OllamaChatMessage[] {
+  return (input.conversation ?? []).slice(-12).flatMap(turn => {
+    const content = turn.content.trim().slice(0, 4000)
+    return content ? [{ role: turn.role, content }] : []
+  })
+}
+export class OllamaAdvisorRuntime implements AdvisorModelRuntime {
+  readonly id = 'ollama-local'
+  readonly mode = 'ollama-local' as const
+  readonly providerSupport = ['Ollama official local API'] as const
+  readonly supportsStreaming = true
+  readonly label: string
+  readonly availability: 'ready' | 'checking' | 'unavailable'
+  private readonly model: string
+  private readonly transport: OllamaTransport
+  constructor(options: { model: string; transport?: OllamaTransport; availability?: 'ready' | 'checking' | 'unavailable' }) {
+    this.model = options.model
+    this.transport = options.transport ?? bridgeTransport
+    this.availability = options.availability ?? 'ready'
+    this.label = 'Ollama · ' + options.model
+  }
+  async generate(input: AdvisorRuntimeInput, signal?: AbortSignal): Promise<AdvisorAnswer> {
+    if (this.availability !== 'ready') throw new Error('Local Ollama model is not available.')
+    const requestId = 'advisor-' + Date.now().toString(36) + '-' + Math.random().toString(36).slice(2, 8)
+    const messages: OllamaChatMessage[] = [{ role: 'system', content: systemPrompt() }, ...safeConversation(input)]
+    messages.push({ role: 'user', content: input.question.trim().slice(0, 4000) })
+    const evidences: AdvisorEvidence[] = []
+    let finalContent = ''
+    let streamed = false
+    let allowDelta = !(input.tools && input.tools.length)
+    const offDelta = this.transport.onDelta(event => {
+      if (event.requestId === requestId && allowDelta) {
+        streamed = true
+        input.onDelta?.(event.text)
+      }
+    })
+    const cancel = () => { void this.transport.cancel(requestId).catch(() => {}) }
+    signal?.addEventListener('abort', cancel, { once: true })
+    try {
+      if (signal?.aborted) throw new DOMException('Advisor request cancelled', 'AbortError')
+      const definitions = input.tools ? [...input.tools] : []
+      const planning = await this.transport.chat(requestId, {
+        model: this.model,
+        messages,
+        tools: definitions,
+        stream: definitions.length === 0,
+      })
+      streamed = streamed || Boolean(planning.streamed && definitions.length === 0)
+      const planningMessage = planning.message ?? {}
+      const calls = Array.isArray(planningMessage.tool_calls) ? planningMessage.tool_calls.slice(0, 8) : []
+      messages.push({ role: 'assistant', content: typeof planningMessage.content === 'string' ? planningMessage.content : '', tool_calls: calls })
+      if (!calls.length) {
+        finalContent = typeof planningMessage.content === 'string' ? planningMessage.content : ''
+      } else {
+        for (const call of calls) {
+          if (signal?.aborted) throw new DOMException('Advisor request cancelled', 'AbortError')
+          const name = toolCallName(call)
+          if (!name) continue
+          input.onToolEvent?.({ name, status: 'started' })
+          const result: AdvisorToolExecution = input.executeTool
+            ? await input.executeTool(name, toolCallArgs(call), signal)
+            : { content: 'Tool execution is unavailable.', evidence: input.evidence }
+          evidences.push(result.evidence)
+          messages.push({ role: 'tool', content: result.content.slice(0, 32_000), tool_name: name })
+          input.onToolEvent?.({ name, status: 'completed' })
+        }
+        if (signal?.aborted) throw new DOMException('Advisor request cancelled', 'AbortError')
+        allowDelta = true
+        const finalResponse = await this.transport.chat(requestId, {
+          model: this.model,
+          messages,
+          tools: [],
+          stream: true,
+        })
+        streamed = streamed || Boolean(finalResponse.streamed)
+        finalContent = typeof finalResponse.message?.content === 'string' ? finalResponse.message.content : ''
+      }
+    } finally {
+      signal?.removeEventListener('abort', cancel)
+      offDelta()
+    }
+    const evidence = mergeEvidence(evidences.length ? evidences : [input.evidence])
+    const deterministicAnswers = await Promise.all((evidences.length ? evidences : [input.evidence]).map(item => new DeterministicAdvisorRuntime().generate({ question: input.question, evidence: item }, signal)))
+    const fallback = await new DeterministicAdvisorRuntime().generate({ question: input.question, evidence }, signal)
+    const verifiedConclusions = Array.from(new Set(deterministicAnswers.map(answer => answer.conclusion).filter(Boolean)))
+    const verifiedConclusion = verifiedConclusions.length ? verifiedConclusions.join(' ') : fallback.conclusion
+    const insight = sanitizeNarrative(finalContent)
+    const conclusion = verifiedConclusion + (insight ? ' Local model context: ' + insight : '')
+    const details = Array.from(new Set([
+      ...deterministicAnswers.flatMap(answer => answer.details),
+      ...fallback.details,
+      ...evidences.flatMap(item => item.refs.map(ref => 'Evidence · ' + ref.label)),
+    ]))
+    return {
+      ...fallback,
+      conclusion: conclusion.slice(0, 1600),
+      details,
+      runtime: { id: this.id, label: this.label, mode: this.mode },
+      generatedByModel: true,
+      streamed,
+    }
+  }
+}

--- a/app/renderer/advisor/runtime.ts
+++ b/app/renderer/advisor/runtime.ts
@@ -1,0 +1,121 @@
+import { formatAdvisorCreditsUsd, formatAdvisorPercent, formatAdvisorUsd, periodLabel, scopeLabel } from './evidence'
+import type { AdvisorAnswer, AdvisorEvidence, AdvisorModelEvidenceRow, AdvisorModelRuntime, AdvisorRuntimeInput } from './types'
+
+export class AdvisorRuntimeUnavailableError extends Error {
+  constructor() {
+    super('No verified Advisor model runtime is configured')
+    this.name = 'AdvisorRuntimeUnavailableError'
+  }
+}
+function throwIfAborted(signal?: AbortSignal): void {
+  if (signal?.aborted) throw new DOMException('Advisor investigation cancelled', 'AbortError')
+}
+function resetLabel(value: string | null): string | null {
+  if (!value) return null
+  const time = Date.parse(value)
+  if (!Number.isFinite(time)) return null
+  const minutes = Math.ceil((time - Date.now()) / 60_000)
+  if (minutes <= 0) return 'reset boundary has passed; refresh for the current window'
+  if (minutes >= 1440) return 'resets in ' + Math.floor(minutes / 1440) + 'd'
+  if (minutes >= 60) return 'resets in ' + Math.floor(minutes / 60) + 'h'
+  return 'resets in ' + minutes + 'm'
+}
+function baseAnswer(evidence: AdvisorEvidence, runtime: AdvisorModelRuntime): AdvisorAnswer {
+  return {
+    conclusion: '',
+    scopeLabel: scopeLabel(evidence.scope),
+    periodLabel: periodLabel(evidence.scope),
+    evidence: evidence.refs,
+    coverage: evidence.coverage,
+    assumptions: evidence.assumptions,
+    unknown: evidence.unknown,
+    nextInvestigations: evidence.nextInvestigations,
+    details: [],
+    runtime: { id: runtime.id, label: runtime.label, mode: runtime.mode },
+  }
+}
+function modelRow(row: AdvisorModelEvidenceRow): string {
+  return row.model + ' · ' + (row.costPerCallUSD === null ? 'cost per call unavailable' : formatAdvisorUsd(row.costPerCallUSD) + ' per observed call') + ' · ' + row.calls.toLocaleString('en-US') + ' calls'
+}
+function spendAnswer(evidence: AdvisorEvidence, answer: AdvisorAnswer): AdvisorAnswer {
+  const spend = evidence.spend
+  if (!spend || evidence.coverage.level === 'unavailable') return { ...answer, conclusion: 'I could not find measured spend for this scope yet.', details: ['No cost or call total was available from the canonical Overview payload.'] }
+  const trend = spend.trend
+  const trendText = trend ? ' The latest returned day was ' + formatAdvisorUsd(trend.latestCostUSD) + ', ' + (trend.direction === 'up' ? 'above' : trend.direction === 'down' ? 'below' : 'near') + ' the ' + trend.comparisonLabel + ' (' + formatAdvisorUsd(trend.comparisonCostUSD) + ').' : ''
+  const driver = spend.models[0]
+  const facts = [
+    spend.measuredCostUSD === null ? null : 'Metrora measured ' + formatAdvisorUsd(spend.measuredCostUSD),
+    spend.calls === null ? null : spend.calls.toLocaleString('en-US') + ' calls',
+    spend.sessions === null ? null : spend.sessions.toLocaleString('en-US') + ' sessions',
+  ].filter((item): item is string => Boolean(item))
+  const intro = facts.length ? facts.join(' across ') + ' in this scope.' : 'Metrora returned no usable measured totals for this scope.'
+  return {
+    ...answer,
+    conclusion: intro + trendText + (driver ? ' Largest represented model driver: ' + driver.name + ' at ' + formatAdvisorUsd(driver.costUSD) + '.' : ''),
+    details: [
+      ...spend.models.slice(0, 4).map(row => 'Model · ' + row.name + ' · ' + formatAdvisorUsd(row.costUSD) + ' · ' + row.calls.toLocaleString('en-US') + ' calls'),
+      ...spend.projects.slice(0, 4).map(row => 'Project · ' + row.name + ' · ' + formatAdvisorUsd(row.costUSD) + ' · ' + row.calls.toLocaleString('en-US') + ' sessions'),
+      ...(trend ? ['History · ' + trend.latestDate + ' vs ' + trend.comparisonLabel + ' · change ' + formatAdvisorUsd(trend.deltaUSD) + (trend.deltaPercent === null ? '' : ' (' + formatAdvisorPercent(trend.deltaPercent) + ')')] : []),
+    ],
+  }
+}
+function modelAnswer(evidence: AdvisorEvidence, answer: AdvisorAnswer): AdvisorAnswer {
+  const model = evidence.modelEfficiency
+  if (!model || !model.rows.length) return { ...answer, conclusion: 'I could not find model detail for this scope yet.', details: ['The canonical model report returned no rows for the selected context.'] }
+  const best = model.rows[0]!
+  return {
+    ...answer,
+    conclusion: 'The lowest observed cost per call' + (model.selectedModel ? ' for ' + model.selectedModel : '') + ' is ' + (best.costPerCallUSD === null ? 'not available' : formatAdvisorUsd(best.costPerCallUSD)) + ' on ' + best.model + '. This is a descriptive cost signal, not proof that the model is better for comparable work.',
+    details: model.rows.slice(0, 8).map(modelRow),
+  }
+}
+function quotaAnswer(evidence: AdvisorEvidence, answer: AdvisorAnswer): AdvisorAnswer {
+  const quota = evidence.quota
+  if (!quota || !quota.providers.length || evidence.coverage.level === 'unavailable') return { ...answer, conclusion: 'No usable provider-reported quota is available for this scope.', details: ['Quota is unavailable, so no remaining percentage, reset, plan, or credit number is shown.'] }
+  const summaries: string[] = []
+  const details: string[] = []
+  for (const provider of quota.providers) {
+    const name = provider.provider === 'claude' ? 'Claude' : 'Codex'
+    const staleNote = provider.freshness === 'stale' ? ' Last observation ' + (provider.observedAt ? new Date(provider.observedAt).toLocaleString('en-US') : 'unknown') + '; refresh failed.' : provider.freshness === 'fresh' ? ' Fresh provider response.' : ' Provider response unavailable.'
+    if (provider.freshness === 'unavailable') {
+      summaries.push(name + ' quota is unavailable.')
+      continue
+    }
+    const windows = provider.windows.map(window => {
+      const reset = resetLabel(window.resetsAt)
+      details.push(name + ' · ' + window.label + ' · ' + window.usedPercent + '% used · ' + window.remainingPercent + '% remaining' + (reset ? ' · ' + reset : ''))
+      return window.label + ' ' + window.remainingPercent + '% remaining'
+    })
+    summaries.push(name + (provider.planLabel ? ' (' + provider.planLabel + ')' : '') + (windows.length ? ' reports ' + windows.join(', ') + '.' : ' reports no quota windows.') + staleNote)
+    if (provider.creditsUSD !== null) details.push(name + ' · provider credits remaining · ' + formatAdvisorCreditsUsd(provider.creditsUSD))
+  }
+  if (quota.measuredSpendUSD !== null) details.push('Metrora usage context · ' + formatAdvisorUsd(quota.measuredSpendUSD) + ' measured spend · separate from provider quota authority.')
+  return { ...answer, conclusion: summaries.join(' '), details }
+}
+export class DeterministicAdvisorRuntime implements AdvisorModelRuntime {
+  readonly id = 'metrora-deterministic-local'
+  readonly label = 'Metrora local evidence runtime'
+  readonly mode = 'deterministic-local' as const
+  readonly providerSupport = [] as const
+  async generate(input: AdvisorRuntimeInput, signal?: AbortSignal): Promise<AdvisorAnswer> {
+    throwIfAborted(signal)
+    const answer = baseAnswer(input.evidence, this)
+    if (input.evidence.intent === 'spend-change') return spendAnswer(input.evidence, answer)
+    if (input.evidence.intent === 'model-efficiency') return modelAnswer(input.evidence, answer)
+    if (input.evidence.intent === 'quota-capacity') return quotaAnswer(input.evidence, answer)
+    return { ...answer, conclusion: 'I can investigate spend changes, observed model efficiency, and provider quota. Try one of the suggested questions.', details: ['This local foundation does not send your question or Metrora data to a hosted model.'] }
+  }
+}
+/** Explicit placeholder for future verified local/BYOK adapters; it never pretends to support a provider. */
+export class UnsupportedAdvisorModelRuntime implements AdvisorModelRuntime {
+  readonly id = 'unsupported-advisor-runtime'
+  readonly label = 'No verified model runtime'
+  readonly mode = 'unsupported' as const
+  readonly providerSupport = [] as const
+  async generate(_input: AdvisorRuntimeInput, _signal?: AbortSignal): Promise<AdvisorAnswer> {
+    throw new AdvisorRuntimeUnavailableError()
+  }
+}
+export function createAdvisorRuntime(): AdvisorModelRuntime {
+  return new DeterministicAdvisorRuntime()
+}

--- a/app/renderer/advisor/source.ts
+++ b/app/renderer/advisor/source.ts
@@ -1,0 +1,28 @@
+import type { AdvisorBridge, AdvisorDataSource, AdvisorScope } from './types'
+
+/** Adapts the existing read-only renderer bridge into the Advisor data boundary. */
+export function createAdvisorDataSource(bridge: AdvisorBridge): AdvisorDataSource {
+  return {
+    getOverview: context => {
+      const project = context.projectId !== 'all' ? context.projectId : undefined
+      return context.range
+        ? project
+          ? bridge.getOverview(context.period, context.provider, context.range, undefined, false, false, project)
+          : bridge.getOverview(context.period, context.provider, context.range)
+        : project
+          ? bridge.getOverview(context.period, context.provider, undefined, undefined, false, false, project)
+          : bridge.getOverview(context.period, context.provider)
+    },
+    getModels: context => {
+      const project = context.projectId !== 'all' ? context.projectId : undefined
+      return context.range
+        ? project
+          ? bridge.getModels(context.period, context.provider, false, context.range, project)
+          : bridge.getModels(context.period, context.provider, false, context.range)
+        : project
+          ? bridge.getModels(context.period, context.provider, false, undefined, project)
+          : bridge.getModels(context.period, context.provider, false)
+    },
+    getQuota: () => bridge.getQuota(false),
+  }
+}

--- a/app/renderer/advisor/tools.test.ts
+++ b/app/renderer/advisor/tools.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import type { MenubarPayload } from '../lib/types'
+import { createAdvisorToolRegistry } from './tools'
+import type { AdvisorDataSource, AdvisorScope } from './types'
+
+const scope: AdvisorScope = { period: 'week', range: null, provider: 'all', projectId: 'all', projectName: 'All projects', model: null }
+function overview(cost: number, model?: string): MenubarPayload {
+  return {
+    current: {
+      cost, calls: cost, sessions: 1, pricingCoverage: 1, topModels: [], topProjects: [], topSessions: [],
+      ...(model ? { modelAccounting: { rows: [{ name: model, cost, calls: cost }], gap: { cost: 0, savingsUSD: 0, calls: 0 }, coverage: { cost: 1, calls: 1 } } } : {}),
+    },
+    history: { daily: [] },
+  } as unknown as MenubarPayload
+}
+
+describe('Advisor tool scope isolation', () => {
+  it('refetches measured spend when a model overrides the supplied Overview scope', async () => {
+    const getOverview = vi.fn(async () => overview(4, 'gpt-safe'))
+    const source = { getOverview, getModels: vi.fn(async () => []), getQuota: vi.fn(async () => []) } satisfies AdvisorDataSource
+    const result = await createAdvisorToolRegistry(source, scope, overview(99)).execute('get_spend_snapshot', { model: 'gpt-safe' })
+
+    expect(getOverview).toHaveBeenCalledWith({ ...scope, model: 'gpt-safe' })
+    expect(result.evidence.scope.model).toBe('gpt-safe')
+    expect(result.evidence.spend?.measuredCostUSD).toBe(4)
+  })
+
+  it('refetches measured usage context when quota provider overrides the supplied scope', async () => {
+    const getOverview = vi.fn(async () => overview(6))
+    const source = { getOverview, getModels: vi.fn(async () => []), getQuota: vi.fn(async () => []) } satisfies AdvisorDataSource
+    const result = await createAdvisorToolRegistry(source, scope, overview(99)).execute('get_quota_snapshot', { provider: 'codex' })
+
+    expect(getOverview).toHaveBeenCalledWith({ ...scope, provider: 'codex' })
+    expect(result.evidence.scope.provider).toBe('codex')
+    expect(result.evidence.quota?.measuredSpendUSD).toBe(6)
+  })
+})

--- a/app/renderer/advisor/tools.ts
+++ b/app/renderer/advisor/tools.ts
@@ -1,0 +1,60 @@
+import type { MenubarPayload, ModelReportRow, QuotaProvider } from '../lib/types'
+import { buildModelEfficiencyEvidence, buildQuotaEvidence, buildSpendEvidence } from './evidence'
+import type { AdvisorDataSource, AdvisorEvidence, AdvisorScope, AdvisorToolDefinition, AdvisorToolExecution, AdvisorToolExecutor } from './types'
+
+export const ADVISOR_TOOL_DEFINITIONS: readonly AdvisorToolDefinition[] = [
+  { type: 'function', function: { name: 'get_spend_snapshot', description: 'Read Metrora measured spend, daily trend, model and Project drivers, and coverage for the selected scope.', parameters: { type: 'object', properties: { model: { type: 'string', description: 'Optional exact model filter' } }, additionalProperties: false } } },
+  { type: 'function', function: { name: 'get_model_efficiency', description: 'Read canonical Metrora model rows and observed cost per call. Do not infer quality or comparable work.', parameters: { type: 'object', properties: { model: { type: 'string', description: 'Optional exact model filter' } }, additionalProperties: false } } },
+  { type: 'function', function: { name: 'get_quota_snapshot', description: 'Read provider-reported quota windows, reset timestamps, freshness, and credits. Never estimate quota from Metrora spend.', parameters: { type: 'object', properties: { provider: { type: 'string', enum: ['all', 'claude', 'codex'] } }, additionalProperties: false } } },
+  { type: 'function', function: { name: 'get_overview_snapshot', description: 'Read the current canonical Metrora overview for the selected period, Project, provider, and model context.', parameters: { type: 'object', properties: { model: { type: 'string', description: 'Optional exact model filter' } }, additionalProperties: false } } },
+  { type: 'function', function: { name: 'get_project_drivers', description: 'Read descriptive Project spend drivers from the canonical Metrora overview. Do not infer causality.', parameters: { type: 'object', properties: {}, additionalProperties: false } } },
+  { type: 'function', function: { name: 'get_session_highlights', description: 'Read content-minimal highest-cost session summaries from the canonical Metrora overview. No raw session content is exposed.', parameters: { type: 'object', properties: {}, additionalProperties: false } } },
+  { type: 'function', function: { name: 'get_coverage_report', description: 'Read Metrora evidence coverage, assumptions, and unknowns for the selected scope.', parameters: { type: 'object', properties: {}, additionalProperties: false } } },
+]
+function toolScope(scope: AdvisorScope, args: Record<string, unknown>): AdvisorScope {
+  const model = typeof args.model === 'string' && args.model.trim() ? args.model.trim() : scope.model
+  const provider = typeof args.provider === 'string' && ['all', 'claude', 'codex'].includes(args.provider) ? args.provider : scope.provider
+  return { ...scope, model, provider }
+}
+function safeJson(value: unknown): string {
+  return JSON.stringify(value, (_key, item) => typeof item === 'number' && !Number.isFinite(item) ? null : item)
+}
+function compactEvidence(evidence: AdvisorEvidence): string {
+  return safeJson({ intent: evidence.intent, scope: evidence.scope, coverage: evidence.coverage, refs: evidence.refs, spend: evidence.spend, modelEfficiency: evidence.modelEfficiency, quota: evidence.quota, assumptions: evidence.assumptions, unknown: evidence.unknown })
+}
+function sameScope(left: AdvisorScope, right: AdvisorScope): boolean {
+  return left.period === right.period
+    && left.provider === right.provider
+    && left.projectId === right.projectId
+    && left.projectName === right.projectName
+    && left.model === right.model
+    && left.range?.from === right.range?.from
+    && left.range?.to === right.range?.to
+}
+export function createAdvisorToolRegistry(source: AdvisorDataSource, scope: AdvisorScope, suppliedOverview: MenubarPayload | null): { definitions: readonly AdvisorToolDefinition[]; execute: AdvisorToolExecutor } {
+  const execute: AdvisorToolExecutor = async (name, args, signal): Promise<AdvisorToolExecution> => {
+    if (signal?.aborted) throw new DOMException('Advisor tool call cancelled', 'AbortError')
+    const nextScope = toolScope(scope, args)
+    if (name === 'get_overview_snapshot' || name === 'get_spend_snapshot' || name === 'get_project_drivers' || name === 'get_session_highlights' || name === 'get_coverage_report') {
+      const overview = suppliedOverview && sameScope(nextScope, scope) ? suppliedOverview : await source.getOverview(nextScope)
+      const label = name === 'get_project_drivers' ? 'tool: Project drivers' : name === 'get_session_highlights' ? 'tool: session highlights' : name === 'get_coverage_report' ? 'tool: coverage report' : name === 'get_overview_snapshot' ? 'tool: overview snapshot' : 'tool: spend snapshot'
+      const evidence = buildSpendEvidence(label, nextScope, overview)
+      return { content: compactEvidence(evidence), evidence }
+    }
+    if (name === 'get_model_efficiency') {
+      const overview = suppliedOverview && sameScope(nextScope, scope) ? suppliedOverview : await source.getOverview(nextScope)
+      let rows: ModelReportRow[] = []
+      try { rows = await source.getModels(nextScope) } catch { /* Overview fallback remains honest. */ }
+      const evidence = buildModelEfficiencyEvidence('tool: model efficiency', nextScope, overview, rows)
+      return { content: compactEvidence(evidence), evidence }
+    }
+    if (name === 'get_quota_snapshot') {
+      let quota: QuotaProvider[] = []
+      try { quota = await source.getQuota() } catch { /* unavailable is factual, not zero. */ }
+      const evidence = buildQuotaEvidence('tool: quota snapshot', nextScope, suppliedOverview, quota)
+      return { content: compactEvidence(evidence), evidence }
+    }
+    throw new Error('Unknown Advisor tool: ' + name)
+  }
+  return { definitions: ADVISOR_TOOL_DEFINITIONS, execute }
+}

--- a/app/renderer/advisor/tools.ts
+++ b/app/renderer/advisor/tools.ts
@@ -49,9 +49,10 @@ export function createAdvisorToolRegistry(source: AdvisorDataSource, scope: Advi
       return { content: compactEvidence(evidence), evidence }
     }
     if (name === 'get_quota_snapshot') {
+      const overview = suppliedOverview && sameScope(nextScope, scope) ? suppliedOverview : await source.getOverview(nextScope)
       let quota: QuotaProvider[] = []
       try { quota = await source.getQuota() } catch { /* unavailable is factual, not zero. */ }
-      const evidence = buildQuotaEvidence('tool: quota snapshot', nextScope, suppliedOverview, quota)
+      const evidence = buildQuotaEvidence('tool: quota snapshot', nextScope, overview, quota)
       return { content: compactEvidence(evidence), evidence }
     }
     throw new Error('Unknown Advisor tool: ' + name)

--- a/app/renderer/advisor/types.ts
+++ b/app/renderer/advisor/types.ts
@@ -1,0 +1,27 @@
+import type { MetroraBridge } from '../lib/metrora-bridge-types'
+import type { DateRange, MenubarPayload, ModelReportRow, Period, QuotaProvider } from '../lib/types'
+
+export type AdvisorIntent = 'spend-change' | 'model-efficiency' | 'quota-capacity' | 'unknown'
+export type AdvisorScope = { period: Period; range: DateRange | null; provider: string; projectId: string; projectName: string; model: string | null }
+export type AdvisorCoverageLevel = 'high' | 'partial' | 'unavailable'
+export type AdvisorCoverage = { level: AdvisorCoverageLevel; label: string; detail: string }
+export type AdvisorEvidenceSource = 'overview' | 'history' | 'models' | 'quota'
+export type AdvisorEvidenceRef = { id: string; label: string; source: AdvisorEvidenceSource }
+export type AdvisorSpendDriver = { name: string; costUSD: number; calls: number }
+export type AdvisorTrend = { direction: 'up' | 'down' | 'flat'; latestCostUSD: number; comparisonCostUSD: number; deltaUSD: number; deltaPercent: number | null; latestDate: string; comparisonLabel: string }
+export type AdvisorSpendEvidence = { measuredCostUSD: number | null; calls: number | null; sessions: number | null; models: AdvisorSpendDriver[]; projects: AdvisorSpendDriver[]; sessionsByCost: AdvisorSpendDriver[]; trend: AdvisorTrend | null; pricingCoverage: number | null }
+export type AdvisorModelEvidenceRow = { model: string; provider: string; calls: number; costUSD: number; outputTokens: number | null; costPerCallUSD: number | null; pricingState: 'priced' | 'partial' | 'unavailable' | 'unknown' }
+export type AdvisorModelEvidence = { rows: AdvisorModelEvidenceRow[]; selectedModel: string | null; comparableWorkWarning: boolean }
+export type AdvisorQuotaWindow = { id: string; label: string; usedPercent: number; remainingPercent: number; resetsAt: string | null }
+export type AdvisorQuotaProvider = { provider: QuotaProvider['provider']; planLabel: string | null; availability: QuotaProvider['availability']; connection: QuotaProvider['connection']; freshness: QuotaProvider['freshness']; observedAt: string | null; windows: AdvisorQuotaWindow[]; creditsUSD: number | null }
+export type AdvisorQuotaEvidence = { providers: AdvisorQuotaProvider[]; measuredSpendUSD: number | null; measuredCalls: number | null }
+export type AdvisorEvidence = { intent: AdvisorIntent; question: string; scope: AdvisorScope; refs: AdvisorEvidenceRef[]; coverage: AdvisorCoverage; assumptions: string[]; unknown: string[]; nextInvestigations: string[]; spend?: AdvisorSpendEvidence; modelEfficiency?: AdvisorModelEvidence; quota?: AdvisorQuotaEvidence }
+export type AdvisorAnswer = { conclusion: string; scopeLabel: string; periodLabel: string; evidence: AdvisorEvidenceRef[]; coverage: AdvisorCoverage; assumptions: string[]; unknown: string[]; nextInvestigations: string[]; details: string[]; runtime: { id: string; label: string; mode: 'ollama-local' | 'deterministic-local' | 'unsupported' }; generatedByModel?: boolean; streamed?: boolean }
+export type AdvisorToolDefinition = { type: 'function'; function: { name: string; description: string; parameters: Record<string, unknown> } }
+export type AdvisorToolExecution = { content: string; evidence: AdvisorEvidence }
+export type AdvisorToolExecutor = (name: string, args: Record<string, unknown>, signal?: AbortSignal) => Promise<AdvisorToolExecution>
+export type AdvisorConversationTurn = { role: 'user' | 'assistant'; content: string }
+export type AdvisorRuntimeInput = { question: string; evidence: AdvisorEvidence; conversation?: AdvisorConversationTurn[]; tools?: readonly AdvisorToolDefinition[]; executeTool?: AdvisorToolExecutor; onToolEvent?: (event: { name: string; status: 'started' | 'completed' }) => void; onDelta?: (text: string) => void }
+export interface AdvisorModelRuntime { readonly id: string; readonly label: string; readonly mode: 'ollama-local' | 'deterministic-local' | 'unsupported'; readonly providerSupport: readonly string[]; readonly availability?: 'ready' | 'checking' | 'unavailable'; readonly supportsStreaming?: boolean; generate(input: AdvisorRuntimeInput, signal?: AbortSignal): Promise<AdvisorAnswer> }
+export type AdvisorDataSource = { getOverview(context: AdvisorScope): Promise<MenubarPayload>; getModels(context: AdvisorScope): Promise<ModelReportRow[]>; getQuota(): Promise<QuotaProvider[]> }
+export type AdvisorBridge = Pick<MetroraBridge, 'getOverview' | 'getModels' | 'getQuota'>

--- a/app/renderer/advisor/types.ts
+++ b/app/renderer/advisor/types.ts
@@ -3,6 +3,16 @@ import type { DateRange, MenubarPayload, ModelReportRow, Period, QuotaProvider }
 
 export type AdvisorIntent = 'spend-change' | 'model-efficiency' | 'quota-capacity' | 'unknown'
 export type AdvisorScope = { period: Period; range: DateRange | null; provider: string; projectId: string; projectName: string; model: string | null }
+export type AdvisorScopeIdentity = Pick<AdvisorScope, 'period' | 'range' | 'projectId' | 'provider' | 'model'>
+export function advisorScopeFingerprint(scope: AdvisorScopeIdentity): string {
+  return JSON.stringify({
+    period: scope.period,
+    range: scope.range ? { from: scope.range.from, to: scope.range.to } : null,
+    projectId: scope.projectId,
+    provider: scope.provider,
+    model: scope.model,
+  })
+}
 export type AdvisorCoverageLevel = 'high' | 'partial' | 'unavailable'
 export type AdvisorCoverage = { level: AdvisorCoverageLevel; label: string; detail: string }
 export type AdvisorEvidenceSource = 'overview' | 'history' | 'models' | 'quota'
@@ -20,7 +30,7 @@ export type AdvisorAnswer = { conclusion: string; scopeLabel: string; periodLabe
 export type AdvisorToolDefinition = { type: 'function'; function: { name: string; description: string; parameters: Record<string, unknown> } }
 export type AdvisorToolExecution = { content: string; evidence: AdvisorEvidence }
 export type AdvisorToolExecutor = (name: string, args: Record<string, unknown>, signal?: AbortSignal) => Promise<AdvisorToolExecution>
-export type AdvisorConversationTurn = { role: 'user' | 'assistant'; content: string }
+export type AdvisorConversationTurn = { role: 'user' | 'assistant'; content: string; scopeFingerprint: string }
 export type AdvisorRuntimeInput = { question: string; evidence: AdvisorEvidence; conversation?: AdvisorConversationTurn[]; tools?: readonly AdvisorToolDefinition[]; executeTool?: AdvisorToolExecutor; onToolEvent?: (event: { name: string; status: 'started' | 'completed' }) => void; onDelta?: (text: string) => void }
 export interface AdvisorModelRuntime { readonly id: string; readonly label: string; readonly mode: 'ollama-local' | 'deterministic-local' | 'unsupported'; readonly providerSupport: readonly string[]; readonly availability?: 'ready' | 'checking' | 'unavailable'; readonly supportsStreaming?: boolean; generate(input: AdvisorRuntimeInput, signal?: AbortSignal): Promise<AdvisorAnswer> }
 export type AdvisorDataSource = { getOverview(context: AdvisorScope): Promise<MenubarPayload>; getModels(context: AdvisorScope): Promise<ModelReportRow[]>; getQuota(): Promise<QuotaProvider[]> }

--- a/app/renderer/components/Sidebar.test.tsx
+++ b/app/renderer/components/Sidebar.test.tsx
@@ -23,10 +23,11 @@ describe('Sidebar', () => {
       'Insights⌘5',
       'Models⌘6',
       'Compare⌘7',
+      'Advisor⌘',
     ])
     expect(within(control).getAllByRole('button').map(item => item.textContent)).toEqual(['Workspace⌘8'])
     expect(within(product).getByRole('button', { name: /Settings.*⌘,/ })).toBeInTheDocument()
-    expect(screen.getAllByRole('button')).toHaveLength(9)
+    expect(screen.getAllByRole('button')).toHaveLength(10)
   })
 
   it('routes by click and keyboard without changing section ids', async () => {

--- a/app/renderer/components/Sidebar.tsx
+++ b/app/renderer/components/Sidebar.tsx
@@ -35,6 +35,9 @@ const NAV_ICONS: Record<Section, ReactNode> = {
   compare: (
     <svg viewBox="0 0 24 24"><path d="M8 3 4 7l4 4"/><path d="M4 7h16"/><path d="M16 21l4-4-4-4"/><path d="M20 17H4"/></svg>
   ),
+  advisor: (
+    <svg viewBox="0 0 24 24"><path d="M5 5.5h14a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2h-6l-4 3v-3H5a2 2 0 0 1-2-2v-8a2 2 0 0 1 2-2Z"/><path d="M8 11h8M8 14h5"/></svg>
+  ),
   plans: (
     <svg viewBox="0 0 24 24"><rect x="2" y="5" width="20" height="14" rx="2" /><line x1="2" y1="10" x2="22" y2="10" /></svg>
   ),

--- a/app/renderer/lib/desktopNavigation.test.ts
+++ b/app/renderer/lib/desktopNavigation.test.ts
@@ -28,18 +28,19 @@ describe('desktop navigation authority', () => {
     }
   })
 
-  it('uses the pre-store task hierarchy without a standalone AI-plan destination', () => {
+  it('keeps Advisor in the Analyze hierarchy without exposing Plans as a shortcut', () => {
     expect(DESKTOP_NAVIGATION_GROUPS).toEqual([
       { id: 'home', label: null, placement: 'primary', sections: ['overview'] },
       { id: 'activity', label: 'Activity', placement: 'primary', sections: ['sessions', 'pullRequests'] },
-      { id: 'analyze', label: 'Analyze', placement: 'primary', sections: ['spend', 'optimize', 'models', 'compare'] },
+      { id: 'analyze', label: 'Analyze', placement: 'primary', sections: ['spend', 'optimize', 'models', 'compare', 'advisor'] },
       { id: 'control', label: 'Control', placement: 'primary', sections: ['workspace'] },
       { id: 'product', label: 'Product', placement: 'utility', sections: ['settings'] },
     ])
     expect(DESKTOP_NAVIGATION_ORDER).toEqual([
-      'overview', 'sessions', 'pullRequests', 'spend', 'optimize', 'models', 'compare', 'workspace', 'settings',
+      'overview', 'sessions', 'pullRequests', 'spend', 'optimize', 'models', 'compare', 'advisor', 'workspace', 'settings',
     ])
     expect(DESKTOP_NAVIGATION_ITEMS.optimize.label).toBe('Insights')
+    expect(DESKTOP_NAVIGATION_ITEMS.advisor.label).toBe('Advisor')
     expect(DESKTOP_NAVIGATION_ITEMS.plans.shortcut).toBe('')
     expect(DESKTOP_NAVIGATION_ITEMS.workspace.shortcut).toBe('8')
     expect(DESKTOP_NAVIGATION_ITEMS.settings.shortcut).toBe(',')

--- a/app/renderer/lib/desktopNavigation.ts
+++ b/app/renderer/lib/desktopNavigation.ts
@@ -6,6 +6,7 @@ export const SECTION_IDS = [
   'optimize',
   'models',
   'compare',
+  'advisor',
   'plans',
   'workspace',
   'settings',
@@ -35,10 +36,7 @@ export const DESKTOP_NAVIGATION_ITEMS: Record<Section, DesktopNavigationItem> = 
   optimize: { id: 'optimize', label: 'Insights', title: 'Insights', shortcut: '5' },
   models: { id: 'models', label: 'Models', title: 'Models', shortcut: '6' },
   compare: { id: 'compare', label: 'Compare', title: 'Compare', shortcut: '7' },
-  // Plans remains a routable internal surface for compatibility and Settings
-  // deep-links, but it is intentionally not a first-class sidebar destination.
-  // Provider subscriptions belong in Home + Settings; reserving "plan" in the
-  // main product navigation avoids colliding with future Metrora billing plans.
+  advisor: { id: 'advisor', label: 'Advisor', title: 'Advisor', shortcut: '' },
   plans: { id: 'plans', label: 'Plans', title: 'Provider plans', shortcut: '' },
   workspace: { id: 'workspace', label: 'Workspace', title: 'Personal workspace', shortcut: '8' },
   settings: { id: 'settings', label: 'Settings', title: 'Settings', shortcut: ',' },
@@ -47,19 +45,13 @@ export const DESKTOP_NAVIGATION_ITEMS: Record<Section, DesktopNavigationItem> = 
 export const DESKTOP_NAVIGATION_GROUPS: readonly DesktopNavigationGroup[] = [
   { id: 'home', label: null, placement: 'primary', sections: ['overview'] },
   { id: 'activity', label: 'Activity', placement: 'primary', sections: ['sessions', 'pullRequests'] },
-  { id: 'analyze', label: 'Analyze', placement: 'primary', sections: ['spend', 'optimize', 'models', 'compare'] },
+  { id: 'analyze', label: 'Analyze', placement: 'primary', sections: ['spend', 'optimize', 'models', 'compare', 'advisor'] },
   { id: 'control', label: 'Control', placement: 'primary', sections: ['workspace'] },
   { id: 'product', label: 'Product', placement: 'utility', sections: ['settings'] },
 ]
 
 export const DESKTOP_NAVIGATION_ORDER: readonly Section[] = DESKTOP_NAVIGATION_GROUPS.flatMap(group => group.sections)
-
-export const SECTION_TITLES: Record<Section, string> = Object.fromEntries(
-  SECTION_IDS.map(id => [id, DESKTOP_NAVIGATION_ITEMS[id].title]),
-) as Record<Section, string>
-
+export const SECTION_TITLES: Record<Section, string> = Object.fromEntries(SECTION_IDS.map(id => [id, DESKTOP_NAVIGATION_ITEMS[id].title])) as Record<Section, string>
 export const SECTION_BY_SHORTCUT: Readonly<Record<string, Section>> = Object.fromEntries(
-  DESKTOP_NAVIGATION_ORDER
-    .map(id => [DESKTOP_NAVIGATION_ITEMS[id].shortcut, id] as const)
-    .filter(([shortcut]) => shortcut.length > 0),
+  DESKTOP_NAVIGATION_ORDER.map(id => [DESKTOP_NAVIGATION_ITEMS[id].shortcut, id] as const).filter(([shortcut]) => shortcut.length > 0),
 )

--- a/app/renderer/lib/desktopSections.ts
+++ b/app/renderer/lib/desktopSections.ts
@@ -36,6 +36,7 @@ export const DESKTOP_SECTION_CAPABILITIES: Record<Section, DesktopSectionCapabil
   optimize: FULL_ANALYTICS_SCOPE,
   models: FULL_ANALYTICS_SCOPE,
   compare: FULL_ANALYTICS_SCOPE,
+  advisor: FULL_ANALYTICS_SCOPE,
   plans: {
     period: false,
     customRange: false,

--- a/app/renderer/lib/metrora-bridge-types.ts
+++ b/app/renderer/lib/metrora-bridge-types.ts
@@ -35,6 +35,10 @@ export interface MetroraBridge extends ProjectBridge {
   /** Subscribe to pushed update-availability status; returns an unsubscribe fn. */
   onUpdateStatus(cb: (status: UpdateStatus) => void): () => void
   getQuota(force?: boolean): Promise<QuotaProvider[]>
+  advisorProbe(): Promise<{ available: boolean; models: string[]; detail: string }>
+  advisorChat(requestId: string, payload: Record<string, unknown>): Promise<{ message: { content: string; tool_calls?: Array<Record<string, unknown>> }; streamed: boolean }>
+  advisorCancel(requestId: string): Promise<boolean>
+  onAdvisorDelta(cb: (event: { requestId: string; text: string }) => void): () => void
   // `fresh` is reserved for explicit Refresh; navigation reads the snapshot.
   getOverview(period: Period, provider: string, range?: DateRange, configSource?: string | null, background?: boolean, fresh?: boolean, projectScopeId?: string | null): Promise<MenubarPayload>
   getPlans(period: Period): Promise<StatusJson>

--- a/app/renderer/main.tsx
+++ b/app/renderer/main.tsx
@@ -8,6 +8,7 @@ import './styles/plain.css'
 import './styles/brand.css'
 import './styles/navigation.css'
 import './styles/overview-home.css'
+import './styles/advisor.css'
 import './styles/workspace.css'
 import './styles/workspace-guidance.css'
 

--- a/app/renderer/sections/Advisor.test.tsx
+++ b/app/renderer/sections/Advisor.test.tsx
@@ -35,11 +35,25 @@ const overview = {
   refresh: vi.fn(),
   refreshFresh: vi.fn(),
 } as unknown as Polled<MenubarPayload>
+const overviewWithOptions = {
+  ...overview,
+  data: {
+    current: { modelAccounting: { rows: [{ name: 'gpt-safe' }] }, topModels: [{ name: 'gpt-safe' }] },
+    projectScope: { options: [{ id: 'project-a', name: 'Project A' }] },
+  },
+} as unknown as Polled<MenubarPayload>
 const answer = {
   conclusion: 'Verified RESPONSE needle.', scopeLabel: 'Last 7 days · All projects · All providers', periodLabel: 'Last 7 days',
   evidence: [], coverage: { level: 'partial', label: 'Partial', detail: 'Test evidence.' }, assumptions: [], unknown: [], nextInvestigations: [], details: [],
   runtime: { id: 'test', label: 'Test', mode: 'deterministic-local' },
 } satisfies AdvisorAnswer
+
+async function submitQuestion(question: string): Promise<void> {
+  const previousCalls = investigate.mock.calls.length
+  fireEvent.change(screen.getByRole('textbox', { name: 'Ask Metrora Advisor' }), { target: { value: question } })
+  fireEvent.click(screen.getByRole('button', { name: /Investigate/ }))
+  await waitFor(() => expect(investigate.mock.calls).toHaveLength(previousCalls + 1))
+}
 
 describe('Advisor workspace', () => {
   beforeEach(() => {
@@ -73,6 +87,63 @@ describe('Advisor workspace', () => {
     expect(investigate).toHaveBeenCalledTimes(2)
     expect(investigate.mock.calls[1]?.[0]).toMatchObject({ question, scope: { provider: 'all', period: 'week' }, conversation: [] })
     expect(container.querySelectorAll('.user-message')).toHaveLength(1)
+  })
+
+  it('retains useful same-scope context for a follow-up', async () => {
+    render(<Advisor period="week" provider="all" projectScopeId="all" range={null} overview={overview} detectedProviders={[]} />)
+    await submitQuestion('First scope question')
+    await submitQuestion('Same scope follow-up')
+
+    expect(investigate.mock.calls[1]?.[0].conversation).toEqual([
+      { role: 'user', content: 'First scope question', scopeFingerprint: expect.any(String) },
+      { role: 'assistant', content: answer.conclusion, scopeFingerprint: expect.any(String) },
+    ])
+    expect(investigate.mock.calls[1]?.[0].conversation[0].scopeFingerprint).toBe(investigate.mock.calls[1]?.[0].conversation[1].scopeFingerprint)
+  })
+
+  it('keeps old messages visible but excludes factual context after a Project change', async () => {
+    render(<Advisor period="week" provider="all" projectScopeId="all" range={null} overview={overviewWithOptions} detectedProviders={[]} />)
+    await submitQuestion('Project A question')
+    fireEvent.change(screen.getByLabelText('Advisor Project'), { target: { value: 'project-a' } })
+    await waitFor(() => expect(screen.getByLabelText('Advisor Project')).toHaveValue('project-a'))
+    await submitQuestion('Project B question')
+
+    expect(investigate.mock.calls[1]?.[0].conversation).toEqual([])
+    expect(screen.getAllByText('Project A question').length).toBeGreaterThan(0)
+  })
+
+  it('excludes factual context after a period change', async () => {
+    render(<Advisor period="week" provider="all" projectScopeId="all" range={null} overview={overview} detectedProviders={[]} />)
+    await submitQuestion('Weekly question')
+    fireEvent.change(screen.getByLabelText('Advisor period'), { target: { value: '30days' } })
+    await waitFor(() => expect(screen.getByLabelText('Advisor period')).toHaveValue('30days'))
+    await submitQuestion('Thirty day question')
+
+    expect(investigate.mock.calls[1]?.[0].conversation).toEqual([])
+  })
+
+  it('excludes factual context after an explicit range change', async () => {
+    const view = render(<Advisor period="week" provider="all" projectScopeId="all" range={{ from: '2026-08-01', to: '2026-08-07' }} overview={overview} detectedProviders={[]} />)
+    await submitQuestion('First range question')
+    view.rerender(<Advisor period="week" provider="all" projectScopeId="all" range={{ from: '2026-08-08', to: '2026-08-14' }} overview={overview} detectedProviders={[]} />)
+    await waitFor(() => expect(screen.getByText(/Aug 8/)).toBeInTheDocument())
+    await submitQuestion('Second range question')
+
+    expect(investigate.mock.calls[1]?.[0].conversation).toEqual([])
+  })
+
+  it('excludes factual context after provider and model changes', async () => {
+    render(<Advisor period="week" provider="all" projectScopeId="all" range={null} overview={overviewWithOptions} detectedProviders={[{ id: 'codex', label: 'Codex' }]} />)
+    await submitQuestion('All provider question')
+    fireEvent.change(screen.getByLabelText('Advisor provider'), { target: { value: 'codex' } })
+    await waitFor(() => expect(screen.getByLabelText('Advisor provider')).toHaveValue('codex'))
+    await submitQuestion('Codex question')
+    expect(investigate.mock.calls[1]?.[0].conversation).toEqual([])
+
+    fireEvent.change(screen.getByLabelText('Advisor model'), { target: { value: 'gpt-safe' } })
+    await waitFor(() => expect(screen.getByLabelText('Advisor model')).toHaveValue('gpt-safe'))
+    await submitQuestion('Model question')
+    expect(investigate.mock.calls[2]?.[0].conversation).toEqual([])
   })
 
   it('searches conversation titles, questions, and answers case-insensitively and can clear the query', async () => {

--- a/app/renderer/sections/Advisor.test.tsx
+++ b/app/renderer/sections/Advisor.test.tsx
@@ -1,14 +1,17 @@
 // @vitest-environment jsdom
-import { render, screen, waitFor } from '@testing-library/react'
-import { describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { Polled } from '../hooks/usePolled'
 import type { MenubarPayload } from '../lib/types'
+import type { AdvisorAnswer } from '../advisor/types'
 import { Advisor } from './Advisor'
 
-const { advisorProbe } = vi.hoisted(() => ({
+const { advisorProbe, investigate } = vi.hoisted(() => ({
   advisorProbe: vi.fn(async () => ({ available: false, models: [], detail: 'Ollama is not running.' })),
+  investigate: vi.fn(),
 }))
+vi.mock('../advisor/kernel', () => ({ createAdvisorKernel: () => ({ investigate }) }))
 vi.mock('../lib/ipc', async importOriginal => {
   const actual = await importOriginal<typeof import('../lib/ipc')>()
   return {
@@ -32,8 +35,17 @@ const overview = {
   refresh: vi.fn(),
   refreshFresh: vi.fn(),
 } as unknown as Polled<MenubarPayload>
+const answer = {
+  conclusion: 'Verified RESPONSE needle.', scopeLabel: 'Last 7 days · All projects · All providers', periodLabel: 'Last 7 days',
+  evidence: [], coverage: { level: 'partial', label: 'Partial', detail: 'Test evidence.' }, assumptions: [], unknown: [], nextInvestigations: [], details: [],
+  runtime: { id: 'test', label: 'Test', mode: 'deterministic-local' },
+} satisfies AdvisorAnswer
 
 describe('Advisor workspace', () => {
+  beforeEach(() => {
+    advisorProbe.mockClear()
+    investigate.mockReset().mockResolvedValue(answer)
+  })
   it('opens with useful prompt families, explicit scope, local history, and evidence rail', async () => {
     render(<Advisor period="week" provider="all" projectScopeId="all" range={null} overview={overview} detectedProviders={[]} />)
 
@@ -45,5 +57,36 @@ describe('Advisor workspace', () => {
     expect(screen.getByRole('complementary', { name: 'Advisor evidence' })).toHaveTextContent('Ask a question to pin its evidence')
     await waitFor(() => expect(screen.getByText('Offline evidence fallback')).toBeInTheDocument())
     expect(advisorProbe).toHaveBeenCalledTimes(1)
+  })
+
+  it('retries the exact failed request in its original conversation and scope without duplicating the user message', async () => {
+    investigate.mockRejectedValueOnce(new Error('temporary failure')).mockResolvedValueOnce(answer)
+    const { container } = render(<Advisor period="week" provider="all" projectScopeId="all" range={null} overview={overview} detectedProviders={[{ id: 'codex', label: 'Codex' }]} />)
+    const question = 'Inspect spend behavior'
+    fireEvent.change(screen.getByRole('textbox', { name: 'Ask Metrora Advisor' }), { target: { value: question } })
+    fireEvent.click(screen.getByRole('button', { name: /Investigate/ }))
+    await screen.findByRole('alert')
+    fireEvent.change(screen.getByLabelText('Advisor provider'), { target: { value: 'codex' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+    await screen.findByText(answer.conclusion)
+
+    expect(investigate).toHaveBeenCalledTimes(2)
+    expect(investigate.mock.calls[1]?.[0]).toMatchObject({ question, scope: { provider: 'all', period: 'week' }, conversation: [] })
+    expect(container.querySelectorAll('.user-message')).toHaveLength(1)
+  })
+
+  it('searches conversation titles, questions, and answers case-insensitively and can clear the query', async () => {
+    render(<Advisor period="week" provider="all" projectScopeId="all" range={null} overview={overview} detectedProviders={[]} />)
+    fireEvent.change(screen.getByRole('textbox', { name: 'Ask Metrora Advisor' }), { target: { value: 'Inspect spend behavior' } })
+    fireEvent.click(screen.getByRole('button', { name: /Investigate/ }))
+    await screen.findByText(answer.conclusion)
+    fireEvent.click(screen.getByRole('button', { name: /New chat/ }))
+    const search = screen.getByRole('textbox', { name: 'Search Advisor history' })
+    fireEvent.change(search, { target: { value: 'response NEEDLE' } })
+    expect(screen.getByRole('button', { name: /Inspect spend behavior/ })).toBeInTheDocument()
+    fireEvent.change(search, { target: { value: 'not-present' } })
+    expect(screen.queryByRole('button', { name: /Inspect spend behavior/ })).not.toBeInTheDocument()
+    fireEvent.change(search, { target: { value: '' } })
+    expect(screen.getByRole('button', { name: /Inspect spend behavior/ })).toBeInTheDocument()
   })
 })

--- a/app/renderer/sections/Advisor.test.tsx
+++ b/app/renderer/sections/Advisor.test.tsx
@@ -1,0 +1,49 @@
+// @vitest-environment jsdom
+import { render, screen, waitFor } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import type { Polled } from '../hooks/usePolled'
+import type { MenubarPayload } from '../lib/types'
+import { Advisor } from './Advisor'
+
+const { advisorProbe } = vi.hoisted(() => ({
+  advisorProbe: vi.fn(async () => ({ available: false, models: [], detail: 'Ollama is not running.' })),
+}))
+vi.mock('../lib/ipc', async importOriginal => {
+  const actual = await importOriginal<typeof import('../lib/ipc')>()
+  return {
+    ...actual,
+    metrora: {
+      ...actual.metrora,
+      advisorProbe,
+      advisorChat: vi.fn(),
+      advisorCancel: vi.fn(async () => false),
+      onAdvisorDelta: vi.fn(() => () => {}),
+    },
+  }
+})
+
+const overview = {
+  data: null,
+  error: null,
+  loading: false,
+  switching: false,
+  lastSuccessAt: null,
+  refresh: vi.fn(),
+  refreshFresh: vi.fn(),
+} as unknown as Polled<MenubarPayload>
+
+describe('Advisor workspace', () => {
+  it('opens with useful prompt families, explicit scope, local history, and evidence rail', async () => {
+    render(<Advisor period="week" provider="all" projectScopeId="all" range={null} overview={overview} detectedProviders={[]} />)
+
+    expect(screen.getByRole('heading', { name: 'Ask Metrora' })).toBeInTheDocument()
+    expect(screen.getByRole('textbox', { name: 'Ask Metrora Advisor' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /What changed in my spend recently/ })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /What quota remains/ })).toBeInTheDocument()
+    expect(screen.getByRole('complementary', { name: 'Advisor conversations' })).toHaveTextContent('Session-local history')
+    expect(screen.getByRole('complementary', { name: 'Advisor evidence' })).toHaveTextContent('Ask a question to pin its evidence')
+    await waitFor(() => expect(screen.getByText('Offline evidence fallback')).toBeInTheDocument())
+    expect(advisorProbe).toHaveBeenCalledTimes(1)
+  })
+})

--- a/app/renderer/sections/Advisor.tsx
+++ b/app/renderer/sections/Advisor.tsx
@@ -14,6 +14,7 @@ import type { AdvisorAnswer, AdvisorConversationTurn, AdvisorScope } from '../ad
 type DetectedProvider = { id: string; label: string }
 type AdvisorMessage = { id: string; role: 'user' | 'assistant'; text?: string; answer?: AdvisorAnswer }
 type AdvisorConversation = { id: string; title: string; messages: AdvisorMessage[] }
+type AdvisorFailedRequest = { question: string; scope: AdvisorScope; conversationId: string; conversation: AdvisorConversationTurn[] }
 type RuntimeState = { status: 'checking' | 'ready' | 'unavailable'; detail: string; models: string[] }
 
 const PERIODS: Array<{ value: Period; label: string }> = PERIOD_OPTIONS.map(option => ({ value: option.value as Period, label: option.label }))
@@ -134,6 +135,7 @@ export function Advisor({
   const [streamPreview, setStreamPreview] = useState('')
   const [toolStatus, setToolStatus] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
+  const [failedRequest, setFailedRequest] = useState<AdvisorFailedRequest | null>(null)
   const [notice, setNotice] = useState<string | null>(null)
   const [selectedAnswerId, setSelectedAnswerId] = useState<string | null>(null)
   const requestController = useRef<AbortController | null>(null)
@@ -142,25 +144,32 @@ export function Advisor({
   const messages = activeConversation.messages
   const selectedAnswer = answerForMessage(messages, selectedAnswerId)
 
-  const updateActiveConversation = useCallback((update: (conversation: AdvisorConversation) => AdvisorConversation) => {
-    setConversations(current => current.map(conversation => conversation.id === activeConversationId ? update(conversation) : conversation))
-  }, [activeConversationId])
+  const updateConversation = useCallback((conversationId: string, update: (conversation: AdvisorConversation) => AdvisorConversation) => {
+    setConversations(current => current.map(conversation => conversation.id === conversationId ? update(conversation) : conversation))
+  }, [])
 
-  const ask = useCallback(async (rawQuestion: string) => {
+  const ask = useCallback(async (rawQuestion: string, retryRequest?: AdvisorFailedRequest) => {
     const question = rawQuestion.trim()
     if (!question || loadingQuestion) return
+    const requestedScope = retryRequest?.scope ?? scope
+    const conversationId = retryRequest?.conversationId ?? activeConversationId
+    const targetConversation = conversations.find(conversation => conversation.id === conversationId)
+    if (!targetConversation) return
     requestController.current?.abort()
     const controller = new AbortController()
     requestController.current = controller
-    const history: AdvisorConversationTurn[] = messages.map(message => ({ role: message.role, content: message.role === 'user' ? message.text ?? '' : message.answer?.conclusion ?? '' }))
-    const userMessage: AdvisorMessage = { id: makeId('user'), role: 'user', text: question }
-    updateActiveConversation(conversation => ({
-      ...conversation,
-      title: conversation.messages.length === 0 ? question.slice(0, 42) : conversation.title,
-      messages: [...conversation.messages, userMessage],
-    }))
+    const history: AdvisorConversationTurn[] = retryRequest?.conversation ?? targetConversation.messages.map(message => ({ role: message.role, content: message.role === 'user' ? message.text ?? '' : message.answer?.conclusion ?? '' }))
+    if (!retryRequest) {
+      const userMessage: AdvisorMessage = { id: makeId('user'), role: 'user', text: question }
+      updateConversation(conversationId, conversation => ({
+        ...conversation,
+        title: conversation.messages.length === 0 ? question.slice(0, 42) : conversation.title,
+        messages: [...conversation.messages, userMessage],
+      }))
+    }
     setComposer('')
     setError(null)
+    setFailedRequest(null)
     setNotice(null)
     setLoadingQuestion(question)
     setStreamPreview('')
@@ -168,8 +177,15 @@ export function Advisor({
     try {
       const answer = await kernel.investigate({
         question,
-        scope,
-        overview: suppliedOverviewMatchesScope ? overview.data : null,
+        scope: requestedScope,
+        overview: requestedScope.period === period
+          && requestedScope.provider === provider
+          && requestedScope.projectId === projectScopeId
+          && requestedScope.range?.from === range?.from
+          && requestedScope.range?.to === range?.to
+          && requestedScope.model === null
+          && !overview.loading
+          && !overview.switching ? overview.data : null,
         conversation: history,
         signal: controller.signal,
         onToolEvent: event => setToolStatus(event.status === 'started' ? 'Investigating ' + event.name.replaceAll('_', ' ') + '…' : null),
@@ -177,18 +193,26 @@ export function Advisor({
       })
       if (controller.signal.aborted) return
       const assistantMessage: AdvisorMessage = { id: makeId('assistant'), role: 'assistant', answer }
-      updateActiveConversation(conversation => ({ ...conversation, messages: [...conversation.messages, assistantMessage] }))
+      updateConversation(conversationId, conversation => ({ ...conversation, messages: [...conversation.messages, assistantMessage] }))
       setSelectedAnswerId(assistantMessage.id)
     } catch (caught) {
       if (isCancelled(caught)) setNotice('Investigation cancelled. Your conversation stays local to this session.')
-      else setError(caught instanceof Error ? caught.message : 'Advisor could not complete this investigation.')
+      else {
+        setFailedRequest({
+          question,
+          scope: { ...requestedScope, range: requestedScope.range ? { ...requestedScope.range } : null },
+          conversationId,
+          conversation: history.map(turn => ({ ...turn })),
+        })
+        setError(caught instanceof Error ? caught.message : 'Advisor could not complete this investigation.')
+      }
     } finally {
       if (requestController.current === controller) requestController.current = null
       setLoadingQuestion(null)
       setStreamPreview('')
       setToolStatus(null)
     }
-  }, [kernel, loadingQuestion, messages, overview.data, scope, updateActiveConversation])
+  }, [activeConversationId, conversations, kernel, loadingQuestion, overview.data, overview.loading, overview.switching, period, projectScopeId, provider, range?.from, range?.to, scope, updateConversation])
 
   const submit = (event: FormEvent) => {
     event.preventDefault()
@@ -212,7 +236,11 @@ export function Advisor({
     setError(null)
     setNotice(null)
   }
-  const filteredConversations = conversations.filter(conversation => conversation.title.toLowerCase().includes(historyQuery.trim().toLowerCase()))
+  const normalizedHistoryQuery = historyQuery.trim().toLowerCase()
+  const filteredConversations = conversations.filter(conversation => !normalizedHistoryQuery || [
+    conversation.title,
+    ...conversation.messages.map(message => message.text ?? message.answer?.conclusion ?? ''),
+  ].some(value => value.toLowerCase().includes(normalizedHistoryQuery)))
   const runtimeLabel = runtimeState.status === 'ready' && ollamaRuntime ? ollamaRuntime.label : 'Offline evidence fallback'
   const runtimeDescription = runtimeState.status === 'ready' && ollamaRuntime
     ? 'Local Ollama model · read-only evidence tools · capability varies by model'
@@ -281,7 +309,7 @@ export function Advisor({
             )
           )}
           {loadingQuestion ? <article className="advisor-message assistant-message pending"><div className="advisor-message-label"><span className="advisor-mini-mark">M</span> Metrora Advisor</div><p className="advisor-tool-progress">{toolStatus ?? 'Thinking with local evidence…'}</p>{streamPreview ? <p className="advisor-stream-preview">{streamPreview}</p> : null}<button type="button" className="advisor-cancel" onClick={cancel}>Cancel</button></article> : null}
-          {error ? <div className="advisor-error" role="alert"><strong>Investigation unavailable.</strong> {error}<button type="button" onClick={() => void ask(composer || loadingQuestion || '')}>Retry</button></div> : null}
+          {error ? <div className="advisor-error" role="alert"><strong>Investigation unavailable.</strong> {error}<button type="button" onClick={() => { if (failedRequest) { setActiveConversationId(failedRequest.conversationId); void ask(failedRequest.question, failedRequest) } }}>Retry</button></div> : null}
           {notice ? <div className="advisor-notice" role="status">{notice}</div> : null}
         </div>
         <form className="advisor-composer" onSubmit={submit}>

--- a/app/renderer/sections/Advisor.tsx
+++ b/app/renderer/sections/Advisor.tsx
@@ -9,10 +9,10 @@ import { createAdvisorKernel } from '../advisor/kernel'
 import { createAdvisorRuntime } from '../advisor/runtime'
 import { OllamaAdvisorRuntime, probeOllama, type OllamaProbeResult } from '../advisor/ollama'
 import { scopeLabel } from '../advisor/evidence'
-import type { AdvisorAnswer, AdvisorConversationTurn, AdvisorScope } from '../advisor/types'
+import { advisorScopeFingerprint, type AdvisorAnswer, type AdvisorConversationTurn, type AdvisorScope } from '../advisor/types'
 
 type DetectedProvider = { id: string; label: string }
-type AdvisorMessage = { id: string; role: 'user' | 'assistant'; text?: string; answer?: AdvisorAnswer }
+type AdvisorMessage = { id: string; role: 'user' | 'assistant'; text?: string; answer?: AdvisorAnswer; scopeFingerprint: string }
 type AdvisorConversation = { id: string; title: string; messages: AdvisorMessage[] }
 type AdvisorFailedRequest = { question: string; scope: AdvisorScope; conversationId: string; conversation: AdvisorConversationTurn[] }
 type RuntimeState = { status: 'checking' | 'ready' | 'unavailable'; detail: string; models: string[] }
@@ -158,9 +158,12 @@ export function Advisor({
     requestController.current?.abort()
     const controller = new AbortController()
     requestController.current = controller
-    const history: AdvisorConversationTurn[] = retryRequest?.conversation ?? targetConversation.messages.map(message => ({ role: message.role, content: message.role === 'user' ? message.text ?? '' : message.answer?.conclusion ?? '' }))
+    const requestedScopeFingerprint = advisorScopeFingerprint(requestedScope)
+    const history: AdvisorConversationTurn[] = retryRequest?.conversation ?? targetConversation.messages
+      .map(message => ({ role: message.role, content: message.role === 'user' ? message.text ?? '' : message.answer?.conclusion ?? '', scopeFingerprint: message.scopeFingerprint }))
+      .filter(turn => turn.scopeFingerprint === requestedScopeFingerprint)
     if (!retryRequest) {
-      const userMessage: AdvisorMessage = { id: makeId('user'), role: 'user', text: question }
+      const userMessage: AdvisorMessage = { id: makeId('user'), role: 'user', text: question, scopeFingerprint: requestedScopeFingerprint }
       updateConversation(conversationId, conversation => ({
         ...conversation,
         title: conversation.messages.length === 0 ? question.slice(0, 42) : conversation.title,
@@ -192,7 +195,7 @@ export function Advisor({
         onDelta: text => setStreamPreview(text),
       })
       if (controller.signal.aborted) return
-      const assistantMessage: AdvisorMessage = { id: makeId('assistant'), role: 'assistant', answer }
+      const assistantMessage: AdvisorMessage = { id: makeId('assistant'), role: 'assistant', answer, scopeFingerprint: requestedScopeFingerprint }
       updateConversation(conversationId, conversation => ({ ...conversation, messages: [...conversation.messages, assistantMessage] }))
       setSelectedAnswerId(assistantMessage.id)
     } catch (caught) {

--- a/app/renderer/sections/Advisor.tsx
+++ b/app/renderer/sections/Advisor.tsx
@@ -1,0 +1,299 @@
+import { useCallback, useEffect, useMemo, useRef, useState, type FormEvent, type KeyboardEvent } from 'react'
+
+import type { Polled } from '../hooks/usePolled'
+import { metrora } from '../lib/ipc'
+import type { DateRange, MenubarPayload, Period } from '../lib/types'
+import { PERIOD_OPTIONS } from '../components/TopBar'
+import { createAdvisorDataSource } from '../advisor/source'
+import { createAdvisorKernel } from '../advisor/kernel'
+import { createAdvisorRuntime } from '../advisor/runtime'
+import { OllamaAdvisorRuntime, probeOllama, type OllamaProbeResult } from '../advisor/ollama'
+import { scopeLabel } from '../advisor/evidence'
+import type { AdvisorAnswer, AdvisorConversationTurn, AdvisorScope } from '../advisor/types'
+
+type DetectedProvider = { id: string; label: string }
+type AdvisorMessage = { id: string; role: 'user' | 'assistant'; text?: string; answer?: AdvisorAnswer }
+type AdvisorConversation = { id: string; title: string; messages: AdvisorMessage[] }
+type RuntimeState = { status: 'checking' | 'ready' | 'unavailable'; detail: string; models: string[] }
+
+const PERIODS: Array<{ value: Period; label: string }> = PERIOD_OPTIONS.map(option => ({ value: option.value as Period, label: option.label }))
+const PROMPTS = [
+  { eyebrow: 'Spend changes', label: 'What changed in my spend recently?', question: 'What changed in my spend recently?' },
+  { eyebrow: 'Model efficiency', label: 'Which model has the lowest observed cost per call?', question: 'Which model has the lowest observed cost per call?' },
+  { eyebrow: 'Capacity', label: 'What quota remains and when does it reset?', question: 'What provider quota remains and when does it reset?' },
+  { eyebrow: 'Projects', label: 'Which Project drove the most spend?', question: 'Which Project drove the most spend in this scope?' },
+]
+
+function makeId(prefix: string): string {
+  return prefix + '-' + Date.now().toString(36) + '-' + Math.random().toString(36).slice(2, 7)
+}
+function isCancelled(error: unknown): boolean {
+  if (error instanceof Error) return error.name === 'AbortError' || error.name === 'AdvisorCancelledError' || /cancel|abort/i.test(error.message)
+  if (error && typeof error === 'object') {
+    const item = error as { kind?: unknown; message?: unknown }
+    return item.kind === 'cancelled' || (typeof item.message === 'string' && /cancel|abort/i.test(item.message))
+  }
+  return false
+}
+function providerLabel(provider: string): string {
+  if (provider === 'all') return 'All providers'
+  return provider.split(/[-\s]+/).filter(Boolean).map(part => part.charAt(0).toUpperCase() + part.slice(1)).join(' ')
+}
+function displayAnswer(answer: AdvisorAnswer): string {
+  return answer.conclusion
+}
+function answerForMessage(messages: AdvisorMessage[], id: string | null): AdvisorAnswer | null {
+  if (id) {
+    const selected = messages.find(message => message.id === id)
+    if (selected?.answer) return selected.answer
+  }
+  return [...messages].reverse().find(message => message.answer)?.answer ?? null
+}
+
+export function Advisor({
+  period,
+  provider,
+  projectScopeId = 'all',
+  range = null,
+  overview,
+  detectedProviders,
+}: {
+  period: Period
+  provider: string
+  projectScopeId?: string
+  range?: DateRange | null
+  overview: Polled<MenubarPayload>
+  detectedProviders: DetectedProvider[]
+}) {
+  const projectOptions = overview.data?.projectScope?.options ?? []
+  const projectName = projectScopeId === 'all'
+    ? 'All projects'
+    : projectOptions.find(option => option.id === projectScopeId)?.name ?? projectScopeId
+  const modelOptions = [...new Set([
+    ...(overview.data?.current.modelAccounting?.rows.map(row => row.name) ?? []),
+    ...(overview.data?.current.topModels.map(row => row.name) ?? []),
+  ])].filter(Boolean).slice(0, 40)
+  const providerOptions = [{ id: 'all', label: 'All providers' }, ...detectedProviders.filter(item => item.id !== 'all')]
+
+  const [scope, setScope] = useState<AdvisorScope>(() => ({
+    period,
+    range,
+    provider,
+    projectId: projectScopeId,
+    projectName,
+    model: null,
+  }))
+  useEffect(() => {
+    setScope(current => ({ ...current, period, range, provider, projectId: projectScopeId, projectName }))
+  }, [period, provider, projectScopeId, projectName, range])
+  useEffect(() => {
+    if (scope.model && !modelOptions.includes(scope.model)) setScope(current => ({ ...current, model: null }))
+  }, [modelOptions, scope.model])
+
+  const source = useMemo(() => createAdvisorDataSource(metrora), [])
+  const fallbackRuntime = useMemo(() => createAdvisorRuntime(), [])
+  const [runtimeState, setRuntimeState] = useState<RuntimeState>({ status: 'checking', detail: 'Checking for a local Ollama model…', models: [] })
+  const [runtimeModel, setRuntimeModel] = useState<string | null>(null)
+  const [ollamaRuntime, setOllamaRuntime] = useState<OllamaAdvisorRuntime | null>(null)
+  const activeRuntime = ollamaRuntime ?? fallbackRuntime
+  const kernel = useMemo(() => createAdvisorKernel(source, activeRuntime), [activeRuntime, source])
+  const probeController = useRef<AbortController | null>(null)
+
+  const checkLocalRuntime = useCallback(async () => {
+    probeController.current?.abort()
+    const controller = new AbortController()
+    probeController.current = controller
+    setRuntimeState({ status: 'checking', detail: 'Checking for a local Ollama model…', models: [] })
+    try {
+      const result: OllamaProbeResult = await probeOllama(controller.signal)
+      if (controller.signal.aborted) return
+      if (result.available && result.models[0]) {
+        const selected = runtimeModel && result.models.includes(runtimeModel) ? runtimeModel : result.models[0]
+        setRuntimeModel(selected)
+        setOllamaRuntime(new OllamaAdvisorRuntime({ model: selected, availability: 'ready' }))
+        setRuntimeState({ status: 'ready', detail: result.detail, models: result.models })
+      } else {
+        setRuntimeModel(null)
+        setOllamaRuntime(null)
+        setRuntimeState({ status: 'unavailable', detail: result.detail, models: [] })
+      }
+    } catch (error) {
+      if (!isCancelled(error)) setRuntimeState({ status: 'unavailable', detail: 'Local runtime probe was cancelled or failed.', models: [] })
+    }
+  }, [runtimeModel])
+  useEffect(() => {
+    void checkLocalRuntime()
+    return () => probeController.current?.abort()
+  }, [checkLocalRuntime])
+
+  const [conversations, setConversations] = useState<AdvisorConversation[]>(() => [{ id: makeId('chat'), title: 'New investigation', messages: [] }])
+  const [activeConversationId, setActiveConversationId] = useState(() => conversations[0]!.id)
+  const [historyQuery, setHistoryQuery] = useState('')
+  const [composer, setComposer] = useState('')
+  const [loadingQuestion, setLoadingQuestion] = useState<string | null>(null)
+  const [streamPreview, setStreamPreview] = useState('')
+  const [toolStatus, setToolStatus] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [notice, setNotice] = useState<string | null>(null)
+  const [selectedAnswerId, setSelectedAnswerId] = useState<string | null>(null)
+  const requestController = useRef<AbortController | null>(null)
+
+  const activeConversation = conversations.find(conversation => conversation.id === activeConversationId) ?? conversations[0]!
+  const messages = activeConversation.messages
+  const selectedAnswer = answerForMessage(messages, selectedAnswerId)
+
+  const updateActiveConversation = useCallback((update: (conversation: AdvisorConversation) => AdvisorConversation) => {
+    setConversations(current => current.map(conversation => conversation.id === activeConversationId ? update(conversation) : conversation))
+  }, [activeConversationId])
+
+  const ask = useCallback(async (rawQuestion: string) => {
+    const question = rawQuestion.trim()
+    if (!question || loadingQuestion) return
+    requestController.current?.abort()
+    const controller = new AbortController()
+    requestController.current = controller
+    const history: AdvisorConversationTurn[] = messages.map(message => ({ role: message.role, content: message.role === 'user' ? message.text ?? '' : message.answer?.conclusion ?? '' }))
+    const userMessage: AdvisorMessage = { id: makeId('user'), role: 'user', text: question }
+    updateActiveConversation(conversation => ({
+      ...conversation,
+      title: conversation.messages.length === 0 ? question.slice(0, 42) : conversation.title,
+      messages: [...conversation.messages, userMessage],
+    }))
+    setComposer('')
+    setError(null)
+    setNotice(null)
+    setLoadingQuestion(question)
+    setStreamPreview('')
+    setToolStatus(null)
+    try {
+      const answer = await kernel.investigate({
+        question,
+        scope,
+        overview: suppliedOverviewMatchesScope ? overview.data : null,
+        conversation: history,
+        signal: controller.signal,
+        onToolEvent: event => setToolStatus(event.status === 'started' ? 'Investigating ' + event.name.replaceAll('_', ' ') + '…' : null),
+        onDelta: text => setStreamPreview(text),
+      })
+      if (controller.signal.aborted) return
+      const assistantMessage: AdvisorMessage = { id: makeId('assistant'), role: 'assistant', answer }
+      updateActiveConversation(conversation => ({ ...conversation, messages: [...conversation.messages, assistantMessage] }))
+      setSelectedAnswerId(assistantMessage.id)
+    } catch (caught) {
+      if (isCancelled(caught)) setNotice('Investigation cancelled. Your conversation stays local to this session.')
+      else setError(caught instanceof Error ? caught.message : 'Advisor could not complete this investigation.')
+    } finally {
+      if (requestController.current === controller) requestController.current = null
+      setLoadingQuestion(null)
+      setStreamPreview('')
+      setToolStatus(null)
+    }
+  }, [kernel, loadingQuestion, messages, overview.data, scope, updateActiveConversation])
+
+  const submit = (event: FormEvent) => {
+    event.preventDefault()
+    void ask(composer)
+  }
+  const composerKeyDown = (event: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (event.key === 'Enter' && !event.shiftKey) {
+      event.preventDefault()
+      void ask(composer)
+    }
+  }
+  const cancel = () => {
+    requestController.current?.abort()
+    setNotice('Cancelling the local investigation…')
+  }
+  const newConversation = () => {
+    const next: AdvisorConversation = { id: makeId('chat'), title: 'New investigation', messages: [] }
+    setConversations(current => [next, ...current])
+    setActiveConversationId(next.id)
+    setSelectedAnswerId(null)
+    setError(null)
+    setNotice(null)
+  }
+  const filteredConversations = conversations.filter(conversation => conversation.title.toLowerCase().includes(historyQuery.trim().toLowerCase()))
+  const runtimeLabel = runtimeState.status === 'ready' && ollamaRuntime ? ollamaRuntime.label : 'Offline evidence fallback'
+  const runtimeDescription = runtimeState.status === 'ready' && ollamaRuntime
+    ? 'Local Ollama model · read-only evidence tools · capability varies by model'
+    : 'Deterministic evidence fallback · no model connected'
+  const latestAnswer = selectedAnswer ?? answerForMessage(messages, null)
+  const suppliedOverviewMatchesScope = scope.period === period
+    && scope.provider === provider
+    && scope.projectId === projectScopeId
+    && scope.range?.from === range?.from
+    && scope.range?.to === range?.to
+    && scope.model === null
+    && !overview.loading
+    && !overview.switching
+
+  return (
+    <section className="advisor-workspace" aria-label="Metrora Advisor">
+      <aside className="advisor-history" aria-label="Advisor conversations">
+        <div className="advisor-history-head">
+          <div className="advisor-brand"><span className="advisor-orb">M</span><div><strong>Advisor</strong><small>Evidence, in plain language</small></div></div>
+          <button className="advisor-new-chat" type="button" onClick={newConversation}>＋ New chat</button>
+        </div>
+        <label className="advisor-search"><span aria-hidden="true">⌕</span><input aria-label="Search Advisor history" placeholder="Search this session" value={historyQuery} onChange={event => setHistoryQuery(event.target.value)} /></label>
+        <div className="advisor-history-list">
+          {filteredConversations.map(conversation => (
+            <button key={conversation.id} type="button" className={conversation.id === activeConversationId ? 'advisor-history-item active' : 'advisor-history-item'} onClick={() => setActiveConversationId(conversation.id)}>
+              <span>{conversation.title}</span><small>{conversation.messages.length ? conversation.messages.length + ' messages' : 'Ready to explore'}</small>
+            </button>
+          ))}
+        </div>
+        <div className="advisor-history-foot">Session-local history · never synced</div>
+      </aside>
+
+      <main className="advisor-main">
+        <header className="advisor-main-head">
+          <div><p className="advisor-kicker">ADVISE · READ ONLY</p><h1>Ask Metrora</h1><p className="advisor-subtitle">Investigate measured usage, model efficiency, Projects, and provider capacity.</p></div>
+          <div className="advisor-runtime-status">
+            <span className={runtimeState.status === 'ready' ? 'advisor-status-dot ready' : 'advisor-status-dot'} />
+            <div><strong>{runtimeLabel}</strong><small>{runtimeDescription} · {runtimeState.detail}</small></div>
+            <button type="button" className="advisor-quiet-button" onClick={() => void checkLocalRuntime()}>{runtimeState.status === 'checking' ? 'Checking…' : 'Check local model'}</button>
+            {runtimeState.models.length ? <label className="advisor-runtime-picker">Runtime<select aria-label="Advisor local runtime model" value={runtimeModel ?? runtimeState.models[0]} onChange={event => { const model = event.target.value; setRuntimeModel(model); setOllamaRuntime(new OllamaAdvisorRuntime({ model, availability: 'ready' })) }}>{runtimeState.models.map(model => <option key={model} value={model}>{model}</option>)}</select></label> : null}
+          </div>
+        </header>
+        <div className="advisor-scope-bar" aria-label="Advisor context">
+          <span className="advisor-scope-label">Context</span>
+          <label>Period<select aria-label="Advisor period" value={scope.period} onChange={event => setScope(current => ({ ...current, period: event.target.value as Period }))}>{PERIODS.map(option => <option key={option.value} value={option.value}>{option.label}</option>)}</select></label>
+          <label>Project<select aria-label="Advisor Project" value={scope.projectId} onChange={event => { const id = event.target.value; setScope(current => ({ ...current, projectId: id, projectName: id === 'all' ? 'All projects' : projectOptions.find(option => option.id === id)?.name ?? id })) }}><option value="all">All projects</option>{projectOptions.map(option => <option key={option.id} value={option.id}>{option.name}</option>)}</select></label>
+          <label>Provider<select aria-label="Advisor provider" value={scope.provider} onChange={event => setScope(current => ({ ...current, provider: event.target.value }))}>{providerOptions.map(option => <option key={option.id} value={option.id}>{option.label}</option>)}</select></label>
+          <label>Model<select aria-label="Advisor model" value={scope.model ?? ''} onChange={event => setScope(current => ({ ...current, model: event.target.value || null }))}><option value="">All models</option>{modelOptions.map(model => <option key={model} value={model}>{model}</option>)}</select></label>
+          <span className="advisor-read-only">Read-only · {scopeLabel(scope)}</span>
+        </div>
+        {runtimeState.status === 'unavailable' ? <div className="advisor-runtime-note"><strong>No local model connected.</strong> You can still use the explicit offline evidence fallback; connect Ollama to unlock free-form model conversation and tool calls. <button type="button" onClick={() => void checkLocalRuntime()}>Try again</button></div> : null}
+        {overview.error && !overview.data ? <div className="advisor-runtime-note warning"><strong>Canonical Metrora data is unavailable.</strong> {overview.error.message}</div> : null}
+        <div className="advisor-thread" aria-live="polite">
+          {messages.length === 0 ? (
+            <div className="advisor-welcome">
+              <span className="advisor-welcome-mark">M</span>
+              <p className="advisor-kicker">LOCAL INVESTIGATION SPACE</p>
+              <h2>What should we look into?</h2>
+              <p>Ask naturally. A connected local model can call Metrora evidence tools; every number stays in verified details.</p>
+              <div className="advisor-prompt-grid">{PROMPTS.map(prompt => <button key={prompt.question} type="button" className="advisor-prompt" onClick={() => void ask(prompt.question)}><small>{prompt.eyebrow}</small><span>{prompt.label}</span><i>↗</i></button>)}</div>
+            </div>
+          ) : (
+            messages.map(message => message.role === 'user'
+              ? <article key={message.id} className="advisor-message user-message"><div className="advisor-message-label">You</div><p>{message.text}</p></article>
+              : <article key={message.id} className={selectedAnswerId === message.id ? 'advisor-message assistant-message selected' : 'advisor-message assistant-message'} onClick={() => setSelectedAnswerId(message.id)}><div className="advisor-message-label"><span className="advisor-mini-mark">M</span> Metrora Advisor <small>{message.answer?.generatedByModel ? 'local model' : 'offline evidence'}</small></div><p className="advisor-conclusion">{displayAnswer(message.answer!)}</p><div className="advisor-answer-meta"><span className={'advisor-coverage ' + message.answer?.coverage.level}>{message.answer?.coverage.label}</span><span>{message.answer?.scopeLabel}</span></div><details onClick={event => event.stopPropagation()}><summary>Evidence & limits</summary><div className="advisor-details">{message.answer?.details.map((detail, index) => <div key={index}>{detail}</div>)}</div><div className="advisor-limits"><strong>Unknown / limits</strong>{message.answer?.unknown.map((item, index) => <div key={index}>{item}</div>)}</div></details>{message.answer?.nextInvestigations.length ? <div className="advisor-followups"><span>Continue with</span>{message.answer.nextInvestigations.map(next => <button type="button" key={next} onClick={event => { event.stopPropagation(); void ask(next) }}>{next}</button>)}</div> : null}</article>
+            )
+          )}
+          {loadingQuestion ? <article className="advisor-message assistant-message pending"><div className="advisor-message-label"><span className="advisor-mini-mark">M</span> Metrora Advisor</div><p className="advisor-tool-progress">{toolStatus ?? 'Thinking with local evidence…'}</p>{streamPreview ? <p className="advisor-stream-preview">{streamPreview}</p> : null}<button type="button" className="advisor-cancel" onClick={cancel}>Cancel</button></article> : null}
+          {error ? <div className="advisor-error" role="alert"><strong>Investigation unavailable.</strong> {error}<button type="button" onClick={() => void ask(composer || loadingQuestion || '')}>Retry</button></div> : null}
+          {notice ? <div className="advisor-notice" role="status">{notice}</div> : null}
+        </div>
+        <form className="advisor-composer" onSubmit={submit}>
+          <textarea aria-label="Ask Metrora Advisor" placeholder="Ask about spend, models, Projects, sessions, or quota…" value={composer} onChange={event => setComposer(event.target.value)} onKeyDown={composerKeyDown} disabled={Boolean(loadingQuestion)} rows={2} />
+          <div className="advisor-composer-foot"><span>Enter to investigate · Shift+Enter for a new line</span>{loadingQuestion ? <button type="button" className="advisor-cancel" onClick={cancel}>Cancel</button> : <button type="submit" className="advisor-send" disabled={!composer.trim()}>Investigate <span>↗</span></button>}</div>
+        </form>
+      </main>
+
+      <aside className="advisor-evidence" aria-label="Advisor evidence">
+        <div className="advisor-evidence-head"><p className="advisor-kicker">PROGRESSIVE DISCLOSURE</p><h2>Evidence</h2><span>Facts stay here. The model is not the authority.</span></div>
+        {latestAnswer ? <div className="advisor-evidence-body"><div className={'advisor-coverage-card ' + latestAnswer.coverage.level}><span>{latestAnswer.coverage.label}</span><p>{latestAnswer.coverage.detail}</p></div><div className="advisor-evidence-section"><h3>Scope</h3><p>{latestAnswer.scopeLabel}</p><p>{latestAnswer.periodLabel}</p></div><div className="advisor-evidence-section"><h3>Sources</h3>{latestAnswer.evidence.map(ref => <div className="advisor-ref" key={ref.id}><i />{ref.label}</div>)}</div><div className="advisor-evidence-section"><h3>Assumptions</h3>{latestAnswer.assumptions.map((item, index) => <p className="advisor-muted-line" key={index}>{item}</p>)}</div><div className="advisor-evidence-section"><h3>Unknown</h3>{latestAnswer.unknown.map((item, index) => <p className="advisor-muted-line" key={index}>{item}</p>)}</div>{latestAnswer.nextInvestigations.length ? <div className="advisor-evidence-section"><h3>Next investigation</h3>{latestAnswer.nextInvestigations.map(next => <button type="button" className="advisor-next-link" key={next} onClick={() => void ask(next)}>{next} <span>↗</span></button>)}</div> : null}</div> : <div className="advisor-evidence-empty"><span>✦</span><p>Ask a question to pin its evidence, scope, coverage, and unknowns here.</p></div>}
+      </aside>
+    </section>
+  )
+}

--- a/app/renderer/styles/advisor.css
+++ b/app/renderer/styles/advisor.css
@@ -1,0 +1,348 @@
+:root {
+  --advisor-ink: #17191f;
+  --advisor-muted: #6d7482;
+  --advisor-line: rgba(35, 39, 49, .12);
+  --advisor-surface: rgba(255,255,255,.86);
+  --advisor-surface-strong: #ffffff;
+  --advisor-tint: #f5f6f8;
+  --advisor-accent: #e65d19;
+  --advisor-accent-soft: rgba(230,93,25,.12);
+  --advisor-blue: #2d6fe5;
+}
+@media (prefers-color-scheme: dark) {
+  :root {
+    --advisor-ink: #f1f2f5;
+    --advisor-muted: #9ba2ae;
+    --advisor-line: rgba(236,239,245,.12);
+    --advisor-surface: rgba(22,24,29,.88);
+    --advisor-surface-strong: #191c22;
+    --advisor-tint: #111318;
+    --advisor-accent: #ff8650;
+    --advisor-accent-soft: rgba(255,134,80,.14);
+    --advisor-blue: #78a5ff;
+  }
+}
+:root[data-theme='light'] {
+  --advisor-ink: #17191f;
+  --advisor-muted: #6d7482;
+  --advisor-line: rgba(35, 39, 49, .12);
+  --advisor-surface: rgba(255,255,255,.86);
+  --advisor-surface-strong: #ffffff;
+  --advisor-tint: #f5f6f8;
+  --advisor-accent: #e65d19;
+  --advisor-accent-soft: rgba(230,93,25,.12);
+  --advisor-blue: #2d6fe5;
+}
+:root[data-theme='dark'] {
+  --advisor-ink: #f1f2f5;
+  --advisor-muted: #9ba2ae;
+  --advisor-line: rgba(236,239,245,.12);
+  --advisor-surface: rgba(22,24,29,.88);
+  --advisor-surface-strong: #191c22;
+  --advisor-tint: #111318;
+  --advisor-accent: #ff8650;
+  --advisor-accent-soft: rgba(255,134,80,.14);
+  --advisor-blue: #78a5ff;
+}
+.advisor-workspace {
+  display: grid;
+  margin: 0;
+  grid-template-columns: 226px minmax(0, 1fr) 278px;
+  flex: 1 1 auto;
+  align-self: stretch;
+  width: 100%;
+  min-height: 0;
+  overflow: hidden;
+  color: var(--advisor-ink);
+  background:
+    radial-gradient(circle at 56% -10%, var(--advisor-accent-soft), transparent 34%),
+    var(--advisor-tint);
+  border-top: 1px solid var(--advisor-line);
+}
+.advisor-history,
+.advisor-evidence {
+  min-width: 0;
+  min-height: 0;
+  background: var(--advisor-surface);
+}
+.advisor-history {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding: 20px 14px 14px;
+  border-right: 1px solid var(--advisor-line);
+}
+.advisor-history-head { display: grid; gap: 18px; }
+.advisor-brand { display: flex; align-items: center; gap: 10px; }
+.advisor-brand strong { display: block; font-size: 14px; letter-spacing: -.02em; }
+.advisor-brand small { display: block; margin-top: 2px; color: var(--advisor-muted); font-size: 10px; }
+.advisor-orb,
+.advisor-welcome-mark,
+.advisor-mini-mark {
+  display: inline-grid;
+  place-items: center;
+  color: #fff;
+  background: linear-gradient(145deg, var(--advisor-accent), #bc3b49);
+  box-shadow: 0 6px 18px rgba(204,73,40,.25);
+}
+.advisor-orb { width: 30px; height: 30px; border-radius: 10px; font-weight: 800; }
+.advisor-new-chat,
+.advisor-send {
+  border: 0;
+  color: #fff;
+  background: var(--advisor-accent);
+  box-shadow: 0 8px 18px rgba(193,70,24,.2);
+}
+.advisor-new-chat {
+  border-radius: 8px;
+  padding: 10px 11px;
+  text-align: left;
+  font-weight: 650;
+  cursor: pointer;
+}
+.advisor-new-chat:hover,
+.advisor-send:hover { filter: brightness(1.06); transform: translateY(-1px); }
+.advisor-search {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  padding: 8px 9px;
+  border: 1px solid var(--advisor-line);
+  border-radius: 8px;
+  color: var(--advisor-muted);
+  background: var(--advisor-tint);
+}
+.advisor-search input {
+  min-width: 0;
+  width: 100%;
+  border: 0;
+  outline: 0;
+  color: inherit;
+  background: transparent;
+  font: inherit;
+  font-size: 11px;
+}
+.advisor-history-list { display: grid; gap: 4px; min-height: 0; overflow: auto; }
+.advisor-history-item {
+  display: grid;
+  gap: 4px;
+  width: 100%;
+  padding: 9px 10px;
+  border: 1px solid transparent;
+  border-radius: 8px;
+  color: var(--advisor-ink);
+  background: transparent;
+  text-align: left;
+  cursor: pointer;
+}
+.advisor-history-item span { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-size: 11px; }
+.advisor-history-item small { color: var(--advisor-muted); font-size: 10px; }
+.advisor-history-item:hover,
+.advisor-history-item.active { border-color: var(--advisor-line); background: var(--advisor-tint); }
+.advisor-history-item.active { box-shadow: inset 2px 0 var(--advisor-accent); }
+.advisor-history-foot { margin-top: auto; color: var(--advisor-muted); font-size: 9px; line-height: 1.4; }
+.advisor-main { display: flex; flex-direction: column; min-width: 0; min-height: 0; }
+.advisor-main-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 20px;
+  padding: 25px 30px 16px;
+  border-bottom: 1px solid var(--advisor-line);
+  background: linear-gradient(180deg, var(--advisor-surface-strong), transparent);
+}
+.advisor-kicker { margin: 0 0 7px; color: var(--advisor-accent); font-size: 9px; font-weight: 800; letter-spacing: .16em; }
+.advisor-main-head h1 { margin: 0; font-size: 25px; letter-spacing: -.045em; }
+.advisor-subtitle { margin: 6px 0 0; color: var(--advisor-muted); font-size: 11px; }
+.advisor-runtime-status { display: flex; align-items: center; gap: 9px; max-width: 360px; color: var(--advisor-muted); }
+.advisor-runtime-status strong { display: block; color: var(--advisor-ink); font-size: 11px; }
+.advisor-runtime-status small { display: block; margin-top: 3px; font-size: 9px; line-height: 1.3; }
+.advisor-status-dot { width: 7px; height: 7px; flex: 0 0 auto; border-radius: 50%; background: var(--advisor-muted); }
+.advisor-status-dot.ready { background: #22a06b; box-shadow: 0 0 0 4px rgba(34,160,107,.12); }
+.advisor-quiet-button {
+  flex: 0 0 auto;
+  border: 1px solid var(--advisor-line);
+  border-radius: 7px;
+  padding: 7px 8px;
+  color: var(--advisor-muted);
+  background: transparent;
+  font: inherit;
+  font-size: 9px;
+  cursor: pointer;
+}
+.advisor-quiet-button:hover { color: var(--advisor-ink); background: var(--advisor-tint); }
+.advisor-runtime-picker { display: grid; gap: 3px; color: var(--advisor-muted); font-size: 9px; }
+.advisor-runtime-picker select {
+  max-width: 116px;
+  border: 1px solid var(--advisor-line);
+  border-radius: 5px;
+  padding: 4px 5px;
+  color: var(--advisor-ink);
+  background: var(--advisor-tint);
+  font: inherit;
+  font-size: 9px;
+}
+.advisor-scope-bar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 46px;
+  padding: 7px 30px;
+  border-bottom: 1px solid var(--advisor-line);
+  color: var(--advisor-muted);
+  background: var(--advisor-surface);
+}
+.advisor-scope-label { margin-right: 4px; color: var(--advisor-ink); font-size: 10px; font-weight: 750; }
+.advisor-scope-bar label { display: inline-flex; align-items: center; gap: 5px; font-size: 9px; }
+.advisor-scope-bar select {
+  max-width: 128px;
+  border: 1px solid var(--advisor-line);
+  border-radius: 6px;
+  padding: 5px 6px;
+  color: var(--advisor-ink);
+  background: var(--advisor-tint);
+  font: inherit;
+  font-size: 10px;
+}
+.advisor-read-only {
+  margin-left: auto;
+  color: var(--advisor-accent);
+  font-size: 9px;
+  font-weight: 700;
+  white-space: nowrap;
+}
+.advisor-runtime-note {
+  margin: 12px 30px 0;
+  padding: 10px 12px;
+  border: 1px solid rgba(230,93,25,.25);
+  border-radius: 8px;
+  color: var(--advisor-muted);
+  background: var(--advisor-accent-soft);
+  font-size: 10px;
+  line-height: 1.45;
+}
+.advisor-runtime-note strong { color: var(--advisor-ink); }
+.advisor-runtime-note button,
+.advisor-followups button,
+.advisor-next-link { border: 0; color: var(--advisor-accent); background: transparent; font: inherit; cursor: pointer; }
+.advisor-thread {
+  display: flex;
+  flex: 1 1 auto;
+  flex-direction: column;
+  gap: 18px;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 26px 30px 20px;
+}
+.advisor-welcome { max-width: 700px; margin: auto; padding: 28px 0 38px; text-align: center; }
+.advisor-welcome-mark { width: 48px; height: 48px; margin-bottom: 16px; border-radius: 16px; font-size: 20px; font-weight: 800; }
+.advisor-welcome h2 { margin: 0; font-size: 26px; letter-spacing: -.045em; }
+.advisor-welcome > p:not(.advisor-kicker) { margin: 10px auto 22px; max-width: 500px; color: var(--advisor-muted); font-size: 12px; line-height: 1.55; }
+.advisor-prompt-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 9px; text-align: left; }
+.advisor-prompt {
+  position: relative;
+  display: grid;
+  gap: 7px;
+  min-height: 76px;
+  padding: 13px;
+  border: 1px solid var(--advisor-line);
+  border-radius: 10px;
+  color: var(--advisor-ink);
+  background: var(--advisor-surface);
+  text-align: left;
+  cursor: pointer;
+  transition: border-color .16s ease, transform .16s ease, box-shadow .16s ease;
+}
+.advisor-prompt:hover { border-color: var(--advisor-accent); box-shadow: 0 8px 24px rgba(34,39,49,.08); transform: translateY(-2px); }
+.advisor-prompt small { color: var(--advisor-accent); font-size: 9px; font-weight: 750; text-transform: uppercase; letter-spacing: .08em; }
+.advisor-prompt span { max-width: 85%; font-size: 11px; line-height: 1.35; }
+.advisor-prompt i { position: absolute; right: 12px; bottom: 11px; color: var(--advisor-muted); font-style: normal; }
+.advisor-message { max-width: 760px; animation: advisor-in .18s ease both; }
+.advisor-message-label { display: flex; align-items: center; gap: 7px; margin-bottom: 7px; color: var(--advisor-muted); font-size: 9px; font-weight: 700; letter-spacing: .03em; }
+.advisor-message-label small { margin-left: 4px; font-weight: 500; }
+.advisor-mini-mark { width: 19px; height: 19px; border-radius: 6px; font-size: 9px; }
+.user-message { align-self: flex-end; max-width: 78%; padding: 10px 13px; border-radius: 12px 12px 3px 12px; color: #fff; background: #303743; }
+.user-message .advisor-message-label { color: rgba(255,255,255,.65); }
+.user-message p { margin: 0; font-size: 12px; line-height: 1.45; }
+.assistant-message { padding: 12px 14px; border: 1px solid var(--advisor-line); border-radius: 12px; background: var(--advisor-surface); }
+.assistant-message.selected { border-color: var(--advisor-accent); box-shadow: 0 8px 25px rgba(30,34,44,.06); }
+.advisor-conclusion { margin: 0; font-size: 13px; line-height: 1.58; }
+.advisor-answer-meta { display: flex; flex-wrap: wrap; gap: 7px; margin-top: 11px; color: var(--advisor-muted); font-size: 9px; }
+.advisor-coverage { padding: 3px 6px; border-radius: 5px; color: #18704f; background: rgba(34,160,107,.12); font-weight: 750; }
+.advisor-coverage.partial { color: #956000; background: rgba(210,145,0,.14); }
+.advisor-coverage.unavailable { color: #a23a34; background: rgba(194,56,47,.12); }
+.advisor-message details { margin-top: 13px; border-top: 1px solid var(--advisor-line); padding-top: 9px; color: var(--advisor-muted); font-size: 10px; }
+.advisor-message summary { cursor: pointer; color: var(--advisor-ink); font-weight: 700; }
+.advisor-details,
+.advisor-limits { display: grid; gap: 5px; margin-top: 9px; line-height: 1.45; }
+.advisor-limits { padding-top: 8px; border-top: 1px dashed var(--advisor-line); }
+.advisor-limits strong { color: var(--advisor-ink); }
+.advisor-followups { display: flex; flex-wrap: wrap; gap: 6px; align-items: center; margin-top: 12px; color: var(--advisor-muted); font-size: 9px; }
+.advisor-followups button { padding: 4px 7px; border: 1px solid var(--advisor-line); border-radius: 5px; font-size: 9px; }
+.advisor-followups button:hover { border-color: var(--advisor-accent); }
+.advisor-tool-progress { margin: 0; color: var(--advisor-accent); font-size: 11px; font-weight: 700; }
+.advisor-stream-preview { margin: 8px 0 0; color: var(--advisor-muted); font-size: 11px; line-height: 1.45; }
+.advisor-cancel { border: 1px solid var(--advisor-line); border-radius: 6px; padding: 5px 8px; color: var(--advisor-muted); background: transparent; font: inherit; font-size: 10px; cursor: pointer; }
+.advisor-cancel:hover { color: var(--advisor-ink); background: var(--advisor-tint); }
+.advisor-error,
+.advisor-notice { padding: 10px 12px; border-radius: 8px; font-size: 10px; line-height: 1.45; }
+.advisor-error { color: #9b3932; background: rgba(194,56,47,.1); }
+.advisor-notice { color: var(--advisor-muted); background: var(--advisor-tint); }
+.advisor-error strong { color: var(--advisor-ink); }
+.advisor-error button { margin-left: 8px; border: 0; color: inherit; background: transparent; text-decoration: underline; cursor: pointer; }
+.advisor-composer {
+  display: grid;
+  gap: 9px;
+  margin: 0 30px 22px;
+  padding: 12px 13px 10px;
+  border: 1px solid var(--advisor-line);
+  border-radius: 12px;
+  background: var(--advisor-surface-strong);
+  box-shadow: 0 10px 30px rgba(30,34,44,.08);
+}
+.advisor-composer textarea { width: 100%; min-height: 44px; resize: vertical; border: 0; outline: 0; color: var(--advisor-ink); background: transparent; font: inherit; font-size: 12px; line-height: 1.5; }
+.advisor-composer textarea::placeholder { color: var(--advisor-muted); }
+.advisor-composer-foot { display: flex; align-items: center; justify-content: space-between; gap: 10px; color: var(--advisor-muted); font-size: 9px; }
+.advisor-send { border-radius: 7px; padding: 7px 10px; font: inherit; font-size: 10px; font-weight: 750; cursor: pointer; }
+.advisor-send:disabled { cursor: not-allowed; opacity: .45; }
+.advisor-evidence { display: flex; flex-direction: column; overflow-y: auto; border-left: 1px solid var(--advisor-line); }
+.advisor-evidence-head { padding: 23px 18px 15px; border-bottom: 1px solid var(--advisor-line); }
+.advisor-evidence-head h2 { margin: 0; font-size: 17px; letter-spacing: -.03em; }
+.advisor-evidence-head > span { display: block; margin-top: 6px; color: var(--advisor-muted); font-size: 9px; line-height: 1.4; }
+.advisor-evidence-body { display: grid; gap: 17px; padding: 17px 18px 24px; }
+.advisor-coverage-card { padding: 10px; border-radius: 8px; background: rgba(34,160,107,.1); }
+.advisor-coverage-card.partial { background: rgba(210,145,0,.12); }
+.advisor-coverage-card.unavailable { background: rgba(194,56,47,.1); }
+.advisor-coverage-card span { color: var(--advisor-ink); font-size: 10px; font-weight: 800; }
+.advisor-coverage-card p { margin: 5px 0 0; color: var(--advisor-muted); font-size: 9px; line-height: 1.4; }
+.advisor-evidence-section { display: grid; gap: 6px; }
+.advisor-evidence-section h3 { margin: 0; color: var(--advisor-muted); font-size: 9px; font-weight: 800; letter-spacing: .1em; text-transform: uppercase; }
+.advisor-evidence-section p { margin: 0; color: var(--advisor-ink); font-size: 10px; line-height: 1.45; }
+.advisor-muted-line { color: var(--advisor-muted) !important; }
+.advisor-ref { display: flex; gap: 7px; align-items: flex-start; color: var(--advisor-ink); font-size: 10px; line-height: 1.35; }
+.advisor-ref i { width: 5px; height: 5px; flex: 0 0 auto; margin-top: 4px; border-radius: 50%; background: var(--advisor-accent); }
+.advisor-next-link { display: flex; justify-content: space-between; gap: 8px; padding: 0; text-align: left; font-size: 10px; line-height: 1.45; }
+.advisor-next-link:hover { text-decoration: underline; }
+.advisor-evidence-empty { margin: auto 18px; color: var(--advisor-muted); text-align: center; }
+.advisor-evidence-empty span { display: block; color: var(--advisor-accent); font-size: 21px; }
+.advisor-evidence-empty p { font-size: 10px; line-height: 1.5; }
+@keyframes advisor-in { from { opacity: 0; transform: translateY(4px); } to { opacity: 1; transform: none; } }
+@media (max-width: 1180px) {
+  .advisor-workspace { grid-template-columns: 190px minmax(0, 1fr) 240px; }
+  .advisor-main-head, .advisor-scope-bar, .advisor-thread { padding-left: 20px; padding-right: 20px; }
+  .advisor-composer { margin-left: 20px; margin-right: 20px; }
+  .advisor-runtime-status { max-width: 280px; }
+}
+@media (max-width: 900px) {
+  .advisor-workspace { grid-template-columns: 0 minmax(0, 1fr) 230px; }
+  .advisor-history { display: none; }
+}
+@media (max-width: 700px) {
+  .advisor-workspace { grid-template-columns: minmax(0, 1fr); }
+  .advisor-evidence { display: none; }
+  .advisor-main-head { display: block; }
+  .advisor-runtime-status { margin-top: 14px; max-width: none; }
+  .advisor-scope-bar { overflow-x: auto; }
+  .advisor-scope-label { position: sticky; left: 0; }
+  .advisor-prompt-grid { grid-template-columns: 1fr; }
+}

--- a/docs/ADVISOR_PUBLIC_FOUNDATION.md
+++ b/docs/ADVISOR_PUBLIC_FOUNDATION.md
@@ -1,0 +1,70 @@
+# Metrora Advisor public foundation
+
+Metrora Advisor is a read-only, local-first investigation surface. It turns a plain-language question into a bounded conversation over canonical Metrora records. It does not execute actions, change provider settings, estimate billing, or act as an accounting authority.
+
+## Public architecture
+
+The public path is deliberately replaceable:
+
+  canonical Metrora records
+          -> deterministic evidence tools
+          -> Advisor Kernel
+          -> AdvisorModelRuntime
+          -> verified local runtime (Ollama first)
+          -> session-local Advisor UI
+
+The deterministic tools own facts, arithmetic, coverage, currency formatting, and provider-quota freshness. A model can choose among the exposed read-only tools and write qualitative context, but its prose never replaces verified evidence. The UI renders the verified evidence rail and details beside the model context.
+
+The first tool set covers:
+
+- overview and measured spend;
+- descriptive Project and content-minimal session highlights;
+- observed model cost-per-call rows;
+- provider-reported quota windows, freshness, reset boundaries, and credits;
+- coverage, assumptions, unknowns, and next investigations.
+
+Tool outputs are compact JSON contracts. They do not include raw source content, prompts, local paths, secrets, or chain-of-thought.
+
+## Runtime boundary
+
+The implemented local transport targets the official Ollama local HTTP API. Model capability remains unverified until an operator selects and uses a local model:
+
+- Electron main is the only process allowed to call http://127.0.0.1:11434;
+- the renderer receives an allowlisted IPC bridge with probe, chat, cancellation, and bounded delta events;
+- the endpoint is fixed to loopback; arbitrary URLs are not accepted;
+- model names are discovered from /api/tags and selected explicitly in the Advisor header;
+- a planning request may return multiple tool calls; tools execute locally; one final request streams with tools disabled;
+- cancellation uses an AbortController in main and a request id in the bridge;
+- timeouts, message/content/response byte caps, stream chunk caps, malformed-chunk caps, and bounded redacted errors are enforced.
+
+Ollama support is model-dependent: a discovered model is not automatically evidence that its tool-calling behavior is capable. The UI says that capability varies by model. The deterministic local runtime remains an explicit offline fallback when no local model is connected; it is not presented as a full free-form chatbot.
+
+No provider SDK or new runtime dependency is required. LM Studio and hosted/cloud BYOK adapters are follow-up work until their Electron boundary, model capability, cancellation, and privacy behavior are proven.
+
+Official provenance references: [Ollama Chat API](https://docs.ollama.com/api/chat), [tool calling](https://docs.ollama.com/capabilities/tool-calling), [streaming](https://docs.ollama.com/capabilities/streaming), and the [Ollama core license](https://github.com/ollama/ollama/blob/main/LICENSE).
+
+## Evidence and truth rules
+
+Metrora measured spend uses the active Metrora currency formatter. Provider-reported credits remain explicitly USD because the provider contract says so. Missing totals stay unavailable; they are never coerced to zero. A provider quota snapshot is distinct from Metrora usage.
+
+Fresh and connected provider snapshots may show values. A stale snapshot is the canonical combination of `freshness: stale` and `availability: unavailable`; it retains last-observed values only when its connection is `stale` or `transientFailure` and its `observedAt` is valid, and says that refresh failed. Unavailable snapshots without valid retained facts show no number, plan, or invented zero. A passed reset boundary is not rendered as “resets now”. No burn-rate, forecast, allocation, routing, or automation is introduced in this tranche.
+
+Trend language is deliberately descriptive: latest returned day versus the average of earlier returned days. It does not claim previous-period causality.
+
+## Privacy and storage
+
+Conversation history is session-local in the renderer and is not synced or persisted by this foundation. The local model receives only the bounded conversation, the current question, tool schemas, and compact evidence-tool results through the local loopback boundary. Raw source content, prompts, paths, secrets, and hidden reasoning are excluded from the public contract.
+
+There is no Metrora gateway, managed inference service, cloud billing path, secret storage requirement, or hosted BYOK in this tranche. If a future provider adapter needs a credential, it must live behind the existing Electron main-process/OS secure-storage boundary and never in renderer JavaScript.
+
+## Public/private boundary
+
+This branch publishes the reusable Advisor Kernel/contracts, deterministic evidence tools, safe local runtime rules, UI, tests, and this conformance/provenance description.
+
+It does not publish proprietary ranking or recommendation systems, private evaluations or playbooks, personalized forecasting, advanced allocation/routing/automation, commercial strategy, or private roadmap material. The public UI is an evidence reader and investigator, not a decision authority.
+
+## Provenance and licenses
+
+The repository is MIT-licensed. This foundation adds no package dependency. Ollama core is MIT-licensed (see the official license link above); this branch incorporates no Ollama code or package, so THIRD_PARTY_NOTICES.md does not change. The Ollama service/API are separate from each model's weights. Model weights may carry independent licenses and must be reviewed by the operator before use. The Advisor interaction pattern is an original Metrora implementation.
+
+Synthetic conformance tests cover the fixed loopback endpoint, incremental NDJSON, cancellation, bounded errors, nullable evidence, mixed quota freshness, unavailable-provider privacy, multi-tool aggregation, deterministic fact authority, and the session-local welcome surface.

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,6 +19,7 @@ This index separates user guidance, current product guarantees, public contracts
 
 - [Product principles](PRODUCT_PRINCIPLES.md) — stable local-first, privacy, evidence and portability commitments.
 - [Architecture](architecture.md) — current responsibility and authority map for the public codebase.
+- [Advisor public foundation](ADVISOR_PUBLIC_FOUNDATION.md) — read-only conversational evidence architecture, local runtime boundary, privacy rules, tests and license provenance.
 - [Canonical history read projection v1](CANONICAL_HISTORY_READ_PROJECTION_V1.md) — shadow observation/activity identity and trusted daily-history boundary.
 - [Canonical history shadow store v1](CANONICAL_HISTORY_SHADOW_STORE_V1.md) — removable content-addressed persistence and cross-refresh reconciliation.
 - [Canonical history parity observer v1](CANONICAL_HISTORY_PARITY_OBSERVER_V1.md) — non-authoritative cache-to-shadow parity validation before snapshot publication.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -62,6 +62,15 @@ The Electron main process owns privileged work:
 - validation of external URLs and export destinations.
 
 The preload bridge exposes a narrow typed API. The renderer runs with context isolation and no Node integration, consumes public DTOs and must not implement its own parser, pricing engine or evidence authority.
+### Advisor — app/renderer/advisor/
+
+Advisor is a read-only conversational layer over canonical desktop records. Its
+public flow is deterministic evidence tools → Advisor Kernel →
+AdvisorModelRuntime → a local loopback runtime → a session-local UI. Electron
+main owns the local model HTTP boundary; the renderer receives only the typed
+preload bridge. See [ADVISOR_PUBLIC_FOUNDATION.md](ADVISOR_PUBLIC_FOUNDATION.md)
+for the public contract, privacy boundary, runtime capability caveats and
+provenance.
 
 State orchestration, domain formatting and presentation are extracted into focused modules before a component or main-process module becomes oversized.
 


### PR DESCRIPTION
## Summary

- Adds a local-first conversational Advisor foundation for Metrora.
- Uses Ollama as the first bounded local runtime with deterministic evidence-before-inference.
- Supports spend/change, model-efficiency, and capacity investigations scoped by project, provider, model, and period.
- Adds streaming and cancellation with session-local conversation state.
- Keeps Advisor read-only: no hosted gateway, no managed service, and no state-changing actions.