### PR TITLE
feat(electron): add progress watchdog v1

### DIFF
--- a/app/electron/cli-watchdog.ts
+++ b/app/electron/cli-watchdog.ts
@@ -1,0 +1,324 @@
+import { spawn, type ChildProcess } from 'node:child_process'
+
+/**
+ * The CLI is launched as a direct child with shell:false. Windows process-tree
+ * ownership is intentionally not claimed here; a follow-up must make that
+ * contract explicit before any tree-wide termination is considered.
+ */
+export const WINDOWS_PROCESS_TREE_STATUS = 'WINDOWS_PROCESS_TREE_V1_1' as const
+
+export const DEFAULT_TERMINATION_GRACE_MS = 250
+export const DEFAULT_HARD_KILL_FALLBACK_MS = 500
+export const DEFAULT_MAX_OUTPUT_BYTES = 16 * 1024 * 1024
+const MAX_PROGRESS_LINE_BYTES = 64 * 1024
+const MAX_PROGRESS_PROVIDERS = 128
+const MAX_PROGRESS_FILES = 1_000_000
+
+export type SpawnSpec = {
+  bin: string
+  args: string[]
+  env: NodeJS.ProcessEnv
+}
+
+export type TrustedProgressEvent =
+  | { kind: 'providers'; providers: string[]; cold?: boolean }
+  | { kind: 'provider'; provider: string; state: 'start' | 'done' | 'skipped'; files?: number }
+  | { kind: 'tick'; provider: string; done: number; total: number }
+
+export type TerminationReason = 'timeout' | 'too-large' | 'cancelled'
+
+export type BoundedProcessResult = {
+  stdout: string
+  stderr: string
+  code: number | null
+  signal?: NodeJS.Signals | null
+  error?: Error
+  reason?: TerminationReason
+}
+
+export type BoundedProcessOptions = {
+  absoluteTimeoutMs: number
+  idleTimeoutMs?: number
+  graceMs?: number
+  maxOutputBytes?: number
+  onStderr?: (chunk: string) => void
+  onProgress?: (event: TrustedProgressEvent) => void
+}
+
+const activeProcesses = new Map<number, (reason?: TerminationReason) => void>()
+let nextProcessId = 1
+
+function asError(value: unknown): Error {
+  return value instanceof Error ? value : new Error(String(value))
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function hasOnlyKeys(value: Record<string, unknown>, allowed: readonly string[]): boolean {
+  const keys = new Set(allowed)
+  return Object.keys(value).every(key => keys.has(key))
+}
+
+function boundedName(value: unknown): value is string {
+  return typeof value === 'string' && /^[a-z0-9][a-z0-9-]{0,63}$/.test(value)
+}
+
+function boundedInteger(value: unknown, max: number): value is number {
+  return typeof value === 'number' && Number.isSafeInteger(value) && value >= 0 && value <= max
+}
+
+/**
+ * Validate the CLI's progress protocol as a state machine. A line with the
+ * marker is not itself a heartbeat: only a well-formed event in the expected
+ * sequence can reset the idle timer. Repeated zero/decreasing ticks, duplicate
+ * provider transitions, unknown providers, malformed JSON, and oversized lines
+ * are ignored.
+ */
+function createProgressGate(onAccepted?: (event: TrustedProgressEvent) => void): (chunk: Buffer) => void {
+  let lineBuffer = ''
+  let lineBytes = 0
+  let discardingLongLine = false
+  let providersDeclared = false
+  const providers = new Set<string>()
+  const providerStates = new Map<string, 'start' | 'done' | 'skipped'>()
+  const ticks = new Map<string, { done: number; total: number }>()
+
+  const accept = (raw: unknown): TrustedProgressEvent | null => {
+    if (!isRecord(raw) || typeof raw.kind !== 'string') return null
+
+    if (raw.kind === 'providers') {
+      if (providersDeclared || !hasOnlyKeys(raw, ['kind', 'providers', 'cold'])) return null
+      if (!Array.isArray(raw.providers) || raw.providers.length > MAX_PROGRESS_PROVIDERS) return null
+      if (raw.cold !== undefined && typeof raw.cold !== 'boolean') return null
+      const names = raw.providers
+      if (!names.every(boundedName)) return null
+      const unique = new Set(names)
+      if (unique.size !== names.length) return null
+      providersDeclared = true
+      for (const name of names) providers.add(name)
+      return raw.cold === undefined
+        ? { kind: 'providers', providers: [...names] }
+        : { kind: 'providers', providers: [...names], cold: raw.cold }
+    }
+
+    if (!providersDeclared || typeof raw.provider !== 'string' || !providers.has(raw.provider)) return null
+
+    if (raw.kind === 'provider') {
+      if (!hasOnlyKeys(raw, ['kind', 'provider', 'state', 'files'])) return null
+      if (raw.state !== 'start' && raw.state !== 'done' && raw.state !== 'skipped') return null
+      const previousState = providerStates.get(raw.provider)
+      if (raw.state === 'start') {
+        if (previousState !== undefined) return null
+      } else if (previousState !== 'start') {
+        return null
+      }
+      if (raw.state === 'start' && raw.files !== undefined) return null
+      if (raw.state !== 'done' && raw.files !== undefined) return null
+      if (raw.files !== undefined && !boundedInteger(raw.files, MAX_PROGRESS_FILES)) return null
+      providerStates.set(raw.provider, raw.state)
+      return raw.files === undefined
+        ? { kind: 'provider', provider: raw.provider, state: raw.state }
+        : { kind: 'provider', provider: raw.provider, state: raw.state, files: raw.files }
+    }
+
+    if (raw.kind === 'tick') {
+      if (!hasOnlyKeys(raw, ['kind', 'provider', 'done', 'total'])) return null
+      if (!boundedInteger(raw.done, MAX_PROGRESS_FILES) || !boundedInteger(raw.total, MAX_PROGRESS_FILES)) return null
+      if (raw.done > raw.total) return null
+      if (providerStates.get(raw.provider) !== 'start') return null
+      const previous = ticks.get(raw.provider)
+      if (previous && (raw.done <= previous.done || raw.total < previous.total)) return null
+      ticks.set(raw.provider, { done: raw.done, total: raw.total })
+      // The initial zero tick establishes a baseline but cannot keep a stalled
+      // process alive. A later strictly increasing tick can.
+      if (raw.done === 0) return null
+      return { kind: 'tick', provider: raw.provider, done: raw.done, total: raw.total }
+    }
+
+    return null
+  }
+
+  const consumeLine = (line: string): void => {
+    if (!line.startsWith('METRORA_PROGRESS ')) return
+    try {
+      const event = accept(JSON.parse(line.slice('METRORA_PROGRESS '.length)))
+      if (!event) return
+      try { onAccepted?.(event) } catch { /* observers cannot break process control */ }
+    } catch {
+      // Malformed progress is ordinary child output, never a heartbeat.
+    }
+  }
+
+  return chunk => {
+    let rest = chunk.toString('utf8')
+    while (rest.length > 0) {
+      const newline = rest.indexOf('\n')
+      if (discardingLongLine) {
+        if (newline < 0) return
+        rest = rest.slice(newline + 1)
+        discardingLongLine = false
+        lineBytes = 0
+        continue
+      }
+
+      if (newline < 0) {
+        const bytes = Buffer.byteLength(rest, 'utf8')
+        if (lineBytes + bytes > MAX_PROGRESS_LINE_BYTES) {
+          lineBuffer = ''
+          lineBytes = 0
+          discardingLongLine = true
+        } else {
+          lineBuffer += rest
+          lineBytes += bytes
+        }
+        return
+      }
+
+      const part = rest.slice(0, newline)
+      const partBytes = Buffer.byteLength(part, 'utf8')
+      const completeBytes = lineBytes + partBytes
+      rest = rest.slice(newline + 1)
+      if (completeBytes <= MAX_PROGRESS_LINE_BYTES) {
+        const completeLine = lineBuffer + part
+        const line = completeLine.endsWith('\r') ? completeLine.slice(0, -1) : completeLine
+        consumeLine(line)
+      }
+      lineBuffer = ''
+      lineBytes = 0
+    }
+  }
+}
+
+function normalizeTimeout(value: number, fallback: number): number {
+  return Number.isFinite(value) && value > 0 ? Math.max(1, Math.floor(value)) : fallback
+}
+
+function chunkBuffer(value: unknown): Buffer {
+  return Buffer.isBuffer(value) ? value : Buffer.from(String(value))
+}
+
+/**
+ * Run one child with bounded stdout/stderr, a fixed absolute deadline, and an
+ * independent idle deadline. Termination is SIGTERM, bounded grace, then
+ * SIGKILL. No process-name or broad process-tree kill is attempted.
+ */
+export function runBoundedProcess(
+  spec: SpawnSpec,
+  options: BoundedProcessOptions,
+): Promise<BoundedProcessResult> {
+  const absoluteTimeoutMs = normalizeTimeout(options.absoluteTimeoutMs, 45_000)
+  const idleTimeoutMs = options.idleTimeoutMs === undefined
+    ? undefined
+    : normalizeTimeout(options.idleTimeoutMs, 45_000)
+  const graceMs = normalizeTimeout(options.graceMs ?? DEFAULT_TERMINATION_GRACE_MS, DEFAULT_TERMINATION_GRACE_MS)
+  const maxOutputBytes = normalizeTimeout(options.maxOutputBytes ?? DEFAULT_MAX_OUTPUT_BYTES, DEFAULT_MAX_OUTPUT_BYTES)
+
+  return new Promise<BoundedProcessResult>(resolve => {
+    let child: ChildProcess
+    try {
+      child = spawn(spec.bin, spec.args, {
+        shell: false,
+        stdio: ['ignore', 'pipe', 'pipe'],
+        env: spec.env,
+      })
+    } catch (error) {
+      resolve({ stdout: '', stderr: '', code: null, error: asError(error) })
+      return
+    }
+
+    const processId = nextProcessId++
+    let stdout = ''
+    let stderr = ''
+    let outputBytes = 0
+    let settled = false
+    let termination: TerminationReason | undefined
+    let absoluteTimer: ReturnType<typeof setTimeout> | undefined
+    let idleTimer: ReturnType<typeof setTimeout> | undefined
+    let killTimer: ReturnType<typeof setTimeout> | undefined
+    let fallbackTimer: ReturnType<typeof setTimeout> | undefined
+
+    const finish = (code: number | null, signal: NodeJS.Signals | null, error?: Error): void => {
+      if (settled) return
+      settled = true
+      if (absoluteTimer !== undefined) clearTimeout(absoluteTimer)
+      if (idleTimer !== undefined) clearTimeout(idleTimer)
+      if (killTimer !== undefined) clearTimeout(killTimer)
+      if (fallbackTimer !== undefined) clearTimeout(fallbackTimer)
+      activeProcesses.delete(processId)
+      resolve({
+        stdout,
+        stderr,
+        code,
+        ...(signal !== null ? { signal } : {}),
+        ...(error ? { error } : {}),
+        ...(termination ? { reason: termination } : {}),
+      })
+    }
+
+    const requestTermination = (reason: TerminationReason = 'cancelled'): void => {
+      if (settled || termination) return
+      termination = reason
+      if (idleTimer !== undefined) clearTimeout(idleTimer)
+      try { child.kill('SIGTERM') } catch { /* proceed to bounded hard kill */ }
+      killTimer = setTimeout(() => {
+        try { child.kill('SIGKILL') } catch { /* close/fallback still settles */ }
+        fallbackTimer = setTimeout(() => finish(null, null), DEFAULT_HARD_KILL_FALLBACK_MS)
+      }, graceMs)
+    }
+
+    const resetIdleTimer = (): void => {
+      if (idleTimeoutMs === undefined || settled || termination) return
+      if (idleTimer !== undefined) clearTimeout(idleTimer)
+      idleTimer = setTimeout(() => requestTermination('timeout'), idleTimeoutMs)
+    }
+
+    const progressGate = createProgressGate(event => {
+      if (settled || termination) return
+      resetIdleTimer()
+      try { options.onProgress?.(event) } catch { /* UI observers are best effort */ }
+    })
+
+    const append = (target: 'stdout' | 'stderr', rawChunk: unknown): Buffer | null => {
+      if (settled || termination) return null
+      const bytes = chunkBuffer(rawChunk)
+      const remaining = maxOutputBytes - outputBytes
+      if (remaining <= 0 || bytes.length > remaining) {
+        if (remaining > 0) {
+          const accepted = bytes.subarray(0, remaining)
+          outputBytes += accepted.length
+          if (target === 'stdout') stdout += accepted.toString('utf8')
+          else stderr += accepted.toString('utf8')
+        }
+        requestTermination('too-large')
+        return null
+      }
+      outputBytes += bytes.length
+      if (target === 'stdout') stdout += bytes.toString('utf8')
+      else stderr += bytes.toString('utf8')
+      return bytes
+    }
+
+    const handleStderr = (rawChunk: unknown): void => {
+      const accepted = append('stderr', rawChunk)
+      if (!accepted || settled || termination) return
+      try { options.onStderr?.(accepted.toString('utf8')) } catch { /* observers are best effort */ }
+      progressGate(accepted)
+    }
+
+    activeProcesses.set(processId, requestTermination)
+    child.stdout?.on('data', (chunk: unknown) => { append('stdout', chunk) })
+    child.stderr?.on('data', handleStderr)
+    child.on('error', error => finish(null, null, asError(error)))
+    child.on('close', (code, signal) => finish(code, signal))
+
+    absoluteTimer = setTimeout(() => requestTermination('timeout'), absoluteTimeoutMs)
+    resetIdleTimer()
+  })
+}
+
+/** Ask every owned child to terminate gracefully, without broad process kills. */
+export function cancelAllBoundedProcesses(): void {
+  for (const cancel of activeProcesses.values()) cancel('cancelled')
+}

--- a/app/electron/cli.test.ts
+++ b/app/electron/cli.test.ts
@@ -4,7 +4,7 @@ import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync, chmodSync 
 import { tmpdir } from 'node:os'
 import { delimiter, dirname, join, isAbsolute, relative, win32, posix } from 'node:path'
 
-import { spawnCli, spawnCliAction, spawnEnvFor, spawnSpecFor, killAll, CliError, nodeManagerDirs, notFoundStage, resolveMetroraPath, resolveTarget } from './cli'
+import { spawnCli, spawnCliAction, spawnEnvFor, spawnSpecFor, killAll, shutdownCli, resetCliShutdownForTests, CliError, nodeManagerDirs, notFoundStage, resolveMetroraPath, resolveTarget } from './cli'
 
 let dir: string
 const originalBin = process.env.METRORA_BIN
@@ -46,12 +46,14 @@ function fakeDevRepoCli(): string {
 }
 
 beforeEach(() => {
+  resetCliShutdownForTests()
   // Keep fixtures on the workspace volume. On Windows, path.relative across
   // drive letters returns an absolute path and invalidates relative-path tests.
   dir = mkdtempSync(join(process.cwd(), '.metrora-cli-'))
 })
 
 afterEach(() => {
+  resetCliShutdownForTests()
   if (originalBin === undefined) delete process.env.METRORA_BIN
   else process.env.METRORA_BIN = originalBin
   if (originalPathDirs === undefined) delete process.env.METRORA_PATH_DIRS
@@ -340,6 +342,109 @@ describe('spawnCli', () => {
   it('rejects with kind "too-large" and kills a binary that floods stdout', async () => {
     fakeBin('flood.js', "const s='x'.repeat(1024*1024); for(let i=0;i<20;i++) process.stdout.write(s); setInterval(()=>{},1000)")
     await expect(spawnCli(['status'])).rejects.toMatchObject({ kind: 'too-large' } satisfies Partial<CliError>)
+  })
+})
+
+describe('bounded process watchdog', () => {
+  function heartbeatScript(lines: string[], intervalMs = 15): string {
+    return [
+      'const lines = ' + JSON.stringify(lines) + ';',
+      'let i = 0;',
+      'const timer = setInterval(() => {',
+      "  if (i < lines.length) process.stderr.write(lines[i++] + '\\n');",
+      '  else { clearInterval(timer); process.stdout.write(JSON.stringify({ ok: 1 })); process.exit(0); }',
+      '}, ' + intervalMs + ');',
+    ].join('\n')
+  }
+
+  it('accepts split valid progress heartbeats without extending the absolute ceiling', async () => {
+    const seen: unknown[] = []
+    const lines = [
+      'METRORA_PROGRESS {"kind":"providers","providers":["claude"]}',
+      'METRORA_PROGRESS {"kind":"provider","provider":"claude","state":"done","files":3}',
+      'METRORA_PROGRESS {"kind":"provider","provider":"claude","state":"start"}',
+      'METRORA_PROGRESS {"kind":"tick","provider":"claude","done":1,"total":3}',
+      'METRORA_PROGRESS {"kind":"tick","provider":"claude","done":2,"total":3}',
+      'METRORA_PROGRESS {"kind":"provider","provider":"claude","state":"done","files":3}',
+    ]
+    fakeBin('valid-heartbeat.cjs', heartbeatScript(lines, 15))
+    const result = await spawnCli(['status'], {
+      timeoutMs: 500,
+      idleTimeoutMs: 70,
+      onProgress: event => seen.push(event),
+    })
+    expect(result).toEqual({ ok: 1 })
+    expect(seen).toHaveLength(5)
+  })
+
+  it('does not treat raw stderr chatter as progress', async () => {
+    fakeBin('raw-chatter.cjs', "setInterval(() => process.stderr.write('raw chatter\\n'), 10)")
+    await expect(spawnCli(['status'], { timeoutMs: 500, idleTimeoutMs: 70 })).rejects.toMatchObject({ kind: 'timeout' })
+  })
+
+  it('does not treat malformed, fake, or decreasing heartbeats as progress', async () => {
+    const lines = [
+      'METRORA_PROGRESS {"kind":"providers","providers":["claude"]}',
+      'METRORA_PROGRESS {"kind":"provider","provider":"claude","state":"done","files":3}',
+      'METRORA_PROGRESS {"kind":"provider","provider":"claude","state":"start"}',
+      'METRORA_PROGRESS {"kind":"tick","provider":"claude","done":1,"total":3}',
+      'METRORA_PROGRESS nope',
+      'METRORA_PROGRESS {"kind":"tick","provider":"claude","done":1,"total":3}',
+      'METRORA_PROGRESS {"kind":"tick","provider":"claude","done":0,"total":3}',
+      'METRORA_PROGRESS {"kind":"tick","provider":"other","done":999,"total":999}',
+    ]
+    const fakeScript = [
+      'const lines = ' + JSON.stringify(lines) + '; let i = 0;',
+      "setInterval(() => { if (i < lines.length) process.stderr.write(lines[i++] + '\\n'); else process.stderr.write('still noisy\\n'); }, 10);",
+    ].join('\n')
+    fakeBin('fake-heartbeat.cjs', fakeScript)
+    await expect(spawnCli(['status'], { timeoutMs: 500, idleTimeoutMs: 70 })).rejects.toMatchObject({ kind: 'timeout' })
+  })
+
+  it('enforces the absolute runtime ceiling even with valid monotonic ticks', async () => {
+    fakeBin('absolute-ceiling.cjs', [
+      "let done = 0;",
+      "process.stderr.write('METRORA_PROGRESS {\"kind\":\"providers\",\"providers\":[\"claude\"]}\\n');",
+      "process.stderr.write('METRORA_PROGRESS {\"kind\":\"provider\",\"provider\":\"claude\",\"state\":\"start\"}\\n');",
+      "setInterval(() => { done += 1; process.stderr.write('METRORA_PROGRESS ' + JSON.stringify({ kind: 'tick', provider: 'claude', done, total: 10000 }) + '\\n'); }, 10);",
+    ].join("\n"))
+    await expect(spawnCli(['status'], { timeoutMs: 170, idleTimeoutMs: 50 })).rejects.toMatchObject({ kind: 'timeout' })
+  })
+
+  it('uses bounded SIGTERM grace and hard-kill fallback for responsive and ignoring children', async () => {
+    fakeBin('term-responsive.cjs', "process.on('SIGTERM', () => process.exit(0)); setInterval(() => {}, 1000)")
+    const responsiveStarted = Date.now()
+    await expect(spawnCli(['status'], { timeoutMs: 60 })).rejects.toMatchObject({ kind: 'timeout' })
+    expect(Date.now() - responsiveStarted).toBeLessThan(1500)
+
+    fakeBin('term-ignoring.cjs', "process.on('SIGTERM', () => {}); setInterval(() => {}, 1000)")
+    const ignoringStarted = Date.now()
+    await expect(spawnCli(['status'], { timeoutMs: 60 })).rejects.toMatchObject({ kind: 'timeout' })
+    expect(Date.now() - ignoringStarted).toBeLessThan(2000)
+  })
+
+  it('marks timed-out and oversized mutations as indeterminate while bounding returned output', async () => {
+    fakeBin('action-flood.cjs', "const s = 'x'.repeat(1024 * 1024); for (let i = 0; i < 20; i++) process.stdout.write(s); setInterval(() => {}, 1000)")
+    const oversized = await spawnCliAction(['currency', 'EUR'])
+    expect(oversized).toMatchObject({ ok: false, code: null, indeterminate: true })
+    expect(oversized.stdout.length).toBeLessThanOrEqual(16 * 1024 * 1024)
+    expect(oversized.stderr.length).toBeLessThanOrEqual(16 * 1024 * 1024)
+
+    fakeBin('action-timeout.cjs', "setInterval(() => {}, 1000)")
+    const timedOut = await spawnCliAction(['currency', 'EUR'], { timeoutMs: 60 })
+    expect(timedOut).toMatchObject({ ok: false, code: null, indeterminate: true })
+  })
+
+  it('does not resurrect a reserved child after terminal shutdown', async () => {
+    const startedFile = join(dir, 'shutdown-started')
+    fakeBin('shutdown-race.cjs', "require('fs').writeFileSync(" + JSON.stringify(startedFile) + ", 'started'); process.stdout.write(JSON.stringify({ ok: 1 }))")
+    const read = spawnCli(['status'])
+    const action = spawnCliAction(['currency', 'EUR'])
+    shutdownCli()
+
+    await expect(read).rejects.toMatchObject({ kind: 'nonzero' })
+    await expect(action).resolves.toMatchObject({ ok: false, code: null })
+    expect(() => readFileSync(startedFile, 'utf8')).toThrow()
   })
 })
 

--- a/app/electron/cli.ts
+++ b/app/electron/cli.ts
@@ -1,4 +1,9 @@
-import { spawn, type ChildProcess } from 'node:child_process'
+import {
+  cancelAllBoundedProcesses,
+  DEFAULT_MAX_OUTPUT_BYTES,
+  runBoundedProcess,
+  type TrustedProgressEvent,
+} from './cli-watchdog'
 import { accessSync, constants, readdirSync, statSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { delimiter, dirname, isAbsolute, join } from 'node:path'
@@ -13,7 +18,7 @@ import {
 // not import Electron so it remains testable in plain Node.
 
 export type CliErrorKind = 'not-found' | 'nonzero' | 'bad-json' | 'timeout' | 'too-large' | 'bad-args'
-export type ActionResult = { ok: boolean; stdout: string; stderr: string; code: number | null }
+export type ActionResult = { ok: boolean; stdout: string; stderr: string; code: number | null; indeterminate?: boolean }
 export type SpawnPriority = 'interactive' | 'background'
 export type CliTarget = { kind: 'external'; bin: string } | { kind: 'bundled'; entry: string }
 type SpawnSpec = { bin: string; args: string[]; env: NodeJS.ProcessEnv }
@@ -39,31 +44,34 @@ export class CliError extends Error {
 }
 
 const DEFAULT_TIMEOUT_MS = 45_000
-const MAX_OUTPUT_BYTES = 16 * 1024 * 1024
+const MAX_OUTPUT_BYTES = DEFAULT_MAX_OUTPUT_BYTES
 const COALESCE_TTL_MS = 5_000
 const MAX_CONCURRENT_CLI = 2
 
-const activeChildren = new Set<ChildProcess>()
 const readInflight = new Map<string, Promise<unknown>>()
 const readCache = new Map<string, { at: number; value: unknown }>()
 
-type SlotWaiter = { resolve: () => void; reject: (err: unknown) => void }
+type SlotWaiter = { resolve: (epoch: number) => void; reject: (err: unknown) => void; epoch: number }
 let running = 0
+let cancellationEpoch = 0
 const interactiveQueue: SlotWaiter[] = []
 const backgroundQueue: SlotWaiter[] = []
+let shutdownRequested = false
 
 function pumpSlots(): void {
   while (running < MAX_CONCURRENT_CLI) {
     const waiter = interactiveQueue.shift() ?? backgroundQueue.shift()
     if (!waiter) return
     running += 1
-    waiter.resolve()
+    waiter.resolve(waiter.epoch)
   }
 }
 
-function acquireSlot(priority: SpawnPriority): Promise<void> {
-  return new Promise<void>((resolve, reject) => {
-    ;(priority === 'background' ? backgroundQueue : interactiveQueue).push({ resolve, reject })
+function acquireSlot(priority: SpawnPriority): Promise<number> {
+  if (shutdownRequested) return Promise.reject(new CliError('nonzero', 'Metrora is shutting down'))
+  const epoch = cancellationEpoch
+  return new Promise<number>((resolve, reject) => {
+    ;(priority === 'background' ? backgroundQueue : interactiveQueue).push({ resolve, reject, epoch })
     pumpSlots()
   })
 }
@@ -73,16 +81,27 @@ function releaseSlot(): void {
   pumpSlots()
 }
 
-/** Reap running children and reject queued work during desktop shutdown. */
+/** Reap owned children and reject queued work during desktop shutdown. */
 export function killAll(): void {
-  for (const child of activeChildren) child.kill('SIGKILL')
-  activeChildren.clear()
+  cancellationEpoch += 1
+  cancelAllBoundedProcesses()
 
   const waiting = [...interactiveQueue, ...backgroundQueue]
   interactiveQueue.length = 0
   backgroundQueue.length = 0
   running = 0
   for (const waiter of waiting) waiter.reject(new CliError('nonzero', 'Metrora cancelled'))
+}
+
+/** Production before-quit entry point: cancellation is terminal for this app process. */
+export function shutdownCli(): void {
+  shutdownRequested = true
+  killAll()
+}
+
+/** Test-only reset for isolated renderer/main-process fixtures. */
+export function resetCliShutdownForTests(): void {
+  shutdownRequested = false
 }
 
 function isExecutableFile(path: string): boolean {
@@ -246,78 +265,36 @@ function runCli(
   cmdLabel: string,
   timeoutMs: number,
   onStderr?: (chunk: string) => void,
+  idleTimeoutMs?: number,
+  onProgress?: (event: TrustedProgressEvent) => void,
 ): Promise<unknown> {
-  return new Promise<unknown>((resolve, reject) => {
-    const child = spawn(spec.bin, spec.args, {
-      shell: false,
-      stdio: ['ignore', 'pipe', 'pipe'],
-      env: spec.env,
-    })
-    activeChildren.add(child)
-
-    let stdout = ''
-    let stderr = ''
-    let total = 0
-    let settled = false
-
-    const finish = (fn: () => void): void => {
-      if (settled) return
-      settled = true
-      clearTimeout(timer)
-      activeChildren.delete(child)
-      fn()
+  return runBoundedProcess(spec, {
+    absoluteTimeoutMs: timeoutMs,
+    idleTimeoutMs,
+    maxOutputBytes: MAX_OUTPUT_BYTES,
+    onStderr,
+    onProgress,
+  }).then(result => {
+    if (result.reason === 'timeout') {
+      throw new CliError('timeout', `Metrora ${cmdLabel} timed out after ${timeoutMs}ms`)
     }
-
-    const timer = setTimeout(() => {
-      finish(() => {
-        child.kill('SIGKILL')
-        reject(new CliError('timeout', `Metrora ${cmdLabel} timed out after ${timeoutMs}ms`))
-      })
-    }, timeoutMs)
-
-    const bump = (bytes: number): void => {
-      total += bytes
-      if (total > MAX_OUTPUT_BYTES) {
-        finish(() => {
-          child.kill('SIGKILL')
-          reject(new CliError('too-large', `Metrora ${cmdLabel} produced more than ${MAX_OUTPUT_BYTES} bytes`))
-        })
-      }
+    if (result.reason === 'too-large') {
+      throw new CliError('too-large', `Metrora ${cmdLabel} produced more than ${MAX_OUTPUT_BYTES} bytes`)
     }
-
-    child.stdout.on('data', chunk => {
-      stdout += chunk
-      bump(chunk.length)
-    })
-    child.stderr.on('data', chunk => {
-      stderr += chunk
-      bump(chunk.length)
-      if (onStderr) {
-        try {
-          onStderr(chunk.toString())
-        } catch {
-          // A progress listener must never terminate the read.
-        }
-      }
-    })
-
-    child.on('error', error => {
-      finish(() => reject(new CliError('not-found', error.message, 'spawn-error')))
-    })
-
-    child.on('close', code => {
-      finish(() => {
-        if (code !== 0) {
-          reject(new CliError('nonzero', stderr.trim() || `Metrora exited with code ${code}`))
-          return
-        }
-        try {
-          resolve(JSON.parse(stdout))
-        } catch {
-          reject(new CliError('bad-json', 'Metrora produced output that was not valid JSON'))
-        }
-      })
-    })
+    if (result.reason === 'cancelled') {
+      throw new CliError('nonzero', 'Metrora cancelled')
+    }
+    if (result.error) {
+      throw new CliError('not-found', result.error.message, 'spawn-error')
+    }
+    if (result.code !== 0) {
+      throw new CliError('nonzero', result.stderr.trim() || `Metrora exited with code ${result.code ?? 'unknown'}`)
+    }
+    try {
+      return JSON.parse(result.stdout)
+    } catch {
+      throw new CliError('bad-json', 'Metrora produced output that was not valid JSON')
+    }
   })
 }
 
@@ -326,11 +303,16 @@ export function spawnCli(
   args: string[],
   opts: {
     timeoutMs?: number
+    idleTimeoutMs?: number
     onStderr?: (chunk: string) => void
+    onProgress?: (event: TrustedProgressEvent) => void
     extraEnv?: NodeJS.ProcessEnv
     priority?: SpawnPriority
   } = {},
 ): Promise<unknown> {
+  if (shutdownRequested) {
+    return Promise.reject(new CliError('nonzero', 'Metrora is shutting down'))
+  }
   const target = resolveTarget()
   if (!target) {
     return Promise.reject(new CliError('not-found', 'Metrora CLI not found', notFoundStage()))
@@ -346,7 +328,7 @@ export function spawnCli(
   const envKey = Object.entries(opts.extraEnv ?? {})
     .filter((entry): entry is [string, string] => entry[1] !== undefined)
     .sort(([a], [b]) => a.localeCompare(b))
-  const key = JSON.stringify([spec.bin, ...spec.args, envKey])
+  const key = JSON.stringify([spec.bin, ...spec.args, envKey, opts.timeoutMs ?? null, opts.idleTimeoutMs ?? null, Boolean(opts.onStderr), Boolean(opts.onProgress)])
   const cached = readCache.get(key)
   if (cached && Date.now() - cached.at < COALESCE_TTL_MS) return Promise.resolve(cached.value)
 
@@ -355,9 +337,11 @@ export function spawnCli(
 
   const priority = opts.priority ?? 'interactive'
   const flight = (async () => {
-    await acquireSlot(priority)
+    const reservation = await acquireSlot(priority)
     try {
-      return await runCli(spec, args[0] ?? '', opts.timeoutMs ?? DEFAULT_TIMEOUT_MS, opts.onStderr)
+      if (shutdownRequested) throw new CliError('nonzero', 'Metrora is shutting down')
+      if (reservation !== cancellationEpoch) throw new CliError('nonzero', 'Metrora cancelled')
+      return await runCli(spec, args[0] ?? '', opts.timeoutMs ?? DEFAULT_TIMEOUT_MS, opts.onStderr, opts.idleTimeoutMs, opts.onProgress)
     } finally {
       releaseSlot()
     }
@@ -380,6 +364,9 @@ export function spawnCliAction(
   opts: { timeoutMs?: number } = {},
 ): Promise<ActionResult> {
   const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS
+  if (shutdownRequested) {
+    return Promise.resolve({ ok: false, stdout: '', stderr: 'Metrora is shutting down', code: null })
+  }
   const target = resolveTarget()
   if (!target) {
     return Promise.resolve({ ok: false, stdout: '', stderr: 'Metrora CLI not found', code: null })
@@ -387,13 +374,17 @@ export function spawnCliAction(
 
   const spec = spawnSpecFor(target, args)
   return (async () => {
+    let reservation: number
     try {
-      await acquireSlot('interactive')
+      reservation = await acquireSlot('interactive')
     } catch {
       return { ok: false, stdout: '', stderr: 'Metrora cancelled', code: null }
     }
 
     try {
+      if (shutdownRequested || reservation !== cancellationEpoch) {
+        return { ok: false, stdout: '', stderr: shutdownRequested ? 'Metrora is shutting down' : 'Metrora cancelled', code: null }
+      }
       return await runAction(spec, args, timeoutMs)
     } finally {
       releaseSlot()
@@ -402,44 +393,42 @@ export function spawnCliAction(
 }
 
 function runAction(spec: SpawnSpec, args: string[], timeoutMs: number): Promise<ActionResult> {
-  return new Promise<ActionResult>(resolve => {
-    const child = spawn(spec.bin, spec.args, {
-      shell: false,
-      stdio: ['ignore', 'pipe', 'pipe'],
-      env: spec.env,
-    })
-    activeChildren.add(child)
+  return runBoundedProcess(spec, {
+    absoluteTimeoutMs: timeoutMs,
+    maxOutputBytes: MAX_OUTPUT_BYTES,
+  }).then(result => {
+    readCache.clear()
 
-    let stdout = ''
-    let stderr = ''
-    let settled = false
-
-    const finish = (result: ActionResult): void => {
-      if (settled) return
-      settled = true
-      clearTimeout(timer)
-      activeChildren.delete(child)
-      readCache.clear()
-      resolve(result)
-    }
-
-    const timer = setTimeout(() => {
-      child.kill('SIGKILL')
-      finish({
+    if (result.reason === 'timeout') {
+      return {
         ok: false,
-        stdout,
+        stdout: result.stdout,
         stderr: `Metrora ${args[0] ?? ''} timed out after ${timeoutMs}ms`,
         code: null,
-      })
-    }, timeoutMs)
-
-    child.stdout.on('data', chunk => {
-      stdout += chunk
-    })
-    child.stderr.on('data', chunk => {
-      stderr += chunk
-    })
-    child.on('error', error => finish({ ok: false, stdout, stderr: error.message, code: null }))
-    child.on('close', code => finish({ ok: code === 0, stdout, stderr, code }))
+        indeterminate: true,
+      }
+    }
+    if (result.reason === 'too-large') {
+      return {
+        ok: false,
+        stdout: result.stdout,
+        stderr: `Metrora ${args[0] ?? ''} exceeded the bounded output limit`,
+        code: null,
+        indeterminate: true,
+      }
+    }
+    if (result.reason === 'cancelled') {
+      return {
+        ok: false,
+        stdout: result.stdout,
+        stderr: `Metrora ${args[0] ?? ''} was cancelled; completion is indeterminate`,
+        code: null,
+        indeterminate: true,
+      }
+    }
+    if (result.error) {
+      return { ok: false, stdout: result.stdout, stderr: result.error.message, code: null }
+    }
+    return { ok: result.code === 0, stdout: result.stdout, stderr: result.stderr, code: result.code }
   })
 }

--- a/app/electron/main.test.ts
+++ b/app/electron/main.test.ts
@@ -496,8 +496,10 @@ describe('createBridgeHandlers (snapshot reads and explicit refresh)', () => {
 
     await handlers['metrora:getOverview']!('30days', 'all', undefined, undefined, false, true)
     expect(opts[1]?.timeoutMs).toBe(10 * 60_000)
+    expect(opts[1]?.idleTimeoutMs).toBe(45_000)
     expect((opts[1]?.extraEnv as Record<string, string> | undefined)?.METRORA_PROGRESS).toBe('1')
     expect(typeof opts[1]?.onStderr).toBe('function')
+    expect(typeof opts[1]?.onProgress).toBe('function')
     expect(emitProgress).toHaveBeenCalledWith({ kind: 'done' })
   })
 

--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -1,7 +1,8 @@
 import { app, BrowserWindow, dialog, ipcMain, Menu, nativeTheme, shell } from 'electron'
 import path from 'node:path'
 
-import { CliError, killAll, resolveMetroraPath, spawnCli, spawnCliAction, type ActionResult, type SpawnPriority } from './cli'
+import { CliError, resolveMetroraPath, shutdownCli, spawnCli, spawnCliAction, type ActionResult, type SpawnPriority } from './cli'
+import type { TrustedProgressEvent } from './cli-watchdog'
 import { createApplicationMenuTemplate } from './menu'
 import { getQuota, sanitizeError } from './quota'
 import { sanitizeQuotaProviders } from './quota/types'
@@ -89,6 +90,8 @@ export type Envelope<T = unknown> = { ok: true; value: T } | { ok: false; error:
 // once it succeeds. Sections gate their own first poll on this one resolving so
 // the cold hydration runs ONCE, not once per section in parallel.
 const WARMUP_TIMEOUT_MS = 10 * 60_000
+// A valid monotonic parser heartbeat may extend idle time, never this ceiling.
+const PROGRESS_IDLE_TIMEOUT_MS = 45_000
 // Wire marker for CLI scan-progress lines (src/parser.ts: PROGRESS_LINE_PREFIX).
 const PROGRESS_LINE_PREFIX = 'METRORA_PROGRESS '
 // IPC channel carrying cold-start scan-progress events to the splash.
@@ -227,7 +230,7 @@ function cliErrorProps(err: unknown, cmd: string | undefined): Record<string, un
 }
 
 type Deps = {
-  spawnCli: (args: string[], opts?: { timeoutMs?: number; onStderr?: (chunk: string) => void; extraEnv?: NodeJS.ProcessEnv; priority?: SpawnPriority }) => Promise<unknown>
+  spawnCli: (args: string[], opts?: { timeoutMs?: number; idleTimeoutMs?: number; onStderr?: (chunk: string) => void; onProgress?: (event: TrustedProgressEvent) => void; extraEnv?: NodeJS.ProcessEnv; priority?: SpawnPriority }) => Promise<unknown>
   spawnCliAction: (args: string[], opts?: { timeoutMs?: number }) => Promise<ActionResult>
   resolveMetroraPath: () => string | null
   getQuota: typeof getQuota
@@ -298,6 +301,8 @@ export function createBridgeHandlers(deps: Deps = { spawnCli, spawnCliAction, re
       }
       const value = await deps.spawnCli(args, {
         timeoutMs: WARMUP_TIMEOUT_MS,
+        idleTimeoutMs: PROGRESS_IDLE_TIMEOUT_MS,
+        onProgress: () => {},
         extraEnv: { METRORA_PROGRESS: '1' },
         onStderr: makeProgressReader(emitProgress),
         ...(priority ? { priority } : {}),
@@ -535,7 +540,7 @@ function bootstrap(): void {
 
   app.on('before-quit', createBeforeQuitHandler({
     getTelemetry: () => telemetryInstance,
-    killAll,
+    killAll: shutdownCli,
     stopShare: stopDesktopShareRuntime,
     quit: () => app.quit(),
   }))


### PR DESCRIPTION
## Summary
- Add the Electron provider progress watchdog with separate absolute and idle timeouts.
- Use trusted monotonic progress parsing, bounded output, graceful termination, and process ownership.
- Preserve queue shutdown epochs, mutation indeterminate/cache invalidation, and Windows process-tree semantics.

## Boundaries
- Architecture: Electron CLI/watchdog and queue lifecycle only; no unrelated provider changes.
- Public Identity: Metrora-owned progress and failure semantics remain authoritative.
- Brand Boundary: no CodeBurn competitive internals or upstream cursor changes.

## Validation
- Reviewed head: `0e49c14d1044d44e04d5a9bb292fa4f4bf730726`
- Base: `main` at `ce02827d7b95282beb6d9779035cd14764c8be3f`
- Focused Electron evidence: 2 files / 137 tests passed.
- Targeted TypeScript validation passed; full app suite was unavailable locally because isolated Electron/Vite dependencies are absent.
- Independent review: PASS.
- Architecture boundaries: success.
- Metrora Public Identity: success.
- Metrora Brand Boundary: success.
- Metrora CI: success (run `32708165323`).
- Windows Candidate: skipped; Windows watchdog semantics are covered by `WINDOWS_PROCESS_TREE_V1_1`.