### PR TITLE
feat(doctor): add provider probe roots

### DIFF
--- a/docs/ADVISOR_PUBLIC_FOUNDATION.md
+++ b/docs/ADVISOR_PUBLIC_FOUNDATION.md
@@ -37,6 +37,8 @@ The implemented local transport targets the official Ollama local HTTP API. Mode
 - cancellation uses an AbortController in main and a request id in the bridge;
 - timeouts, message/content/response byte caps, stream chunk caps, malformed-chunk caps, and bounded redacted errors are enforced.
 
+Metrora owns the final privacy boundary: model narrative is bounded and sanitized before it enters the public Advisor answer, and raw model deltas are not forwarded to the renderer. Unsafe narrative is dropped while deterministic evidence remains available. Tool-facing results stay content-minimal, so a model cannot turn unrestricted paths, source content, prompts, secrets or internal identifiers into an answer through an unreviewed output channel.
+
 Ollama support is model-dependent: a discovered model is not automatically evidence that its tool-calling behavior is capable. The UI says that capability varies by model. The deterministic local runtime remains an explicit offline fallback when no local model is connected; it is not presented as a full free-form chatbot.
 
 No provider SDK or new runtime dependency is required. LM Studio and hosted/cloud BYOK adapters are follow-up work until their Electron boundary, model capability, cancellation, and privacy behavior are proven.

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -74,6 +74,8 @@ metrora compare --provider claude
 metrora optimize --apply --dry-run
 ```
 
+`metrora doctor` is read-only and bounded. It reports source families as explicit states such as `PRESENT`, `PRESENT_EMPTY`, `MISSING`, `INACCESSIBLE`, `MALFORMED`, `UNSUPPORTED_VARIANT` or `UNKNOWN`, with paths redacted. Current root diagnostics include Codebuff/Manicode channel roots (or `CODEBUFF_DATA_DIR`), Gemini `~/.gemini/tmp`, and Mistral Vibe `VIBE_HOME/logs/session` or `~/.vibe/logs/session`; Doctor does not authenticate, refresh credentials, create files or modify provider state.
+
 Experimental commands label heuristic or incomplete methodology explicitly. Their output should not be presented as stronger evidence than the source permits.
 
 ## Bench and local runtime evidence

--- a/docs/providers/hermes.md
+++ b/docs/providers/hermes.md
@@ -53,6 +53,8 @@ Terminal command arguments are exposed as `bashCommands` for Metrora's command b
 
 The shared session cache fingerprints Hermes state DB files. `HERMES_HOME` is included in the provider environment fingerprint so changing the runtime home invalidates stale cached results.
 
+To preserve growth from cumulative sessions across refreshes, Metrora maintains a bounded, Metrora-owned observation sidecar at `<Metrora cache>/hermes/v1/observation-ledger.json`. The JSON state is versioned, atomically published, private, content-digested and replay-safe; it stores bounded counter snapshots and deltas rather than prompts, responses or source code. Counter resets or source replacement start a bounded new epoch and never emit negative usage. If authoritative actual cost arrives after estimated or calculated evidence, the parser emits an explicit correction channel instead of adding actual cost to the earlier estimate.
+
 ## Pricing evidence
 
 `actual_cost_usd` is bound as client-metered evidence when present, including

--- a/src/doctor-source-diagnostics.ts
+++ b/src/doctor-source-diagnostics.ts
@@ -1,5 +1,5 @@
 import { statSync } from 'node:fs'
-import { lstat, open, readdir, readFile } from 'node:fs/promises'
+import { lstat, open, opendir, readFile } from 'node:fs/promises'
 import { homedir } from 'node:os'
 import { delimiter as pathDelimiter, join } from 'node:path'
 
@@ -160,11 +160,26 @@ export function redactText(value: string): string {
     .replace(/(^|[\s("'])\/[^"'\n]*/g, '$1<redacted-path>')
 }
 
+async function readBoundedDirectoryEntries(path: string): Promise<string[]> {
+  const directory = await opendir(path)
+  const entries: string[] = []
+  try {
+    while (entries.length < MAX_DIRECTORY_ENTRIES) {
+      const entry = await directory.read()
+      if (!entry) break
+      entries.push(entry.name)
+    }
+    return entries
+  } finally {
+    await directory.close().catch(() => {})
+  }
+}
+
 export async function inspectPath(path: string): Promise<DoctorPathProbe> {
   try {
     const info = await lstat(path)
     if (info.isDirectory()) {
-      const entries = await readdir(path)
+      const entries = await readBoundedDirectoryEntries(path)
       return entries.length === 0
         ? { state: 'PRESENT_EMPTY', reason: 'directory is readable but has no entries', entries }
         : { state: 'PRESENT', reason: 'directory is readable', entries: entries.slice(0, MAX_DIRECTORY_ENTRIES) }
@@ -184,7 +199,7 @@ async function readDirectory(path: string): Promise<DoctorPathProbe> {
   try {
     const info = await lstat(path)
     if (!info.isDirectory()) return { state: 'UNSUPPORTED_VARIANT', reason: 'expected a directory' }
-    const entries = await readdir(path)
+    const entries = await readBoundedDirectoryEntries(path)
     return entries.length === 0
       ? { state: 'PRESENT_EMPTY', reason: 'directory is readable but has no supported sources', entries }
       : { state: 'PRESENT', reason: 'directory is readable', entries: entries.slice(0, MAX_DIRECTORY_ENTRIES) }

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -340,11 +340,11 @@ export async function collectDoctorReport(
     const cache = opts.cache ?? await loadCache()
     const sampleLimit = opts.sampleLimit ?? DEFAULT_SAMPLE_LIMIT
 
-  // Doctor promises to be strictly read-only, but sample-parsing drives real
-  // provider parsers, and cursor's writes its results cache to disk before its
-  // first yield. The flag tells cache writers to stand down for this process
-  // while doctor collects; restored afterwards so long-lived embedders (tests,
-  // MCP) keep normal behavior.
+    // Doctor promises to be strictly read-only, but sample-parsing drives real
+    // provider parsers, and cursor's writes its results cache to disk before its
+    // first yield. The flag tells cache writers to stand down for this process
+    // while doctor collects; restored afterwards so long-lived embedders (tests,
+    // MCP) keep normal behavior.
     const providers: DoctorProviderReport[] = []
     for (const provider of filtered) {
       providers.push(await collectOneProvider(provider, cache, sampleLimit))

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -330,21 +330,21 @@ export async function collectDoctorReport(
   providerFilter?: string,
   opts: CollectDoctorOptions = {},
 ): Promise<DoctorReport> {
-  const all = opts.providers ?? await getAllProviders()
-  const filtered = providerFilter && providerFilter !== 'all'
-    ? all.filter(p => p.name === providerFilter)
-    : all
-  const cache = opts.cache ?? await loadCache()
-  const sampleLimit = opts.sampleLimit ?? DEFAULT_SAMPLE_LIMIT
+  const prevSuppress = process.env['METRORA_SUPPRESS_CACHE_WRITES']
+  process.env['METRORA_SUPPRESS_CACHE_WRITES'] = '1'
+  try {
+    const all = opts.providers ?? await getAllProviders()
+    const filtered = providerFilter && providerFilter !== 'all'
+      ? all.filter(p => p.name === providerFilter)
+      : all
+    const cache = opts.cache ?? await loadCache()
+    const sampleLimit = opts.sampleLimit ?? DEFAULT_SAMPLE_LIMIT
 
   // Doctor promises to be strictly read-only, but sample-parsing drives real
   // provider parsers, and cursor's writes its results cache to disk before its
   // first yield. The flag tells cache writers to stand down for this process
   // while doctor collects; restored afterwards so long-lived embedders (tests,
   // MCP) keep normal behavior.
-  const prevSuppress = process.env['METRORA_SUPPRESS_CACHE_WRITES']
-  process.env['METRORA_SUPPRESS_CACHE_WRITES'] = '1'
-  try {
     const providers: DoctorProviderReport[] = []
     for (const provider of filtered) {
       providers.push(await collectOneProvider(provider, cache, sampleLimit))

--- a/src/providers/codebuff.ts
+++ b/src/providers/codebuff.ts
@@ -4,7 +4,7 @@ import { homedir } from 'os'
 
 import { calculateCost } from '../models.js'
 import { extractBashCommands } from '../bash-utils.js'
-import type { Provider, SessionSource, SessionParser, ParsedProviderCall } from './types.js'
+import type { Provider, SessionSource, SessionParser, ParsedProviderCall, ProbeRoot } from './types.js'
 
 // Codebuff (formerly Manicode) uses a credit-based billing system. The local
 // chat-messages.json doesn't record per-call token counts the way Claude Code
@@ -432,6 +432,16 @@ function createParser(source: SessionSource, seenKeys: Set<string>): SessionPars
   }
 }
 
+function codebuffProbeRoots(baseDir: string): ProbeRoot[] {
+  const defaultBaseDir = join(homedir(), '.config', 'manicode')
+  if (process.env['CODEBUFF_DATA_DIR'] || baseDir !== defaultBaseDir) {
+    return [{ path: baseDir, label: 'data' }]
+  }
+
+  const configDir = join(homedir(), '.config')
+  return CHANNELS.map(channel => ({ path: join(configDir, channel), label: channel }))
+}
+
 export function createCodebuffProvider(baseDir?: string): Provider {
   const dir = getCodebuffBaseDir(baseDir)
 
@@ -449,6 +459,10 @@ export function createCodebuffProvider(baseDir?: string): Provider {
 
     async discoverSessions(): Promise<SessionSource[]> {
       return discoverSessionsInBase(dir)
+    },
+
+    async probeRoots(): Promise<ProbeRoot[]> {
+      return codebuffProbeRoots(dir)
     },
 
     createSessionParser(source: SessionSource, seenKeys: Set<string>): SessionParser {

--- a/src/providers/gemini.ts
+++ b/src/providers/gemini.ts
@@ -5,7 +5,7 @@ import { homedir } from 'os'
 import { readSessionFile } from '../fs-utils.js'
 import { calculateCost } from '../models.js'
 import { extractBashCommands } from '../bash-utils.js'
-import type { Provider, SessionSource, SessionParser, ParsedProviderCall } from './types.js'
+import type { Provider, SessionSource, SessionParser, ParsedProviderCall, ProbeRoot } from './types.js'
 
 /** Bump whenever unchanged Gemini session files must be re-reviewed for sharing. */
 export const GEMINI_PARSER_VERSION = 'message-token-ledger-v1'
@@ -277,6 +277,10 @@ export function createGeminiProvider(): Provider {
 
     async discoverSessions(): Promise<SessionSource[]> {
       return discoverSessions()
+    },
+
+    async probeRoots(): Promise<ProbeRoot[]> {
+      return [{ path: getGeminiTmpDir(), label: 'tmp' }]
     },
 
     createSessionParser(source: SessionSource, seenKeys: Set<string>): SessionParser {

--- a/src/providers/mistral-vibe.ts
+++ b/src/providers/mistral-vibe.ts
@@ -6,7 +6,7 @@ import { readSessionFile, readSessionLines } from '../fs-utils.js'
 import { normalizeExplicitModelProvider } from '../model-provider.js'
 import { calculateCost } from '../models.js'
 import { extractBashCommands } from '../bash-utils.js'
-import type { Provider, SessionSource, SessionParser, ParsedProviderCall } from './types.js'
+import type { Provider, SessionSource, SessionParser, ParsedProviderCall, ProbeRoot } from './types.js'
 import { safeNumber } from '../parser.js'
 
 const METADATA_FILENAME = 'meta.json'
@@ -433,6 +433,10 @@ export function createMistralVibeProvider(sessionsDir?: string): Provider {
       }
 
       return sources
+    },
+
+    async probeRoots(): Promise<ProbeRoot[]> {
+      return [{ path: dir, label: 'session' }]
     },
 
     createSessionParser(source: SessionSource, seenKeys: Set<string>): SessionParser {

--- a/src/session-cache.ts
+++ b/src/session-cache.ts
@@ -417,11 +417,7 @@ async function adoptLegacyCache(): Promise<SessionCache> {
     const raw = await readFile(getLegacyCachePath(), 'utf-8')
     const parsed = JSON.parse(raw)
     if (!isValidCache(parsed)) return emptyCache()
-    // Doctor may load a legacy cache only to report provider health. Preserve
-    // the read-only contract by returning the validated payload without minting
-    // the current versioned file during that diagnostic pass.
-    if (process.env['METRORA_SUPPRESS_CACHE_WRITES']) return parsed
-    await saveCache(parsed).catch(() => {})
+    if (!process.env['METRORA_SUPPRESS_CACHE_WRITES']) await saveCache(parsed).catch(() => {})
     return parsed
   } catch {
     return emptyCache()

--- a/src/session-cache.ts
+++ b/src/session-cache.ts
@@ -417,6 +417,10 @@ async function adoptLegacyCache(): Promise<SessionCache> {
     const raw = await readFile(getLegacyCachePath(), 'utf-8')
     const parsed = JSON.parse(raw)
     if (!isValidCache(parsed)) return emptyCache()
+    // Doctor may load a legacy cache only to report provider health. Preserve
+    // the read-only contract by returning the validated payload without minting
+    // the current versioned file during that diagnostic pass.
+    if (process.env['METRORA_SUPPRESS_CACHE_WRITES']) return parsed
     await saveCache(parsed).catch(() => {})
     return parsed
   } catch {

--- a/tests/doctor-bounded-sources.test.ts
+++ b/tests/doctor-bounded-sources.test.ts
@@ -7,6 +7,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { collectDoctorReport, renderDoctorJson, renderDoctorTable } from '../src/doctor.js'
 import { classifyDoctorError, DOCTOR_SOURCE_STATES, redactOverridePath, redactText } from '../src/doctor-source-diagnostics.js'
 import { getCopilotDoctorProbeRoots } from '../src/providers/copilot-paths.js'
+import { createCodebuffProvider } from '../src/providers/codebuff.js'
+import { createMistralVibeProvider } from '../src/providers/mistral-vibe.js'
 import { createCopilotProvider } from '../src/providers/copilot.js'
 import { getCursorDoctorProbeRoots, getCursorWorkspaceStorageDir } from '../src/providers/cursor-paths.js'
 import { createCursorProvider } from '../src/providers/cursor.js'
@@ -152,6 +154,59 @@ describe('bounded source diagnostic primitive', () => {
     expect(json).not.toContain(secretValue)
     expect(table).not.toContain(secretValue)
     expect(json).toContain('<override-path>')
+  })
+})
+
+describe('Codebuff and Mistral Vibe Doctor families', () => {
+  it('distinguishes a Codebuff override as missing, empty, and present without leaking the path', async () => {
+    const codebuffRoot = join(root, 'private-codebuff-root')
+    vi.stubEnv('CODEBUFF_DATA_DIR', codebuffRoot)
+    const provider = createCodebuffProvider()
+
+    let row = only(await collectDoctorReport('codebuff', { providers: [provider], cache: emptyCache(), sampleLimit: 0 }), 'codebuff')
+    expect(row.families[0]).toMatchObject({
+      family: 'data',
+      state: 'MISSING',
+      root: '<override-path>',
+      override: 'CODEBUFF_DATA_DIR',
+    })
+    expect(row.verdict).toContain('source is missing')
+
+    await mkdir(codebuffRoot, { recursive: true })
+    row = only(await collectDoctorReport('codebuff', { providers: [provider], cache: emptyCache(), sampleLimit: 0 }), 'codebuff')
+    expect(row.families[0]?.state).toBe('PRESENT_EMPTY')
+
+    await writeFile(join(codebuffRoot, 'read-only-marker'), 'present')
+    row = only(await collectDoctorReport('codebuff', { providers: [provider], cache: emptyCache(), sampleLimit: 0 }), 'codebuff')
+    expect(row.families[0]?.state).toBe('PRESENT')
+
+    const json = renderDoctorJson({ generatedAt: new Date().toISOString(), providers: [row] })
+    const table = renderDoctorTable({ generatedAt: new Date().toISOString(), providers: [row] }, { color: false })
+    expect(json).not.toContain(codebuffRoot)
+    expect(table).not.toContain(codebuffRoot)
+  })
+
+  it('distinguishes a Mistral Vibe VIBE_HOME root as missing, empty, and present', async () => {
+    const vibeHome = join(root, 'private-vibe-home')
+    const sessionsRoot = join(vibeHome, 'logs', 'session')
+    vi.stubEnv('VIBE_HOME', vibeHome)
+    const provider = createMistralVibeProvider()
+
+    let row = only(await collectDoctorReport('mistral-vibe', { providers: [provider], cache: emptyCache(), sampleLimit: 0 }), 'mistral-vibe')
+    expect(row.families[0]).toMatchObject({
+      family: 'session',
+      state: 'MISSING',
+      root: '<override-path>',
+      override: 'VIBE_HOME',
+    })
+
+    await mkdir(sessionsRoot, { recursive: true })
+    row = only(await collectDoctorReport('mistral-vibe', { providers: [provider], cache: emptyCache(), sampleLimit: 0 }), 'mistral-vibe')
+    expect(row.families[0]?.state).toBe('PRESENT_EMPTY')
+
+    await writeFile(join(sessionsRoot, 'read-only-marker'), 'present')
+    row = only(await collectDoctorReport('mistral-vibe', { providers: [provider], cache: emptyCache(), sampleLimit: 0 }), 'mistral-vibe')
+    expect(row.families[0]?.state).toBe('PRESENT')
   })
 })
 

--- a/tests/doctor-bounded-sources.test.ts
+++ b/tests/doctor-bounded-sources.test.ts
@@ -1,11 +1,11 @@
 import { createRequire } from 'node:module'
-import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { mkdir, mkdtemp, rm, stat, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { collectDoctorReport, renderDoctorJson, renderDoctorTable } from '../src/doctor.js'
-import { classifyDoctorError, DOCTOR_SOURCE_STATES, redactOverridePath, redactText } from '../src/doctor-source-diagnostics.js'
+import { classifyDoctorError, DOCTOR_SOURCE_STATES, inspectPath, redactOverridePath, redactText } from '../src/doctor-source-diagnostics.js'
 import { getCopilotDoctorProbeRoots } from '../src/providers/copilot-paths.js'
 import { createCodebuffProvider } from '../src/providers/codebuff.js'
 import { createMistralVibeProvider } from '../src/providers/mistral-vibe.js'
@@ -14,7 +14,7 @@ import { getCursorDoctorProbeRoots, getCursorWorkspaceStorageDir } from '../src/
 import { createCursorProvider } from '../src/providers/cursor.js'
 import { getKiroDoctorProbeRoots } from '../src/providers/kiro-paths.js'
 import { createKiroProvider } from '../src/providers/kiro.js'
-import { PROVIDER_ENV_VARS, emptyCache } from '../src/session-cache.js'
+import { PROVIDER_ENV_VARS, emptyCache, sessionCachePath } from '../src/session-cache.js'
 import type { Provider } from '../src/providers/types.js'
 
 const requireForTest = createRequire(import.meta.url)
@@ -69,6 +69,35 @@ describe('bounded source diagnostic primitive', () => {
     const row = only(await collectDoctorReport('codex', { providers: [provider], cache: emptyCache() }), 'codex')
     expect(row.families.map(family => family.state)).toEqual(['MISSING', 'PRESENT_EMPTY'])
     expect(row.families.every(family => family.root === '<redacted-path>')).toBe(true)
+  })
+
+  it('caps generic directory evidence at the bounded entry limit', async () => {
+    const largeRoot = join(root, 'large-root')
+    await mkdir(largeRoot, { recursive: true })
+    await Promise.all(Array.from({ length: 140 }, (_, index) => writeFile(join(largeRoot, `entry-${index}`), 'x')))
+    const probe = await inspectPath(largeRoot)
+    expect(probe.state).toBe('PRESENT')
+    expect(probe.entries).toHaveLength(128)
+  })
+
+  it('does not migrate a legacy cache while loading a read-only Doctor report', async () => {
+    const cacheDir = join(root, 'cache')
+    const legacyPath = join(cacheDir, 'session-cache.json')
+    vi.stubEnv('METRORA_CACHE_DIR', cacheDir)
+    await mkdir(cacheDir, { recursive: true })
+    await writeFile(legacyPath, JSON.stringify(emptyCache()))
+    const provider: Provider = {
+      name: 'codex',
+      displayName: 'Codex',
+      modelDisplayName: model => model,
+      toolDisplayName: tool => tool,
+      discoverSessions: async () => [],
+      createSessionParser: () => ({ async *parse() {} }),
+    }
+
+    await collectDoctorReport('codex', { providers: [provider], sampleLimit: 0 })
+    await expect(stat(legacyPath)).resolves.toBeTruthy()
+    await expect(stat(sessionCachePath())).rejects.toMatchObject({ code: 'ENOENT' })
   })
 
   it('redacts override values and source paths in both output modes', async () => {

--- a/tests/providers/codebuff.test.ts
+++ b/tests/providers/codebuff.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { mkdtemp, mkdir, writeFile, rm } from 'fs/promises'
 import { join } from 'path'
 import { tmpdir } from 'os'
@@ -73,6 +73,15 @@ async function writeChat(
 }
 
 describe('codebuff provider - session discovery', () => {
+  it('reports all authoritative channel roots by default and one explicit override root when configured', async () => {
+    vi.stubEnv('CODEBUFF_DATA_DIR', '')
+    const defaultRoots = await createCodebuffProvider().probeRoots!()
+    expect(defaultRoots.map(root => root.label)).toEqual(['manicode', 'manicode-dev', 'manicode-staging'])
+
+    const override = join(tmpDir, 'private-codebuff-root')
+    const overrideRoots = await createCodebuffProvider(override).probeRoots!()
+    expect(overrideRoots).toEqual([{ path: override, label: 'data' }])
+  })
   it('discovers sessions under projects/<name>/chats/<chatId>/', async () => {
     await writeChat(
       tmpDir,

--- a/tests/providers/gemini.test.ts
+++ b/tests/providers/gemini.test.ts
@@ -1,6 +1,6 @@
 import { mkdtemp, rm, writeFile } from 'fs/promises'
 import { join } from 'path'
-import { tmpdir } from 'os'
+import { homedir, tmpdir } from 'os'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
 import { createGeminiProvider } from '../../src/providers/gemini.js'
@@ -33,6 +33,11 @@ async function parseFixture(messages: unknown[]): Promise<ParsedProviderCall[]> 
 }
 
 describe('gemini provider', () => {
+  it('reports the authoritative ~/.gemini/tmp root for Doctor', async () => {
+    expect(await createGeminiProvider().probeRoots!()).toEqual([
+      { path: join(homedir(), '.gemini', 'tmp'), label: 'tmp' },
+    ])
+  })
   it('emits one provider call per Gemini message with token usage', async () => {
     const calls = await parseFixture([
       {

--- a/tests/providers/mistral-vibe.test.ts
+++ b/tests/providers/mistral-vibe.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { mkdtemp, mkdir, writeFile, rm } from 'fs/promises'
 import { join } from 'path'
 import { tmpdir } from 'os'
@@ -114,6 +114,13 @@ async function collect(sourcePath: string, provider = createMistralVibeProvider(
 }
 
 describe('mistral-vibe provider - session discovery', () => {
+  it('reports the authoritative logs/session root and honors VIBE_HOME', async () => {
+    const vibeHome = join(tmpDir, 'private-vibe-home')
+    vi.stubEnv('VIBE_HOME', vibeHome)
+    expect(await createMistralVibeProvider().probeRoots!()).toEqual([
+      { path: join(vibeHome, 'logs', 'session'), label: 'session' },
+    ])
+  })
   it('discovers Vibe session folders and derives project from metadata cwd', async () => {
     const sessionDir = await writeSession('session_20260511_100000_sessiona', metadata({
       sessionId: 'session-a',


### PR DESCRIPTION
## Summary
- Add bounded, read-only provider probe roots for Doctor diagnostics.
- Preserve privacy suppression before cache loading and bound generic directory enumeration.
- Keep the probe roots diagnostic-only; no Kiro or Devin changes.

## Boundaries
- Architecture: Doctor diagnostics and provider probe roots only; no unrelated provider changes.
- Public Identity: Metrora-owned diagnostic states and privacy boundaries remain authoritative.
- Brand Boundary: no CodeBurn competitive internals or upstream cursor changes.

## Validation
- Reviewed head: `59f40fd9e3d7ed1636fe945ed8341cc43fcbeddd`
- Base: `main` at `ce02827d7b95282beb6d9779035cd14764c8be3f`
- Same-branch remediation: source-size ratchet containment only; read-only cache behavior preserved.
- Local focused remediation tests: 122/122; typecheck, source-size ratchet, and diff-check passed.
- Independent original review: PASS; independent remediation review: PASS.
- Architecture boundaries: success.
- Metrora Public Identity: success.
- Metrora Brand Boundary: success.
- Metrora CI: success (run `32709198857`).
- Workspace production scanner: success on Ubuntu and Windows.
- Windows Candidate: skipped; not applicable to this branch.