### PR TITLE
feat(capacity): clarify provider quota experience

### DIFF
--- a/app/renderer/sections/Plans.test.tsx
+++ b/app/renderer/sections/Plans.test.tsx
@@ -117,8 +117,10 @@ describe('Plans', () => {
     const { container } = render(<Plans period="30days" />)
 
     expect(await screen.findByText('Max 20x')).toBeInTheDocument()
-    expect(screen.getByText('25% used · resets in 2h 29m')).toBeInTheDocument()
-    expect(screen.getByText('92% used · resets in 3d 14h')).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Capacity' })).toBeInTheDocument()
+    expect(screen.getByLabelText('Capacity status: Fresh')).toBeInTheDocument()
+    expect(screen.getByText('25% used · 75% remaining · resets in 2h 29m')).toBeInTheDocument()
+    expect(screen.getByText('92% used · 8% remaining · resets in 3d 14h')).toBeInTheDocument()
     expect(container.querySelector('[data-testid="quota-track-five_hour"] i')).toHaveClass('accent')
     expect(container.querySelector('[data-testid="quota-track-seven_day"] i')).toHaveClass('bad')
     expect(screen.getByText('Not connected. Log in with the Codex CLI.')).toBeInTheDocument()
@@ -133,6 +135,22 @@ describe('Plans', () => {
     expect(screen.getByText('On track')).toHaveClass('pace', 'ok')
     expect(screen.queryByText('Claude Max')).not.toBeInTheDocument()
     expect(screen.queryByText('API usage')).not.toBeInTheDocument()
+  })
+
+  it('keeps provider provenance in a progressive details disclosure', async () => {
+    getPlans.mockResolvedValue(baseStatus)
+    getQuota.mockResolvedValue([quota('codex', { planLabel: 'Plus', credits: { balance: 3.5, currency: 'USD' } })])
+
+    const { container } = render(<Plans period="30days" />)
+
+    await screen.findByText('Credits remaining · $3.50')
+    const details = container.querySelector('details.quota-details')
+    expect(details).not.toHaveAttribute('open')
+    fireEvent.click(screen.getByText('Provider details'))
+    expect(details).toHaveAttribute('open')
+    expect(details).toHaveTextContent('Source')
+    expect(details).toHaveTextContent('Provider-reported')
+    expect(details).toHaveTextContent('Observed')
   })
 
   it('renders provider credits when no quota windows are present', async () => {
@@ -154,6 +172,23 @@ describe('Plans', () => {
     expect(await screen.findByText('Credits remaining · $0.00')).toBeInTheDocument()
   })
 
+  it('labels a passed reset boundary without fabricating unavailable capacity', async () => {
+    getPlans.mockResolvedValue(baseStatus)
+    getQuota.mockResolvedValue([
+      quota('claude', {
+        planLabel: 'Pro',
+        windows: [{ id: 'primary', label: 'Primary', usedFraction: 1, resetsAt: '2026-07-11T00:00:00.000Z', windowSeconds: null }],
+      }),
+      quota('codex', { connection: 'transientFailure', availability: 'unavailable', freshness: 'unavailable', observedAt: null }),
+    ])
+
+    render(<Plans period="30days" />)
+
+    expect(await screen.findByText('100% used · 0% remaining · reset passed')).toBeInTheDocument()
+    expect(screen.getByLabelText('Capacity status: Unavailable')).toBeInTheDocument()
+    expect(screen.queryAllByTestId(/^quota-track-/)).toHaveLength(1)
+  })
+
   it('renders stale credits-only last-good data with its original observation note', async () => {
     getPlans.mockResolvedValue(baseStatus)
     getQuota.mockResolvedValue([quota('codex', {
@@ -167,6 +202,7 @@ describe('Plans', () => {
     render(<Plans period="30days" />)
 
     expect(await screen.findByText(/Showing last provider-reported quota from/)).toBeInTheDocument()
+    expect(screen.getByLabelText('Capacity status: Stale')).toBeInTheDocument()
     expect(screen.getByText('Credits remaining · $3.50')).toBeInTheDocument()
   })
 

--- a/app/renderer/sections/Plans.tsx
+++ b/app/renderer/sections/Plans.tsx
@@ -100,7 +100,14 @@ export function Plans({ period, refreshToken = 0, onNavigate, ready = true }: { 
       </div>
       <div className={motionClass('body', 'section-fade')}>
         {budgetReport.data && budgetReport.error && <StaleBanner error={budgetReport.error} />}
-        {renderQuota(quota.data, quota.error, reconnect)}
+        <section className="capacity-section" aria-labelledby="capacity-heading">
+          <div className="capacity-section-head">
+            <h2 id="capacity-heading" className="plans-section-heading">Capacity</h2>
+            <span className="capacity-authority">Provider-reported</span>
+          </div>
+          <p className="capacity-intro">Quota and credits from each provider. Metrora usage and local budgets stay separate.</p>
+          {renderQuota(quota.data, quota.error, reconnect)}
+        </section>
         {renderBudgetPlans(budgetReport.data, budgetReport.error, manualPlans)}
       </div>
     </>
@@ -111,8 +118,8 @@ function renderQuota(data: QuotaProvider[] | null, error: ReturnType<typeof useP
   if (!data) {
     if (error) {
       return (
-        <Panel title="Live quota">
-          <p className="quota-connection-note quota-terminal">Live quota is unavailable.</p>
+        <Panel title="Provider capacity">
+          <p className="quota-connection-note quota-terminal">Provider capacity is unavailable.</p>
         </Panel>
       )
     }
@@ -121,8 +128,8 @@ function renderQuota(data: QuotaProvider[] | null, error: ReturnType<typeof useP
 
   if (data.length === 0) {
     return (
-      <Panel title="Live quota">
-        <p className="quota-connection-note">No quota providers available.</p>
+      <Panel title="Provider capacity">
+        <p className="quota-connection-note">No provider capacity is available.</p>
       </Panel>
     )
   }
@@ -172,12 +179,32 @@ function ConnectionIndicator({ connection }: { connection: QuotaProvider['connec
 }
 
 function QuotaContent({ quota, onReconnect }: { quota: QuotaProvider; onReconnect: () => void }) {
+  const status = <QuotaStatus quota={quota} />
   if (quota.connection === 'disconnected' || quota.connection === 'accessDenied') {
-    return <ConnectAffordance provider={quota.provider} connection={quota.connection} onRefresh={onReconnect} />
+    return (
+      <>
+        {status}
+        <ConnectAffordance provider={quota.provider} connection={quota.connection} onRefresh={onReconnect} />
+        <QuotaDetails quota={quota} />
+      </>
+    )
   }
-  if (quota.connection === 'loading') return <p className="quota-connection-note">Loading quota…</p>
+  if (quota.connection === 'loading') {
+    return (
+      <>
+        {status}
+        <p className="quota-connection-note">Loading quota…</p>
+      </>
+    )
+  }
   if (quota.connection === 'terminalFailure') {
-    return <p className="quota-connection-note quota-terminal">Quota is currently unavailable.</p>
+    return (
+      <>
+        {status}
+        <p className="quota-connection-note quota-terminal">Provider capacity is currently unavailable.</p>
+        <QuotaDetails quota={quota} />
+      </>
+    )
   }
   const stale = quota.freshness === 'stale' || quota.connection === 'stale' || quota.connection === 'transientFailure'
   const note = isRateLimited(quota)
@@ -186,21 +213,79 @@ function QuotaContent({ quota, onReconnect }: { quota: QuotaProvider; onReconnec
       ? staleQuotaNote(quota)
       : null
   if (quota.freshness === 'unavailable') {
-    return note
-      ? <p className="quota-connection-note">{note}</p>
-      : <p className="quota-connection-note">The provider did not report quota evidence.</p>
+    return (
+      <>
+        {status}
+        {note
+          ? <p className="quota-connection-note">{note}</p>
+          : <p className="quota-connection-note">The provider did not report quota evidence.</p>}
+        <QuotaDetails quota={quota} />
+      </>
+    )
   }
 
   const hasWindows = quota.windows.length > 0
 
   return (
     <>
+      {status}
       {note ? <p className="quota-connection-note">{note}</p> : null}
       {hasWindows
         ? <div className="quota-windows">{quota.windows.map(window => <QuotaMeter key={window.id} window={window} />)}</div>
         : <p className="quota-connection-note">The provider did not report quota windows.</p>}
       {quota.credits !== null ? <div className="quota-footer"><span>Credits remaining · ${quota.credits.balance.toFixed(2)}</span></div> : null}
+      <QuotaDetails quota={quota} />
     </>
+  )
+}
+
+function QuotaStatus({ quota }: { quota: QuotaProvider }) {
+  const state = quotaStatus(quota)
+  const observed = quota.freshness === 'unavailable' ? null : formatObservedAt(quota.observedAt)
+  const observation = observed
+    ? `${quota.freshness === 'stale' ? 'Last observed' : 'Observed'} ${observed}`
+    : null
+  return (
+    <div className={`quota-status quota-status-${state.tone}`} aria-label={`Capacity status: ${state.label}`}>
+      <span className="quota-status-label"><i />{state.label}</span>
+      {observation ? <span className="quota-status-observed">{observation}</span> : null}
+    </div>
+  )
+}
+
+function quotaStatus(quota: QuotaProvider): { label: string; tone: 'fresh' | 'stale' | 'warn' | 'bad' | 'muted' } {
+  if (quota.rateLimit.state === 'backoff') return { label: 'Rate limited', tone: 'warn' }
+  if (quota.connection === 'disconnected') return { label: 'Disconnected', tone: 'muted' }
+  if (quota.connection === 'accessDenied') return { label: 'Access needed', tone: 'warn' }
+  if (quota.connection === 'loading') return { label: 'Loading', tone: 'muted' }
+  if (quota.connection === 'terminalFailure') return { label: 'Unavailable', tone: 'bad' }
+  if (quota.freshness === 'stale' || (quota.connection === 'stale' && quota.freshness !== 'unavailable')) {
+    return { label: 'Stale', tone: 'stale' }
+  }
+  if (quota.freshness === 'fresh' && quota.connection === 'connected') return { label: 'Fresh', tone: 'fresh' }
+  return { label: 'Unavailable', tone: 'muted' }
+}
+
+function freshnessLabel(quota: QuotaProvider): string {
+  if (quota.freshness === 'fresh') return 'Fresh'
+  if (quota.freshness === 'stale') return 'Stale'
+  return 'Unavailable'
+}
+
+function QuotaDetails({ quota }: { quota: QuotaProvider }) {
+  const observed = quota.freshness === 'unavailable' ? null : formatObservedAt(quota.observedAt)
+  const retryAt = quota.rateLimit.state === 'backoff' ? formatObservedAt(quota.rateLimit.retryAt) : null
+  return (
+    <details className="quota-details">
+      <summary>Provider details</summary>
+      <div className="quota-detail-grid">
+        <span>Source</span><span>Provider-reported</span>
+        <span>Status</span><span>{quotaStatus(quota).label}</span>
+        <span>Freshness</span><span>{freshnessLabel(quota)}</span>
+        <span>Observed</span><span>{observed ?? 'Not available'}</span>
+        {retryAt ? <><span>Retry after</span><span>{retryAt}</span></> : null}
+      </div>
+    </details>
   )
 }
 
@@ -211,15 +296,23 @@ function staleQuotaNote(quota: QuotaProvider): string {
   return `Showing last provider-reported quota from ${new Intl.DateTimeFormat('en-US', { dateStyle: 'medium', timeStyle: 'short' }).format(observed)}.`
 }
 
+function formatObservedAt(value: string | null): string | null {
+  if (!value) return null
+  const observed = new Date(value)
+  if (Number.isNaN(observed.getTime())) return null
+  return new Intl.DateTimeFormat('en-US', { dateStyle: 'medium', timeStyle: 'short' }).format(observed)
+}
+
 function QuotaMeter({ window }: { window: QuotaWindow }) {
-  const percent = Math.round(window.usedFraction * 100)
+  const percent = Math.round(Math.min(1, Math.max(0, window.usedFraction)) * 100)
+  const remaining = 100 - percent
   const severity = window.usedFraction >= 0.9 ? 'bad' : window.usedFraction >= 0.7 ? 'warn' : 'accent'
   const reset = formatResetTime(window.resetsAt)
   return (
     <div className="quota-window">
       <div className="quota-window-labels">
         <span>{window.label}</span>
-        <span>{percent}% used{reset ? ` · resets ${reset}` : ''}</span>
+        <span>{percent}% used · {remaining}% remaining{reset ? ` · ${reset}` : ''}</span>
       </div>
       <div className="track" data-testid={`quota-track-${window.id}`}>
         <i className={severity} style={{ width: `${Math.min(100, Math.max(0, percent))}%` }} />
@@ -233,13 +326,13 @@ function formatResetTime(resetsAt: string | null): string | null {
   const reset = Date.parse(resetsAt)
   if (!Number.isFinite(reset)) return null
   const remainingMinutes = Math.floor((reset - Date.now()) / 60_000)
-  if (remainingMinutes <= 0) return 'now'
+  if (remainingMinutes <= 0) return 'reset passed'
   const days = Math.floor(remainingMinutes / (24 * 60))
   const hours = Math.floor((remainingMinutes % (24 * 60)) / 60)
   const minutes = remainingMinutes % 60
-  if (days > 0) return `in ${days}d${hours > 0 ? ` ${hours}h` : ''}`
-  if (hours > 0) return `in ${hours}h${minutes > 0 ? ` ${minutes}m` : ''}`
-  return `in ${minutes}m`
+  if (days > 0) return `resets in ${days}d${hours > 0 ? ` ${hours}h` : ''}`
+  if (hours > 0) return `resets in ${hours}h${minutes > 0 ? ` ${minutes}m` : ''}`
+  return `resets in ${minutes}m`
 }
 
 function PlanPanel({ plan }: { plan: JsonPlanSummary }) {

--- a/app/renderer/styles/plain.css
+++ b/app/renderer/styles/plain.css
@@ -491,7 +491,12 @@ td:first-child { font-size: var(--fs-body); font-weight: var(--fw-body); }
 .track i.warn { background: var(--warn); }
 .track i.bad { background: var(--bad); }
 
-/* Plans: live subscription quota, followed by manual dollar budgets. */
+/* Plans: provider-reported capacity, followed by separate local budget plans. */
+.capacity-section { display: grid; width: 100%; gap: 8px; }
+.capacity-section-head { display: flex; align-items: baseline; gap: 9px; }
+.capacity-section-head .plans-section-heading { margin-bottom: 0; }
+.capacity-authority { color: var(--mut2); font-size: 10px; font-weight: 560; letter-spacing: .04em; text-transform: uppercase; }
+.capacity-intro { margin: -2px 0 1px; color: var(--mut); font-size: 11.5px; line-height: 1.45; }
 .quota-title { display: inline-flex; align-items: baseline; gap: 8px; }
 .quota-title small { color: var(--mut); font-size: 10.5px; font-weight: 520; }
 .quota-connection { display: inline-flex; align-items: center; gap: 5px; color: var(--mut); font-size: 10px; font-weight: 520; }
@@ -501,6 +506,16 @@ td:first-child { font-size: var(--fs-body); font-weight: var(--fw-body); }
 .quota-connection-terminalFailure i { background: var(--bad); }
 .quota-connection-note { margin: 0; color: var(--mut); font-size: 12px; }
 .quota-connection-note.quota-terminal { color: var(--bad); }
+.quota-status { display: flex; align-items: center; flex-wrap: wrap; gap: 8px; margin: 0 0 10px; color: var(--mut); font-size: 10.5px; }
+.quota-status-label { display: inline-flex; align-items: center; gap: 5px; font-weight: 620; }
+.quota-status-label i { width: 6px; height: 6px; border-radius: 50%; background: var(--mut2); }
+.quota-status-fresh .quota-status-label { color: var(--ok); }
+.quota-status-fresh .quota-status-label i { background: var(--ok); }
+.quota-status-stale .quota-status-label, .quota-status-warn .quota-status-label { color: var(--warn); }
+.quota-status-stale .quota-status-label i, .quota-status-warn .quota-status-label i { background: var(--warn); }
+.quota-status-bad .quota-status-label { color: var(--bad); }
+.quota-status-bad .quota-status-label i { background: var(--bad); }
+.quota-status-observed { margin-left: auto; color: var(--mut2); font-family: var(--mono); font-size: 10px; font-variant-numeric: tabular-nums; }
 .quota-connect { display: flex; flex-wrap: wrap; align-items: baseline; gap: 8px; }
 .quota-connect-toggle { flex: none; }
 .quota-connect-guide { flex-basis: 100%; display: flex; flex-direction: column; align-items: flex-start; gap: 6px; margin-top: 4px; }
@@ -512,6 +527,12 @@ td:first-child { font-size: var(--fs-body); font-weight: var(--fw-body); }
 .quota-window-labels span:last-child { margin-left: auto; color: var(--mut); font-family: var(--mono); font-size: 11px; font-variant-numeric: tabular-nums; text-align: right; }
 .quota-window .track { margin-top: 7px; }
 .quota-footer { display: flex; flex-direction: column; gap: 3px; margin-top: 13px; padding-top: 10px; border-top: 1px solid var(--line2); color: var(--mut); font-size: 10.5px; }
+.quota-details { margin-top: 12px; padding-top: 9px; border-top: 1px solid var(--line2); color: var(--mut); font-size: 10.5px; }
+.quota-details summary { cursor: pointer; font-weight: 560; list-style-position: inside; }
+.quota-details summary:hover { color: var(--ink); }
+.quota-detail-grid { display: grid; grid-template-columns: auto minmax(0, 1fr); gap: 5px 12px; margin-top: 8px; }
+.quota-detail-grid span:nth-child(odd) { color: var(--mut2); }
+.quota-detail-grid span:nth-child(even) { color: var(--ink); font-family: var(--mono); font-size: 10px; font-variant-numeric: tabular-nums; text-align: right; }
 .plans-section-heading { margin: 2px 0 8px; color: var(--mut); font-size: 11px; font-weight: 600; letter-spacing: .04em; text-transform: uppercase; }
 .budget-plans { display: grid; width: 100%; gap: 12px; }
 .budget-plans > .panel { width: 100%; }


### PR DESCRIPTION
## Summary
- make provider-reported capacity authority explicit
- show truthful freshness/status, observed timestamps, used and remaining percentages, reset boundary, and progressive provider details
- preserve stale, unavailable, disconnected, access-needed, loading, and rate-limited states without fabricated values

## Verification
- `npm --prefix app test -- --run renderer/sections/Plans.test.tsx`
- `npm --prefix app test -- --run`
- `npm --prefix app run typecheck`
- `npm run build:cli`
- `npm --prefix app run build`

This PR is UI-only; no quota authority, backend, Advisor, macOS, Android, Store, Play, or release changes.