### PR TITLE
feat(bench): add local Ollama BenchRunV1 slice

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ The root npm package is intentionally private and is not an official distributio
 | `metrora audit` | Compare provider evidence with displayed token and cost totals. |
 | `metrora doctor` | Diagnose provider discovery and parsing health. |
 | `metrora export` | Export usage as CSV or JSON. |
+| `metrora bench local --model <model>` | Run bounded synthetic runtime evidence against a local Ollama model; no quality or ranking score. |
 
 Most analytical commands support provider, project and date filters. The [CLI reference](docs/CLI_REFERENCE.md) groups the public commands by task and explains compatibility boundaries.
 
@@ -197,6 +198,7 @@ Start from the [documentation index](docs/README.md):
 
 - [Getting started](docs/GETTING_STARTED.md)
 - [CLI reference](docs/CLI_REFERENCE.md)
+- [BenchRunV1 local Ollama](docs/BENCHRUN_V1_OLLAMA_LOCAL.md)
 - [Supported tools](docs/SUPPORTED_TOOLS.md)
 - [Product principles](docs/PRODUCT_PRINCIPLES.md)
 - [Pricing history](docs/PRICING_HISTORY.md)

--- a/docs/BENCHRUN_V1_OLLAMA_LOCAL.md
+++ b/docs/BENCHRUN_V1_OLLAMA_LOCAL.md
@@ -1,0 +1,85 @@
+# BenchRunV1 local Ollama
+
+BenchRunV1 is Metrora’s first small, public Bench slice. It records bounded
+local runtime evidence for one explicitly selected Ollama model using a fixed,
+versioned synthetic workload.
+
+It is not a model-quality benchmark. It does not score accuracy, coding,
+reasoning, pass rate or “best” model; it does not rank or recommend models; it
+does not calculate cost or quota; and it does not read Metrora Usage records or
+real user work.
+
+## Run it
+
+```bash
+metrora bench local --model <ollama-model>
+metrora bench local --model <ollama-model> --format json --output ./benchrun.json
+```
+
+The model is required and must be selected explicitly. The runtime boundary is
+fixed to `http://127.0.0.1:11434`; there is no V1 option for a remote or
+arbitrary OpenAI-compatible endpoint. Ollama must already be running locally.
+The default per-request timeout is 30 seconds. `--timeout-ms` may narrow or
+extend it only within the bounded 50–120000 ms range.
+
+On an unavailable runtime, timeout, cancellation or malformed response, the
+CLI prints a bounded diagnostic and exits non-zero. `--format json` still
+emits the JSON-safe run contract when a run has partial or failed evidence.
+
+## Fixed methodology
+
+- one warmup request followed by five measured requests;
+- the same `metrora.benchrun.synthetic.v1@1.0.0` fixture and request
+  parameters for every request;
+- generation parameters: `temperature: 0`, `seed: 1729`, `num_predict: 64`;
+- streaming `/api/generate` requests, with bounded response bytes, chunks,
+  events, NDJSON lines and generated output;
+- no dataset loading, filesystem prompt discovery, source-repository access or
+  user-content input.
+
+Ollama/model support can still vary. A fixed seed and temperature do not prove
+cross-model or cross-version deterministic text generation; that limitation is
+retained as an evidence boundary rather than converted into a quality claim.
+
+## BenchRunV1 contract
+
+The artifact uses schema `metrora.bench-run.v1` and runner
+`ollama-local-v1@1.0.0`. It contains:
+
+- run, runner, fixture, selected/reported model and local runtime identity;
+- factual environment identity limited to OS, architecture and Node version;
+- fixed generation parameters and the `1 + 5` methodology;
+- start/end timestamps and per-run success, failure or cancellation state;
+- Metrora-observed request latency, time to first streamed content, bounded
+  response/chunk/event counts, output character length and output digest;
+- nullable Ollama-reported duration and token fields;
+- measured-run aggregates using count, min, median, max and mean;
+- failures, unstarted-run exclusions, termination status and a result digest.
+
+Observed timing and runtime-reported timing/token data remain separate. Ollama
+duration and token fields remain `null` when the runtime does not report them;
+they are never replaced with zero or an estimate. Raw generated text is not
+written to the artifact.
+
+The result digest covers the versioned fixture, fixed generation contract,
+selected/reported model and per-run output/result metadata. It excludes run
+timestamps and timing values, so timing variation alone does not change the
+result identity. It is an evidence digest, not a reproducibility or quality
+guarantee.
+
+## Runtime and provenance
+
+The implementation uses Node’s bounded HTTP `fetch` and no Ollama SDK or model
+provider dependency. The response shape follows the official Ollama
+[`/api/generate`](https://docs.ollama.com/api/generate),
+[`/api/version`](https://docs.ollama.com/api-reference/get-version) and
+[`streaming`](https://docs.ollama.com/api/streaming) documentation. Ollama’s
+reported duration values are nanoseconds, and the stream is newline-delimited
+JSON. No Ollama source code is copied into Metrora, so no third-party notice is
+added by this slice. Individual model weights remain subject to their own
+licenses and operator review.
+
+An output artifact is written only when the user supplies `--output`; the
+write is local, bounded and atomic. There is no upload, publication, managed
+compute path, cloud credential, persistent Bench database or Desktop Bench
+navigation in V1.

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -76,6 +76,17 @@ metrora optimize --apply --dry-run
 
 Experimental commands label heuristic or incomplete methodology explicitly. Their output should not be presented as stronger evidence than the source permits.
 
+## Bench and local runtime evidence
+
+| Command | Purpose |
+| --- | --- |
+| `metrora bench local --model <model>` | Run one warmup plus five measured requests against the fixed local Ollama loopback endpoint using the versioned synthetic BenchRunV1 fixture. |
+
+The Bench command records runtime/performance evidence only. It does not read
+user prompts or source repositories, score quality, rank models, calculate cost
+or quota, or connect to hosted inference. Use `--format json --output <path>`
+to export the bounded local artifact. See [BenchRunV1 local Ollama](BENCHRUN_V1_OLLAMA_LOCAL.md).
+
 ## Cost and plan configuration
 
 | Command | Purpose |

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,7 @@ This index separates user guidance, current product guarantees, public contracts
 
 - [Getting started](GETTING_STARTED.md) — build from source, run the first reports and understand the current distribution boundary.
 - [CLI reference](CLI_REFERENCE.md) — public commands grouped by task.
+- [BenchRunV1 local Ollama](BENCHRUN_V1_OLLAMA_LOCAL.md) — bounded synthetic runtime evidence from an explicitly selected local Ollama model.
 - [Supported tools](SUPPORTED_TOOLS.md) — local collector coverage and evidence boundaries.
 - [Provider documentation](providers/) — source locations, formats, limitations and parser notes for individual integrations.
 

--- a/src/bench/cli.ts
+++ b/src/bench/cli.ts
@@ -1,0 +1,101 @@
+import { resolve } from 'node:path'
+import { Command } from 'commander'
+import { atomicWritePrivateFile } from '../local-state/atomic-file.js'
+import { BENCH_RUNNER_ID, type BenchRunV1, type NumericSummaryV1 } from './contract-v1.js'
+import { runBenchRunV1, validateBenchTimeoutMs } from './run-v1.js'
+
+function parseTimeout(value: string): number {
+  const parsed = Number(value)
+  return validateBenchTimeoutMs(parsed)
+}
+
+function formatSummary(summary: NumericSummaryV1 | null, unit: string): string {
+  if (!summary) return 'unavailable'
+  const median = Number.isInteger(summary.median) ? String(summary.median) : summary.median.toFixed(2)
+  return `${median} ${unit} median (n=${summary.count})`
+}
+
+export function renderBenchRunV1(result: BenchRunV1): string {
+  const measured = result.aggregate.measured
+  const lines = [
+    `BenchRunV1 ${result.status}`,
+    `  runner: ${result.runner.id}@${result.runner.version}`,
+    `  model: ${result.model.selected}${result.model.reported ? ` (reported ${result.model.reported})` : ''}`,
+    `  fixture: ${result.fixture.packId}@${result.fixture.version} (${result.fixture.digest.slice(0, 12)})`,
+    `  runs: ${result.generation.warmupCount} warmup + ${result.generation.measuredRunCount} measured; ${measured.successful}/${measured.planned} measured successful`,
+    `  request latency: ${formatSummary(measured.observed.requestLatencyMs, 'ms')}`,
+    `  first content: ${formatSummary(measured.observed.timeToFirstContentMs, 'ms')}`,
+    `  output chars: ${formatSummary(measured.observed.outputChars, 'chars')}`,
+    `  eval tokens (runtime-reported): ${formatSummary(measured.runtimeReported.evalCount, 'tokens')}`,
+    `  Ollama version: ${result.runtime.version ?? 'unavailable'}`,
+    `  result digest: ${result.resultDigest}`,
+  ]
+  if (result.termination.status !== 'none') {
+    lines.push(`  termination: ${result.termination.status}`)
+  }
+  if (result.failures.length > 0) {
+    lines.push(`  failure: ${result.failures[0]!.message}`)
+  }
+  if (result.exclusions.length > 0) {
+    lines.push(`  exclusions: ${result.exclusions.length} planned run(s) not started`)
+  }
+  return lines.join('\n') + '\n'
+}
+
+export function registerBenchCommands(program: Command): void {
+  const bench = program
+    .command('bench')
+    .description('Run bounded synthetic local runtime evidence; no quality, ranking, or cost scoring')
+
+  bench
+    .command('local')
+    .description('Run BenchRunV1 against a local Ollama model')
+    .requiredOption('--model <model>', 'Explicit local Ollama model name')
+    .option('--format <format>', 'Output format: table, json', 'table')
+    .option('--output <path>', 'Write the JSON evidence artifact to this local path')
+    .option('--timeout-ms <ms>', 'Bound each local request (50-120000 ms)', parseTimeout, 30_000)
+    .action(async (options: { model: string; format: string; output?: string; timeoutMs: number }) => {
+      const format = options.format.toLowerCase()
+      if (format !== 'table' && format !== 'json') {
+        process.stderr.write('metrora bench local: --format must be table or json.\n')
+        process.exitCode = 2
+        return
+      }
+
+      const controller = new AbortController()
+      const onSigint = () => controller.abort()
+      process.once('SIGINT', onSigint)
+      let result: BenchRunV1
+      try {
+        result = await runBenchRunV1({
+          model: options.model,
+          signal: controller.signal,
+          timeoutMs: options.timeoutMs,
+        })
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error)
+        process.stderr.write(`metrora bench local: ${message}\n`)
+        process.exitCode = 2
+        return
+      } finally {
+        process.removeListener('SIGINT', onSigint)
+      }
+
+      let outputPath: string | undefined
+      if (options.output) {
+        outputPath = resolve(options.output)
+        try {
+          await atomicWritePrivateFile(outputPath, JSON.stringify(result, null, 2) + '\n')
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error)
+          process.stderr.write(`metrora bench local: could not write evidence artifact: ${message}\n`)
+          process.exitCode = 1
+        }
+      }
+
+      if (format === 'json') process.stdout.write(JSON.stringify(result, null, 2) + '\n')
+      else process.stdout.write(renderBenchRunV1(result))
+      if (outputPath) process.stderr.write(`BenchRunV1 evidence artifact: ${outputPath}\n`)
+      if (result.status !== 'completed') process.exitCode = 1
+    })
+}

--- a/src/bench/contract-v1.ts
+++ b/src/bench/contract-v1.ts
@@ -1,0 +1,149 @@
+export const BENCH_RUN_SCHEMA_VERSION = 'metrora.bench-run.v1'
+export const BENCH_RUNNER_ID = 'ollama-local-v1'
+export const BENCH_RUNNER_VERSION = '1.0.0'
+export const WARMUP_RUN_COUNT = 1
+export const MEASURED_RUN_COUNT = 5
+
+export const FIXED_GENERATION_PARAMETERS = {
+  temperature: 0,
+  seed: 1729,
+  numPredict: 64,
+} as const
+
+export type BenchRunStatus = 'completed' | 'failed' | 'cancelled'
+export type BenchTerminationStatus = 'none' | 'cancelled' | 'timeout'
+export type BenchPhase = 'warmup' | 'measured'
+
+export type BenchFailureCode =
+  | 'runtime-unavailable'
+  | 'transport-error'
+  | 'http-error'
+  | 'model-not-found'
+  | 'runtime-error'
+  | 'malformed-response'
+  | 'response-limit'
+  | 'timeout'
+  | 'cancelled'
+
+export type RuntimeReportedMetricsV1 = {
+  totalDurationNs: number | null
+  loadDurationNs: number | null
+  promptEvalCount: number | null
+  promptEvalDurationNs: number | null
+  evalCount: number | null
+  evalDurationNs: number | null
+}
+
+export type ObservedMetricsV1 = {
+  requestLatencyMs: number | null
+  timeToFirstContentMs: number | null
+  responseBytes: number
+  streamChunks: number
+  streamEvents: number
+  outputChars: number
+  outputDigest: string | null
+}
+
+export type BenchRunEvidenceV1 = {
+  phase: BenchPhase
+  index: number
+  status: 'success' | 'failed' | 'cancelled'
+  startedAt: string
+  endedAt: string
+  reportedModel: string | null
+  observed: ObservedMetricsV1
+  runtimeReported: RuntimeReportedMetricsV1
+  failure: { code: BenchFailureCode; message: string } | null
+}
+
+export type NumericSummaryV1 = {
+  count: number
+  min: number
+  median: number
+  max: number
+  mean: number
+}
+
+export type BenchAggregateV1 = {
+  measured: {
+    planned: number
+    attempted: number
+    successful: number
+    failed: number
+    excluded: number
+    observed: {
+      requestLatencyMs: NumericSummaryV1 | null
+      timeToFirstContentMs: NumericSummaryV1 | null
+      outputChars: NumericSummaryV1 | null
+    }
+    runtimeReported: {
+      totalDurationNs: NumericSummaryV1 | null
+      loadDurationNs: NumericSummaryV1 | null
+      promptEvalCount: NumericSummaryV1 | null
+      promptEvalDurationNs: NumericSummaryV1 | null
+      evalCount: NumericSummaryV1 | null
+      evalDurationNs: NumericSummaryV1 | null
+    }
+  }
+}
+
+export type BenchRunV1 = {
+  schemaVersion: typeof BENCH_RUN_SCHEMA_VERSION
+  runId: string
+  runner: {
+    id: typeof BENCH_RUNNER_ID
+    version: typeof BENCH_RUNNER_VERSION
+  }
+  fixture: {
+    packId: string
+    version: string
+    caseId: string
+    digest: string
+  }
+  model: {
+    selected: string
+    reported: string | null
+  }
+  runtime: {
+    id: 'ollama-local'
+    endpoint: 'http://127.0.0.1:11434'
+    version: string | null
+  }
+  environment: {
+    os: string
+    arch: string
+    node: string
+  }
+  generation: {
+    parameters: {
+      temperature: number
+      seed: number
+      numPredict: number
+    }
+    warmupCount: typeof WARMUP_RUN_COUNT
+    measuredRunCount: typeof MEASURED_RUN_COUNT
+    fixturePolicy: 'same-versioned-synthetic-fixture-for-every-request'
+  }
+  startedAt: string
+  endedAt: string
+  status: BenchRunStatus
+  termination: {
+    status: BenchTerminationStatus
+    phase: BenchPhase | 'preflight' | null
+    index: number | null
+  }
+  runs: BenchRunEvidenceV1[]
+  failures: Array<{
+    phase: BenchPhase | 'preflight'
+    index: number
+    code: BenchFailureCode
+    message: string
+  }>
+  exclusions: Array<{
+    phase: BenchPhase
+    index: number
+    reason: 'not-started-after-failure' | 'not-started-after-cancellation'
+  }>
+  aggregate: BenchAggregateV1
+  resultDigest: string
+}

--- a/src/bench/fixture-v1.ts
+++ b/src/bench/fixture-v1.ts
@@ -1,0 +1,14 @@
+import { sha256Json } from './serialization.js'
+
+export const SYNTHETIC_FIXTURE_PACK = {
+  packId: 'metrora.benchrun.synthetic.v1',
+  version: '1.0.0',
+  caseId: 'bounded-single-turn',
+  prompt: [
+    'This is a synthetic Metrora BenchRun V1 workload.',
+    'Return one short neutral sentence confirming that the bounded fixture was received.',
+    'Do not discuss model quality, ranking, pricing, or real user work.',
+  ].join(' '),
+} as const
+
+export const SYNTHETIC_FIXTURE_DIGEST = sha256Json(SYNTHETIC_FIXTURE_PACK)

--- a/src/bench/ollama-local.ts
+++ b/src/bench/ollama-local.ts
@@ -1,0 +1,435 @@
+import {
+  BENCH_RUNNER_ID,
+  FIXED_GENERATION_PARAMETERS,
+  type BenchFailureCode,
+  type RuntimeReportedMetricsV1,
+} from './contract-v1.js'
+import { SYNTHETIC_FIXTURE_PACK } from './fixture-v1.js'
+import { sha256Text } from './serialization.js'
+
+export const OLLAMA_LOCAL_BASE_URL = 'http://127.0.0.1:11434' as const
+export const OLLAMA_GENERATE_URL = `${OLLAMA_LOCAL_BASE_URL}/api/generate` as const
+export const OLLAMA_VERSION_URL = `${OLLAMA_LOCAL_BASE_URL}/api/version` as const
+
+export const DEFAULT_OLLAMA_TIMEOUT_MS = 30_000
+export const MAX_RESPONSE_BYTES = 1_048_576
+export const MAX_OUTPUT_BYTES = 32_768
+export const MAX_NDJSON_LINE_BYTES = 262_144
+export const MAX_STREAM_CHUNKS = 4_096
+export const MAX_STREAM_EVENTS = 4_096
+export const MAX_MODEL_ID_LENGTH = 200
+
+export type BenchFetch = typeof fetch
+
+export class BenchOllamaError extends Error {
+  constructor(
+    public readonly code: BenchFailureCode,
+    message: string,
+    public readonly httpStatus?: number,
+  ) {
+    super(message)
+    this.name = 'BenchOllamaError'
+  }
+}
+
+export type OllamaGenerateEvidence = {
+  reportedModel: string | null
+  observed: {
+    requestLatencyMs: number
+    timeToFirstContentMs: number | null
+    responseBytes: number
+    streamChunks: number
+    streamEvents: number
+    outputChars: number
+    outputDigest: string
+  }
+  runtimeReported: RuntimeReportedMetricsV1
+}
+
+type MonotonicClock = () => number
+
+type RequestBoundaryOptions = {
+  signal?: AbortSignal
+  timeoutMs: number
+}
+
+class RequestBoundary {
+  readonly controller = new AbortController()
+  private timeoutHandle: ReturnType<typeof setTimeout> | undefined
+  private readonly removeExternalListener: (() => void) | undefined
+  private readonly timeoutPromise: Promise<never>
+  private readonly cancelPromise: Promise<never> | undefined
+  private timedOut = false
+  private cancelled = false
+
+  constructor({ signal, timeoutMs }: RequestBoundaryOptions) {
+    this.timeoutPromise = new Promise<never>((_, reject) => {
+      this.timeoutHandle = setTimeout(() => {
+        this.timedOut = true
+        this.controller.abort()
+        reject(new BenchOllamaError('timeout', `Ollama ${BENCH_RUNNER_ID} request timed out.`))
+      }, timeoutMs)
+    })
+
+    if (signal) {
+      const onAbort = () => {
+        this.cancelled = true
+        this.controller.abort(signal.reason)
+      }
+      if (signal.aborted) onAbort()
+      else signal.addEventListener('abort', onAbort, { once: true })
+      this.removeExternalListener = () => signal.removeEventListener('abort', onAbort)
+      this.cancelPromise = new Promise<never>((_, reject) => {
+        if (signal.aborted) reject(new BenchOllamaError('cancelled', 'BenchRunV1 cancellation requested.'))
+        else signal.addEventListener('abort', () => reject(new BenchOllamaError('cancelled', 'BenchRunV1 cancellation requested.')), { once: true })
+      })
+    }
+  }
+
+  async race<T>(promise: Promise<T>): Promise<T> {
+    const contenders: Promise<unknown>[] = [promise, this.timeoutPromise]
+    if (this.cancelPromise) contenders.push(this.cancelPromise)
+    return await Promise.race(contenders) as T
+  }
+
+  wasTimedOut(): boolean {
+    return this.timedOut
+  }
+
+  wasCancelled(): boolean {
+    return this.cancelled
+  }
+
+  dispose(): void {
+    if (this.timeoutHandle) clearTimeout(this.timeoutHandle)
+    this.removeExternalListener?.()
+  }
+}
+
+export function validateOllamaModelId(model: string): string {
+  const normalized = model.trim()
+  if (!normalized || normalized !== model) {
+    throw new Error('model must be a non-empty Ollama model name without surrounding whitespace')
+  }
+  if (normalized.length > MAX_MODEL_ID_LENGTH || /[\u0000-\u001f\u007f]/.test(normalized)) {
+    throw new Error(`model must be at most ${MAX_MODEL_ID_LENGTH} characters and contain no control characters`)
+  }
+  return normalized
+}
+
+function normalizeBoundaryError(error: unknown, boundary: RequestBoundary): BenchOllamaError {
+  if (error instanceof BenchOllamaError) return error
+  if (boundary.wasTimedOut()) return new BenchOllamaError('timeout', `Ollama ${BENCH_RUNNER_ID} request timed out.`)
+  if (boundary.wasCancelled()) return new BenchOllamaError('cancelled', 'BenchRunV1 cancellation requested.')
+  return new BenchOllamaError('transport-error', 'Ollama local runtime request failed.')
+}
+
+function getFetch(fetchImpl?: BenchFetch): BenchFetch {
+  const request = fetchImpl ?? globalThis.fetch
+  if (typeof request !== 'function') {
+    throw new BenchOllamaError('runtime-unavailable', 'Ollama local runtime is unavailable: fetch is not available.')
+  }
+  return request
+}
+
+function objectValue(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new BenchOllamaError('malformed-response', 'Ollama returned malformed JSON data.')
+  }
+  return value as Record<string, unknown>
+}
+
+function optionalModel(record: Record<string, unknown>): string | null {
+  if (!Object.hasOwn(record, 'model') || record.model === null) return null
+  if (typeof record.model !== 'string' || !record.model || record.model.length > MAX_MODEL_ID_LENGTH) {
+    throw new BenchOllamaError('malformed-response', 'Ollama returned an invalid model identity.')
+  }
+  return record.model
+}
+
+function optionalRuntimeMetric(record: Record<string, unknown>, key: string): number | null {
+  if (!Object.hasOwn(record, key) || record[key] === null) return null
+  const value = record[key]
+  if (!Number.isSafeInteger(value) || (value as number) < 0) {
+    throw new BenchOllamaError('malformed-response', `Ollama returned an invalid ${key} metric.`)
+  }
+  return value as number
+}
+
+function runtimeMetricsFrom(record: Record<string, unknown>): RuntimeReportedMetricsV1 {
+  return {
+    totalDurationNs: optionalRuntimeMetric(record, 'total_duration'),
+    loadDurationNs: optionalRuntimeMetric(record, 'load_duration'),
+    promptEvalCount: optionalRuntimeMetric(record, 'prompt_eval_count'),
+    promptEvalDurationNs: optionalRuntimeMetric(record, 'prompt_eval_duration'),
+    evalCount: optionalRuntimeMetric(record, 'eval_count'),
+    evalDurationNs: optionalRuntimeMetric(record, 'eval_duration'),
+  }
+}
+
+function appendOutput(current: string, value: unknown): string {
+  if (value === undefined) return current
+  if (typeof value !== 'string') {
+    throw new BenchOllamaError('malformed-response', 'Ollama returned a non-text response chunk.')
+  }
+  const next = current + value
+  if (Buffer.byteLength(next, 'utf8') > MAX_OUTPUT_BYTES) {
+    throw new BenchOllamaError('response-limit', `Ollama response exceeded the ${MAX_OUTPUT_BYTES}-byte output limit.`)
+  }
+  return next
+}
+
+function parseNdjsonEvent(
+  line: string,
+  state: {
+    doneSeen: boolean
+    reportedModel: string | null
+    output: string
+    runtimeReported: RuntimeReportedMetricsV1
+    streamEvents: number
+    firstContentAt: number | null
+  },
+  monotonicNow: MonotonicClock,
+  startedAt: number,
+): void {
+  const trimmed = line.trim()
+  if (!trimmed) return
+  if (state.doneSeen) {
+    throw new BenchOllamaError('malformed-response', 'Ollama returned data after the final stream event.')
+  }
+  state.streamEvents += 1
+  if (state.streamEvents > MAX_STREAM_EVENTS) {
+    throw new BenchOllamaError('response-limit', `Ollama response exceeded the ${MAX_STREAM_EVENTS}-event limit.`)
+  }
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(trimmed)
+  } catch {
+    throw new BenchOllamaError('malformed-response', 'Ollama returned malformed NDJSON.')
+  }
+  const record = objectValue(parsed)
+  if (typeof record.done !== 'boolean') {
+    throw new BenchOllamaError('malformed-response', 'Ollama stream event omitted its done flag.')
+  }
+  if (Object.hasOwn(record, 'error') && record.error !== null && record.error !== undefined) {
+    throw new BenchOllamaError('runtime-error', 'Ollama reported a generation failure.')
+  }
+
+  const model = optionalModel(record)
+  if (model !== null) {
+    if (state.reportedModel !== null && state.reportedModel !== model) {
+      throw new BenchOllamaError('malformed-response', 'Ollama changed model identity during a run.')
+    }
+    state.reportedModel = model
+  }
+
+  if (Object.hasOwn(record, 'response')) {
+    const before = state.output
+    state.output = appendOutput(state.output, record.response)
+    if (before.length !== state.output.length && state.firstContentAt === null) {
+      state.firstContentAt = Math.max(0, monotonicNow() - startedAt)
+    }
+  }
+
+  if (record.done) {
+    state.runtimeReported = runtimeMetricsFrom(record)
+    state.doneSeen = true
+  }
+}
+
+async function readResponseText(
+  response: Response,
+  boundary: RequestBoundary,
+  maxBytes: number,
+): Promise<string> {
+  if (!response.body) throw new BenchOllamaError('malformed-response', 'Ollama returned an empty response body.')
+  const reader = response.body.getReader()
+  const decoder = new TextDecoder('utf-8', { fatal: true })
+  let text = ''
+  let bytes = 0
+  try {
+    while (true) {
+      const next = await boundary.race(reader.read())
+      if (next.done) break
+      if (!next.value) throw new BenchOllamaError('malformed-response', 'Ollama returned an empty response chunk.')
+      bytes += next.value.byteLength
+      if (bytes > maxBytes) throw new BenchOllamaError('response-limit', 'Ollama response exceeded its byte limit.')
+      try {
+        text += decoder.decode(next.value, { stream: true })
+      } catch {
+        throw new BenchOllamaError('malformed-response', 'Ollama returned invalid UTF-8 data.')
+      }
+    }
+    try {
+      text += decoder.decode()
+    } catch {
+      throw new BenchOllamaError('malformed-response', 'Ollama returned incomplete UTF-8 data.')
+    }
+    return text
+  } finally {
+    reader.releaseLock()
+  }
+}
+
+export async function fetchOllamaVersion(options: {
+  fetchImpl?: BenchFetch
+  signal?: AbortSignal
+  timeoutMs?: number
+} = {}): Promise<string | null> {
+  const request = getFetch(options.fetchImpl)
+  const boundary = new RequestBoundary({
+    signal: options.signal,
+    timeoutMs: options.timeoutMs ?? DEFAULT_OLLAMA_TIMEOUT_MS,
+  })
+  try {
+    const response = await boundary.race(request(OLLAMA_VERSION_URL, {
+      method: 'GET',
+      headers: { accept: 'application/json' },
+      signal: boundary.controller.signal,
+    }))
+    if (!response.ok) return null
+    const text = await readResponseText(response, boundary, 16_384)
+    let parsed: unknown
+    try {
+      parsed = JSON.parse(text)
+    } catch {
+      return null
+    }
+    const record = objectValue(parsed)
+    if (typeof record.version !== 'string' || !record.version || record.version.length > 128) return null
+    return record.version
+  } catch (error) {
+    const normalized = normalizeBoundaryError(error, boundary)
+    if (normalized.code === 'timeout' || normalized.code === 'cancelled') throw normalized
+    return null
+  } finally {
+    boundary.dispose()
+  }
+}
+
+export async function runOllamaGenerate(options: {
+  model: string
+  fetchImpl?: BenchFetch
+  signal?: AbortSignal
+  timeoutMs?: number
+  monotonicNow?: MonotonicClock
+}): Promise<OllamaGenerateEvidence> {
+  const model = validateOllamaModelId(options.model)
+  const request = getFetch(options.fetchImpl)
+  const monotonicNow = options.monotonicNow ?? (() => performance.now())
+  const boundary = new RequestBoundary({
+    signal: options.signal,
+    timeoutMs: options.timeoutMs ?? DEFAULT_OLLAMA_TIMEOUT_MS,
+  })
+  const startedAt = monotonicNow()
+  let reader: ReadableStreamDefaultReader<Uint8Array> | undefined
+  let responseBytes = 0
+  let streamChunks = 0
+  const state = {
+    doneSeen: false,
+    reportedModel: null as string | null,
+    output: '',
+    runtimeReported: {
+      totalDurationNs: null,
+      loadDurationNs: null,
+      promptEvalCount: null,
+      promptEvalDurationNs: null,
+      evalCount: null,
+      evalDurationNs: null,
+    } satisfies RuntimeReportedMetricsV1,
+    streamEvents: 0,
+    firstContentAt: null as number | null,
+  }
+
+  try {
+    const response = await boundary.race(request(OLLAMA_GENERATE_URL, {
+      method: 'POST',
+      headers: { accept: 'application/x-ndjson', 'content-type': 'application/json' },
+      body: JSON.stringify({
+        model,
+        prompt: SYNTHETIC_FIXTURE_PACK.prompt,
+        stream: true,
+        keep_alive: '5m',
+        options: {
+          temperature: FIXED_GENERATION_PARAMETERS.temperature,
+          seed: FIXED_GENERATION_PARAMETERS.seed,
+          num_predict: FIXED_GENERATION_PARAMETERS.numPredict,
+        },
+      }),
+      signal: boundary.controller.signal,
+    }))
+
+    if (!response.ok) {
+      const code: BenchFailureCode = response.status === 404 ? 'model-not-found' : 'http-error'
+      throw new BenchOllamaError(code, response.status === 404
+        ? 'Ollama could not find the selected model.'
+        : `Ollama returned HTTP status ${response.status}.`, response.status)
+    }
+    if (!response.body) throw new BenchOllamaError('malformed-response', 'Ollama returned an empty response body.')
+    reader = response.body.getReader()
+    const decoder = new TextDecoder('utf-8', { fatal: true })
+    let pendingLine = ''
+    while (true) {
+      const next = await boundary.race(reader.read())
+      if (next.done) break
+      if (!next.value) throw new BenchOllamaError('malformed-response', 'Ollama returned an empty response chunk.')
+      streamChunks += 1
+      if (streamChunks > MAX_STREAM_CHUNKS) {
+        throw new BenchOllamaError('response-limit', `Ollama response exceeded the ${MAX_STREAM_CHUNKS}-chunk limit.`)
+      }
+      responseBytes += next.value.byteLength
+      if (responseBytes > MAX_RESPONSE_BYTES) {
+        throw new BenchOllamaError('response-limit', `Ollama response exceeded the ${MAX_RESPONSE_BYTES}-byte limit.`)
+      }
+      let decoded: string
+      try {
+        decoded = decoder.decode(next.value, { stream: true })
+      } catch {
+        throw new BenchOllamaError('malformed-response', 'Ollama returned invalid UTF-8 data.')
+      }
+      pendingLine += decoded
+      if (Buffer.byteLength(pendingLine, 'utf8') > MAX_NDJSON_LINE_BYTES) {
+        throw new BenchOllamaError('response-limit', `Ollama returned an NDJSON line over the ${MAX_NDJSON_LINE_BYTES}-byte limit.`)
+      }
+      let newline = pendingLine.indexOf('\n')
+      while (newline >= 0) {
+        const line = pendingLine.slice(0, newline)
+        pendingLine = pendingLine.slice(newline + 1)
+        parseNdjsonEvent(line, state, monotonicNow, startedAt)
+        newline = pendingLine.indexOf('\n')
+      }
+    }
+    try {
+      pendingLine += decoder.decode()
+    } catch {
+      throw new BenchOllamaError('malformed-response', 'Ollama returned incomplete UTF-8 data.')
+    }
+    if (Buffer.byteLength(pendingLine, 'utf8') > MAX_NDJSON_LINE_BYTES) {
+      throw new BenchOllamaError('response-limit', `Ollama returned an NDJSON line over the ${MAX_NDJSON_LINE_BYTES}-byte limit.`)
+    }
+    parseNdjsonEvent(pendingLine, state, monotonicNow, startedAt)
+    if (!state.doneSeen) throw new BenchOllamaError('malformed-response', 'Ollama stream ended before a final event.')
+
+    const outputDigest = sha256Text(state.output)
+    return {
+      reportedModel: state.reportedModel,
+      observed: {
+        requestLatencyMs: Math.max(0, monotonicNow() - startedAt),
+        timeToFirstContentMs: state.firstContentAt === null ? null : Math.max(0, state.firstContentAt),
+        responseBytes,
+        streamChunks,
+        streamEvents: state.streamEvents,
+        outputChars: Array.from(state.output).length,
+        outputDigest,
+      },
+      runtimeReported: state.runtimeReported,
+    }
+  } catch (error) {
+    await reader?.cancel().catch(() => undefined)
+    throw normalizeBoundaryError(error, boundary)
+  } finally {
+    reader?.releaseLock()
+    boundary.dispose()
+  }
+}

--- a/src/bench/run-v1.ts
+++ b/src/bench/run-v1.ts
@@ -1,0 +1,381 @@
+import { randomUUID } from 'node:crypto'
+import { arch, platform, release } from 'node:os'
+import {
+  BENCH_RUNNER_ID,
+  BENCH_RUNNER_VERSION,
+  BENCH_RUN_SCHEMA_VERSION,
+  FIXED_GENERATION_PARAMETERS,
+  MEASURED_RUN_COUNT,
+  WARMUP_RUN_COUNT,
+  type BenchAggregateV1,
+  type BenchFailureCode,
+  type BenchPhase,
+  type BenchRunEvidenceV1,
+  type BenchRunV1,
+  type NumericSummaryV1,
+  type ObservedMetricsV1,
+  type RuntimeReportedMetricsV1,
+} from './contract-v1.js'
+import { SYNTHETIC_FIXTURE_DIGEST, SYNTHETIC_FIXTURE_PACK } from './fixture-v1.js'
+import {
+  BenchOllamaError,
+  DEFAULT_OLLAMA_TIMEOUT_MS,
+  fetchOllamaVersion,
+  OLLAMA_LOCAL_BASE_URL,
+  runOllamaGenerate,
+  validateOllamaModelId,
+  type BenchFetch,
+} from './ollama-local.js'
+import { sha256Json } from './serialization.js'
+
+export type BenchRunOptions = {
+  model: string
+  fetchImpl?: BenchFetch
+  signal?: AbortSignal
+  timeoutMs?: number
+  now?: () => Date
+  monotonicNow?: () => number
+  runId?: string
+}
+
+type FailureRecord = {
+  phase: BenchPhase | 'preflight'
+  index: number
+  code: BenchFailureCode
+  message: string
+}
+
+const EMPTY_RUNTIME_METRICS: RuntimeReportedMetricsV1 = {
+  totalDurationNs: null,
+  loadDurationNs: null,
+  promptEvalCount: null,
+  promptEvalDurationNs: null,
+  evalCount: null,
+  evalDurationNs: null,
+}
+
+const EMPTY_OBSERVED_METRICS: ObservedMetricsV1 = {
+  requestLatencyMs: null,
+  timeToFirstContentMs: null,
+  responseBytes: 0,
+  streamChunks: 0,
+  streamEvents: 0,
+  outputChars: 0,
+  outputDigest: null,
+}
+
+function isoNow(now: () => Date): string {
+  return now().toISOString()
+}
+
+function failureMessage(code: BenchFailureCode, fallback: string): string {
+  switch (code) {
+    case 'runtime-unavailable':
+    case 'transport-error':
+      return `Ollama local runtime unavailable at ${OLLAMA_LOCAL_BASE_URL}. Start Ollama and retry.`
+    case 'model-not-found':
+      return 'Ollama could not find the selected local model.'
+    case 'timeout':
+      return `Ollama local request timed out after the bounded timeout.`
+    case 'cancelled':
+      return 'BenchRunV1 cancellation requested; remaining runs were not started.'
+    case 'malformed-response':
+      return 'Ollama returned malformed runtime data; the run failed closed.'
+    case 'response-limit':
+      return 'Ollama response exceeded the bounded BenchRunV1 response limit.'
+    case 'runtime-error':
+      return 'Ollama reported a generation failure for the selected model.'
+    case 'http-error':
+      return fallback.startsWith('Ollama returned HTTP') ? fallback : 'Ollama local runtime returned an HTTP error.'
+  }
+}
+
+function asFailure(error: unknown): { code: BenchFailureCode; message: string } {
+  if (error instanceof BenchOllamaError) {
+    return { code: error.code, message: failureMessage(error.code, error.message) }
+  }
+  return {
+    code: 'transport-error',
+    message: failureMessage('transport-error', 'Ollama local runtime request failed.'),
+  }
+}
+
+function numericSummary(values: number[]): NumericSummaryV1 | null {
+  if (values.length === 0) return null
+  const sorted = [...values].sort((a, b) => a - b)
+  const middle = Math.floor(sorted.length / 2)
+  const median = sorted.length % 2 === 1
+    ? sorted[middle]!
+    : (sorted[middle - 1]! + sorted[middle]!) / 2
+  return {
+    count: sorted.length,
+    min: sorted[0]!,
+    median,
+    max: sorted[sorted.length - 1]!,
+    mean: sorted.reduce((sum, value) => sum + value, 0) / sorted.length,
+  }
+}
+
+function successfulMeasuredRuns(runs: BenchRunEvidenceV1[]): BenchRunEvidenceV1[] {
+  return runs.filter(run => run.phase === 'measured' && run.status === 'success')
+}
+
+function metricValues(runs: BenchRunEvidenceV1[], read: (run: BenchRunEvidenceV1) => number | null): number[] {
+  return successfulMeasuredRuns(runs)
+    .map(read)
+    .filter((value): value is number => value !== null)
+}
+
+function buildAggregate(runs: BenchRunEvidenceV1[], exclusions: BenchRunV1['exclusions']): BenchAggregateV1 {
+  const measuredRuns = runs.filter(run => run.phase === 'measured')
+  const successful = successfulMeasuredRuns(runs)
+  return {
+    measured: {
+      planned: MEASURED_RUN_COUNT,
+      attempted: measuredRuns.length,
+      successful: successful.length,
+      failed: measuredRuns.filter(run => run.status !== 'success').length,
+      excluded: exclusions.filter(exclusion => exclusion.phase === 'measured').length,
+      observed: {
+        requestLatencyMs: numericSummary(metricValues(runs, run => run.observed.requestLatencyMs)),
+        timeToFirstContentMs: numericSummary(metricValues(runs, run => run.observed.timeToFirstContentMs)),
+        outputChars: numericSummary(metricValues(runs, run => run.observed.outputChars)),
+      },
+      runtimeReported: {
+        totalDurationNs: numericSummary(metricValues(runs, run => run.runtimeReported.totalDurationNs)),
+        loadDurationNs: numericSummary(metricValues(runs, run => run.runtimeReported.loadDurationNs)),
+        promptEvalCount: numericSummary(metricValues(runs, run => run.runtimeReported.promptEvalCount)),
+        promptEvalDurationNs: numericSummary(metricValues(runs, run => run.runtimeReported.promptEvalDurationNs)),
+        evalCount: numericSummary(metricValues(runs, run => run.runtimeReported.evalCount)),
+        evalDurationNs: numericSummary(metricValues(runs, run => run.runtimeReported.evalDurationNs)),
+      },
+    },
+  }
+}
+
+function resultDigest(input: {
+  model: BenchRunV1['model']
+  runtimeVersion: string | null
+  runs: BenchRunEvidenceV1[]
+}): string {
+  return sha256Json({
+    schemaVersion: BENCH_RUN_SCHEMA_VERSION,
+    runner: { id: BENCH_RUNNER_ID, version: BENCH_RUNNER_VERSION },
+    fixtureDigest: SYNTHETIC_FIXTURE_DIGEST,
+    model: input.model,
+    runtimeVersion: input.runtimeVersion,
+    generation: {
+      parameters: FIXED_GENERATION_PARAMETERS,
+      warmupCount: WARMUP_RUN_COUNT,
+      measuredRunCount: MEASURED_RUN_COUNT,
+    },
+    runs: input.runs.map(run => ({
+      phase: run.phase,
+      index: run.index,
+      status: run.status,
+      reportedModel: run.reportedModel,
+      outputDigest: run.observed.outputDigest,
+      outputChars: run.observed.outputChars,
+      promptEvalCount: run.runtimeReported.promptEvalCount,
+      evalCount: run.runtimeReported.evalCount,
+      failure: run.failure?.code ?? null,
+    })),
+  })
+}
+
+function makeExclusions(
+  exclusions: BenchRunV1['exclusions'],
+  phase: BenchPhase,
+  startIndex: number,
+  reason: 'not-started-after-failure' | 'not-started-after-cancellation',
+): void {
+  const endIndex = phase === 'warmup' ? WARMUP_RUN_COUNT : MEASURED_RUN_COUNT
+  for (let index = startIndex; index <= endIndex; index++) exclusions.push({ phase, index, reason })
+}
+
+function makeRunEvidence(
+  phase: BenchPhase,
+  index: number,
+  now: () => Date,
+  status: BenchRunEvidenceV1['status'],
+  reportedModel: string | null,
+  observed: ObservedMetricsV1,
+  runtimeReported: RuntimeReportedMetricsV1,
+  failure: BenchRunEvidenceV1['failure'],
+  startedAt: string,
+): BenchRunEvidenceV1 {
+  return {
+    phase,
+    index,
+    status,
+    startedAt,
+    endedAt: isoNow(now),
+    reportedModel,
+    observed,
+    runtimeReported,
+    failure,
+  }
+}
+
+export function validateBenchTimeoutMs(value: number): number {
+  if (!Number.isSafeInteger(value) || value < 50 || value > 120_000) {
+    throw new Error('timeout must be an integer from 50 to 120000 milliseconds')
+  }
+  return value
+}
+
+export async function runBenchRunV1(options: BenchRunOptions): Promise<BenchRunV1> {
+  const model = validateOllamaModelId(options.model)
+  const now = options.now ?? (() => new Date())
+  const monotonicNow = options.monotonicNow ?? (() => performance.now())
+  const timeoutMs = validateBenchTimeoutMs(options.timeoutMs ?? DEFAULT_OLLAMA_TIMEOUT_MS)
+  const startedAt = isoNow(now)
+  let runtimeVersion: string | null = null
+  const runs: BenchRunEvidenceV1[] = []
+  const failures: BenchRunV1['failures'] = []
+  const exclusions: BenchRunV1['exclusions'] = []
+  let termination: BenchRunV1['termination'] = { status: 'none', phase: null, index: null }
+  let status: BenchRunV1['status'] = 'completed'
+
+  try {
+    runtimeVersion = await fetchOllamaVersion({
+      fetchImpl: options.fetchImpl,
+      signal: options.signal,
+      timeoutMs,
+    })
+  } catch (error) {
+    const failure = asFailure(error)
+    failures.push({ phase: 'preflight', index: 0, ...failure })
+    status = failure.code === 'cancelled' ? 'cancelled' : 'failed'
+    termination = {
+      status: failure.code === 'cancelled' ? 'cancelled' : failure.code === 'timeout' ? 'timeout' : 'none',
+      phase: 'preflight',
+      index: 0,
+    }
+    makeExclusions(exclusions, 'warmup', 1, failure.code === 'cancelled' ? 'not-started-after-cancellation' : 'not-started-after-failure')
+    makeExclusions(exclusions, 'measured', 1, failure.code === 'cancelled' ? 'not-started-after-cancellation' : 'not-started-after-failure')
+  }
+
+  const runOne = async (phase: BenchPhase, index: number): Promise<BenchRunEvidenceV1> => {
+    const runStartedAt = isoNow(now)
+    try {
+      if (options.signal?.aborted) throw new BenchOllamaError('cancelled', 'BenchRunV1 cancellation requested.')
+      const evidence = await runOllamaGenerate({
+        model,
+        fetchImpl: options.fetchImpl,
+        signal: options.signal,
+        timeoutMs,
+        monotonicNow,
+      })
+      return makeRunEvidence(
+        phase,
+        index,
+        now,
+        'success',
+        evidence.reportedModel,
+        evidence.observed,
+        evidence.runtimeReported,
+        null,
+        runStartedAt,
+      )
+    } catch (error) {
+      const failure = asFailure(error)
+      return makeRunEvidence(
+        phase,
+        index,
+        now,
+        failure.code === 'cancelled' ? 'cancelled' : 'failed',
+        null,
+        { ...EMPTY_OBSERVED_METRICS },
+        { ...EMPTY_RUNTIME_METRICS },
+        failure,
+        runStartedAt,
+      )
+    }
+  }
+
+  if (failures.length === 0) {
+    const warmup = await runOne('warmup', 1)
+    runs.push(warmup)
+    if (warmup.failure) {
+      failures.push({ phase: warmup.phase, index: warmup.index, ...warmup.failure })
+      status = warmup.status === 'cancelled' ? 'cancelled' : 'failed'
+      termination = {
+        status: warmup.status === 'cancelled' ? 'cancelled' : warmup.failure.code === 'timeout' ? 'timeout' : 'none',
+        phase: warmup.phase,
+        index: warmup.index,
+      }
+      makeExclusions(exclusions, 'measured', 1, warmup.status === 'cancelled' ? 'not-started-after-cancellation' : 'not-started-after-failure')
+    }
+  }
+
+  if (failures.length === 0) {
+    for (let index = 1; index <= MEASURED_RUN_COUNT; index++) {
+      if (options.signal?.aborted) {
+        status = 'cancelled'
+        termination = { status: 'cancelled', phase: 'measured', index }
+        makeExclusions(exclusions, 'measured', index, 'not-started-after-cancellation')
+        break
+      }
+      const measured = await runOne('measured', index)
+      runs.push(measured)
+      if (measured.failure) {
+        failures.push({ phase: measured.phase, index: measured.index, ...measured.failure })
+        status = measured.status === 'cancelled' ? 'cancelled' : 'failed'
+        termination = {
+          status: measured.status === 'cancelled' ? 'cancelled' : measured.failure.code === 'timeout' ? 'timeout' : 'none',
+          phase: measured.phase,
+          index: measured.index,
+        }
+        makeExclusions(exclusions, 'measured', index + 1, measured.status === 'cancelled' ? 'not-started-after-cancellation' : 'not-started-after-failure')
+        break
+      }
+    }
+  }
+
+  const reportedModels = [...new Set(runs
+    .map(run => run.reportedModel)
+    .filter((value): value is string => value !== null))]
+  const resultModel = { selected: model, reported: reportedModels.length === 1 ? reportedModels[0]! : null }
+
+  const aggregate = buildAggregate(runs, exclusions)
+  const result: BenchRunV1 = {
+    schemaVersion: BENCH_RUN_SCHEMA_VERSION,
+    runId: options.runId ?? randomUUID(),
+    runner: { id: BENCH_RUNNER_ID, version: BENCH_RUNNER_VERSION },
+    fixture: {
+      packId: SYNTHETIC_FIXTURE_PACK.packId,
+      version: SYNTHETIC_FIXTURE_PACK.version,
+      caseId: SYNTHETIC_FIXTURE_PACK.caseId,
+      digest: SYNTHETIC_FIXTURE_DIGEST,
+    },
+    model: resultModel,
+    runtime: {
+      id: 'ollama-local',
+      endpoint: OLLAMA_LOCAL_BASE_URL,
+      version: runtimeVersion,
+    },
+    environment: {
+      os: `${platform()} ${release()}`,
+      arch: arch(),
+      node: process.version,
+    },
+    generation: {
+      parameters: { ...FIXED_GENERATION_PARAMETERS },
+      warmupCount: WARMUP_RUN_COUNT,
+      measuredRunCount: MEASURED_RUN_COUNT,
+      fixturePolicy: 'same-versioned-synthetic-fixture-for-every-request',
+    },
+    startedAt,
+    endedAt: isoNow(now),
+    status,
+    termination,
+    runs,
+    failures,
+    exclusions,
+    aggregate,
+    resultDigest: '',
+  }
+  result.resultDigest = resultDigest({ model: result.model, runtimeVersion, runs })
+  return result
+}

--- a/src/bench/serialization.ts
+++ b/src/bench/serialization.ts
@@ -1,0 +1,29 @@
+import { createHash } from 'node:crypto'
+
+/**
+ * Small canonical JSON encoder for the JSON-safe values used by BenchRunV1.
+ * Object keys are sorted; array order remains meaningful.
+ */
+export function canonicalJson(value: unknown): string {
+  if (value === null) return 'null'
+  if (typeof value === 'string' || typeof value === 'boolean') return JSON.stringify(value)
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) throw new Error('BenchRunV1 cannot hash a non-finite number')
+    return JSON.stringify(value)
+  }
+  if (value === undefined) return 'null'
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(',')}]`
+  if (typeof value === 'object') {
+    const record = value as Record<string, unknown>
+    return `{${Object.keys(record).sort().map(key => `${JSON.stringify(key)}:${canonicalJson(record[key])}`).join(',')}}`
+  }
+  throw new Error(`BenchRunV1 cannot hash value of type ${typeof value}`)
+}
+
+export function sha256Text(value: string): string {
+  return createHash('sha256').update(value, 'utf8').digest('hex')
+}
+
+export function sha256Json(value: unknown): string {
+  return sha256Text(canonicalJson(value))
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -33,7 +33,7 @@ import { formatDateRangeLabel, parseDateRangeFlags, parseDayFlag, parseDaysFlag,
 import { runOptimize } from './optimize.js'
 import { registerActCommands } from './act/cli.js'
 import { registerGuardCommands } from './guard/cli.js'
-import { registerSyncCommands } from './sync/cli.js'
+import { registerSyncCommands } from './sync/cli.js'; import { registerBenchCommands } from './bench/cli.js'
 import { runContextCommand } from './context-tree.js'
 import { renderCompare } from './compare.js'
 import { computeBudgetStatus, daysInMonth, diffCalendarDays, type BudgetStatus, type BudgetTier } from './budget.js'
@@ -2322,6 +2322,6 @@ program
 
 registerActCommands(program)
 registerGuardCommands(program)
-registerSyncCommands(program); registerProjectCommands(program)
+registerSyncCommands(program); registerProjectCommands(program); registerBenchCommands(program)
 
 program.parse()

--- a/tests/bench-cli.test.ts
+++ b/tests/bench-cli.test.ts
@@ -1,0 +1,20 @@
+import { spawnSync } from 'node:child_process'
+import { describe, expect, it } from 'vitest'
+
+describe('metrora bench local CLI', () => {
+  it('exposes the user-invokable local BenchRunV1 entrypoint', () => {
+    const result = spawnSync(process.execPath, ['--import', 'tsx', 'src/cli.ts', 'bench', 'local', '--help'], {
+      cwd: process.cwd(),
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        METRORA_TZ: 'UTC',
+      },
+    })
+    expect(result.status).toBe(0)
+    expect(result.stdout).toContain('Usage: metrora bench local [options]')
+    expect(result.stdout).toContain('--model <model>')
+    expect(result.stdout).toContain('--output <path>')
+    expect(result.stdout).toContain('--timeout-ms <ms>')
+  })
+})

--- a/tests/bench-run-v1.test.ts
+++ b/tests/bench-run-v1.test.ts
@@ -1,0 +1,226 @@
+import { describe, expect, it } from 'vitest'
+import {
+  BENCH_RUNNER_ID,
+  BENCH_RUNNER_VERSION,
+  BENCH_RUN_SCHEMA_VERSION,
+  MEASURED_RUN_COUNT,
+  WARMUP_RUN_COUNT,
+} from '../src/bench/contract-v1.js'
+import {
+  MAX_OUTPUT_BYTES,
+  OLLAMA_GENERATE_URL,
+  OLLAMA_LOCAL_BASE_URL,
+  OLLAMA_VERSION_URL,
+  type BenchFetch,
+} from '../src/bench/ollama-local.js'
+import { SYNTHETIC_FIXTURE_DIGEST, SYNTHETIC_FIXTURE_PACK } from '../src/bench/fixture-v1.js'
+import { runBenchRunV1 } from '../src/bench/run-v1.js'
+import { sha256Json } from '../src/bench/serialization.js'
+
+type FetchCall = { url: string; init?: RequestInit; body?: Record<string, unknown> }
+
+function streamResponse(events: unknown[], status = 200): Response {
+  const body = events.map(event => JSON.stringify(event)).join('\n') + '\n'
+  return new Response(body, {
+    status,
+    headers: { 'content-type': 'application/x-ndjson' },
+  })
+}
+
+function successfulEvents(withMetrics = true, output = 'synthetic fixture received'): unknown[] {
+  return [
+    { model: 'qwen3:8b', response: output, done: false },
+    withMetrics
+      ? {
+          model: 'qwen3:8b',
+          response: '',
+          done: true,
+          total_duration: 1_000_000,
+          load_duration: 100_000,
+          prompt_eval_count: 17,
+          prompt_eval_duration: 200_000,
+          eval_count: 8,
+          eval_duration: 700_000,
+        }
+      : { model: 'qwen3:8b', response: '', done: true },
+  ]
+}
+
+function makeFetch(options: {
+  generateResponse?: (call: number, body: Record<string, unknown>) => Response | Promise<Response>
+} = {}): { fetchImpl: BenchFetch; calls: FetchCall[] } {
+  const calls: FetchCall[] = []
+  let generateCalls = 0
+  const fetchImpl: BenchFetch = async (input, init) => {
+    const url = String(input)
+    const body = typeof init?.body === 'string' ? JSON.parse(init.body) as Record<string, unknown> : undefined
+    calls.push({ url, init, body })
+    if (url === OLLAMA_VERSION_URL) return new Response(JSON.stringify({ version: '0.12.6' }), { status: 200 })
+    if (url !== OLLAMA_GENERATE_URL) return new Response('not found', { status: 404 })
+    generateCalls += 1
+    return options.generateResponse?.(generateCalls, body ?? {}) ?? streamResponse(successfulEvents())
+  }
+  return { fetchImpl, calls }
+}
+
+function generationCalls(calls: FetchCall[]): FetchCall[] {
+  return calls.filter(call => call.url === OLLAMA_GENERATE_URL)
+}
+
+describe('BenchRunV1 ollama-local', () => {
+  it('exposes a versioned manifest and deterministic fixture identity', () => {
+    expect(BENCH_RUN_SCHEMA_VERSION).toBe('metrora.bench-run.v1')
+    expect(BENCH_RUNNER_ID).toBe('ollama-local-v1')
+    expect(BENCH_RUNNER_VERSION).toBe('1.0.0')
+    expect(WARMUP_RUN_COUNT).toBe(1)
+    expect(MEASURED_RUN_COUNT).toBe(5)
+    expect(SYNTHETIC_FIXTURE_DIGEST).toBe(sha256Json(SYNTHETIC_FIXTURE_PACK))
+  })
+
+  it('runs exactly one warmup and five measured requests with fixed synthetic input and parameters', async () => {
+    const { fetchImpl, calls } = makeFetch()
+    const result = await runBenchRunV1({ model: 'qwen3:8b', fetchImpl, runId: 'test-run', timeoutMs: 1000 })
+    const generate = generationCalls(calls)
+
+    expect(result.status).toBe('completed')
+    expect(generate).toHaveLength(6)
+    expect(result.runs.map(run => `${run.phase}:${run.index}`)).toEqual([
+      'warmup:1',
+      'measured:1',
+      'measured:2',
+      'measured:3',
+      'measured:4',
+      'measured:5',
+    ])
+    expect(new Set(generate.map(call => JSON.stringify(call.body))).size).toBe(1)
+    expect(generate[0]?.body).toMatchObject({
+      model: 'qwen3:8b',
+      prompt: SYNTHETIC_FIXTURE_PACK.prompt,
+      stream: true,
+      keep_alive: '5m',
+      options: { temperature: 0, seed: 1729, num_predict: 64 },
+    })
+    expect(result.generation.parameters).toEqual({ temperature: 0, seed: 1729, numPredict: 64 })
+    expect(result.fixture.digest).toBe(SYNTHETIC_FIXTURE_DIGEST)
+    expect(result.runtime.endpoint).toBe(OLLAMA_LOCAL_BASE_URL)
+    expect(calls.every(call => call.url.startsWith(OLLAMA_LOCAL_BASE_URL))).toBe(true)
+  })
+
+  it('keeps runtime-reported token metadata factual and distinguishes missing values', async () => {
+    const withTokens = await runBenchRunV1({ model: 'qwen3:8b', fetchImpl: makeFetch().fetchImpl, timeoutMs: 1000 })
+    expect(withTokens.runs[1]?.runtimeReported.promptEvalCount).toBe(17)
+    expect(withTokens.runs[1]?.runtimeReported.evalCount).toBe(8)
+    expect(withTokens.aggregate.measured.runtimeReported.evalCount).toMatchObject({ count: 5, median: 8 })
+
+    const withoutTokens = await runBenchRunV1({
+      model: 'qwen3:8b',
+      fetchImpl: makeFetch({ generateResponse: () => streamResponse(successfulEvents(false)) }).fetchImpl,
+      timeoutMs: 1000,
+    })
+    expect(withoutTokens.runs[1]?.runtimeReported.promptEvalCount).toBeNull()
+    expect(withoutTokens.runs[1]?.runtimeReported.evalCount).toBeNull()
+    expect(withoutTokens.aggregate.measured.runtimeReported.evalCount).toBeNull()
+  })
+
+  it('fails closed on malformed NDJSON/JSON and records exclusions', async () => {
+    const result = await runBenchRunV1({
+      model: 'qwen3:8b',
+      fetchImpl: makeFetch({ generateResponse: () => new Response('{not-json}\n', { status: 200 }) }).fetchImpl,
+      timeoutMs: 1000,
+    })
+    expect(result.status).toBe('failed')
+    expect(result.runs[0]?.failure?.code).toBe('malformed-response')
+    expect(result.aggregate.measured.attempted).toBe(0)
+    expect(result.exclusions).toHaveLength(5)
+  })
+
+  it('bounds generated output and response handling', async () => {
+    const oversizedOutput = 'x'.repeat(MAX_OUTPUT_BYTES + 1)
+    const result = await runBenchRunV1({
+      model: 'qwen3:8b',
+      fetchImpl: makeFetch({ generateResponse: () => streamResponse(successfulEvents(true, oversizedOutput)) }).fetchImpl,
+      timeoutMs: 1000,
+    })
+    expect(result.status).toBe('failed')
+    expect(result.failures[0]?.code).toBe('response-limit')
+    expect(result.runs[0]?.observed.outputDigest).toBeNull()
+  })
+
+  it('records a bounded timeout without hanging the run', async () => {
+    const { calls } = makeFetch()
+    const fetchImpl: BenchFetch = async (input, init) => {
+      const url = String(input)
+      calls.push({ url, init })
+      if (url === OLLAMA_VERSION_URL) return new Response(JSON.stringify({ version: '0.12.6' }), { status: 200 })
+      return await new Promise<Response>((_resolve, reject) => {
+        if (init?.signal?.aborted) reject(new DOMException('Aborted', 'AbortError'))
+        else init?.signal?.addEventListener('abort', () => reject(new DOMException('Aborted', 'AbortError')), { once: true })
+      })
+    }
+    const result = await runBenchRunV1({ model: 'qwen3:8b', fetchImpl, timeoutMs: 50 })
+    expect(result.status).toBe('failed')
+    expect(result.termination.status).toBe('timeout')
+    expect(result.failures[0]?.code).toBe('timeout')
+  })
+
+  it('records cancellation and excludes runs not started after the abort', async () => {
+    const controller = new AbortController()
+    const fetchImpl: BenchFetch = async (input, init) => {
+      const url = String(input)
+      if (url === OLLAMA_VERSION_URL) return new Response(JSON.stringify({ version: '0.12.6' }), { status: 200 })
+      return await new Promise<Response>((_resolve, reject) => {
+        if (init?.signal?.aborted) reject(new DOMException('Aborted', 'AbortError'))
+        else init?.signal?.addEventListener('abort', () => reject(new DOMException('Aborted', 'AbortError')), { once: true })
+      })
+    }
+    const pending = runBenchRunV1({ model: 'qwen3:8b', fetchImpl, signal: controller.signal, timeoutMs: 1000 })
+    setTimeout(() => controller.abort(), 10)
+    const result = await pending
+    expect(result.status).toBe('cancelled')
+    expect(result.termination.status).toBe('cancelled')
+    expect(result.failures[0]?.code).toBe('cancelled')
+    expect(result.exclusions.length).toBeGreaterThan(0)
+  })
+
+  it('preserves partial failure semantics instead of fabricating missing repetitions', async () => {
+    const { fetchImpl } = makeFetch({
+      generateResponse: (call) => call === 3
+        ? new Response('runtime failure', { status: 503 })
+        : streamResponse(successfulEvents()),
+    })
+    const result = await runBenchRunV1({ model: 'qwen3:8b', fetchImpl, timeoutMs: 1000 })
+    expect(result.status).toBe('failed')
+    expect(result.runs.map(run => `${run.phase}:${run.index}`)).toEqual(['warmup:1', 'measured:1', 'measured:2'])
+    expect(result.aggregate.measured).toMatchObject({ planned: 5, attempted: 2, successful: 1, failed: 1, excluded: 3 })
+    expect(result.exclusions.map(exclusion => exclusion.index)).toEqual([3, 4, 5])
+  })
+
+  it('keeps result digest stable when only timing changes', async () => {
+    let generationCall = 0
+    const makeTimedFetch = (): BenchFetch => async (input, init) => {
+      const url = String(input)
+      if (url === OLLAMA_VERSION_URL) return new Response(JSON.stringify({ version: '0.12.6' }), { status: 200 })
+      generationCall += 1
+      return streamResponse([
+        { model: 'qwen3:8b', response: 'same result', done: false },
+        { model: 'qwen3:8b', response: '', done: true, total_duration: generationCall, eval_count: 8, prompt_eval_count: 17 },
+      ])
+    }
+    const first = await runBenchRunV1({ model: 'qwen3:8b', fetchImpl: makeTimedFetch(), timeoutMs: 1000 })
+    generationCall = 100
+    const second = await runBenchRunV1({ model: 'qwen3:8b', fetchImpl: makeTimedFetch(), timeoutMs: 1000 })
+    expect(first.resultDigest).toBe(second.resultDigest)
+  })
+
+  it('does not expose quality, cost, ranking, or user-content fields', async () => {
+    const result = await runBenchRunV1({ model: 'qwen3:8b', fetchImpl: makeFetch().fetchImpl, timeoutMs: 1000 })
+    const serialized = JSON.stringify(result)
+    expect(serialized).not.toContain('quality')
+    expect(serialized).not.toContain('cost')
+    expect(serialized).not.toContain('ranking')
+    expect(serialized).not.toContain('top secret user prompt')
+    expect(result).not.toHaveProperty('prompt')
+    expect(result).not.toHaveProperty('response')
+    expect(result).not.toHaveProperty('score')
+  })
+})


### PR DESCRIPTION
## Summary

- add the CLI-first `metrora bench local --model <model>` BenchRunV1 vertical slice;
- use only fixed loopback Ollama HTTP endpoints with a versioned synthetic fixture, bounded streaming, cancellation and fail-closed parsing;
- emit factual Metrora-observed and Ollama-reported metrics with nullable unavailable values and a deterministic result digest;
- add public documentation and focused mock-runtime coverage.

## Validation

- `npx vitest run tests/bench-run-v1.test.ts tests/bench-cli.test.ts` — 11 passed;
- core suite `npx vitest run --no-file-parallelism --exclude "app/**"` — 335 files passed, 2 skipped; 3261 tests passed, 5 skipped;
- `npx tsc --noEmit`;
- `npm run build:cli`;
- source-size ratchet against base `4dcd6fa1f685b996f19f419181c3d2229204f5f7`;
- public identity, pricing docs and `git diff --check`.

No Advisor files, commercial files or new dependencies are changed. Manual CLI validation also confirmed the bounded non-zero failure path when Ollama is unavailable; no quality, cost, quota, ranking or recommendation claim is produced.