### PR TITLE
feat(advisor): ship AdvisorToolV1 conformance contract

### DIFF
--- a/app/electron/advisor-runtime.test.ts
+++ b/app/electron/advisor-runtime.test.ts
@@ -34,19 +34,16 @@ describe('Electron Advisor local runtime', () => {
     expect(calls[0]?.url).toBe('http://127.0.0.1:11434/api/tags')
   })
 
-  it('reads NDJSON incrementally, caps content, and exposes deltas without waiting for text()', async () => {
+  it('reads NDJSON incrementally and caps content without exposing raw deltas', async () => {
     const fetchImpl = (async () => streamedResponse([
       '{"message":{"content":"Measured "}}',
       '\n{"message":{"content":"evidence."},"done":true}\n',
     ])) as typeof fetch
-    const deltas: string[] = []
-    const result = await chatOllamaMain(fetchImpl, payload, undefined, text => deltas.push(text))
+    const result = await chatOllamaMain(fetchImpl, payload)
 
     expect(result.streamed).toBe(true)
     expect(result.message.content).toBe('Measured evidence.')
-    expect(deltas).toEqual(['Measured ', 'Measured evidence.'])
   })
-
   it('fails closed when one valid reader-backed NDJSON record exceeds the content cap', async () => {
     const response = streamedResponse([JSON.stringify({ message: { content: 'x'.repeat(32_001) } }) + '\n'])
 
@@ -90,5 +87,33 @@ describe('Electron Advisor local runtime', () => {
     const result = await pending
     expect(result).toEqual({ ok: false, error: { kind: 'cancelled', message: 'Advisor request cancelled.' } })
     expect(rejectRequest).not.toBeNull()
+  })
+  it('fails closed before fetch when the parent signal is already aborted', async () => {
+    const controller = new AbortController()
+    controller.abort()
+    let calls = 0
+    const fetchImpl = (async () => { calls += 1; return textOnlyResponse('{}') }) as typeof fetch
+    await expect(chatOllamaMain(fetchImpl, payload, controller.signal)).rejects.toMatchObject({ name: 'AbortError' })
+    await expect(probeOllamaMain(fetchImpl, controller.signal)).rejects.toMatchObject({ name: 'AbortError' })
+    expect(calls).toBe(0)
+  })
+  it('uses UTF-8 byte bounds for streamed content and model requests', async () => {
+    const unicode = '€'.repeat(11_000)
+    const response = streamedResponse([JSON.stringify({ message: { content: unicode } }) + '\n'])
+    await expect(chatOllamaMain(async () => response, payload)).rejects.toThrow('content limit')
+
+    const oversizedPayload = { ...payload, tools: [{ type: 'function', function: { name: 'x', parameters: { blob: 'x'.repeat(2 * 1024 * 1024) } } }] }
+    await expect(chatOllamaMain(async () => textOnlyResponse('{}'), oversizedPayload)).rejects.toThrow('request exceeded')
+  })
+
+  it('does not forward raw model deltas from the production IPC handler', async () => {
+    const fetchImpl = (async () => streamedResponse([
+      '{"message":{"content":"token=supersecretvalue"}}\n',
+    ])) as typeof fetch
+    const deltas: string[] = []
+    const handlers = createAdvisorRuntimeHandlers(fetchImpl)
+    const result = await handlers['metrora:advisorChat']('request-raw-boundary', payload, (text: string) => deltas.push(text))
+    expect(result).toMatchObject({ ok: true })
+    expect(deltas).toEqual([])
   })
 })

--- a/app/electron/advisor-runtime.ts
+++ b/app/electron/advisor-runtime.ts
@@ -15,6 +15,14 @@ export type AdvisorRuntimeChatPayload = {
 export type AdvisorRuntimeChatResult = { message: { content: string; tool_calls?: Array<Record<string, unknown>> }; streamed: boolean }
 type FetchLike = typeof fetch
 
+function byteLength(value: string): number {
+  return new TextEncoder().encode(value).byteLength
+}
+function boundedMessageContent(value: string): string {
+  if (byteLength(value) > 32_000) throw new Error('Local runtime message exceeded the content limit.')
+  return value
+}
+
 function boundedError(error: unknown): Error {
   const raw = error instanceof Error ? error.message : String(error)
   return new Error(raw.replace(/[\r\n]+/g, ' ').replace(/[A-Za-z]:\\[^ ]+|\/[^ ]+/g, '[local path]').slice(0, 240))
@@ -22,14 +30,22 @@ function boundedError(error: unknown): Error {
 function validModel(model: string): boolean {
   return /^[A-Za-z0-9][A-Za-z0-9._:/-]{0,160}$/.test(model)
 }
+function abortError(): Error {
+  const error = new Error('The operation was aborted.')
+  error.name = 'AbortError'
+  return error
+}
+function throwIfAborted(signal: AbortSignal): void {
+  if (signal.aborted) throw abortError()
+}
 function timeoutSignal(parent?: AbortSignal, timeoutMs = CHAT_TIMEOUT_MS): { signal: AbortSignal; dispose: () => void } {
   const controller = new AbortController()
   const timer = setTimeout(() => controller.abort(), timeoutMs)
   const forward = () => controller.abort()
-  parent?.addEventListener('abort', forward, { once: true })
+  if (parent?.aborted) controller.abort()
+  else parent?.addEventListener('abort', forward, { once: true })
   return { signal: controller.signal, dispose: () => { clearTimeout(timer); parent?.removeEventListener('abort', forward) } }
-}
-async function boundedText(response: Response): Promise<string> {
+}async function boundedText(response: Response): Promise<string> {
   const reader = response.body?.getReader()
   if (!reader) {
     const text = await response.text()
@@ -51,7 +67,9 @@ async function boundedText(response: Response): Promise<string> {
 async function fetchJson(fetchImpl: FetchLike, url: string, init: RequestInit, timeoutMs: number, parent?: AbortSignal): Promise<Record<string, unknown>> {
   const timed = timeoutSignal(parent, timeoutMs)
   try {
+    throwIfAborted(timed.signal)
     const response = await fetchImpl(url, { ...init, signal: timed.signal })
+    throwIfAborted(timed.signal)
     if (!response.ok) throw new Error('Local runtime returned HTTP ' + response.status + '.')
     const text = await boundedText(response)
     const value = JSON.parse(text) as unknown
@@ -71,25 +89,43 @@ export async function probeOllamaMain(fetchImpl: FetchLike = fetch, parent?: Abo
     return { available: false, models: [], detail: boundedError(error).message }
   }
 }
+function isRecord(value: unknown): value is Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false
+  const prototype = Object.getPrototypeOf(value)
+  return prototype === Object.prototype || prototype === null
+}
 function parseToolCalls(value: unknown): Array<Record<string, unknown>> {
-  if (!Array.isArray(value)) return []
-  return value.filter(row => row && typeof row === 'object').slice(0, 16) as Array<Record<string, unknown>>
+  if (value === undefined) return []
+  if (!Array.isArray(value)) throw new Error('Local runtime tool_calls must be an array.')
+  return value.slice(0, 16).map(call => {
+    if (!isRecord(call) || !isRecord(call.function) || typeof call.function.name !== 'string' || !call.function.name.trim()) {
+      throw new Error('Local runtime returned a malformed tool call.')
+    }
+    const args = call.function.arguments
+    if (args !== undefined && typeof args !== 'string' && !isRecord(args)) throw new Error('Local runtime returned malformed tool arguments.')
+    return { function: { name: call.function.name, ...(args !== undefined ? { arguments: args } : {}) } }
+  })
 }
 function messageResult(raw: Record<string, unknown>, streamed: boolean): AdvisorRuntimeChatResult {
-  const message = raw.message && typeof raw.message === 'object' ? raw.message as Record<string, unknown> : {}
+  if (!isRecord(raw.message)) throw new Error('Local runtime returned a malformed message.')
+  const message = raw.message
+  if (message.content !== undefined && typeof message.content !== 'string') throw new Error('Local runtime returned malformed message content.')
+  const toolCalls = parseToolCalls(message.tool_calls)
+  if (message.content === undefined && toolCalls.length === 0) throw new Error('Local runtime returned an empty message.')
   return {
     message: {
-      content: typeof message.content === 'string' ? message.content.slice(0, 32_000) : '',
-      tool_calls: parseToolCalls(message.tool_calls),
+      content: typeof message.content === 'string' ? boundedMessageContent(message.content) : '',
+      tool_calls: toolCalls,
     },
     streamed,
   }
 }
-function parseNdjsonText(text: string, onDelta?: (text: string) => void): AdvisorRuntimeChatResult {
+function parseNdjsonText(text: string): AdvisorRuntimeChatResult {
   let content = ''
   const toolCalls: Array<Record<string, unknown>> = []
   let malformed = 0
   let chunks = 0
+  let validMessages = 0
   for (const line of text.split(/\r?\n/).filter(Boolean)) {
     chunks += 1
     if (chunks > MAX_STREAM_CHUNKS) throw new Error('Local runtime stream exceeded the chunk limit.')
@@ -99,32 +135,39 @@ function parseNdjsonText(text: string, onDelta?: (text: string) => void): Adviso
       if (malformed > MAX_MALFORMED_CHUNKS) throw new Error('Local runtime stream contained too many malformed chunks.')
       continue
     }
-    if (!value || typeof value !== 'object') {
+    if (!isRecord(value)) {
       malformed += 1
       if (malformed > MAX_MALFORMED_CHUNKS) throw new Error('Local runtime stream contained too many malformed chunks.')
       continue
     }
-    const message = (value as { message?: unknown }).message
-    if (!message || typeof message !== 'object') continue
-    const row = message as Record<string, unknown>
-    if (typeof row.content === 'string') {
-      content += row.content
-      if (content.length > 32_000) throw new Error('Local runtime message exceeded the content limit.')
-      onDelta?.(content)
+    const message = value.message
+    if (message === undefined && value.done === true) continue
+    if (!isRecord(message)) {
+      malformed += 1
+      if (malformed > MAX_MALFORMED_CHUNKS) throw new Error('Local runtime stream contained too many malformed chunks.')
+      continue
     }
-    const calls = parseToolCalls(row.tool_calls)
+    validMessages += 1
+    if (message.content !== undefined) {
+      if (typeof message.content !== 'string') throw new Error('Local runtime returned malformed message content.')
+      content += message.content
+      if (byteLength(content) > 32_000) throw new Error('Local runtime message exceeded the content limit.')
+    }
+    const calls = parseToolCalls(message.tool_calls)
     if (calls.length) toolCalls.push(...calls)
   }
+  if (validMessages === 0) throw new Error('Local runtime stream contained no valid messages.')
   return { message: { content, tool_calls: toolCalls.slice(0, 16) }, streamed: true }
 }
-async function streamNdjsonResponse(response: Response, onDelta?: (text: string) => void): Promise<AdvisorRuntimeChatResult> {
+async function streamNdjsonResponse(response: Response): Promise<AdvisorRuntimeChatResult> {
   const reader = response.body?.getReader()
-  if (!reader) return parseNdjsonText(await boundedText(response), onDelta)
+  if (!reader) return parseNdjsonText(await boundedText(response))
   const decoder = new TextDecoder()
   let pending = ''
   let bytes = 0
   let chunks = 0
   let malformed = 0
+  let validMessages = 0
   let content = ''
   const toolCalls: Array<Record<string, unknown>> = []
   const consume = (line: string) => {
@@ -137,20 +180,25 @@ async function streamNdjsonResponse(response: Response, onDelta?: (text: string)
       if (malformed > MAX_MALFORMED_CHUNKS) throw new Error('Local runtime stream contained too many malformed chunks.')
       return
     }
-    if (!value || typeof value !== 'object') {
+    if (!isRecord(value)) {
       malformed += 1
       if (malformed > MAX_MALFORMED_CHUNKS) throw new Error('Local runtime stream contained too many malformed chunks.')
       return
     }
-    const message = (value as { message?: unknown }).message
-    if (!message || typeof message !== 'object') return
-    const row = message as Record<string, unknown>
-    if (typeof row.content === 'string') {
-      content += row.content
-      if (content.length > 32_000) throw new Error('Local runtime message exceeded the content limit.')
-      onDelta?.(content)
+    const message = value.message
+    if (message === undefined && value.done === true) return
+    if (!isRecord(message)) {
+      malformed += 1
+      if (malformed > MAX_MALFORMED_CHUNKS) throw new Error('Local runtime stream contained too many malformed chunks.')
+      return
     }
-    const calls = parseToolCalls(row.tool_calls)
+    validMessages += 1
+    if (message.content !== undefined) {
+      if (typeof message.content !== 'string') throw new Error('Local runtime returned malformed message content.')
+      content += message.content
+      if (byteLength(content) > 32_000) throw new Error('Local runtime message exceeded the content limit.')
+    }
+    const calls = parseToolCalls(message.tool_calls)
     if (calls.length) toolCalls.push(...calls)
   }
   while (true) {
@@ -165,32 +213,57 @@ async function streamNdjsonResponse(response: Response, onDelta?: (text: string)
   }
   pending += decoder.decode()
   consume(pending)
+  if (validMessages === 0) throw new Error('Local runtime stream contained no valid messages.')
   return { message: { content, tool_calls: toolCalls.slice(0, 16) }, streamed: true }
 }
-async function chatOnce(fetchImpl: FetchLike, payload: AdvisorRuntimeChatPayload, parent?: AbortSignal, onDelta?: (text: string) => void): Promise<AdvisorRuntimeChatResult> {
+const ADVISOR_MESSAGE_ROLES = new Set(['system', 'user', 'assistant', 'tool'])
+
+function validateChatPayload(value: unknown): asserts value is AdvisorRuntimeChatPayload {
+  if (!isRecord(value) || typeof value.model !== 'string' || !validModel(value.model)) throw new Error('Local runtime model is invalid.')
+  if (!Array.isArray(value.messages) || !Array.isArray(value.tools) || value.messages.length > 32 || value.tools.length > 12) {
+    throw new Error('Local runtime request exceeded the safety limit.')
+  }
+  if (typeof value.stream !== 'boolean') throw new Error('Local runtime stream flag is invalid.')
+  for (const message of value.messages) {
+    if (!isRecord(message) || typeof message.role !== 'string' || !ADVISOR_MESSAGE_ROLES.has(message.role)) throw new Error('Local runtime request contains a malformed message.')
+    if (typeof message.content !== 'string') throw new Error('Local runtime request contains malformed message content.')
+    boundedMessageContent(message.content)
+    if (message.tool_calls !== undefined) parseToolCalls(message.tool_calls)
+  }
+  for (const tool of value.tools) {
+    if (!isRecord(tool) || tool.type !== 'function' || !isRecord(tool.function) || typeof tool.function.name !== 'string' || !tool.function.name.trim()) {
+      throw new Error('Local runtime request contains a malformed tool definition.')
+    }
+    if (tool.function.parameters !== undefined && !isRecord(tool.function.parameters)) throw new Error('Local runtime request contains malformed tool parameters.')
+  }
+}
+async function chatOnce(fetchImpl: FetchLike, payload: AdvisorRuntimeChatPayload, parent?: AbortSignal): Promise<AdvisorRuntimeChatResult> {
   const timed = timeoutSignal(parent, CHAT_TIMEOUT_MS)
   try {
+    throwIfAborted(timed.signal)
     const response = await fetchImpl(LOOPBACK_ENDPOINT + '/api/chat', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(payload),
       signal: timed.signal,
     })
+    throwIfAborted(timed.signal)
     if (!response.ok) throw new Error('Local runtime returned HTTP ' + response.status + '.')
-    if (payload.stream) return streamNdjsonResponse(response, onDelta)
+    if (payload.stream) return streamNdjsonResponse(response)
     const text = await boundedText(response)
     const value = JSON.parse(text) as unknown
     if (!value || typeof value !== 'object') throw new Error('Local runtime returned invalid JSON.')
     return messageResult(value as Record<string, unknown>, false)
   } finally { timed.dispose() }
 }
-export async function chatOllamaMain(fetchImpl: FetchLike, payload: AdvisorRuntimeChatPayload, parent?: AbortSignal, onDelta?: (text: string) => void): Promise<AdvisorRuntimeChatResult> {
+export async function chatOllamaMain(fetchImpl: FetchLike, payload: AdvisorRuntimeChatPayload, parent?: AbortSignal): Promise<AdvisorRuntimeChatResult> {
   if (!fetchImpl) throw new Error('Node fetch is unavailable.')
   if (!payload || !validModel(payload.model)) throw new Error('Local runtime model is invalid.')
-  if (!Array.isArray(payload.messages) || !Array.isArray(payload.tools) || payload.messages.length > 32 || payload.tools.length > 12) throw new Error('Local runtime request exceeded the safety limit.')
-  const encoded = JSON.stringify(payload)
-  if (encoded.length > MAX_RESPONSE_BYTES) throw new Error('Local runtime request exceeded the safety limit.')
-  return chatOnce(fetchImpl, { ...payload, stream: Boolean(payload.stream) }, parent, onDelta)
+  validateChatPayload(payload)
+  let encoded: string
+  try { encoded = JSON.stringify(payload) } catch { throw new Error('Local runtime request is not JSON-safe.') }
+  if (byteLength(encoded) > MAX_RESPONSE_BYTES) throw new Error('Local runtime request exceeded the safety limit.')
+  return chatOnce(fetchImpl, payload, parent)
 }
 function validRequestId(value: unknown): value is string {
   return typeof value === 'string' && /^[A-Za-z0-9._:-]{1,128}$/.test(value)
@@ -202,12 +275,12 @@ export function createAdvisorRuntimeHandlers(fetchImpl: FetchLike = fetch): Reco
     'metrora:advisorProbe': async () => {
       try { return { ok: true, value: await probeOllamaMain(fetchImpl) } } catch (error) { return fail(error) }
     },
-    'metrora:advisorChat': async (requestId: string, payload: AdvisorRuntimeChatPayload, onDelta?: (text: string) => void) => {
+    'metrora:advisorChat': async (requestId: string, payload: AdvisorRuntimeChatPayload) => {
       if (!validRequestId(requestId)) return fail(new Error('Advisor request id is invalid.'), 'validation')
       const controller = new AbortController()
       flights.set(requestId, controller)
       try {
-        const value = await chatOllamaMain(fetchImpl, payload, controller.signal, typeof onDelta === 'function' ? onDelta : undefined)
+        const value = await chatOllamaMain(fetchImpl, payload, controller.signal)
         return { ok: true, value }
       } catch (error) {
         return controller.signal.aborted ? fail(new Error('Advisor request cancelled.'), 'cancelled') : fail(error)

--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -429,12 +429,6 @@ function registerHandlers(): void {
   for (const [channel, handler] of Object.entries(handlers)) {
     for (const alias of ipcChannelAliases(channel)) {
       ipcMain.handle(alias, (event, ...args) => {
-        if (channel === 'metrora:advisorChat') {
-          const requestId = typeof args[0] === 'string' ? args[0] : ''
-          return handler(...args, (text: string) => {
-            try { event.sender.send('metrora:advisorDelta', { requestId, text }) } catch { /* window closed */ }
-          })
-        }
         return handler(...args)
       })
     }

--- a/app/renderer/advisor/conformance.test.ts
+++ b/app/renderer/advisor/conformance.test.ts
@@ -1,0 +1,213 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from 'vitest'
+
+import { buildSpendEvidence } from './evidence'
+import { createAdvisorConformanceFixture, createAdvisorStaleConformanceFixture, createAdvisorUnavailableConformanceFixture } from './conformance'
+import {
+  ADVISOR_TOOL_CONTRACT,
+  ADVISOR_TOOL_DEFINITIONS,
+  AdvisorToolContractError,
+  ADVISOR_TOOL_MODEL_FILTER_MAX_LENGTH,
+} from './contract'
+import { createAdvisorToolRegistry } from './tools'
+import { OllamaAdvisorRuntime, type OllamaTransport } from './ollama'
+import type { AdvisorDataSource, AdvisorEvidence, AdvisorScope } from './types'
+
+const TOOL_NAMES = [
+  'get_spend_snapshot',
+  'get_model_efficiency',
+  'get_quota_snapshot',
+  'get_overview_snapshot',
+  'get_project_drivers',
+  'get_session_highlights',
+  'get_coverage_report',
+] as const
+
+function expectContractError(error: unknown, code: AdvisorToolContractError['code']): void {
+  expect(error).toBeInstanceOf(AdvisorToolContractError)
+  expect((error as AdvisorToolContractError).code).toBe(code)
+}
+
+async function rejectsWithCode(operation: Promise<unknown>, code: AdvisorToolContractError['code']): Promise<void> {
+  try {
+    await operation
+    throw new Error('Expected Advisor contract failure.')
+  } catch (error) {
+    expectContractError(error, code)
+  }
+}
+
+function scriptedTransport(toolCalls: unknown[], finalContent = 'The observed pattern is worth a closer look.'): OllamaTransport {
+  let index = 0
+  let listener: ((event: { requestId: string; text: string }) => void) | null = null
+  return {
+    probe: async () => ({ available: true, models: ['synthetic-model'], detail: 'synthetic' }),
+    cancel: async () => true,
+    onDelta: callback => {
+      listener = callback
+      return () => { listener = null }
+    },
+    chat: async (requestId, _payload) => {
+      if (index++ === 0) return { streamed: false, message: { content: '', tool_calls: toolCalls as Array<{ function?: { name?: string; arguments?: unknown } }> } }
+      listener?.({ requestId, text: finalContent })
+      return { streamed: true, message: { content: finalContent } }
+    },
+  }
+}
+
+describe('AdvisorToolV1 reusable conformance suite', () => {
+  it('publishes the stable seven-tool identity, version, schemas, and JSON-safe contract', () => {
+    expect(ADVISOR_TOOL_CONTRACT.contractVersion).toBe('advisor-tool-v1')
+    expect(ADVISOR_TOOL_CONTRACT.schemaVersion).toBe(1)
+    expect(ADVISOR_TOOL_DEFINITIONS.map(tool => tool.function.name)).toEqual(TOOL_NAMES)
+    expect(ADVISOR_TOOL_CONTRACT.scope.immutable).toBe(true)
+    expect(JSON.parse(JSON.stringify(ADVISOR_TOOL_CONTRACT))).toEqual(expect.objectContaining({ contractVersion: 'advisor-tool-v1', schemaVersion: 1 }))
+    for (const tool of ADVISOR_TOOL_DEFINITIONS) {
+      const parameters = tool.function.parameters as Record<string, unknown>
+      expect(parameters).toMatchObject({ type: 'object', additionalProperties: false, required: [] })
+      expect(JSON.parse(JSON.stringify(tool))).toEqual(tool)
+    }
+  })
+
+  it('executes every tool with bounded JSON-safe, content-minimal output', async () => {
+    const fixture = createAdvisorConformanceFixture()
+    const registry = createAdvisorToolRegistry(fixture.source, fixture.scope, fixture.overview)
+    for (const name of TOOL_NAMES) {
+      const args = name === 'get_quota_snapshot' ? { provider: 'claude' } : name === 'get_spend_snapshot' || name === 'get_model_efficiency' || name === 'get_overview_snapshot' ? { model: 'gpt-safe' } : {}
+      const result = await registry.execute(name, args)
+      expect(() => JSON.parse(result.content)).not.toThrow()
+      expect(new TextEncoder().encode(result.content).byteLength).toBeLessThanOrEqual(32 * 1024)
+      expect(result.envelope).toMatchObject({ contractVersion: 'advisor-tool-v1', tool: name, privacy: 'content-minimal' })
+      expect(() => JSON.stringify(result.envelope)).not.toThrow()
+    }
+  })
+
+  it('succeeds for a valid call and keeps the Metrora invocation scope immutable', async () => {
+    const fixture = createAdvisorConformanceFixture()
+    const registry = createAdvisorToolRegistry(fixture.source, fixture.scope, fixture.overview)
+    const result = await registry.execute('get_spend_snapshot', { model: 'gpt-safe' })
+    expect(result.evidence.scope).toMatchObject({ ...fixture.scope, model: 'gpt-safe' })
+    expect(result.envelope?.scope).toMatchObject({ ...fixture.scope, model: 'gpt-safe' })
+    expect(Object.isFrozen(registry.scope)).toBe(true)
+    expect(Object.isFrozen(result.envelope?.scope)).toBe(true)
+    expect(fixture.reads.overviews).toContainEqual({ ...fixture.scope, model: 'gpt-safe' })
+  })
+
+  it('fails closed for unknown tools, wrong types, unsupported providers, malformed filters, and additional args', async () => {
+    const fixture = createAdvisorConformanceFixture()
+    const registry = createAdvisorToolRegistry(fixture.source, fixture.scope, fixture.overview)
+    await rejectsWithCode(registry.execute('unknown_tool', {}), 'unknown-tool')
+    await rejectsWithCode(registry.execute('get_spend_snapshot', { model: 42 }), 'invalid-argument-type')
+    await rejectsWithCode(registry.execute('get_quota_snapshot', { provider: 'openai' }), 'invalid-argument-value')
+    await rejectsWithCode(registry.execute('get_spend_snapshot', { model: '   ' }), 'invalid-argument-value')
+    await rejectsWithCode(registry.execute('get_spend_snapshot', { model: 'x'.repeat(ADVISOR_TOOL_MODEL_FILTER_MAX_LENGTH + 1) }), 'invalid-argument-value')
+    await rejectsWithCode(registry.execute('get_project_drivers', { model: 'gpt-safe' }), 'additional-argument')
+    expect(fixture.reads.overviews).toHaveLength(0)
+    expect(fixture.reads.quotas).toBe(0)
+  })
+
+  it('keeps unavailable provider authority unavailable and preserves an explicit factual zero', async () => {
+    const unavailable = createAdvisorUnavailableConformanceFixture()
+    const unavailableResult = await createAdvisorToolRegistry(unavailable.source, unavailable.scope, unavailable.overview).execute('get_quota_snapshot', { provider: 'codex' })
+    expect(unavailableResult.envelope).toMatchObject({ unavailable: true, freshness: 'unavailable' })
+    expect(unavailableResult.evidence.coverage.level).toBe('unavailable')
+    expect(unavailableResult.content).not.toContain('"creditsUSD":0')
+
+    const factual = createAdvisorConformanceFixture()
+    const factualResult = await createAdvisorToolRegistry(factual.source, factual.scope, factual.overview).execute('get_quota_snapshot', { provider: 'claude' })
+    expect(factualResult.evidence.quota?.providers[0]?.creditsUSD).toBe(0)
+    expect(factualResult.content).toContain('"creditsUSD":0')
+  })
+
+  it('keeps stale provider evidence labelled stale instead of refreshing or estimating it', async () => {
+    const fixture = createAdvisorStaleConformanceFixture()
+    const result = await createAdvisorToolRegistry(fixture.source, fixture.scope, fixture.overview).execute('get_quota_snapshot', { provider: 'codex' })
+    expect(result.envelope?.freshness).toBe('stale')
+    expect(result.evidence.coverage.level).toBe('partial')
+    expect(result.evidence.quota?.providers[0]).toMatchObject({ freshness: 'stale', availability: 'unavailable', creditsUSD: 0 })
+    expect(result.content).toContain('"freshness":"stale"')
+  })
+
+  it('honors cancellation before a read and after an asynchronous read', async () => {
+    const fixture = createAdvisorConformanceFixture()
+    const before = new AbortController()
+    before.abort()
+    await expect(createAdvisorToolRegistry(fixture.source, fixture.scope, fixture.overview).execute('get_spend_snapshot', {}, before.signal)).rejects.toMatchObject({ name: 'AbortError' })
+    expect(fixture.reads.overviews).toHaveLength(0)
+
+    let started = false
+    let release: (() => void) | undefined
+    const gate = new Promise<void>(resolve => { release = resolve })
+    const slowSource: AdvisorDataSource = {
+      getOverview: async () => { started = true; await gate; return fixture.overview },
+      getModels: async () => [],
+      getQuota: async () => [],
+    }
+    const controller = new AbortController()
+    const pending = createAdvisorToolRegistry(slowSource, fixture.scope, null).execute('get_spend_snapshot', {}, controller.signal)
+    await vi.waitFor(() => expect(started).toBe(true))
+    controller.abort()
+    release?.()
+    await expect(pending).rejects.toMatchObject({ name: 'AbortError' })
+  })
+
+  it('does not expose raw prompts, responses, source code, secrets, or unrestricted paths', async () => {
+    const fixture = createAdvisorConformanceFixture()
+    const sensitiveOverview = {
+      ...fixture.overview,
+      rawPrompt: 'RAW_PROMPT_SHOULD_NOT_LEAK',
+      rawResponse: 'RAW_RESPONSE_SHOULD_NOT_LEAK',
+      sourceCode: 'RAW_SOURCE_SHOULD_NOT_LEAK',
+      secret: 'sk-secret-value-should-not-leak',
+      current: {
+        ...fixture.overview.current,
+        topProjects: [{ name: 'C:\\Users\\sirag\\secret-project', cost: 12, sessions: 2 }],
+      },
+    } as unknown as typeof fixture.overview
+    const sourceFixture = createAdvisorConformanceFixture({ overview: sensitiveOverview })
+    const result = await createAdvisorToolRegistry(sourceFixture.source, sourceFixture.scope, sensitiveOverview).execute('get_project_drivers', {})
+    for (const value of ['RAW_PROMPT_SHOULD_NOT_LEAK', 'RAW_RESPONSE_SHOULD_NOT_LEAK', 'RAW_SOURCE_SHOULD_NOT_LEAK', 'sk-secret-value-should-not-leak', 'C:\\Users\\sirag\\secret-project']) expect(result.content).not.toContain(value)
+    expect(result.content).toContain('[redacted]')
+  })
+
+  it('is deterministic for the same fixture and rejects mixed-scope evidence', async () => {
+    const fixture = createAdvisorConformanceFixture()
+    const registry = createAdvisorToolRegistry(fixture.source, fixture.scope, fixture.overview)
+    const first = await registry.execute('get_spend_snapshot', {})
+    const second = await registry.execute('get_spend_snapshot', {})
+    expect(second.content).toBe(first.content)
+    expect(JSON.stringify(second.envelope)).toBe(JSON.stringify(first.envelope))
+
+    const claude = await registry.execute('get_quota_snapshot', { provider: 'claude' })
+    const runtime = new OllamaAdvisorRuntime({ model: 'synthetic-model', transport: scriptedTransport([
+      { function: { name: 'get_quota_snapshot', arguments: { provider: 'claude' } } },
+      { function: { name: 'get_quota_snapshot', arguments: { provider: 'codex' } } },
+    ]) })
+    const answer = await runtime.generate({
+      question: 'Compare provider quota',
+      evidence: claude.evidence,
+      tools: ADVISOR_TOOL_DEFINITIONS,
+      toolContract: ADVISOR_TOOL_CONTRACT,
+      executeTool: registry.execute,
+    })
+    expect(answer.coverage).toMatchObject({ level: 'unavailable', label: 'Conflicting evidence scopes' })
+    expect(answer.evidence).toEqual([])
+  })
+
+  it('prevents malformed runtime calls from reaching evidence reads and runs the Ollama adapter on synthetic fixtures', async () => {
+    const fixture = createAdvisorConformanceFixture()
+    const registry = createAdvisorToolRegistry(fixture.source, fixture.scope, null)
+    const evidence = buildSpendEvidence('synthetic', fixture.scope, fixture.overview)
+    const execute = vi.fn(registry.execute)
+    const malformedRuntime = new OllamaAdvisorRuntime({ model: 'synthetic-model', transport: scriptedTransport([{ function: { name: 'get_spend_snapshot', arguments: '{"model":' } }]) })
+    await expect(malformedRuntime.generate({ question: 'What changed?', evidence, tools: ADVISOR_TOOL_DEFINITIONS, toolContract: ADVISOR_TOOL_CONTRACT, executeTool: execute })).rejects.toMatchObject({ code: 'invalid-arguments' })
+    expect(execute).not.toHaveBeenCalled()
+    expect(fixture.reads.overviews).toHaveLength(0)
+
+    const runtime = new OllamaAdvisorRuntime({ model: 'synthetic-model', transport: scriptedTransport([{ function: { name: 'get_spend_snapshot', arguments: '{}' } }]) })
+    const answer = await runtime.generate({ question: 'What changed?', evidence, tools: ADVISOR_TOOL_DEFINITIONS, toolContract: ADVISOR_TOOL_CONTRACT, executeTool: registry.execute })
+    expect(answer.generatedByModel).toBe(true)
+    expect(answer.evidence.length).toBeGreaterThan(0)
+    expect(fixture.reads.overviews).toHaveLength(1)
+  })
+})

--- a/app/renderer/advisor/conformance.test.ts
+++ b/app/renderer/advisor/conformance.test.ts
@@ -210,4 +210,30 @@ describe('AdvisorToolV1 reusable conformance suite', () => {
     expect(answer.evidence.length).toBeGreaterThan(0)
     expect(fixture.reads.overviews).toHaveLength(1)
   })
+
+  it('keeps content-minimal evidence safe for no-digit secrets, paths, and internal identifiers', async () => {
+    const fixture = createAdvisorConformanceFixture()
+    const sensitiveOverview = {
+      ...fixture.overview,
+      current: {
+        ...fixture.overview.current,
+        topModels: [{ name: 'token=supersecretvalue', cost: 8, calls: 2 }],
+        topProjects: [
+          { name: 'project/alpha', cost: 6, sessions: 1 },
+          { name: '/home/alice/private/project', cost: 6, sessions: 1 },
+        ],
+        topSessions: [{ project: 'raw prompt marker text', cost: 12, calls: 1 }],
+      },
+    } as unknown as typeof fixture.overview
+    const scope = { ...fixture.scope, projectId: 'account-secret', projectName: 'project/alpha' }
+    const registry = createAdvisorToolRegistry(fixture.source, scope, sensitiveOverview)
+    const result = await registry.execute('get_spend_snapshot', {})
+    const serialized = result.content + JSON.stringify(result.envelope)
+    for (const value of ['supersecretvalue', '/home/alice/private/project', 'raw prompt marker text', 'account-secret']) {
+      expect(serialized).not.toContain(value)
+    }
+    expect(serialized).toContain('project/alpha')
+    expect(result.envelope?.scope.projectId).toBe('[scoped-project]')
+    expect(result.content).toContain('[redacted]')
+  })
 })

--- a/app/renderer/advisor/conformance.ts
+++ b/app/renderer/advisor/conformance.ts
@@ -1,0 +1,113 @@
+import type { MenubarPayload, ModelReportRow, QuotaProvider } from '../lib/types'
+import type { AdvisorDataSource, AdvisorScope } from './types'
+
+export const ADVISOR_CONFORMANCE_SCOPE: AdvisorScope = Object.freeze({
+  period: 'week',
+  range: null,
+  provider: 'all',
+  projectId: 'all',
+  projectName: 'All projects',
+  model: null,
+})
+
+export type AdvisorConformanceReads = {
+  overviews: AdvisorScope[]
+  models: AdvisorScope[]
+  quotas: number
+}
+
+export type AdvisorConformanceFixture = {
+  scope: AdvisorScope
+  overview: MenubarPayload
+  models: ModelReportRow[]
+  quota: QuotaProvider[]
+  reads: AdvisorConformanceReads
+  source: AdvisorDataSource
+}
+
+function overview(): MenubarPayload {
+  return {
+    current: {
+      cost: 12,
+      calls: 3,
+      sessions: 2,
+      pricingCoverage: 1,
+      topModels: [
+        { name: 'gpt-safe', cost: 8, calls: 2 },
+        { name: 'local-safe', cost: 4, calls: 1 },
+      ],
+      topProjects: [{ name: 'Project A', cost: 12, sessions: 2 }],
+      topSessions: [{ project: 'Project A', cost: 8, calls: 1 }],
+      modelAccounting: {
+        rows: [{ name: 'gpt-safe', cost: 8, calls: 2 }],
+        gap: { cost: 0, savingsUSD: 0, calls: 0 },
+        coverage: { cost: 1, calls: 1 },
+      },
+    },
+    history: { daily: [{ date: '2026-08-22', cost: 4 }, { date: '2026-08-23', cost: 8 }] },
+  } as unknown as MenubarPayload
+}
+
+function modelRows(): ModelReportRow[] {
+  const priced = { state: 'priced' as const, totalCalls: 2, coveredCalls: 2, pricedCalls: 2, explicitZeroCalls: 0, unavailableCalls: 0, unknownCalls: 0, missingPriceRecordCalls: 0 }
+  return [
+    { provider: 'codex', providerDisplayName: 'Codex', model: 'gpt-safe', modelDisplayName: 'GPT Safe', category: null, inputTokens: 10, outputTokens: 20, cacheWriteTokens: 0, cacheReadTokens: 0, totalTokens: 30, costUSD: 8, savingsUSD: 0, savingsBaselineModel: '', calls: 2, pricing: priced, credits: null },
+    { provider: 'codex', providerDisplayName: 'Codex', model: 'local-safe', modelDisplayName: 'Local Safe', category: null, inputTokens: 5, outputTokens: 10, cacheWriteTokens: 0, cacheReadTokens: 0, totalTokens: 15, costUSD: 4, savingsUSD: 0, savingsBaselineModel: '', calls: 1, pricing: priced, credits: null },
+  ]
+}
+
+function quotaSnapshot(provider: 'claude' | 'codex', freshness: 'fresh' | 'stale' | 'unavailable', availability: 'available' | 'unavailable'): QuotaProvider {
+  const factual = freshness !== 'unavailable'
+  return {
+    schemaVersion: 1,
+    provider,
+    authority: 'provider-reported',
+    availability,
+    connection: freshness === 'stale' ? 'stale' : availability === 'available' ? 'connected' : 'terminalFailure',
+    freshness,
+    observedAt: factual ? '2026-08-23T12:00:00Z' : null,
+    planLabel: factual ? 'Pro' : null,
+    windows: factual ? [{ id: 'window', label: 'Five-hour window', usedFraction: 0.2, resetsAt: '2026-08-23T15:00:00Z', windowSeconds: 18_000 }] : [],
+    credits: factual ? { balance: 0, currency: 'USD' } : null,
+    rateLimit: { state: 'clear', retryAt: null },
+  }
+}
+
+export function createAdvisorConformanceFixture(options: { quota?: QuotaProvider[]; overview?: MenubarPayload } = {}): AdvisorConformanceFixture {
+  const reads: AdvisorConformanceReads = { overviews: [], models: [], quotas: 0 }
+  const fixtureOverview = options.overview ?? overview()
+  const fixtureModels = modelRows()
+  const fixtureQuota = options.quota ?? [quotaSnapshot('claude', 'fresh', 'available'), quotaSnapshot('codex', 'stale', 'unavailable')]
+  const source: AdvisorDataSource = {
+    getOverview: async (scope, signal) => {
+      if (signal?.aborted) throw new DOMException('Advisor data read cancelled', 'AbortError')
+      reads.overviews.push({ ...scope, range: scope.range ? { ...scope.range } : null })
+      await Promise.resolve()
+      if (signal?.aborted) throw new DOMException('Advisor data read cancelled', 'AbortError')
+      return fixtureOverview
+    },
+    getModels: async (scope, signal) => {
+      if (signal?.aborted) throw new DOMException('Advisor data read cancelled', 'AbortError')
+      reads.models.push({ ...scope, range: scope.range ? { ...scope.range } : null })
+      await Promise.resolve()
+      if (signal?.aborted) throw new DOMException('Advisor data read cancelled', 'AbortError')
+      return fixtureModels
+    },
+    getQuota: async signal => {
+      if (signal?.aborted) throw new DOMException('Advisor data read cancelled', 'AbortError')
+      reads.quotas += 1
+      await Promise.resolve()
+      if (signal?.aborted) throw new DOMException('Advisor data read cancelled', 'AbortError')
+      return fixtureQuota
+    },
+  }
+  return { scope: ADVISOR_CONFORMANCE_SCOPE, overview: fixtureOverview, models: fixtureModels, quota: fixtureQuota, reads, source }
+}
+
+export function createAdvisorUnavailableConformanceFixture(): AdvisorConformanceFixture {
+  return createAdvisorConformanceFixture({ quota: [quotaSnapshot('codex', 'unavailable', 'unavailable')] })
+}
+
+export function createAdvisorStaleConformanceFixture(): AdvisorConformanceFixture {
+  return createAdvisorConformanceFixture({ quota: [quotaSnapshot('codex', 'stale', 'unavailable')] })
+}

--- a/app/renderer/advisor/contract.ts
+++ b/app/renderer/advisor/contract.ts
@@ -1,0 +1,331 @@
+import type {
+  AdvisorCoverage,
+  AdvisorEvidence,
+  AdvisorEvidenceSemantics,
+  AdvisorJsonObject,
+  AdvisorScope,
+  AdvisorToolArgumentName,
+  AdvisorToolAuthority,
+  AdvisorToolContract,
+  AdvisorToolDefinition,
+  AdvisorToolFreshness,
+  AdvisorToolName,
+  AdvisorToolResultEnvelope,
+} from './types'
+import { ADVISOR_TOOL_CONTRACT_VERSION, ADVISOR_TOOL_SCHEMA_VERSION } from './types'
+
+/** Maximum untrusted argument content accepted from a model/runtime call. */
+export const ADVISOR_TOOL_ARGUMENT_MAX_BYTES = 8 * 1024
+/** Maximum serialized content returned to a model/runtime from one tool call. */
+export const ADVISOR_TOOL_OUTPUT_MAX_BYTES = 32 * 1024
+/** Exact model filters are identifiers, not arbitrary free-form scope objects. */
+export const ADVISOR_TOOL_MODEL_FILTER_MAX_LENGTH = 256
+
+const PERIOD_VALUES = ['today', 'week', '30days', 'month', 'all', 'lifetime'] as const
+const PROVIDER_FILTER_VALUES = ['all', 'claude', 'codex'] as const
+const CONTROL_CHARACTERS = /[\u0000-\u001f\u007f]/
+
+export type AdvisorToolValidationCode =
+  | 'unknown-tool'
+  | 'invalid-arguments'
+  | 'additional-argument'
+  | 'invalid-argument-type'
+  | 'invalid-argument-value'
+  | 'argument-too-large'
+  | 'invalid-scope'
+  | 'authority-unavailable'
+  | 'output-too-large'
+  | 'invalid-output'
+
+export class AdvisorToolContractError extends Error {
+  readonly code: AdvisorToolValidationCode
+
+  constructor(code: AdvisorToolValidationCode, message: string) {
+    super(message)
+    this.name = 'AdvisorToolContractError'
+    this.code = code
+  }
+}
+
+function definition(
+  name: AdvisorToolName,
+  description: string,
+  properties: Record<string, unknown> = {},
+): AdvisorToolDefinition {
+  return {
+    type: 'function',
+    function: {
+      name,
+      description,
+      parameters: {
+        type: 'object',
+        properties,
+        required: [],
+        additionalProperties: false,
+      },
+    },
+  }
+}
+
+const definitions: readonly AdvisorToolDefinition[] = Object.freeze([
+  definition('get_spend_snapshot', 'Read Metrora measured spend, daily trend, model and Project drivers, and coverage for the selected scope.', {
+    model: { type: 'string', description: 'Optional exact model filter; bounded identifier.' },
+  }),
+  definition('get_model_efficiency', 'Read canonical Metrora model rows and observed cost per call. Do not infer quality or comparable work.', {
+    model: { type: 'string', description: 'Optional exact model filter; bounded identifier.' },
+  }),
+  definition('get_quota_snapshot', 'Read provider-reported quota windows, reset timestamps, freshness, and credits. Never estimate quota from Metrora spend.', {
+    provider: { type: 'string', enum: [...PROVIDER_FILTER_VALUES], description: 'Optional factual supported-provider filter.' },
+  }),
+  definition('get_overview_snapshot', 'Read the current canonical Metrora overview for the selected period, Project, provider, and model context.', {
+    model: { type: 'string', description: 'Optional exact model filter; bounded identifier.' },
+  }),
+  definition('get_project_drivers', 'Read descriptive Project spend drivers from the canonical Metrora overview. Do not infer causality.'),
+  definition('get_session_highlights', 'Read content-minimal highest-cost session summaries from the canonical Metrora overview. No raw session content is exposed.'),
+  definition('get_coverage_report', 'Read Metrora evidence coverage, assumptions, and unknowns for the selected scope.'),
+])
+
+const allowedFilters: Readonly<Record<AdvisorToolName, readonly AdvisorToolArgumentName[]>> = Object.freeze({
+  get_spend_snapshot: ['model'],
+  get_model_efficiency: ['model'],
+  get_quota_snapshot: ['provider'],
+  get_overview_snapshot: ['model'],
+  get_project_drivers: [],
+  get_session_highlights: [],
+  get_coverage_report: [],
+})
+
+export const ADVISOR_TOOL_CONTRACT: AdvisorToolContract = Object.freeze({
+  contractVersion: ADVISOR_TOOL_CONTRACT_VERSION,
+  schemaVersion: ADVISOR_TOOL_SCHEMA_VERSION,
+  tools: definitions,
+  scope: Object.freeze({
+    immutable: true,
+    dimensions: Object.freeze(['period', 'range', 'provider', 'projectId', 'projectName', 'model']),
+    allowedFilters,
+  }),
+  output: Object.freeze({ maxBytes: ADVISOR_TOOL_OUTPUT_MAX_BYTES, privacy: 'content-minimal', jsonSafe: true }),
+})
+
+export const ADVISOR_TOOL_DEFINITIONS = definitions
+
+function byteLength(value: string): number {
+  return new TextEncoder().encode(value).byteLength
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false
+  try {
+    const prototype = Object.getPrototypeOf(value)
+    return prototype === Object.prototype || prototype === null
+  } catch {
+    return false
+  }
+}
+
+function jsonSafe(value: unknown, seen: Set<object>): unknown {
+  if (value === null || typeof value === 'string' || typeof value === 'boolean') return value
+  if (typeof value === 'number') return Number.isFinite(value) ? value : null
+  if (typeof value !== 'object') return null
+  if (seen.has(value)) throw new AdvisorToolContractError('invalid-output', 'Advisor tool output must not contain cycles.')
+  seen.add(value)
+  try {
+    if (Array.isArray(value)) return value.map(item => jsonSafe(item, seen))
+    if (!isPlainObject(value)) return null
+    const result: Record<string, unknown> = {}
+    for (const key of Object.keys(value).sort()) result[key] = jsonSafe(value[key], seen)
+    return result
+  } finally {
+    seen.delete(value)
+  }
+}
+
+/** Serializes an allowlisted result deterministically and enforces the wire bound. */
+export function boundedAdvisorJson(value: unknown, maxBytes = ADVISOR_TOOL_OUTPUT_MAX_BYTES): string {
+  const safe = jsonSafe(value, new Set())
+  const serialized = JSON.stringify(safe)
+  if (typeof serialized !== 'string') throw new AdvisorToolContractError('invalid-output', 'Advisor tool output is not JSON-safe.')
+  if (byteLength(serialized) > maxBytes) throw new AdvisorToolContractError('output-too-large', 'Advisor tool output exceeded its safety limit.')
+  return serialized
+}
+
+export function parseAdvisorToolArguments(value: unknown): Record<string, unknown> {
+  if (value === undefined) return {}
+  let parsed: unknown = value
+  if (typeof value === 'string') {
+    if (byteLength(value) > ADVISOR_TOOL_ARGUMENT_MAX_BYTES) throw new AdvisorToolContractError('argument-too-large', 'Advisor tool arguments exceeded their safety limit.')
+    try { parsed = JSON.parse(value) } catch { throw new AdvisorToolContractError('invalid-arguments', 'Advisor tool arguments were not valid JSON.') }
+  }
+  if (!isPlainObject(parsed)) throw new AdvisorToolContractError('invalid-arguments', 'Advisor tool arguments must be a JSON object.')
+  const serialized = boundedAdvisorJson(parsed, ADVISOR_TOOL_ARGUMENT_MAX_BYTES)
+  return JSON.parse(serialized) as Record<string, unknown>
+}
+
+function modelFilter(value: unknown): string {
+  if (typeof value !== 'string') throw new AdvisorToolContractError('invalid-argument-type', 'Advisor model filter must be a string.')
+  const normalized = value.trim()
+  if (!normalized) throw new AdvisorToolContractError('invalid-argument-value', 'Advisor model filter must not be empty.')
+  if (normalized.length > ADVISOR_TOOL_MODEL_FILTER_MAX_LENGTH || CONTROL_CHARACTERS.test(normalized)) {
+    throw new AdvisorToolContractError('invalid-argument-value', 'Advisor model filter is malformed or too large.')
+  }
+  return normalized
+}
+
+function providerFilter(value: unknown): string {
+  if (typeof value !== 'string') throw new AdvisorToolContractError('invalid-argument-type', 'Advisor provider filter must be a string.')
+  if (!(PROVIDER_FILTER_VALUES as readonly string[]).includes(value)) throw new AdvisorToolContractError('invalid-argument-value', 'Advisor provider filter is not supported by the factual quota contract.')
+  return value
+}
+
+export function isAdvisorToolName(value: unknown): value is AdvisorToolName {
+  return typeof value === 'string' && definitions.some(item => item.function.name === value)
+}
+
+export function assertAdvisorToolName(value: unknown): AdvisorToolName {
+  if (!isAdvisorToolName(value)) throw new AdvisorToolContractError('unknown-tool', 'Unknown Advisor tool: ' + String(value))
+  return value
+}
+
+export function validateAdvisorToolArguments(name: unknown, value: unknown): AdvisorJsonObject {
+  const tool = assertAdvisorToolName(name)
+  const args = parseAdvisorToolArguments(value)
+  const allowed = allowedFilters[tool]
+  for (const key of Object.keys(args)) {
+    if (!(allowed as readonly string[]).includes(key)) throw new AdvisorToolContractError('additional-argument', 'Additional Advisor tool argument is not allowed: ' + key)
+  }
+  const normalized: AdvisorJsonObject = {}
+  if (Object.prototype.hasOwnProperty.call(args, 'model')) normalized.model = modelFilter(args.model)
+  if (Object.prototype.hasOwnProperty.call(args, 'provider')) normalized.provider = providerFilter(args.provider)
+  return normalized
+}
+
+export function normalizeAdvisorToolCall(name: unknown, value: unknown): { name: AdvisorToolName; arguments: AdvisorJsonObject } {
+  const tool = assertAdvisorToolName(name)
+  return { name: tool, arguments: validateAdvisorToolArguments(tool, value) }
+}
+
+/**
+ * Compatibility boundary for runtimes that have not yet received the full
+ * Metrora contract envelope. Strict callers should pass `toolContract` and
+ * use `normalizeAdvisorToolCall`; the looser path still rejects malformed
+ * JSON, unknown identities, wrong primitive types, and arbitrary objects.
+ */
+export function normalizeAdvisorRuntimeToolCall(name: unknown, value: unknown, suppliedDefinitions: readonly AdvisorToolDefinition[] = []): { name: AdvisorToolName; arguments: AdvisorJsonObject } {
+  const tool = assertAdvisorToolName(name)
+  const definition = suppliedDefinitions.find(item => item.function.name === tool)
+  const parameters = definition?.function.parameters
+  if (parameters?.additionalProperties === false) return normalizeAdvisorToolCall(tool, value)
+  const args = parseAdvisorToolArguments(value)
+  const normalized: AdvisorJsonObject = {}
+  for (const key of Object.keys(args)) {
+    if (key === 'model') normalized.model = modelFilter(args.model)
+    else if (key === 'provider') normalized.provider = providerFilter(args.provider)
+    else throw new AdvisorToolContractError('additional-argument', 'Additional Advisor tool argument is not allowed: ' + key)
+  }
+  return { name: tool, arguments: normalized }
+}
+
+export function assertBoundedAdvisorToolContent(value: unknown): string {
+  if (typeof value !== 'string') throw new AdvisorToolContractError('invalid-output', 'Advisor tool content must be a string.')
+  const parsed = JSON.parse(boundedAdvisorJson(JSON.parse(value), ADVISOR_TOOL_OUTPUT_MAX_BYTES))
+  if (!isPlainObject(parsed)) throw new AdvisorToolContractError('invalid-output', 'Advisor tool content must be a JSON object.')
+  return boundedAdvisorJson(parsed, ADVISOR_TOOL_OUTPUT_MAX_BYTES)
+}
+
+function validDate(value: unknown): value is string {
+  if (typeof value !== 'string' || !/^\d{4}-\d{2}-\d{2}$/.test(value)) return false
+  const parsed = new Date(value + 'T00:00:00Z')
+  return Number.isFinite(parsed.getTime()) && parsed.toISOString().slice(0, 10) === value
+}
+
+function scopeText(value: unknown, label: string): string {
+  if (typeof value !== 'string' || !value.trim() || value.length > ADVISOR_TOOL_MODEL_FILTER_MAX_LENGTH || CONTROL_CHARACTERS.test(value)) {
+    throw new AdvisorToolContractError('invalid-scope', 'Advisor invocation ' + label + ' is invalid.')
+  }
+  return value.trim()
+}
+
+function deepFreeze<T>(value: T): T {
+  if (!value || typeof value !== 'object' || Object.isFrozen(value)) return value
+  Object.freeze(value)
+  for (const child of Object.values(value as Record<string, unknown>)) deepFreeze(child)
+  return value
+}
+
+/** Captures the Metrora-owned scope before a runtime can see or reuse it. */
+export function snapshotAdvisorScope(scope: AdvisorScope): AdvisorScope {
+  if (!scope || typeof scope !== 'object' || !(PERIOD_VALUES as readonly string[]).includes(scope.period)) {
+    throw new AdvisorToolContractError('invalid-scope', 'Advisor invocation period is invalid.')
+  }
+  const range = scope.range
+    ? (() => {
+        if (!validDate(scope.range.from) || !validDate(scope.range.to) || scope.range.from > scope.range.to) throw new AdvisorToolContractError('invalid-scope', 'Advisor invocation date range is invalid.')
+        return { from: scope.range.from, to: scope.range.to }
+      })()
+    : null
+  const copy: AdvisorScope = {
+    period: scope.period,
+    range,
+    provider: scopeText(scope.provider, 'provider'),
+    projectId: scopeText(scope.projectId, 'Project'),
+    projectName: scopeText(scope.projectName, 'Project name'),
+    model: scope.model === null ? null : modelFilter(scope.model),
+  }
+  return deepFreeze(copy)
+}
+
+function authorityForTool(name: AdvisorToolName, evidence: AdvisorEvidence): AdvisorToolAuthority {
+  if (name === 'get_quota_snapshot') return evidence.quota && evidence.spend ? 'mixed' : 'provider-reported'
+  return evidence.refs.some(ref => ref.source === 'overview' || ref.source === 'history' || ref.source === 'models') ? 'metrora-canonical' : 'unknown'
+}
+
+function freshnessForTool(name: AdvisorToolName, evidence: AdvisorEvidence): AdvisorToolFreshness {
+  if (name !== 'get_quota_snapshot') return evidence.coverage.level === 'unavailable' ? 'unavailable' : 'unknown'
+  const providers = evidence.quota?.providers ?? []
+  if (!providers.length) return 'unavailable'
+  const factual = providers.filter(provider => provider.windows.length > 0 || provider.planLabel !== null || provider.creditsUSD !== null)
+  if (!factual.length) return 'unavailable'
+  const fresh = factual.filter(provider => provider.freshness === 'fresh').length
+  const stale = factual.filter(provider => provider.freshness === 'stale').length
+  if (fresh === factual.length) return 'fresh'
+  if (stale === factual.length) return 'stale'
+  return 'mixed'
+}
+
+function semanticsForTool(name: AdvisorToolName, evidence: AdvisorEvidence): AdvisorEvidenceSemantics[] {
+  if (evidence.coverage.level === 'unavailable') return [{ source: 'unknown', authority: 'unknown', status: 'unknown' }]
+  const semantics: AdvisorEvidenceSemantics[] = []
+  if (name === 'get_quota_snapshot') {
+    semantics.push({ source: 'quota', authority: 'provider-reported', status: 'observed' })
+    if (evidence.quota?.measuredSpendUSD !== null && evidence.quota?.measuredSpendUSD !== undefined) semantics.push({ source: 'overview', authority: 'metrora-canonical', status: 'observed' })
+  } else {
+    semantics.push({ source: 'overview', authority: 'metrora-canonical', status: 'observed' })
+    if (evidence.spend?.trend) semantics.push({ source: 'history', authority: 'metrora-canonical', status: 'derived' })
+    if (evidence.modelEfficiency?.rows.some(row => row.costPerCallUSD !== null)) semantics.push({ source: 'models', authority: 'metrora-canonical', status: 'derived' })
+  }
+  return semantics
+}
+
+export function createAdvisorToolResultEnvelope(
+  name: AdvisorToolName,
+  scope: AdvisorScope,
+  args: AdvisorJsonObject,
+  evidence: AdvisorEvidence,
+  output: AdvisorJsonObject,
+): AdvisorToolResultEnvelope {
+  const coverage: AdvisorCoverage = evidence.coverage
+  return {
+    contractVersion: ADVISOR_TOOL_CONTRACT_VERSION,
+    tool: name,
+    scope: snapshotAdvisorScope(scope),
+    arguments: args,
+    authority: authorityForTool(name, evidence),
+    freshness: freshnessForTool(name, evidence),
+    coverage,
+    semantics: semanticsForTool(name, evidence),
+    evidenceRefs: evidence.refs,
+    unavailable: coverage.level === 'unavailable',
+    privacy: 'content-minimal',
+    output,
+  }
+}

--- a/app/renderer/advisor/contract.ts
+++ b/app/renderer/advisor/contract.ts
@@ -13,6 +13,7 @@ import type {
   AdvisorToolResultEnvelope,
 } from './types'
 import { ADVISOR_TOOL_CONTRACT_VERSION, ADVISOR_TOOL_SCHEMA_VERSION } from './types'
+import { containsAdvisorSensitiveText, contentMinimalCoverage, contentMinimalEvidence, contentMinimalEvidenceRefs, contentMinimalScope, sanitizeAdvisorDisplayText } from './privacy'
 
 /** Maximum untrusted argument content accepted from a model/runtime call. */
 export const ADVISOR_TOOL_ARGUMENT_MAX_BYTES = 8 * 1024
@@ -226,12 +227,8 @@ export function normalizeAdvisorRuntimeToolCall(name: unknown, value: unknown, s
 }
 
 export function assertBoundedAdvisorToolContent(value: unknown): string {
-  if (typeof value !== 'string') throw new AdvisorToolContractError('invalid-output', 'Advisor tool content must be a string.')
-  const parsed = JSON.parse(boundedAdvisorJson(JSON.parse(value), ADVISOR_TOOL_OUTPUT_MAX_BYTES))
-  if (!isPlainObject(parsed)) throw new AdvisorToolContractError('invalid-output', 'Advisor tool content must be a JSON object.')
-  return boundedAdvisorJson(parsed, ADVISOR_TOOL_OUTPUT_MAX_BYTES)
+  return assertStrictBoundedAdvisorToolContent(value)
 }
-
 function validDate(value: unknown): value is string {
   if (typeof value !== 'string' || !/^\d{4}-\d{2}-\d{2}$/.test(value)) return false
   const parsed = new Date(value + 'T00:00:00Z')
@@ -313,19 +310,69 @@ export function createAdvisorToolResultEnvelope(
   evidence: AdvisorEvidence,
   output: AdvisorJsonObject,
 ): AdvisorToolResultEnvelope {
-  const coverage: AdvisorCoverage = evidence.coverage
-  return {
+  return createContentMinimalAdvisorToolResultEnvelope(name, scope, args, evidence, output)
+}
+const CONTENT_MINIMAL_SOURCE_VALUES = new Set(['overview', 'history', 'models', 'quota'])
+const CONTENT_MINIMAL_PROVIDER_VALUES = new Set(['all', 'claude', 'codex', '[provider]'])
+
+function containsUnsafeAdvisorToolContent(value: unknown, key = ''): boolean {
+  const normalizedKey = key.replace(/[^a-z0-9]/giu, '').toLowerCase()
+  if (/(?:token|password|secret|credential|path|rawprompt|rawresponse|rawsource|prompt|response|snippet|sourcecode|windowid|accountid|sessionid|internalid)/u.test(normalizedKey)) return true
+  if (value === null || typeof value === 'boolean' || typeof value === 'number') return false
+  if (typeof value === 'string') return containsAdvisorSensitiveText(value)
+  if (Array.isArray(value)) return value.some(item => containsUnsafeAdvisorToolContent(item, key))
+  if (!isPlainObject(value)) return true
+  for (const [childKey, child] of Object.entries(value)) {
+    const normalizedChildKey = childKey.replace(/[^a-z0-9]/giu, '').toLowerCase()
+    if (normalizedChildKey === 'source' && (typeof child !== 'string' || !CONTENT_MINIMAL_SOURCE_VALUES.has(child))) return true
+    if (normalizedChildKey === 'provider' && (typeof child !== 'string' || !CONTENT_MINIMAL_PROVIDER_VALUES.has(child))) return true
+    if (normalizedChildKey === 'id' && (typeof child !== 'string' || !/^evidence-\d+$/u.test(child))) return true
+    if (normalizedChildKey === 'projectid' && (typeof child !== 'string' || (child !== 'all' && child !== '[scoped-project]'))) return true
+    if (containsUnsafeAdvisorToolContent(child, childKey)) return true
+  }
+  return false
+}/** Strict model-facing tool content parser. */
+export function assertStrictBoundedAdvisorToolContent(value: unknown): string {
+  if (typeof value !== 'string') throw new AdvisorToolContractError('invalid-output', 'Advisor tool content must be a string.')
+  if (byteLength(value) > ADVISOR_TOOL_OUTPUT_MAX_BYTES) throw new AdvisorToolContractError('output-too-large', 'Advisor tool content exceeded its safety limit.')
+  let parsed: unknown
+  try { parsed = JSON.parse(value) } catch { throw new AdvisorToolContractError('invalid-output', 'Advisor tool content must be valid JSON.') }
+  if (!isPlainObject(parsed)) throw new AdvisorToolContractError('invalid-output', 'Advisor tool content must be a JSON object.')
+  const serialized = boundedAdvisorJson(parsed, ADVISOR_TOOL_OUTPUT_MAX_BYTES)
+  if (containsUnsafeAdvisorToolContent(parsed)) throw new AdvisorToolContractError('invalid-output', 'Advisor tool content failed the privacy boundary.')
+  if (containsAdvisorSensitiveText(serialized)) throw new AdvisorToolContractError('invalid-output', 'Advisor tool content failed the privacy boundary.')
+  return serialized
+}
+
+/** Result envelope boundary: only content-minimal scope/evidence crosses to a model. */
+export function createContentMinimalAdvisorToolResultEnvelope(
+  name: AdvisorToolName,
+  scope: AdvisorScope,
+  args: AdvisorJsonObject,
+  evidence: AdvisorEvidence,
+  output: AdvisorJsonObject,
+): AdvisorToolResultEnvelope {
+  const safeScope = snapshotAdvisorScope(contentMinimalScope(scope))
+  void output
+  const safeArguments: AdvisorJsonObject = {}
+  if (typeof args.model === 'string') safeArguments.model = sanitizeAdvisorDisplayText(args.model)
+  if (args.provider === 'claude' || args.provider === 'codex') safeArguments.provider = args.provider
+  const safeCoverage = contentMinimalCoverage(evidence.coverage)
+  const safeOutput = JSON.parse(boundedAdvisorJson(contentMinimalEvidence(evidence), ADVISOR_TOOL_OUTPUT_MAX_BYTES)) as AdvisorJsonObject
+  const envelope: AdvisorToolResultEnvelope = {
     contractVersion: ADVISOR_TOOL_CONTRACT_VERSION,
     tool: name,
-    scope: snapshotAdvisorScope(scope),
-    arguments: args,
+    scope: safeScope,
+    arguments: safeArguments,
     authority: authorityForTool(name, evidence),
     freshness: freshnessForTool(name, evidence),
-    coverage,
+    coverage: safeCoverage,
     semantics: semanticsForTool(name, evidence),
-    evidenceRefs: evidence.refs,
-    unavailable: coverage.level === 'unavailable',
+    evidenceRefs: contentMinimalEvidenceRefs(evidence.refs),
+    unavailable: safeCoverage.level === 'unavailable',
     privacy: 'content-minimal',
-    output,
+    output: safeOutput,
   }
+  boundedAdvisorJson(envelope, ADVISOR_TOOL_OUTPUT_MAX_BYTES)
+  return envelope
 }

--- a/app/renderer/advisor/kernel.ts
+++ b/app/renderer/advisor/kernel.ts
@@ -9,6 +9,9 @@ export class AdvisorCancelledError extends Error {
 function throwIfAborted(signal?: AbortSignal): void {
   if (signal?.aborted) throw new AdvisorCancelledError()
 }
+function rethrowCancellation(error: unknown, signal?: AbortSignal): void {
+  if (signal?.aborted || (error instanceof Error && (error.name === 'AbortError' || /cancel|abort/i.test(error.message)))) throw error
+}
 export type AdvisorKernel = {
   investigate(input: { question: string; scope: AdvisorScope; overview?: MenubarPayload | null; conversation?: AdvisorConversationTurn[]; signal?: AbortSignal; onToolEvent?: (event: { name: string; status: 'started' | 'completed' }) => void; onDelta?: (text: string) => void }): Promise<AdvisorAnswer>
 }
@@ -16,12 +19,12 @@ async function deterministicEvidence(source: AdvisorDataSource, intent: ReturnTy
   if (intent === 'spend-change') return buildSpendEvidence(question, scope, overview)
   if (intent === 'model-efficiency') {
     let rows: ModelReportRow[] = []
-    try { rows = await source.getModels(scope) } catch { /* Overview fallback. */ }
+    try { rows = await source.getModels(scope, signal) } catch (error) { rethrowCancellation(error, signal) /* Overview fallback. */ }
     throwIfAborted(signal)
     return buildModelEfficiencyEvidence(question, scope, overview, rows)
   }
   let quota: QuotaProvider[] = []
-  try { quota = await source.getQuota() } catch { /* unavailable != zero */ }
+  try { quota = await source.getQuota(signal) } catch (error) { rethrowCancellation(error, signal) /* unavailable != zero */ }
   throwIfAborted(signal)
   return buildQuotaEvidence(question, scope, overview, quota)
 }
@@ -33,11 +36,11 @@ export function createAdvisorKernel(source: AdvisorDataSource, runtime: AdvisorM
       const intent = classifyAdvisorQuestion(question)
       let evidence = buildUnknownEvidence(question, scope)
       if (intent !== 'unknown') {
-        const overview = suppliedOverview ?? await source.getOverview(scope)
+        const overview = suppliedOverview ?? (signal ? await source.getOverview(scope, signal) : await source.getOverview(scope))
         throwIfAborted(signal)
         evidence = await deterministicEvidence(source, intent, question, scope, overview, signal)
       }
-      return runtime.generate({ question, evidence, conversation, tools: toolRegistry.definitions, executeTool: toolRegistry.execute, onToolEvent, onDelta }, signal)
+      return runtime.generate({ question, evidence, conversation, tools: toolRegistry.definitions, toolContract: toolRegistry.contract, executeTool: toolRegistry.execute, onToolEvent, onDelta }, signal)
     },
   }
 }

--- a/app/renderer/advisor/ollama.test.ts
+++ b/app/renderer/advisor/ollama.test.ts
@@ -248,4 +248,66 @@ describe('Ollama Advisor renderer state machine', () => {
     expect(answer.details.join(' ')).not.toMatch(/41|73|claude spend|codex spend/i)
     expect(finalRequests).toEqual([])
   })
+
+  it('buffers split sensitive streaming content and emits no raw or post-hoc narrative', async () => {
+    const deltas: string[] = []
+    let listener: ((event: { requestId: string; text: string }) => void) | null = null
+    const transport: OllamaTransport = {
+      probe: async () => ({ available: true, models: ['llama3.2'], detail: 'ready' }),
+      cancel: async () => true,
+      onDelta: callback => {
+        listener = callback
+        return () => { listener = null }
+      },
+      chat: async (requestId, payload) => {
+        const tools = Array.isArray(payload.tools) ? payload.tools : []
+        if (tools.length > 0) {
+          return { streamed: false, message: { content: '', tool_calls: [{ function: { name: 'get_spend_snapshot', arguments: '{}' } }] } }
+        }
+        listener?.({ requestId, text: 'safe qualitative context ' })
+        listener?.({ requestId, text: 'token=supersecretvalue' })
+        return { streamed: true, message: { content: 'safe final context' } }
+      },
+    }
+    const answer = await new OllamaAdvisorRuntime({ model: 'llama3.2', transport }).generate({
+      question: 'What changed in spend?',
+      evidence: spendEvidence,
+      tools: [{ type: 'function', function: { name: 'get_spend_snapshot', description: 'spend', parameters: { type: 'object' } } }],
+      executeTool: async () => ({ content: '{"safe":true}', evidence: spendEvidence }),
+      onDelta: text => deltas.push(text),
+    })
+    expect(deltas).toEqual([])
+    expect(answer.conclusion).not.toContain('supersecretvalue')
+    expect(answer.conclusion).not.toContain('Local model context')
+    expect(answer.streamed).toBe(false)
+  })
+  it('fails closed on buffered stream overflow even when the final response is safe', async () => {
+    const deltas: string[] = []
+    let listener: ((event: { requestId: string; text: string }) => void) | null = null
+    const transport: OllamaTransport = {
+      probe: async () => ({ available: true, models: ['llama3.2'], detail: 'ready' }),
+      cancel: async () => true,
+      onDelta: callback => {
+        listener = callback
+        return () => { listener = null }
+      },
+      chat: async (requestId, payload) => {
+        if (Array.isArray(payload.tools) && payload.tools.length > 0) {
+          return { streamed: false, message: { content: '', tool_calls: [{ function: { name: 'get_spend_snapshot', arguments: '{}' } }] } }
+        }
+        listener?.({ requestId, text: 'x'.repeat(9 * 1024) })
+        return { streamed: true, message: { content: 'safe final response' } }
+      },
+    }
+    const answer = await new OllamaAdvisorRuntime({ model: 'llama3.2', transport }).generate({
+      question: 'What changed in spend?',
+      evidence: spendEvidence,
+      tools: [{ type: 'function', function: { name: 'get_spend_snapshot', description: 'spend', parameters: { type: 'object' } } }],
+      executeTool: async () => ({ content: '{"safe":true}', evidence: spendEvidence }),
+      onDelta: text => deltas.push(text),
+    })
+    expect(deltas).toEqual([])
+    expect(answer.conclusion).not.toContain('Local model context')
+    expect(answer.streamed).toBe(false)
+  })
 })

--- a/app/renderer/advisor/ollama.ts
+++ b/app/renderer/advisor/ollama.ts
@@ -1,14 +1,15 @@
 import { metrora } from '../lib/ipc'
 import { DeterministicAdvisorRuntime } from './runtime'
+import { ADVISOR_TOOL_OUTPUT_MAX_BYTES, AdvisorToolContractError, normalizeAdvisorRuntimeToolCall, normalizeAdvisorToolCall } from './contract'
 import { advisorScopeFingerprint, type AdvisorAnswer, type AdvisorCoverageLevel, type AdvisorEvidence, type AdvisorModelRuntime, type AdvisorRuntimeInput, type AdvisorToolExecution } from './types'
 
-type OllamaToolCall = { function?: { name?: string; arguments?: Record<string, unknown> | string } }
+type OllamaToolCall = { function?: { name?: string; arguments?: unknown } }
 type OllamaChatMessage = { role: 'system' | 'user' | 'assistant' | 'tool'; content: string; tool_calls?: OllamaToolCall[]; tool_name?: string }
 type OllamaResponse = { message?: { content?: string; tool_calls?: OllamaToolCall[] }; streamed?: boolean }
 export type OllamaProbeResult = { available: boolean; models: string[]; detail: string }
 export type OllamaTransport = {
   probe: (signal?: AbortSignal) => Promise<OllamaProbeResult>
-  chat: (requestId: string, payload: Record<string, unknown>) => Promise<OllamaResponse>
+  chat: (requestId: string, payload: Record<string, unknown>, signal?: AbortSignal) => Promise<OllamaResponse>
   cancel: (requestId: string) => Promise<boolean>
   onDelta: (callback: (event: { requestId: string; text: string }) => void) => () => void
 }
@@ -17,7 +18,10 @@ const bridgeTransport: OllamaTransport = {
     if (signal?.aborted) return Promise.reject(new DOMException('Advisor request cancelled', 'AbortError'))
     return metrora.advisorProbe()
   },
-  chat: (requestId, payload) => metrora.advisorChat(requestId, payload),
+  chat: (requestId, payload, signal) => {
+    if (signal?.aborted) return Promise.reject(new DOMException('Advisor request cancelled', 'AbortError'))
+    return metrora.advisorChat(requestId, payload)
+  },
   cancel: requestId => metrora.advisorCancel(requestId),
   onDelta: callback => metrora.onAdvisorDelta(callback),
 }
@@ -28,16 +32,6 @@ export async function probeOllama(signal?: AbortSignal, transport: OllamaTranspo
     if (signal?.aborted) throw error
     return { available: false, models: [], detail: 'Local Ollama is unavailable.' }
   }
-}
-function parseArguments(value: unknown): Record<string, unknown> {
-  if (value && typeof value === 'object') return value as Record<string, unknown>
-  if (typeof value === 'string') {
-    try {
-      const parsed = JSON.parse(value)
-      return parsed && typeof parsed === 'object' ? parsed as Record<string, unknown> : {}
-    } catch { return {} }
-  }
-  return {}
 }
 function extractNarrative(value: string): string {
   const trimmed = value.trim().replace(/^\s*\x60\x60\x60(?:json|text)?\s*/i, '').replace(/\s*\x60\x60\x60$/, '').trim()
@@ -135,8 +129,12 @@ function mergeEvidence(items: AdvisorEvidence[], fallback: AdvisorEvidence): Adv
 function toolCallName(call: OllamaToolCall): string {
   return typeof call.function?.name === 'string' ? call.function.name : ''
 }
-function toolCallArgs(call: OllamaToolCall): Record<string, unknown> {
-  return parseArguments(call.function?.arguments)
+function boundedToolContent(content: string): string {
+  if (new TextEncoder().encode(content).byteLength > ADVISOR_TOOL_OUTPUT_MAX_BYTES) throw new AdvisorToolContractError('output-too-large', 'Advisor tool content exceeded its safety limit.')
+  return content
+}
+function throwIfAborted(signal?: AbortSignal): void {
+  if (signal?.aborted) throw new DOMException('Advisor request cancelled', 'AbortError')
 }
 function safeConversation(input: AdvisorRuntimeInput): OllamaChatMessage[] {
   const currentScopeFingerprint = advisorScopeFingerprint(input.evidence.scope)
@@ -162,6 +160,7 @@ export class OllamaAdvisorRuntime implements AdvisorModelRuntime {
   }
   async generate(input: AdvisorRuntimeInput, signal?: AbortSignal): Promise<AdvisorAnswer> {
     if (this.availability !== 'ready') throw new Error('Local Ollama model is not available.')
+    throwIfAborted(signal)
     const requestId = 'advisor-' + Date.now().toString(36) + '-' + Math.random().toString(36).slice(2, 8)
     const messages: OllamaChatMessage[] = [{ role: 'system', content: systemPrompt() }, ...safeConversation(input)]
     messages.push({ role: 'user', content: input.question.trim().slice(0, 4000) })
@@ -178,14 +177,15 @@ export class OllamaAdvisorRuntime implements AdvisorModelRuntime {
     const cancel = () => { void this.transport.cancel(requestId).catch(() => {}) }
     signal?.addEventListener('abort', cancel, { once: true })
     try {
-      if (signal?.aborted) throw new DOMException('Advisor request cancelled', 'AbortError')
-      const definitions = input.tools ? [...input.tools] : []
+      throwIfAborted(signal)
+      const definitions = input.toolContract?.tools ? [...input.toolContract.tools] : input.tools ? [...input.tools] : []
       const planning = await this.transport.chat(requestId, {
         model: this.model,
         messages,
         tools: definitions,
         stream: definitions.length === 0,
-      })
+      }, signal)
+      throwIfAborted(signal)
       const planningMessage = planning.message ?? {}
       const calls = Array.isArray(planningMessage.tool_calls) ? planningMessage.tool_calls.slice(0, 8) : []
       messages.push({ role: 'assistant', content: typeof planningMessage.content === 'string' ? planningMessage.content : '', tool_calls: calls })
@@ -193,20 +193,22 @@ export class OllamaAdvisorRuntime implements AdvisorModelRuntime {
         finalContent = typeof planningMessage.content === 'string' ? planningMessage.content : ''
       } else {
         for (const call of calls) {
-          if (signal?.aborted) throw new DOMException('Advisor request cancelled', 'AbortError')
-          const name = toolCallName(call)
-          if (!name) continue
-          input.onToolEvent?.({ name, status: 'started' })
-          const result: AdvisorToolExecution = input.executeTool
-            ? await input.executeTool(name, toolCallArgs(call), signal)
-            : { content: 'Tool execution is unavailable.', evidence: input.evidence }
+          throwIfAborted(signal)
+          if (!call || typeof call !== 'object') throw new AdvisorToolContractError('invalid-arguments', 'Malformed Advisor runtime tool call.')
+          const normalized = input.toolContract
+            ? normalizeAdvisorToolCall(toolCallName(call), call.function?.arguments)
+            : normalizeAdvisorRuntimeToolCall(toolCallName(call), call.function?.arguments, definitions)
+          input.onToolEvent?.({ name: normalized.name, status: 'started' })
+          if (!input.executeTool) throw new AdvisorToolContractError('authority-unavailable', 'Advisor tool execution is unavailable.')
+          const result: AdvisorToolExecution = await input.executeTool(normalized.name, normalized.arguments, signal)
+          throwIfAborted(signal)
           evidences.push(result.evidence)
-          messages.push({ role: 'tool', content: result.content.slice(0, 32_000), tool_name: name })
-          input.onToolEvent?.({ name, status: 'completed' })
+          messages.push({ role: 'tool', content: boundedToolContent(result.content), tool_name: normalized.name })
+          input.onToolEvent?.({ name: normalized.name, status: 'completed' })
         }
         const validToolEvidence = !hasMixedEvidenceScopes(evidences)
           && evidences.some(item => item.intent !== 'unknown' && item.coverage.level !== 'unavailable' && item.refs.length > 0)
-        if (signal?.aborted) throw new DOMException('Advisor request cancelled', 'AbortError')
+        throwIfAborted(signal)
         if (validToolEvidence) {
           allowDelta = true
           const finalResponse = await this.transport.chat(requestId, {
@@ -214,7 +216,8 @@ export class OllamaAdvisorRuntime implements AdvisorModelRuntime {
             messages,
             tools: [],
             stream: true,
-          })
+          }, signal)
+          throwIfAborted(signal)
           streamed = streamed || Boolean(finalResponse.streamed)
           finalContent = typeof finalResponse.message?.content === 'string' ? finalResponse.message.content : ''
         }
@@ -223,12 +226,14 @@ export class OllamaAdvisorRuntime implements AdvisorModelRuntime {
       signal?.removeEventListener('abort', cancel)
       offDelta()
     }
+    throwIfAborted(signal)
     const evidenceItems = evidences.length ? evidences : [input.evidence]
     const evidence = mergeEvidence(evidenceItems, input.evidence)
     const homogeneous = !hasMixedEvidenceScopes(evidenceItems)
     const deterministicItems = homogeneous ? evidenceItems : [evidence]
     const deterministicAnswers = await Promise.all(deterministicItems.map(item => new DeterministicAdvisorRuntime().generate({ question: input.question, evidence: item }, signal)))
     const fallback = await new DeterministicAdvisorRuntime().generate({ question: input.question, evidence }, signal)
+    throwIfAborted(signal)
     const verifiedConclusions = Array.from(new Set(deterministicAnswers.map(answer => answer.conclusion).filter(Boolean)))
     const verifiedConclusion = verifiedConclusions.length ? verifiedConclusions.join(' ') : fallback.conclusion
     const hasValidEvidence = evidences.length > 0 && homogeneous && evidences.some(item => item.intent !== 'unknown' && item.coverage.level !== 'unavailable' && item.refs.length > 0)

--- a/app/renderer/advisor/ollama.ts
+++ b/app/renderer/advisor/ollama.ts
@@ -1,7 +1,8 @@
 import { metrora } from '../lib/ipc'
 import { DeterministicAdvisorRuntime } from './runtime'
-import { ADVISOR_TOOL_OUTPUT_MAX_BYTES, AdvisorToolContractError, normalizeAdvisorRuntimeToolCall, normalizeAdvisorToolCall } from './contract'
+import { ADVISOR_TOOL_OUTPUT_MAX_BYTES, AdvisorToolContractError, assertStrictBoundedAdvisorToolContent, normalizeAdvisorRuntimeToolCall, normalizeAdvisorToolCall } from './contract'
 import { advisorScopeFingerprint, type AdvisorAnswer, type AdvisorCoverageLevel, type AdvisorEvidence, type AdvisorModelRuntime, type AdvisorRuntimeInput, type AdvisorToolExecution } from './types'
+import { ADVISOR_MODEL_NARRATIVE_MAX_BYTES, boundedAdvisorText, sanitizeAdvisorAnswer, sanitizeAdvisorNarrative } from './privacy'
 
 type OllamaToolCall = { function?: { name?: string; arguments?: unknown } }
 type OllamaChatMessage = { role: 'system' | 'user' | 'assistant' | 'tool'; content: string; tool_calls?: OllamaToolCall[]; tool_name?: string }
@@ -42,10 +43,14 @@ function extractNarrative(value: string): string {
   return trimmed
 }
 function sanitizeNarrative(value: string): string {
-  const original = extractNarrative(value)
-  if (/\d/.test(original)) return ''
-  const text = original.trim()
-  return text.length > 800 ? text.slice(0, 797) + '…' : text
+  return sanitizeAdvisorNarrative(extractNarrative(value))
+}
+function byteLength(value: string): number {
+  return new TextEncoder().encode(value).byteLength
+}
+function boundedModelText(value: unknown): string {
+  if (typeof value !== 'string' || byteLength(value) > ADVISOR_MODEL_NARRATIVE_MAX_BYTES) return ''
+  return value
 }
 function systemPrompt(): string {
   return [
@@ -129,8 +134,9 @@ function mergeEvidence(items: AdvisorEvidence[], fallback: AdvisorEvidence): Adv
 function toolCallName(call: OllamaToolCall): string {
   return typeof call.function?.name === 'string' ? call.function.name : ''
 }
-function boundedToolContent(content: string): string {
-  if (new TextEncoder().encode(content).byteLength > ADVISOR_TOOL_OUTPUT_MAX_BYTES) throw new AdvisorToolContractError('output-too-large', 'Advisor tool content exceeded its safety limit.')
+function boundedToolContent(content: string, strict = false): string {
+  if (strict) return assertStrictBoundedAdvisorToolContent(content)
+  if (byteLength(content) > ADVISOR_TOOL_OUTPUT_MAX_BYTES) throw new AdvisorToolContractError('output-too-large', 'Advisor tool content exceeded its safety limit.')
   return content
 }
 function throwIfAborted(signal?: AbortSignal): void {
@@ -168,11 +174,17 @@ export class OllamaAdvisorRuntime implements AdvisorModelRuntime {
     let finalContent = ''
     let streamed = false
     let allowDelta = false
+    let streamBuffer = ''
+    let streamOverflow = false
     const offDelta = this.transport.onDelta(event => {
-      if (event.requestId === requestId && allowDelta && !/\d/.test(event.text)) {
-        streamed = true
-        input.onDelta?.(event.text)
+      if (event.requestId !== requestId || !allowDelta) return
+      const nextBytes = byteLength(streamBuffer) + byteLength(event.text)
+      if (nextBytes > ADVISOR_MODEL_NARRATIVE_MAX_BYTES) {
+        streamOverflow = true
+        return
       }
+      streamBuffer += event.text
+      streamed = true
     })
     const cancel = () => { void this.transport.cancel(requestId).catch(() => {}) }
     signal?.addEventListener('abort', cancel, { once: true })
@@ -188,24 +200,30 @@ export class OllamaAdvisorRuntime implements AdvisorModelRuntime {
       throwIfAborted(signal)
       const planningMessage = planning.message ?? {}
       const calls = Array.isArray(planningMessage.tool_calls) ? planningMessage.tool_calls.slice(0, 8) : []
-      messages.push({ role: 'assistant', content: typeof planningMessage.content === 'string' ? planningMessage.content : '', tool_calls: calls })
+      const planningContent = boundedModelText(planningMessage.content)
       if (!calls.length) {
-        finalContent = typeof planningMessage.content === 'string' ? planningMessage.content : ''
+        messages.push({ role: 'assistant', content: planningContent, tool_calls: [] })
+        finalContent = planningContent
       } else {
+        const assistantMessage: OllamaChatMessage = { role: 'assistant', content: planningContent, tool_calls: [] }
+        messages.push(assistantMessage)
+        const normalizedCalls: OllamaToolCall[] = []
         for (const call of calls) {
           throwIfAborted(signal)
           if (!call || typeof call !== 'object') throw new AdvisorToolContractError('invalid-arguments', 'Malformed Advisor runtime tool call.')
           const normalized = input.toolContract
             ? normalizeAdvisorToolCall(toolCallName(call), call.function?.arguments)
             : normalizeAdvisorRuntimeToolCall(toolCallName(call), call.function?.arguments, definitions)
+          normalizedCalls.push({ function: { name: normalized.name, arguments: JSON.stringify(normalized.arguments) } })
           input.onToolEvent?.({ name: normalized.name, status: 'started' })
           if (!input.executeTool) throw new AdvisorToolContractError('authority-unavailable', 'Advisor tool execution is unavailable.')
           const result: AdvisorToolExecution = await input.executeTool(normalized.name, normalized.arguments, signal)
           throwIfAborted(signal)
           evidences.push(result.evidence)
-          messages.push({ role: 'tool', content: boundedToolContent(result.content), tool_name: normalized.name })
+          messages.push({ role: 'tool', content: boundedToolContent(result.content, Boolean(input.toolContract)), tool_name: normalized.name })
           input.onToolEvent?.({ name: normalized.name, status: 'completed' })
         }
+        assistantMessage.tool_calls = normalizedCalls
         const validToolEvidence = !hasMixedEvidenceScopes(evidences)
           && evidences.some(item => item.intent !== 'unknown' && item.coverage.level !== 'unavailable' && item.refs.length > 0)
         throwIfAborted(signal)
@@ -219,7 +237,7 @@ export class OllamaAdvisorRuntime implements AdvisorModelRuntime {
           }, signal)
           throwIfAborted(signal)
           streamed = streamed || Boolean(finalResponse.streamed)
-          finalContent = typeof finalResponse.message?.content === 'string' ? finalResponse.message.content : ''
+          finalContent = boundedModelText(finalResponse.message?.content)
         }
       }
     } finally {
@@ -237,20 +255,22 @@ export class OllamaAdvisorRuntime implements AdvisorModelRuntime {
     const verifiedConclusions = Array.from(new Set(deterministicAnswers.map(answer => answer.conclusion).filter(Boolean)))
     const verifiedConclusion = verifiedConclusions.length ? verifiedConclusions.join(' ') : fallback.conclusion
     const hasValidEvidence = evidences.length > 0 && homogeneous && evidences.some(item => item.intent !== 'unknown' && item.coverage.level !== 'unavailable' && item.refs.length > 0)
-    const insight = hasValidEvidence ? sanitizeNarrative(finalContent) : ''
+    const narrativeSource = streamOverflow ? '' : (streamBuffer ? streamBuffer : finalContent)
+    const insight = hasValidEvidence ? sanitizeNarrative(narrativeSource) : ''
     const conclusion = verifiedConclusion + (insight ? ' Local model context: ' + insight : '')
     const details = Array.from(new Set([
       ...deterministicAnswers.flatMap(answer => answer.details),
       ...fallback.details,
       ...(homogeneous ? evidences.flatMap(item => item.refs.map(ref => 'Evidence · ' + ref.label)) : []),
     ]))
-    return {
+    if (insight && hasValidEvidence) input.onDelta?.(insight)
+    return sanitizeAdvisorAnswer({
       ...fallback,
-      conclusion: conclusion.slice(0, 1600),
+      conclusion: boundedAdvisorText(conclusion),
       details,
       runtime: { id: this.id, label: this.label, mode: this.mode },
       generatedByModel: true,
-      streamed,
-    }
+      streamed: Boolean(insight && streamed),
+    })
   }
 }

--- a/app/renderer/advisor/privacy.test.ts
+++ b/app/renderer/advisor/privacy.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  containsAdvisorSensitiveText,
+  sanitizeAdvisorDisplayText,
+  sanitizeAdvisorNarrative,
+} from './privacy'
+import { assertStrictBoundedAdvisorToolContent, createContentMinimalAdvisorToolResultEnvelope } from './contract'
+import { createAdvisorConformanceFixture } from './conformance'
+
+describe('Advisor deterministic privacy boundary', () => {
+  it.each([
+    '/home/alice/private/project',
+    'C:\\Users\\alice\\secret',
+    '/Users/alice/private',
+    'token=supersecretvalue',
+    'password=mysecret',
+    'bearer abcdefghijklmnopqrstuvwxyz',
+    'raw prompt marker text',
+    'source snippets from a local file',
+  ])('drops no-digit sensitive narrative: %s', value => {
+    expect(containsAdvisorSensitiveText(value)).toBe(true)
+    expect(sanitizeAdvisorNarrative(value)).toBe('')
+  })
+
+  it('redacts sensitive display spans while retaining safe factual prose', () => {
+    expect(sanitizeAdvisorDisplayText('C:\\Users\\alice\\secret project')).toContain('[redacted]')
+    expect(sanitizeAdvisorDisplayText('project/alpha')).toBe('project/alpha')
+    expect(sanitizeAdvisorDisplayText('Measured cost 12 across project/alpha')).toBe('Measured cost 12 across project/alpha')
+    expect(sanitizeAdvisorNarrative('The observed pattern remains qualitative and local.')).toBe('The observed pattern remains qualitative and local.')
+  })
+
+  it('drops suspicious high-entropy credential-like text without digits in the surrounding prose', () => {
+    const secret = 'aBcDeFgHiJkLmNoPqRsTuVwXyZaBcDeF'
+    expect(containsAdvisorSensitiveText(secret)).toBe(true)
+    expect(sanitizeAdvisorNarrative('The result is ' + secret)).toBe('')
+  })
+  it('rejects nested secret keys and underscore-delimited raw markers', () => {
+    expect(() => assertStrictBoundedAdvisorToolContent(JSON.stringify({ token: 'supersecretvalue' }))).toThrow()
+    expect(() => assertStrictBoundedAdvisorToolContent(JSON.stringify({ raw_prompt_marker_text: 'private prompt' }))).toThrow()
+    expect(containsAdvisorSensitiveText('raw_prompt_marker_text')).toBe(true)
+    expect(sanitizeAdvisorDisplayText('raw_prompt_marker_text')).not.toContain('raw_prompt_marker_text')
+  })
+  it('bounds direct envelope construction and strips arbitrary arguments and provenance', async () => {
+    const fixture = createAdvisorConformanceFixture()
+    const { createAdvisorToolRegistry } = await import('./tools')
+    const result = await createAdvisorToolRegistry(fixture.source, fixture.scope, fixture.overview).execute('get_spend_snapshot', {})
+    const unsafeEvidence = {
+      ...result.evidence,
+      refs: [{ id: 'internal-account-secret', label: '/home/alice/private/project', source: 'provider-secret' }],
+    } as unknown as typeof result.evidence
+    const envelope = createContentMinimalAdvisorToolResultEnvelope(
+      'get_spend_snapshot',
+      fixture.scope,
+      { model: 'token=supersecretvalue', extra: 'internal-account-secret' },
+      unsafeEvidence,
+      { unsafe: 'ignored' },
+    )
+    const serialized = JSON.stringify(envelope)
+    expect(new TextEncoder().encode(serialized).byteLength).toBeLessThanOrEqual(32 * 1024)
+    expect(serialized).not.toContain('supersecretvalue')
+    expect(serialized).not.toContain('internal-account-secret')
+    expect(serialized).not.toContain('/home/alice/private/project')
+    expect(envelope.arguments).toEqual({ model: '[redacted]' })
+    expect(envelope.evidenceRefs).toEqual([])
+  })
+})
+

--- a/app/renderer/advisor/privacy.ts
+++ b/app/renderer/advisor/privacy.ts
@@ -1,0 +1,260 @@
+import type {
+  AdvisorAnswer,
+  AdvisorCoverage,
+  AdvisorEvidence,
+  AdvisorEvidenceRef,
+  AdvisorJsonObject,
+  AdvisorScope,
+} from './types'
+
+/**
+ * The privacy boundary is intentionally conservative. It is used for values
+ * that may cross into a model/tool payload, not for canonical evidence kept
+ * inside Metrora. A redaction is explicit; it never invents a replacement.
+ */
+export const ADVISOR_MODEL_NARRATIVE_MAX_BYTES = 8 * 1024
+export const ADVISOR_ANSWER_TEXT_MAX_BYTES = 8 * 1024
+export const ADVISOR_CONTENT_MINIMAL_TEXT_MAX_LENGTH = 160
+
+const REDACTION = '[redacted]'
+const CONTROL_CHARACTERS = /[\u0000-\u001f\u007f]/g
+
+// Only roots that are materially indicative of local filesystem provenance
+// are classified here. Names such as "project/alpha" remain valid display
+// names; a generic slash is not enough to make a project name sensitive.
+const PATH_PATTERN = /(?:\b[A-Za-z]:[\\/][^\s"'<>|]+|(?:^|[\s([{])\\\\[^\s"'<>|]+|(?:^|[\s([{])(?:~[\\/]|\/(?:Users|users|home|private|var|tmp|mnt|opt|root|srv|workspace|workspaces)(?:\/|$))[^\s"'<>|,.;!?)]*|\b(?:file|local|vscode-file):\/\/[^\s"'<>|]+|(?:^|[\s([{])(?:\.\.?[\\/])[^\s"'<>|,.;!?)]*)/giu
+const SECRET_ASSIGNMENT_PATTERN = /\b(?:api[-_ ]?key|access[-_ ]?token|auth(?:entication)?[-_ ]?token|client[-_ ]?secret|private[-_ ]?key|secret|password|passwd|credential|token)\b\s*(?:=|:)\s*[^\s,;]+/giu
+const BEARER_PATTERN = /\bbearer\s+[^\s,;]+/giu
+const KEY_PREFIX_PATTERN = /\b(?:sk|rk|pk|gh[pousr]|xox[baprs]-)[-_A-Za-z0-9]{12,}\b/giu
+const RAW_CONTENT_MARKER_PATTERN = /(?<![\p{L}\p{N}])(?:raw[_ -]?(?:prompt|response|source)(?:[_ -]?(?:marker|text|content|snippet|should[_ -]?not[_ -]?leak))*|(?:prompt|response|source)[_ -]?(?:marker|text|content|snippet|should[_ -]?not[_ -]?leak)(?:[_ -]?(?:marker|text|content|snippet|should[_ -]?not[_ -]?leak))*|source[_ -]?(?:code|snippet|content|snippets?)(?:[_ -]?(?:marker|text|content|snippet|should[_ -]?not[_ -]?leak))*)(?![\p{L}\p{N}])/giu
+const NUMERIC_CHARACTER_PATTERN = /\p{N}/u
+const NUMBER_WORD_PATTERN = /\b(?:zero|one|two|three|four|five|six|seven|eight|nine|ten|eleven|twelve|thirteen|fourteen|fifteen|sixteen|seventeen|eighteen|nineteen|twenty|thirty|forty|fifty|hundred|thousand|million|billion|first|second|third|uno|due|tre|quattro|cinque|sei|sette|otto|nove|dieci|primo|secondo|terzo)\b/iu
+const CONTENT_MINIMAL_EVIDENCE_SOURCES = ['overview', 'history', 'models', 'quota'] as const
+const CONTENT_MINIMAL_PROVIDER_NAMES = ['all', 'claude', 'codex'] as const
+const SAFE_ANSWER_EVIDENCE_ID_PATTERN = /^(?:spend|quota|spend-(?:claude|codex)|overview\.(?:current|history\.daily|models|projects|sessions|modelAccounting)|models\.report|quota\.(?:claude|codex))$/u
+
+function contentMinimalSource(value: unknown): typeof CONTENT_MINIMAL_EVIDENCE_SOURCES[number] | null {
+  return typeof value === 'string' && (CONTENT_MINIMAL_EVIDENCE_SOURCES as readonly string[]).includes(value) ? value as typeof CONTENT_MINIMAL_EVIDENCE_SOURCES[number] : null
+}
+function contentMinimalProvider(value: unknown): typeof CONTENT_MINIMAL_PROVIDER_NAMES[number] | null {
+  return typeof value === 'string' && (CONTENT_MINIMAL_PROVIDER_NAMES as readonly string[]).includes(value) ? value as typeof CONTENT_MINIMAL_PROVIDER_NAMES[number] : null
+}
+function contentMinimalTimestamp(value: unknown): string | null {
+  if (typeof value !== 'string' || value.length > 64) return null
+  const parsed = Date.parse(value)
+  return Number.isFinite(parsed) ? new Date(parsed).toISOString() : null
+}
+
+function byteLength(value: string): number {
+  return new TextEncoder().encode(value).byteLength
+}
+
+function entropy(value: string): number {
+  if (!value) return 0
+  const counts = new Map<string, number>()
+  for (const character of value) counts.set(character, (counts.get(character) ?? 0) + 1)
+  let result = 0
+  for (const count of counts.values()) {
+    const probability = count / value.length
+    result -= probability * Math.log2(probability)
+  }
+  return result
+}
+
+function looksLikeHighEntropyCredential(value: string): boolean {
+  if (value.length < 20 || /\s/u.test(value)) return false
+  if (!/^[\p{L}\p{N}+/_=-]+$/u.test(value)) return false
+  const classes = Number(/[\p{Ll}]/u.test(value)) + Number(/[\p{Lu}]/u.test(value)) + Number(/[\p{N}]/u.test(value)) + Number(/[+/_=-]/u.test(value))
+  return value.length >= 24 && classes >= 1 && entropy(value) >= 3.6
+}
+function containsAdvisorNumericClaim(value: string): boolean {
+  return NUMERIC_CHARACTER_PATTERN.test(value) || NUMBER_WORD_PATTERN.test(value)
+}
+
+function resetPatterns(): void {
+  PATH_PATTERN.lastIndex = 0
+  SECRET_ASSIGNMENT_PATTERN.lastIndex = 0
+  BEARER_PATTERN.lastIndex = 0
+  KEY_PREFIX_PATTERN.lastIndex = 0
+  RAW_CONTENT_MARKER_PATTERN.lastIndex = 0
+}
+
+function replaceSensitiveSegments(value: string): string {
+  let result = value
+  result = result.replace(PATH_PATTERN, REDACTION)
+  result = result.replace(SECRET_ASSIGNMENT_PATTERN, REDACTION)
+  result = result.replace(BEARER_PATTERN, REDACTION)
+  result = result.replace(KEY_PREFIX_PATTERN, REDACTION)
+  result = result.replace(RAW_CONTENT_MARKER_PATTERN, REDACTION)
+  result = result.split(/(\s+)/u).map(token => looksLikeHighEntropyCredential(token) ? REDACTION : token).join('')
+  resetPatterns()
+  return result
+}
+
+export function containsAdvisorSensitiveText(value: string): boolean {
+  if (!value) return false
+  const matched = PATH_PATTERN.test(value) || SECRET_ASSIGNMENT_PATTERN.test(value) || BEARER_PATTERN.test(value) || KEY_PREFIX_PATTERN.test(value) || RAW_CONTENT_MARKER_PATTERN.test(value)
+  resetPatterns()
+  return matched || value.split(/\s+/u).some(looksLikeHighEntropyCredential)
+}
+
+/** Redacts sensitive spans while retaining safe factual text and digits. */
+export function sanitizeAdvisorDisplayText(value: string, maxLength = ADVISOR_CONTENT_MINIMAL_TEXT_MAX_LENGTH): string {
+  const normalized = value.replace(CONTROL_CHARACTERS, ' ').trim()
+  if (!normalized) return REDACTION
+  const redacted = replaceSensitiveSegments(normalized).replace(/\s{2,}/gu, ' ').trim()
+  if (!redacted) return REDACTION
+  if (redacted.length <= maxLength) return redacted
+  return redacted.slice(0, Math.max(0, maxLength - 1)).trimEnd() + '…'
+}
+
+/**
+ * Model prose has a stricter policy than human-facing deterministic facts:
+ * any numeric claim or sensitive class invalidates the whole narrative.
+ */
+export function sanitizeAdvisorNarrative(value: string, maxBytes = ADVISOR_MODEL_NARRATIVE_MAX_BYTES): string {
+  const normalized = value.replace(CONTROL_CHARACTERS, ' ').trim()
+  if (!normalized || containsAdvisorNumericClaim(normalized) || containsAdvisorSensitiveText(normalized)) return ''
+  const safe = sanitizeAdvisorDisplayText(normalized, Number.MAX_SAFE_INTEGER)
+  if (safe === REDACTION || containsAdvisorSensitiveText(safe) || containsAdvisorNumericClaim(safe)) return ''
+  if (byteLength(safe) <= maxBytes) return safe
+  return ''
+}
+
+export function boundedAdvisorText(value: string, maxBytes = ADVISOR_ANSWER_TEXT_MAX_BYTES): string {
+  if (byteLength(value) <= maxBytes) return value
+  let end = value.length
+  while (end > 0 && byteLength(value.slice(0, end)) > maxBytes) end -= 1
+  return value.slice(0, end)
+}
+
+export function contentMinimalScope(scope: AdvisorScope): AdvisorScope {
+  return {
+    period: scope.period,
+    range: scope.range ? { from: scope.range.from, to: scope.range.to } : null,
+    provider: contentMinimalProvider(scope.provider) ?? '[provider]',
+    // Raw internal Project/account identities are not model-facing evidence.
+    projectId: scope.projectId === 'all' ? 'all' : '[scoped-project]',
+    projectName: sanitizeAdvisorDisplayText(scope.projectName),
+    model: scope.model === null ? null : sanitizeAdvisorDisplayText(scope.model),
+  }
+}
+
+export function contentMinimalCoverage(coverage: AdvisorCoverage): AdvisorCoverage {
+  return {
+    level: coverage.level,
+    label: sanitizeAdvisorDisplayText(coverage.label),
+    detail: sanitizeAdvisorDisplayText(coverage.detail),
+  }
+}
+
+export function contentMinimalEvidenceRefs(refs: AdvisorEvidenceRef[]): AdvisorEvidenceRef[] {
+  return refs.flatMap((ref, index) => {
+    const source = contentMinimalSource(ref.source)
+    if (!source) return []
+    return [{
+      // Evidence IDs are internal correlation keys. A stable local ordinal is
+      // sufficient for the model and avoids exposing provider/account IDs.
+      id: 'evidence-' + (index + 1),
+      label: sanitizeAdvisorDisplayText(ref.label),
+      source,
+    }]
+  })
+}
+
+export function sanitizeAdvisorAnswer(answer: AdvisorAnswer): AdvisorAnswer {
+  const coverage = contentMinimalCoverage(answer.coverage)
+  const safeText = (value: string) => boundedAdvisorText(sanitizeAdvisorDisplayText(value, Number.MAX_SAFE_INTEGER))
+  return {
+    ...answer,
+    conclusion: safeText(answer.conclusion),
+    scopeLabel: safeText(answer.scopeLabel),
+    periodLabel: safeText(answer.periodLabel),
+    evidence: answer.evidence.flatMap((ref, index) => {
+      const source = contentMinimalSource(ref.source)
+      if (!source) return []
+      const candidate = sanitizeAdvisorDisplayText(ref.id, 64)
+      const id = SAFE_ANSWER_EVIDENCE_ID_PATTERN.test(candidate) ? candidate : 'evidence-' + (index + 1)
+      return [{ id, label: sanitizeAdvisorDisplayText(ref.label), source }]
+    }),
+    coverage,
+    assumptions: answer.assumptions.map(safeText),
+    unknown: answer.unknown.map(safeText),
+    nextInvestigations: answer.nextInvestigations.map(safeText),
+    details: answer.details.map(safeText),
+  }
+}
+
+/** Explicitly allowlisted model-facing evidence projection. */
+export function contentMinimalEvidence(evidence: AdvisorEvidence): AdvisorJsonObject {
+  const spend = evidence.spend
+    ? {
+        measuredCostUSD: evidence.spend.measuredCostUSD,
+        calls: evidence.spend.calls,
+        sessions: evidence.spend.sessions,
+        pricingCoverage: evidence.spend.pricingCoverage,
+        models: evidence.spend.models.map(row => ({ name: sanitizeAdvisorDisplayText(row.name), costUSD: row.costUSD, calls: row.calls })),
+        projects: evidence.spend.projects.map(row => ({ name: sanitizeAdvisorDisplayText(row.name), costUSD: row.costUSD, calls: row.calls })),
+        sessionsByCost: evidence.spend.sessionsByCost.map(row => ({ name: sanitizeAdvisorDisplayText(row.name), costUSD: row.costUSD, calls: row.calls })),
+        trend: evidence.spend.trend
+          ? {
+              direction: evidence.spend.trend.direction,
+              latestCostUSD: evidence.spend.trend.latestCostUSD,
+              comparisonCostUSD: evidence.spend.trend.comparisonCostUSD,
+              deltaUSD: evidence.spend.trend.deltaUSD,
+              deltaPercent: evidence.spend.trend.deltaPercent,
+              latestDate: evidence.spend.trend.latestDate,
+              comparisonLabel: sanitizeAdvisorDisplayText(evidence.spend.trend.comparisonLabel),
+            }
+          : null,
+      }
+    : null
+  const modelEfficiency = evidence.modelEfficiency
+    ? {
+        selectedModel: evidence.modelEfficiency.selectedModel === null ? null : sanitizeAdvisorDisplayText(evidence.modelEfficiency.selectedModel),
+        comparableWorkWarning: evidence.modelEfficiency.comparableWorkWarning,
+        rows: evidence.modelEfficiency.rows.map(row => ({
+          model: sanitizeAdvisorDisplayText(row.model),
+          provider: contentMinimalProvider(row.provider) ?? '[provider]',
+          calls: row.calls,
+          costUSD: row.costUSD,
+          outputTokens: row.outputTokens,
+          costPerCallUSD: row.costPerCallUSD,
+          pricingState: row.pricingState,
+        })),
+      }
+    : null
+  const quota = evidence.quota
+    ? {
+        measuredSpendUSD: evidence.quota.measuredSpendUSD,
+        measuredCalls: evidence.quota.measuredCalls,
+        providers: evidence.quota.providers.filter(provider => contentMinimalProvider(provider.provider) !== null).map(provider => ({
+          provider: contentMinimalProvider(provider.provider)!,
+          planLabel: provider.planLabel === null ? null : sanitizeAdvisorDisplayText(provider.planLabel),
+          availability: provider.availability,
+          connection: provider.connection,
+          freshness: provider.freshness,
+          observedAt: contentMinimalTimestamp(provider.observedAt),
+          windows: provider.windows.map(window => ({
+            label: sanitizeAdvisorDisplayText(window.label),
+            usedPercent: window.usedPercent,
+            remainingPercent: window.remainingPercent,
+            resetsAt: contentMinimalTimestamp(window.resetsAt),
+          })),
+          creditsUSD: provider.creditsUSD,
+        })),
+      }
+    : null
+  return {
+    intent: evidence.intent,
+    scope: contentMinimalScope(evidence.scope),
+    coverage: contentMinimalCoverage(evidence.coverage),
+    refs: contentMinimalEvidenceRefs(evidence.refs),
+    spend,
+    modelEfficiency,
+    quota,
+    assumptions: evidence.assumptions.map(value => sanitizeAdvisorDisplayText(value)),
+    unknown: evidence.unknown.map(value => sanitizeAdvisorDisplayText(value)),
+    nextInvestigations: evidence.nextInvestigations.map(value => sanitizeAdvisorDisplayText(value)),
+  }
+}

--- a/app/renderer/advisor/runtime.ts
+++ b/app/renderer/advisor/runtime.ts
@@ -1,5 +1,6 @@
 import { formatAdvisorCreditsUsd, formatAdvisorPercent, formatAdvisorUsd, periodLabel, scopeLabel } from './evidence'
 import type { AdvisorAnswer, AdvisorEvidence, AdvisorModelEvidenceRow, AdvisorModelRuntime, AdvisorRuntimeInput } from './types'
+import { sanitizeAdvisorAnswer } from './privacy'
 
 export class AdvisorRuntimeUnavailableError extends Error {
   constructor() {
@@ -100,9 +101,9 @@ export class DeterministicAdvisorRuntime implements AdvisorModelRuntime {
   async generate(input: AdvisorRuntimeInput, signal?: AbortSignal): Promise<AdvisorAnswer> {
     throwIfAborted(signal)
     const answer = baseAnswer(input.evidence, this)
-    if (input.evidence.intent === 'spend-change') return spendAnswer(input.evidence, answer)
-    if (input.evidence.intent === 'model-efficiency') return modelAnswer(input.evidence, answer)
-    if (input.evidence.intent === 'quota-capacity') return quotaAnswer(input.evidence, answer)
+    if (input.evidence.intent === 'spend-change') return sanitizeAdvisorAnswer(spendAnswer(input.evidence, answer))
+    if (input.evidence.intent === 'model-efficiency') return sanitizeAdvisorAnswer(modelAnswer(input.evidence, answer))
+    if (input.evidence.intent === 'quota-capacity') return sanitizeAdvisorAnswer(quotaAnswer(input.evidence, answer))
     return { ...answer, conclusion: 'I can investigate spend changes, observed model efficiency, and provider quota. Try one of the suggested questions.', details: ['This local foundation does not send your question or Metrora data to a hosted model.'] }
   }
 }

--- a/app/renderer/advisor/source.ts
+++ b/app/renderer/advisor/source.ts
@@ -3,26 +3,39 @@ import type { AdvisorBridge, AdvisorDataSource, AdvisorScope } from './types'
 /** Adapts the existing read-only renderer bridge into the Advisor data boundary. */
 export function createAdvisorDataSource(bridge: AdvisorBridge): AdvisorDataSource {
   return {
-    getOverview: context => {
+    getOverview: async (context, signal) => {
+      if (signal?.aborted) throw new DOMException('Advisor data read cancelled', 'AbortError')
       const project = context.projectId !== 'all' ? context.projectId : undefined
-      return context.range
+      const result = context.range
         ? project
           ? bridge.getOverview(context.period, context.provider, context.range, undefined, false, false, project)
           : bridge.getOverview(context.period, context.provider, context.range)
         : project
           ? bridge.getOverview(context.period, context.provider, undefined, undefined, false, false, project)
           : bridge.getOverview(context.period, context.provider)
+      const overview = await result
+      if (signal?.aborted) throw new DOMException('Advisor data read cancelled', 'AbortError')
+      return overview
     },
-    getModels: context => {
+    getModels: async (context, signal) => {
+      if (signal?.aborted) throw new DOMException('Advisor data read cancelled', 'AbortError')
       const project = context.projectId !== 'all' ? context.projectId : undefined
-      return context.range
+      const result = context.range
         ? project
           ? bridge.getModels(context.period, context.provider, false, context.range, project)
           : bridge.getModels(context.period, context.provider, false, context.range)
         : project
           ? bridge.getModels(context.period, context.provider, false, undefined, project)
           : bridge.getModels(context.period, context.provider, false)
+      const models = await result
+      if (signal?.aborted) throw new DOMException('Advisor data read cancelled', 'AbortError')
+      return models
     },
-    getQuota: () => bridge.getQuota(false),
+    getQuota: async signal => {
+      if (signal?.aborted) throw new DOMException('Advisor data read cancelled', 'AbortError')
+      const quota = await bridge.getQuota(false)
+      if (signal?.aborted) throw new DOMException('Advisor data read cancelled', 'AbortError')
+      return quota
+    },
   }
 }

--- a/app/renderer/advisor/tools.ts
+++ b/app/renderer/advisor/tools.ts
@@ -4,7 +4,7 @@ import {
   ADVISOR_TOOL_DEFINITIONS,
   AdvisorToolContractError,
   boundedAdvisorJson,
-  createAdvisorToolResultEnvelope,
+  createContentMinimalAdvisorToolResultEnvelope,
   snapshotAdvisorScope,
   validateAdvisorToolArguments,
 } from './contract'
@@ -20,67 +20,12 @@ import type {
   AdvisorToolExecutor,
   AdvisorToolName,
 } from './types'
+import * as advisorPrivacy from './privacy'
 
 export { ADVISOR_TOOL_CONTRACT, ADVISOR_TOOL_DEFINITIONS }
 
-const PATH_LIKE_TEXT = /^(?:[a-z]:[\\/]|\\\\|\/(?:users|home|private|var|tmp|mnt)(?:\/|$))/i
-const SECRET_LIKE_TEXT = /(?:bearer\s+|api[_-]?key\s*[=:]|secret\s*[=:]|password\s*[=:]|token\s*[=:]|(?:sk|gh[pousr])-[a-z0-9_-]{12,})/i
-
-function contentMinimalText(value: string, fallback = '[redacted]'): string {
-  const trimmed = value.trim()
-  if (!trimmed || PATH_LIKE_TEXT.test(trimmed) || SECRET_LIKE_TEXT.test(trimmed)) return fallback
-  return trimmed.length > 160 ? trimmed.slice(0, 157) + '…' : trimmed
-}
-
-function contentMinimalScope(scope: AdvisorScope): AdvisorJsonObject {
-  return {
-    period: scope.period,
-    range: scope.range,
-    provider: contentMinimalText(scope.provider),
-    projectId: contentMinimalText(scope.projectId),
-    projectName: contentMinimalText(scope.projectName),
-    model: scope.model === null ? null : contentMinimalText(scope.model),
-  }
-}
-
-function contentMinimalEvidence(evidence: AdvisorEvidence): AdvisorJsonObject {
-  return {
-    intent: evidence.intent,
-    scope: contentMinimalScope(evidence.scope),
-    coverage: evidence.coverage,
-    refs: evidence.refs.map(ref => ({ id: ref.id, label: contentMinimalText(ref.label), source: ref.source })),
-    spend: evidence.spend
-      ? {
-          ...evidence.spend,
-          models: evidence.spend.models.map(row => ({ ...row, name: contentMinimalText(row.name) })),
-          projects: evidence.spend.projects.map(row => ({ ...row, name: contentMinimalText(row.name) })),
-          sessionsByCost: evidence.spend.sessionsByCost.map(row => ({ ...row, name: contentMinimalText(row.name) })),
-        }
-      : null,
-    modelEfficiency: evidence.modelEfficiency
-      ? {
-          ...evidence.modelEfficiency,
-          selectedModel: evidence.modelEfficiency.selectedModel === null ? null : contentMinimalText(evidence.modelEfficiency.selectedModel),
-          rows: evidence.modelEfficiency.rows.map(row => ({ ...row, model: contentMinimalText(row.model), provider: contentMinimalText(row.provider) })),
-        }
-      : null,
-    quota: evidence.quota
-      ? {
-          ...evidence.quota,
-          providers: evidence.quota.providers.map(provider => ({
-            ...provider,
-            planLabel: provider.planLabel === null ? null : contentMinimalText(provider.planLabel),
-            windows: provider.windows.map(window => ({ ...window, label: contentMinimalText(window.label) })),
-          })),
-        }
-      : null,
-    assumptions: evidence.assumptions,
-    unknown: evidence.unknown,
-  }
-}
-
 function compactEvidence(evidence: AdvisorEvidence): { content: string; output: AdvisorJsonObject } {
-  const content = boundedAdvisorJson(contentMinimalEvidence(evidence))
+  const content = boundedAdvisorJson(advisorPrivacy.contentMinimalEvidence(evidence))
   return { content, output: JSON.parse(content) as AdvisorJsonObject }
 }
 
@@ -121,7 +66,7 @@ function resultFor(name: AdvisorToolName, scope: AdvisorScope, args: AdvisorJson
   return {
     content: compact.content,
     evidence,
-    envelope: createAdvisorToolResultEnvelope(name, scope, args, evidence, compact.output),
+    envelope: createContentMinimalAdvisorToolResultEnvelope(name, scope, args, evidence, compact.output),
   }
 }
 

--- a/app/renderer/advisor/tools.ts
+++ b/app/renderer/advisor/tools.ts
@@ -1,27 +1,89 @@
 import type { MenubarPayload, ModelReportRow, QuotaProvider } from '../lib/types'
+import {
+  ADVISOR_TOOL_CONTRACT,
+  ADVISOR_TOOL_DEFINITIONS,
+  AdvisorToolContractError,
+  boundedAdvisorJson,
+  createAdvisorToolResultEnvelope,
+  snapshotAdvisorScope,
+  validateAdvisorToolArguments,
+} from './contract'
 import { buildModelEfficiencyEvidence, buildQuotaEvidence, buildSpendEvidence } from './evidence'
-import type { AdvisorDataSource, AdvisorEvidence, AdvisorScope, AdvisorToolDefinition, AdvisorToolExecution, AdvisorToolExecutor } from './types'
+import type {
+  AdvisorDataSource,
+  AdvisorEvidence,
+  AdvisorJsonObject,
+  AdvisorScope,
+  AdvisorToolContract,
+  AdvisorToolDefinition,
+  AdvisorToolExecution,
+  AdvisorToolExecutor,
+  AdvisorToolName,
+} from './types'
 
-export const ADVISOR_TOOL_DEFINITIONS: readonly AdvisorToolDefinition[] = [
-  { type: 'function', function: { name: 'get_spend_snapshot', description: 'Read Metrora measured spend, daily trend, model and Project drivers, and coverage for the selected scope.', parameters: { type: 'object', properties: { model: { type: 'string', description: 'Optional exact model filter' } }, additionalProperties: false } } },
-  { type: 'function', function: { name: 'get_model_efficiency', description: 'Read canonical Metrora model rows and observed cost per call. Do not infer quality or comparable work.', parameters: { type: 'object', properties: { model: { type: 'string', description: 'Optional exact model filter' } }, additionalProperties: false } } },
-  { type: 'function', function: { name: 'get_quota_snapshot', description: 'Read provider-reported quota windows, reset timestamps, freshness, and credits. Never estimate quota from Metrora spend.', parameters: { type: 'object', properties: { provider: { type: 'string', enum: ['all', 'claude', 'codex'] } }, additionalProperties: false } } },
-  { type: 'function', function: { name: 'get_overview_snapshot', description: 'Read the current canonical Metrora overview for the selected period, Project, provider, and model context.', parameters: { type: 'object', properties: { model: { type: 'string', description: 'Optional exact model filter' } }, additionalProperties: false } } },
-  { type: 'function', function: { name: 'get_project_drivers', description: 'Read descriptive Project spend drivers from the canonical Metrora overview. Do not infer causality.', parameters: { type: 'object', properties: {}, additionalProperties: false } } },
-  { type: 'function', function: { name: 'get_session_highlights', description: 'Read content-minimal highest-cost session summaries from the canonical Metrora overview. No raw session content is exposed.', parameters: { type: 'object', properties: {}, additionalProperties: false } } },
-  { type: 'function', function: { name: 'get_coverage_report', description: 'Read Metrora evidence coverage, assumptions, and unknowns for the selected scope.', parameters: { type: 'object', properties: {}, additionalProperties: false } } },
-]
-function toolScope(scope: AdvisorScope, args: Record<string, unknown>): AdvisorScope {
-  const model = typeof args.model === 'string' && args.model.trim() ? args.model.trim() : scope.model
-  const provider = typeof args.provider === 'string' && ['all', 'claude', 'codex'].includes(args.provider) ? args.provider : scope.provider
-  return { ...scope, model, provider }
+export { ADVISOR_TOOL_CONTRACT, ADVISOR_TOOL_DEFINITIONS }
+
+const PATH_LIKE_TEXT = /^(?:[a-z]:[\\/]|\\\\|\/(?:users|home|private|var|tmp|mnt)(?:\/|$))/i
+const SECRET_LIKE_TEXT = /(?:bearer\s+|api[_-]?key\s*[=:]|secret\s*[=:]|password\s*[=:]|token\s*[=:]|(?:sk|gh[pousr])-[a-z0-9_-]{12,})/i
+
+function contentMinimalText(value: string, fallback = '[redacted]'): string {
+  const trimmed = value.trim()
+  if (!trimmed || PATH_LIKE_TEXT.test(trimmed) || SECRET_LIKE_TEXT.test(trimmed)) return fallback
+  return trimmed.length > 160 ? trimmed.slice(0, 157) + '…' : trimmed
 }
-function safeJson(value: unknown): string {
-  return JSON.stringify(value, (_key, item) => typeof item === 'number' && !Number.isFinite(item) ? null : item)
+
+function contentMinimalScope(scope: AdvisorScope): AdvisorJsonObject {
+  return {
+    period: scope.period,
+    range: scope.range,
+    provider: contentMinimalText(scope.provider),
+    projectId: contentMinimalText(scope.projectId),
+    projectName: contentMinimalText(scope.projectName),
+    model: scope.model === null ? null : contentMinimalText(scope.model),
+  }
 }
-function compactEvidence(evidence: AdvisorEvidence): string {
-  return safeJson({ intent: evidence.intent, scope: evidence.scope, coverage: evidence.coverage, refs: evidence.refs, spend: evidence.spend, modelEfficiency: evidence.modelEfficiency, quota: evidence.quota, assumptions: evidence.assumptions, unknown: evidence.unknown })
+
+function contentMinimalEvidence(evidence: AdvisorEvidence): AdvisorJsonObject {
+  return {
+    intent: evidence.intent,
+    scope: contentMinimalScope(evidence.scope),
+    coverage: evidence.coverage,
+    refs: evidence.refs.map(ref => ({ id: ref.id, label: contentMinimalText(ref.label), source: ref.source })),
+    spend: evidence.spend
+      ? {
+          ...evidence.spend,
+          models: evidence.spend.models.map(row => ({ ...row, name: contentMinimalText(row.name) })),
+          projects: evidence.spend.projects.map(row => ({ ...row, name: contentMinimalText(row.name) })),
+          sessionsByCost: evidence.spend.sessionsByCost.map(row => ({ ...row, name: contentMinimalText(row.name) })),
+        }
+      : null,
+    modelEfficiency: evidence.modelEfficiency
+      ? {
+          ...evidence.modelEfficiency,
+          selectedModel: evidence.modelEfficiency.selectedModel === null ? null : contentMinimalText(evidence.modelEfficiency.selectedModel),
+          rows: evidence.modelEfficiency.rows.map(row => ({ ...row, model: contentMinimalText(row.model), provider: contentMinimalText(row.provider) })),
+        }
+      : null,
+    quota: evidence.quota
+      ? {
+          ...evidence.quota,
+          providers: evidence.quota.providers.map(provider => ({
+            ...provider,
+            planLabel: provider.planLabel === null ? null : contentMinimalText(provider.planLabel),
+            windows: provider.windows.map(window => ({ ...window, label: contentMinimalText(window.label) })),
+          })),
+        }
+      : null,
+    assumptions: evidence.assumptions,
+    unknown: evidence.unknown,
+  }
 }
+
+function compactEvidence(evidence: AdvisorEvidence): { content: string; output: AdvisorJsonObject } {
+  const content = boundedAdvisorJson(contentMinimalEvidence(evidence))
+  return { content, output: JSON.parse(content) as AdvisorJsonObject }
+}
+
 function sameScope(left: AdvisorScope, right: AdvisorScope): boolean {
   return left.period === right.period
     && left.provider === right.provider
@@ -31,31 +93,109 @@ function sameScope(left: AdvisorScope, right: AdvisorScope): boolean {
     && left.range?.from === right.range?.from
     && left.range?.to === right.range?.to
 }
-export function createAdvisorToolRegistry(source: AdvisorDataSource, scope: AdvisorScope, suppliedOverview: MenubarPayload | null): { definitions: readonly AdvisorToolDefinition[]; execute: AdvisorToolExecutor } {
-  const execute: AdvisorToolExecutor = async (name, args, signal): Promise<AdvisorToolExecution> => {
-    if (signal?.aborted) throw new DOMException('Advisor tool call cancelled', 'AbortError')
-    const nextScope = toolScope(scope, args)
-    if (name === 'get_overview_snapshot' || name === 'get_spend_snapshot' || name === 'get_project_drivers' || name === 'get_session_highlights' || name === 'get_coverage_report') {
-      const overview = suppliedOverview && sameScope(nextScope, scope) ? suppliedOverview : await source.getOverview(nextScope)
-      const label = name === 'get_project_drivers' ? 'tool: Project drivers' : name === 'get_session_highlights' ? 'tool: session highlights' : name === 'get_coverage_report' ? 'tool: coverage report' : name === 'get_overview_snapshot' ? 'tool: overview snapshot' : 'tool: spend snapshot'
-      const evidence = buildSpendEvidence(label, nextScope, overview)
-      return { content: compactEvidence(evidence), evidence }
-    }
-    if (name === 'get_model_efficiency') {
-      const overview = suppliedOverview && sameScope(nextScope, scope) ? suppliedOverview : await source.getOverview(nextScope)
-      let rows: ModelReportRow[] = []
-      try { rows = await source.getModels(nextScope) } catch { /* Overview fallback remains honest. */ }
-      const evidence = buildModelEfficiencyEvidence('tool: model efficiency', nextScope, overview, rows)
-      return { content: compactEvidence(evidence), evidence }
-    }
-    if (name === 'get_quota_snapshot') {
-      const overview = suppliedOverview && sameScope(nextScope, scope) ? suppliedOverview : await source.getOverview(nextScope)
-      let quota: QuotaProvider[] = []
-      try { quota = await source.getQuota() } catch { /* unavailable is factual, not zero. */ }
-      const evidence = buildQuotaEvidence('tool: quota snapshot', nextScope, overview, quota)
-      return { content: compactEvidence(evidence), evidence }
-    }
-    throw new Error('Unknown Advisor tool: ' + name)
+
+function throwIfAborted(signal?: AbortSignal): void {
+  if (signal?.aborted) throw new DOMException('Advisor tool call cancelled', 'AbortError')
+}
+
+function cancellationLike(error: unknown): boolean {
+  if (error instanceof Error) return error.name === 'AbortError' || /cancel|abort/i.test(error.message)
+  return Boolean(error && typeof error === 'object' && 'name' in error && (error as { name?: unknown }).name === 'AbortError')
+}
+
+function rethrowCancellation(error: unknown, signal?: AbortSignal): void {
+  if (signal?.aborted || cancellationLike(error)) throw error
+}
+
+function nextToolScope(scope: AdvisorScope, name: AdvisorToolName, args: AdvisorJsonObject): AdvisorScope {
+  const next = { ...scope, range: scope.range ? { ...scope.range } : null }
+  if (name === 'get_spend_snapshot' || name === 'get_model_efficiency' || name === 'get_overview_snapshot') {
+    if (Object.prototype.hasOwnProperty.call(args, 'model')) next.model = String(args.model)
   }
-  return { definitions: ADVISOR_TOOL_DEFINITIONS, execute }
+  if (name === 'get_quota_snapshot' && Object.prototype.hasOwnProperty.call(args, 'provider')) next.provider = String(args.provider)
+  return snapshotAdvisorScope(next)
+}
+
+function resultFor(name: AdvisorToolName, scope: AdvisorScope, args: AdvisorJsonObject, evidence: AdvisorEvidence): AdvisorToolExecution {
+  const compact = compactEvidence(evidence)
+  return {
+    content: compact.content,
+    evidence,
+    envelope: createAdvisorToolResultEnvelope(name, scope, args, evidence, compact.output),
+  }
+}
+
+async function optionalModels(source: AdvisorDataSource, scope: AdvisorScope, signal?: AbortSignal): Promise<ModelReportRow[]> {
+  try {
+    const rows = signal ? await source.getModels(scope, signal) : await source.getModels(scope)
+    throwIfAborted(signal)
+    return Array.isArray(rows) ? rows : []
+  } catch (error) {
+    rethrowCancellation(error, signal)
+    return []
+  }
+}
+
+async function optionalQuota(source: AdvisorDataSource, signal?: AbortSignal): Promise<QuotaProvider[]> {
+  try {
+    const rows = signal ? await source.getQuota(signal) : await source.getQuota()
+    throwIfAborted(signal)
+    return Array.isArray(rows) ? rows : []
+  } catch (error) {
+    rethrowCancellation(error, signal)
+    return []
+  }
+}
+
+export type AdvisorToolRegistry = {
+  contract: AdvisorToolContract
+  definitions: readonly AdvisorToolDefinition[]
+  scope: AdvisorScope
+  execute: AdvisorToolExecutor
+}
+
+export function createAdvisorToolRegistry(source: AdvisorDataSource, scope: AdvisorScope, suppliedOverview: MenubarPayload | null): AdvisorToolRegistry {
+  const invocationScope = snapshotAdvisorScope(scope)
+  const execute: AdvisorToolExecutor = async (name, args, signal): Promise<AdvisorToolExecution> => {
+    throwIfAborted(signal)
+    const normalizedName = typeof name === 'string' ? name : String(name)
+    const normalizedArgs = validateAdvisorToolArguments(normalizedName, args)
+    const nextScope = nextToolScope(invocationScope, normalizedName as AdvisorToolName, normalizedArgs)
+    throwIfAborted(signal)
+
+    if (normalizedName === 'get_overview_snapshot' || normalizedName === 'get_spend_snapshot' || normalizedName === 'get_project_drivers' || normalizedName === 'get_session_highlights' || normalizedName === 'get_coverage_report') {
+      const overview = suppliedOverview && sameScope(nextScope, invocationScope)
+        ? suppliedOverview
+        : signal ? await source.getOverview(nextScope, signal) : await source.getOverview(nextScope)
+      throwIfAborted(signal)
+      const label = normalizedName === 'get_project_drivers'
+        ? 'tool: Project drivers'
+        : normalizedName === 'get_session_highlights'
+          ? 'tool: session highlights'
+          : normalizedName === 'get_coverage_report'
+            ? 'tool: coverage report'
+            : normalizedName === 'get_overview_snapshot'
+              ? 'tool: overview snapshot'
+              : 'tool: spend snapshot'
+      return resultFor(normalizedName, nextScope, normalizedArgs, buildSpendEvidence(label, nextScope, overview))
+    }
+    if (normalizedName === 'get_model_efficiency') {
+      const overview = suppliedOverview && sameScope(nextScope, invocationScope)
+        ? suppliedOverview
+        : signal ? await source.getOverview(nextScope, signal) : await source.getOverview(nextScope)
+      throwIfAborted(signal)
+      const evidence = buildModelEfficiencyEvidence('tool: model efficiency', nextScope, overview, await optionalModels(source, nextScope, signal))
+      return resultFor(normalizedName, nextScope, normalizedArgs, evidence)
+    }
+    if (normalizedName === 'get_quota_snapshot') {
+      const overview = suppliedOverview && sameScope(nextScope, invocationScope)
+        ? suppliedOverview
+        : signal ? await source.getOverview(nextScope, signal) : await source.getOverview(nextScope)
+      throwIfAborted(signal)
+      const evidence = buildQuotaEvidence('tool: quota snapshot', nextScope, overview, await optionalQuota(source, signal))
+      return resultFor(normalizedName, nextScope, normalizedArgs, evidence)
+    }
+    throw new AdvisorToolContractError('unknown-tool', 'Unknown Advisor tool: ' + normalizedName)
+  }
+  return { contract: ADVISOR_TOOL_CONTRACT, definitions: ADVISOR_TOOL_DEFINITIONS, scope: invocationScope, execute }
 }

--- a/app/renderer/advisor/types.ts
+++ b/app/renderer/advisor/types.ts
@@ -17,6 +17,16 @@ export type AdvisorCoverageLevel = 'high' | 'partial' | 'unavailable'
 export type AdvisorCoverage = { level: AdvisorCoverageLevel; label: string; detail: string }
 export type AdvisorEvidenceSource = 'overview' | 'history' | 'models' | 'quota'
 export type AdvisorEvidenceRef = { id: string; label: string; source: AdvisorEvidenceSource }
+export type AdvisorJsonValue = null | string | number | boolean | { [key: string]: AdvisorJsonValue } | AdvisorJsonValue[]
+export type AdvisorJsonObject = { [key: string]: AdvisorJsonValue }
+export type AdvisorToolName = 'get_spend_snapshot' | 'get_model_efficiency' | 'get_quota_snapshot' | 'get_overview_snapshot' | 'get_project_drivers' | 'get_session_highlights' | 'get_coverage_report'
+export type AdvisorToolArgumentName = 'model' | 'provider'
+export type AdvisorToolAuthority = 'metrora-canonical' | 'provider-reported' | 'mixed' | 'unknown'
+export type AdvisorToolFreshness = 'fresh' | 'stale' | 'mixed' | 'unavailable' | 'unknown'
+export type AdvisorEvidenceValueStatus = 'observed' | 'derived' | 'estimated' | 'unknown'
+export type AdvisorEvidenceSemantics = { source: AdvisorEvidenceSource | 'unknown'; authority: AdvisorToolAuthority; status: AdvisorEvidenceValueStatus }
+export const ADVISOR_TOOL_CONTRACT_VERSION = 'advisor-tool-v1' as const
+export const ADVISOR_TOOL_SCHEMA_VERSION = 1 as const
 export type AdvisorSpendDriver = { name: string; costUSD: number; calls: number }
 export type AdvisorTrend = { direction: 'up' | 'down' | 'flat'; latestCostUSD: number; comparisonCostUSD: number; deltaUSD: number; deltaPercent: number | null; latestDate: string; comparisonLabel: string }
 export type AdvisorSpendEvidence = { measuredCostUSD: number | null; calls: number | null; sessions: number | null; models: AdvisorSpendDriver[]; projects: AdvisorSpendDriver[]; sessionsByCost: AdvisorSpendDriver[]; trend: AdvisorTrend | null; pricingCoverage: number | null }
@@ -28,10 +38,32 @@ export type AdvisorQuotaEvidence = { providers: AdvisorQuotaProvider[]; measured
 export type AdvisorEvidence = { intent: AdvisorIntent; question: string; scope: AdvisorScope; refs: AdvisorEvidenceRef[]; coverage: AdvisorCoverage; assumptions: string[]; unknown: string[]; nextInvestigations: string[]; spend?: AdvisorSpendEvidence; modelEfficiency?: AdvisorModelEvidence; quota?: AdvisorQuotaEvidence }
 export type AdvisorAnswer = { conclusion: string; scopeLabel: string; periodLabel: string; evidence: AdvisorEvidenceRef[]; coverage: AdvisorCoverage; assumptions: string[]; unknown: string[]; nextInvestigations: string[]; details: string[]; runtime: { id: string; label: string; mode: 'ollama-local' | 'deterministic-local' | 'unsupported' }; generatedByModel?: boolean; streamed?: boolean }
 export type AdvisorToolDefinition = { type: 'function'; function: { name: string; description: string; parameters: Record<string, unknown> } }
-export type AdvisorToolExecution = { content: string; evidence: AdvisorEvidence }
+export type AdvisorToolInvocation = { contractVersion: typeof ADVISOR_TOOL_CONTRACT_VERSION; tool: AdvisorToolName; scope: AdvisorScope; arguments: AdvisorJsonObject }
+export type AdvisorToolResultEnvelope = {
+  contractVersion: typeof ADVISOR_TOOL_CONTRACT_VERSION
+  tool: AdvisorToolName
+  scope: AdvisorScope
+  arguments: AdvisorJsonObject
+  authority: AdvisorToolAuthority
+  freshness: AdvisorToolFreshness
+  coverage: AdvisorCoverage
+  semantics: AdvisorEvidenceSemantics[]
+  evidenceRefs: AdvisorEvidenceRef[]
+  unavailable: boolean
+  privacy: 'content-minimal'
+  output: AdvisorJsonObject
+}
+export type AdvisorToolContract = {
+  contractVersion: typeof ADVISOR_TOOL_CONTRACT_VERSION
+  schemaVersion: typeof ADVISOR_TOOL_SCHEMA_VERSION
+  tools: readonly AdvisorToolDefinition[]
+  scope: { immutable: true; dimensions: readonly string[]; allowedFilters: Readonly<Record<AdvisorToolName, readonly AdvisorToolArgumentName[]>> }
+  output: { maxBytes: number; privacy: 'content-minimal'; jsonSafe: true }
+}
+export type AdvisorToolExecution = { content: string; evidence: AdvisorEvidence; envelope?: AdvisorToolResultEnvelope }
 export type AdvisorToolExecutor = (name: string, args: Record<string, unknown>, signal?: AbortSignal) => Promise<AdvisorToolExecution>
 export type AdvisorConversationTurn = { role: 'user' | 'assistant'; content: string; scopeFingerprint: string }
-export type AdvisorRuntimeInput = { question: string; evidence: AdvisorEvidence; conversation?: AdvisorConversationTurn[]; tools?: readonly AdvisorToolDefinition[]; executeTool?: AdvisorToolExecutor; onToolEvent?: (event: { name: string; status: 'started' | 'completed' }) => void; onDelta?: (text: string) => void }
+export type AdvisorRuntimeInput = { question: string; evidence: AdvisorEvidence; conversation?: AdvisorConversationTurn[]; tools?: readonly AdvisorToolDefinition[]; toolContract?: AdvisorToolContract; executeTool?: AdvisorToolExecutor; onToolEvent?: (event: { name: string; status: 'started' | 'completed' }) => void; onDelta?: (text: string) => void }
 export interface AdvisorModelRuntime { readonly id: string; readonly label: string; readonly mode: 'ollama-local' | 'deterministic-local' | 'unsupported'; readonly providerSupport: readonly string[]; readonly availability?: 'ready' | 'checking' | 'unavailable'; readonly supportsStreaming?: boolean; generate(input: AdvisorRuntimeInput, signal?: AbortSignal): Promise<AdvisorAnswer> }
-export type AdvisorDataSource = { getOverview(context: AdvisorScope): Promise<MenubarPayload>; getModels(context: AdvisorScope): Promise<ModelReportRow[]>; getQuota(): Promise<QuotaProvider[]> }
+export type AdvisorDataSource = { getOverview(context: AdvisorScope, signal?: AbortSignal): Promise<MenubarPayload>; getModels(context: AdvisorScope, signal?: AbortSignal): Promise<ModelReportRow[]>; getQuota(signal?: AbortSignal): Promise<QuotaProvider[]> }
 export type AdvisorBridge = Pick<MetroraBridge, 'getOverview' | 'getModels' | 'getQuota'>

--- a/docs/ADVISOR_PUBLIC_FOUNDATION.md
+++ b/docs/ADVISOR_PUBLIC_FOUNDATION.md
@@ -15,6 +15,16 @@ The public path is deliberately replaceable:
 
 The deterministic tools own facts, arithmetic, coverage, currency formatting, and provider-quota freshness. A model can choose among the exposed read-only tools and write qualitative context, but its prose never replaces verified evidence. The UI renders the verified evidence rail and details beside the model context.
 
+## Shipped AdvisorToolV1 Community contract
+
+The public tool boundary is versioned as `advisor-tool-v1` with schema version `1`. The contract keeps these seven identities stable: `get_spend_snapshot`, `get_model_efficiency`, `get_quota_snapshot`, `get_overview_snapshot`, `get_project_drivers`, `get_session_highlights`, and `get_coverage_report`.
+
+Metrora captures an immutable invocation scope before a runtime sees a tool call. Period, custom date range, Project, provider authority, and model context cannot be replaced by a model-supplied scope object. The only bounded filters are an exact model identifier on the applicable usage tools and a factual `all`/`claude`/`codex` provider filter on provider quota. Unknown tools, malformed or additional arguments, unsupported providers, and pathological identifiers fail closed before an evidence read.
+
+Each result is bounded JSON and carries the tool identity, invocation scope, canonical authority, freshness, coverage, observed/derived/unknown semantics, evidence references, explicit unavailable state, and a `content-minimal` privacy classification. Metrora usage remains canonical measured/derived evidence; quota remains provider-reported evidence. Explicit zero remains zero, stale evidence remains labelled stale, and unavailable evidence is never converted into zero. The serialized tool payload is capped at 32 KiB and excludes raw prompts, responses, source, patches, secrets, credentials, account identifiers, and unrestricted local paths.
+
+The reusable synthetic conformance fixtures and suite live beside the Advisor contract in `app/renderer/advisor/conformance.ts` and `conformance.test.ts`. They run without a model, network, provider SDK, or Ollama installation and are also used to exercise the current Ollama adapter. Cancellation is checked before reads, after asynchronous reads, before the final runtime envelope, and on the local runtime boundary.
+
 The first tool set covers:
 
 - overview and measured spend;


### PR DESCRIPTION
## Summary
- Ship the reviewed AdvisorToolV1 conformance contract for the existing Advisor tools.
- Enforce bounded arguments, immutable Metrora-owned scope, JSON-safe content-minimal output, authority/freshness/coverage semantics, cancellation, and privacy-safe buffering.
- Keep raw model/provider deltas out of the public event surface.

## Boundaries
- Architecture: Advisor contract and adapter behavior only; no unrelated provider or governance changes.
- Public Identity: Metrora-owned contract and public semantics remain authoritative.
- Brand Boundary: no CodeBurn competitive internals or upstream cursor changes.

## Validation
- Reviewed head: `6bac430978297691d96fd1acbc64a37907c41973`
- Base: `main` at `ce02827d7b95282beb6d9779035cd14764c8be3f`
- Local App: 85 files / 698 tests passed; typecheck passed.
- Independent review: PASS.
- Architecture boundaries: success.
- Metrora Public Identity: success.
- Metrora Brand Boundary: success.
- Metrora CI: success (run `32708055266`).
- Windows Candidate: skipped; not applicable to this branch.