### PR TITLE
perf(discovery): add bounded provider concurrency

### DIFF
--- a/scripts/benchmark-provider-discovery.mjs
+++ b/scripts/benchmark-provider-discovery.mjs
@@ -1,22 +1,37 @@
+import { mkdtemp, mkdir, readdir, readFile, rm, stat, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { performance } from 'node:perf_hooks'
 
 import { discoverAllSessionsWithOutcomes, discoverProviderWithOutcome } from '../src/providers/index.ts'
 import { ProviderDiscoveryPartialError } from '../src/providers/discovery-outcome.ts'
 
+const REAL_IO_ITERATIONS = 5
+const REAL_IO_SCALES = [
+  { name: 'small', providers: 4, sessionsPerProvider: 24 },
+  { name: 'medium', providers: 8, sessionsPerProvider: 64 },
+  { name: 'large', providers: 12, sessionsPerProvider: 128 },
+]
+const FIXTURE_PROVIDER_PREFIX = 'fixture-discovery-'
+
 const pause = ms => new Promise(resolve => setTimeout(resolve, ms))
-const source = name => ({ provider: name, path: '/' + name + '.jsonl', project: name + '-project' })
-const provider = (name, delayMs, behavior = 'success') => ({
-  name,
-  displayName: name,
-  modelDisplayName: value => value,
-  toolDisplayName: value => value,
-  discoverSessions: async () => {
-    await pause(delayMs)
-    if (behavior === 'failure') throw new Error('synthetic failure')
-    if (behavior === 'partial') throw new ProviderDiscoveryPartialError([source(name)])
-    return [source(name)]
-  },
-})
+const round = value => Number(value.toFixed(1))
+const source = (name, filePath, project) => ({ provider: name, path: filePath, project })
+
+function timerProvider(name, delayMs, behavior = 'success') {
+  return {
+    name,
+    displayName: name,
+    modelDisplayName: value => value,
+    toolDisplayName: value => value,
+    discoverSessions: async () => {
+      await pause(delayMs)
+      if (behavior === 'failure') throw new Error('synthetic failure')
+      if (behavior === 'partial') throw new ProviderDiscoveryPartialError([source(name, '/' + name + '.jsonl', name + '-project')])
+      return [source(name, '/' + name + '.jsonl', name + '-project')]
+    },
+  }
+}
 
 async function sequential(providers) {
   const outcomes = []
@@ -24,7 +39,7 @@ async function sequential(providers) {
   return outcomes
 }
 
-async function bounded(providers, concurrency) {
+async function boundedLocal(providers, concurrency) {
   const outcomes = new Array(providers.length)
   let cursor = 0
   const worker = async () => {
@@ -40,46 +55,195 @@ async function bounded(providers, concurrency) {
 
 async function timed(operation) {
   const started = performance.now()
-  const outcomes = await operation()
-  return { ms: Number((performance.now() - started).toFixed(1)), outcomes }
+  const value = await operation()
+  return { ms: performance.now() - started, value }
 }
 
-const cases = [
-  ['small', 2, 8],
-  ['medium', 8, 12],
-  ['large', 16, 12],
-  ['failure', 8, 12, 2, 'failure'],
-  ['partial', 8, 12, 3, 'partial'],
-]
-const measurements = []
-for (const [name, count, delayMs, specialIndex, behavior] of cases) {
-  const make = () => Array.from({ length: count }, (_, index) => provider('synthetic-' + index, delayMs, index === specialIndex ? behavior : 'success'))
-  const serial = await timed(() => sequential(make()))
-  const bounded2 = await timed(() => discoverAllSessionsWithOutcomes('all', make()))
-  const candidate4 = await timed(() => bounded(make(), 4))
-  measurements.push({
+function outcomeSignature(outcomes) {
+  return outcomes.map(item => item.provider + ':' + item.status + ':' + item.sources.map(sourceValue => sourceValue.path + '|' + sourceValue.project).sort().join(',')).join('|')
+}
+
+function ordered(providers) {
+  return [...providers].sort((left, right) => left.name < right.name ? -1 : left.name > right.name ? 1 : 0)
+}
+
+function makeFileProvider(name, providerRoot, sessionsPerProvider) {
+  return {
     name,
-    providers: count,
-    sequentialMs: serial.ms,
-    bounded2Ms: bounded2.ms,
-    candidate4Ms: candidate4.ms,
-    bounded2Statuses: bounded2.outcomes.outcomes.map(item => item.status),
-    candidate4Statuses: candidate4.outcomes.map(item => item.status),
-  })
+    displayName: name,
+    modelDisplayName: value => value,
+    toolDisplayName: value => value,
+    discoverSessions: async () => {
+      const entries = await readdir(providerRoot, { withFileTypes: true })
+      const sessionDirectory = entries.find(entry => entry.isDirectory() && entry.name === 'sessions')
+      if (!sessionDirectory) return []
+
+      for (const entry of entries.filter(item => item.isFile() && (item.name === 'sessions.db' || item.name === 'sessions.db-wal'))) {
+        const metadataPath = join(providerRoot, entry.name)
+        const metadata = await stat(metadataPath)
+        if (!metadata.isFile()) throw new Error('fixture metadata is not a file')
+        await readFile(metadataPath)
+      }
+
+      const sessionRoot = join(providerRoot, sessionDirectory.name)
+      const sessionEntries = (await readdir(sessionRoot, { withFileTypes: true }))
+        .filter(entry => entry.isFile() && entry.name.endsWith('.jsonl'))
+        .sort((left, right) => left.name.localeCompare(right.name))
+      const sources = []
+      for (const entry of sessionEntries) {
+        const filePath = join(sessionRoot, entry.name)
+        const metadata = await stat(filePath)
+        if (!metadata.isFile()) continue
+        const content = await readFile(filePath, 'utf8')
+        const record = JSON.parse(content)
+        if (record.provider !== name || record.sessionIndex < 0 || record.sessionIndex >= sessionsPerProvider) continue
+        sources.push(source(name, filePath, record.project))
+      }
+      return sources
+    },
+  }
 }
 
-const started = []
-let releaseGate
-const gate = new Promise(resolve => { releaseGate = resolve })
-const controller = new AbortController()
-const cancellationProviders = Array.from({ length: 6 }, (_, index) => ({
-  ...provider('cancel-' + index, 0),
-  discoverSessions: async () => { started.push(index); await gate; return [source('cancel-' + index)] },
-}))
-const cancellation = discoverAllSessionsWithOutcomes('all', cancellationProviders, controller.signal)
-while (started.length < 2) await pause(1)
-controller.abort()
-const cancellationResult = await cancellation
-releaseGate()
+async function createRealFixture(scale, iteration) {
+  const root = await mkdtemp(join(tmpdir(), 'metrora-provider-discovery-'))
+  const providers = []
+  try {
+    await Promise.all(Array.from({ length: scale.providers }, async (_, index) => {
+      const name = FIXTURE_PROVIDER_PREFIX + scale.name + '-' + index
+      const providerRoot = join(root, name)
+      const sessionRoot = join(providerRoot, 'sessions')
+      await mkdir(sessionRoot, { recursive: true })
+      await writeFile(join(providerRoot, 'sessions.db'), JSON.stringify({ format: 'sqlite-fixture', provider: name, iteration, rows: scale.sessionsPerProvider }), 'utf8')
+      await writeFile(join(providerRoot, 'sessions.db-wal'), JSON.stringify({ format: 'sqlite-wal-fixture', provider: name, frames: scale.sessionsPerProvider }), 'utf8')
+      await Promise.all(Array.from({ length: scale.sessionsPerProvider }, (_, sessionIndex) => {
+        const record = {
+          provider: name,
+          project: name + '-project-' + (sessionIndex % 4),
+          sessionIndex,
+          usage: { inputTokens: 100 + sessionIndex, outputTokens: 40 + (sessionIndex % 7) },
+        }
+        return writeFile(join(sessionRoot, 'session-' + String(sessionIndex).padStart(4, '0') + '.jsonl'), JSON.stringify(record) + '\n', 'utf8')
+      }))
+      providers.push(makeFileProvider(name, providerRoot, scale.sessionsPerProvider))
+    }))
+    return { root, providers }
+  } catch (error) {
+    await rm(root, { recursive: true, force: true })
+    throw error
+  }
+}
 
-console.log(JSON.stringify({ measurements, cancellation: { started, statuses: cancellationResult.outcomes.map(item => item.status) } }, null, 2))
+async function measureRealIoScale(scale) {
+  const measurements = []
+  for (let iteration = 0; iteration < REAL_IO_ITERATIONS; iteration += 1) {
+    const fixture = await createRealFixture(scale, iteration)
+    try {
+      const providers = ordered(fixture.providers)
+      const firstBounded = iteration % 2 === 1
+      const first = firstBounded
+        ? await timed(() => discoverAllSessionsWithOutcomes('all', providers))
+        : await timed(() => sequential(providers))
+      const second = firstBounded
+        ? await timed(() => sequential(providers))
+        : await timed(() => discoverAllSessionsWithOutcomes('all', providers))
+      const serial = firstBounded ? second : first
+      const bounded2 = firstBounded ? first : second
+      const serialOutcomes = serial.value.outcomes ?? serial.value
+      const boundedOutcomes = bounded2.value.outcomes
+      measurements.push({
+        iteration: iteration + 1,
+        first: firstBounded ? 'bound-2' : 'sequential',
+        sequentialMs: round(serial.ms),
+        bounded2Ms: round(bounded2.ms),
+        correctness: outcomeSignature(serialOutcomes) === outcomeSignature(boundedOutcomes),
+        sourceCount: bounded2.value.sources.length,
+      })
+    } finally {
+      await rm(fixture.root, { recursive: true, force: true })
+    }
+  }
+  const sequentialMedianMs = round(median(measurements.map(item => item.sequentialMs)))
+  const bounded2MedianMs = round(median(measurements.map(item => item.bounded2Ms)))
+  const improvementPercent = round((1 - bounded2MedianMs / sequentialMedianMs) * 100)
+  return {
+    scale: scale.name,
+    providers: scale.providers,
+    sessionsPerProvider: scale.sessionsPerProvider,
+    iterations: REAL_IO_ITERATIONS,
+    measurements,
+    sequentialMedianMs,
+    bounded2MedianMs,
+    improvementPercent,
+    meaningfulGain: bounded2MedianMs < sequentialMedianMs * 0.9,
+    correctness: measurements.every(item => item.correctness),
+  }
+}
+
+function median(values) {
+  const sorted = [...values].sort((left, right) => left - right)
+  const middle = Math.floor(sorted.length / 2)
+  return sorted.length % 2 ? sorted[middle] : (sorted[middle - 1] + sorted[middle]) / 2
+}
+
+async function runTimerSanity() {
+  const cases = [
+    ['small', 2, 8],
+    ['medium', 8, 12],
+    ['large', 16, 12],
+    ['failure', 8, 12, 2, 'failure'],
+    ['partial', 8, 12, 3, 'partial'],
+  ]
+  const measurements = []
+  for (const [name, count, delayMs, specialIndex, behavior] of cases) {
+    const serial = await timed(() => sequential(Array.from({ length: count }, (_, index) => timerProvider('timer-' + name + '-' + index, delayMs, index === specialIndex ? behavior : 'success'))))
+    const bounded2 = await timed(() => discoverAllSessionsWithOutcomes('all', Array.from({ length: count }, (_, index) => timerProvider('timer-' + name + '-' + index, delayMs, index === specialIndex ? behavior : 'success'))))
+    const candidate4 = await timed(() => boundedLocal(Array.from({ length: count }, (_, index) => timerProvider('timer-' + name + '-' + index, delayMs, index === specialIndex ? behavior : 'success')), 4))
+    measurements.push({ name, providers: count, sequentialMs: round(serial.ms), bounded2Ms: round(bounded2.ms), candidate4Ms: round(candidate4.ms) })
+  }
+  return { purpose: 'scheduler sanity only; not production authorization evidence', measurements }
+}
+
+async function runCancellationCheck() {
+  const started = []
+  let releaseGate
+  const gate = new Promise(resolve => { releaseGate = resolve })
+  const controller = new AbortController()
+  const providers = Array.from({ length: 6 }, (_, index) => ({
+    ...timerProvider('cancel-' + index, 0),
+    discoverSessions: async () => {
+      started.push(index)
+      await gate
+      return [source('cancel-' + index, '/cancel-' + index + '.jsonl', 'cancel-project')]
+    },
+  }))
+  const pending = discoverAllSessionsWithOutcomes('all', providers, controller.signal)
+  while (started.length < 2) await pause(1)
+  controller.abort()
+  const result = await pending
+  releaseGate()
+  return { started, statuses: result.outcomes.map(item => item.status), noAdditionalProvidersLaunched: started.length === 2 }
+}
+
+const realIo = []
+for (const scale of REAL_IO_SCALES) realIo.push(await measureRealIoScale(scale))
+const meaningfulScales = realIo.filter(item => item.meaningfulGain).length
+const correctness = realIo.every(item => item.correctness)
+const retainProductionBound2 = correctness && meaningfulScales >= 2
+const decision = retainProductionBound2
+  ? 'RETAIN_PRODUCTION_CONCURRENCY_2'
+  : 'NO_PRODUCTION_CHANGE_INSUFFICIENT_REAL_IO_GAIN'
+
+console.log(JSON.stringify({
+  benchmark: 'provider-discovery-real-io-v1',
+  methodology: {
+    physicalCorpus: 'temporary directories with readdir, stat, SQLite/WAL-style metadata reads, and JSONL session file reads',
+    comparison: 'sequential versus the production bound of two on the same corpus per iteration',
+    iterations: REAL_IO_ITERATIONS,
+    scales: REAL_IO_SCALES,
+    meaningfulGainRule: 'at least 10% median improvement on at least two of three scales with matching outcomes',
+  },
+  decision,
+  realIo,
+  timerSanity: await runTimerSanity(),
+  cancellation: await runCancellationCheck(),
+}, null, 2))

--- a/scripts/benchmark-provider-discovery.mjs
+++ b/scripts/benchmark-provider-discovery.mjs
@@ -1,0 +1,85 @@
+import { performance } from 'node:perf_hooks'
+
+import { discoverAllSessionsWithOutcomes, discoverProviderWithOutcome } from '../src/providers/index.ts'
+import { ProviderDiscoveryPartialError } from '../src/providers/discovery-outcome.ts'
+
+const pause = ms => new Promise(resolve => setTimeout(resolve, ms))
+const source = name => ({ provider: name, path: '/' + name + '.jsonl', project: name + '-project' })
+const provider = (name, delayMs, behavior = 'success') => ({
+  name,
+  displayName: name,
+  modelDisplayName: value => value,
+  toolDisplayName: value => value,
+  discoverSessions: async () => {
+    await pause(delayMs)
+    if (behavior === 'failure') throw new Error('synthetic failure')
+    if (behavior === 'partial') throw new ProviderDiscoveryPartialError([source(name)])
+    return [source(name)]
+  },
+})
+
+async function sequential(providers) {
+  const outcomes = []
+  for (const item of providers) outcomes.push(await discoverProviderWithOutcome(item))
+  return outcomes
+}
+
+async function bounded(providers, concurrency) {
+  const outcomes = new Array(providers.length)
+  let cursor = 0
+  const worker = async () => {
+    while (true) {
+      const index = cursor++
+      if (index >= providers.length) return
+      outcomes[index] = await discoverProviderWithOutcome(providers[index])
+    }
+  }
+  await Promise.all(Array.from({ length: Math.min(concurrency, providers.length) }, worker))
+  return outcomes
+}
+
+async function timed(operation) {
+  const started = performance.now()
+  const outcomes = await operation()
+  return { ms: Number((performance.now() - started).toFixed(1)), outcomes }
+}
+
+const cases = [
+  ['small', 2, 8],
+  ['medium', 8, 12],
+  ['large', 16, 12],
+  ['failure', 8, 12, 2, 'failure'],
+  ['partial', 8, 12, 3, 'partial'],
+]
+const measurements = []
+for (const [name, count, delayMs, specialIndex, behavior] of cases) {
+  const make = () => Array.from({ length: count }, (_, index) => provider('synthetic-' + index, delayMs, index === specialIndex ? behavior : 'success'))
+  const serial = await timed(() => sequential(make()))
+  const bounded2 = await timed(() => discoverAllSessionsWithOutcomes('all', make()))
+  const candidate4 = await timed(() => bounded(make(), 4))
+  measurements.push({
+    name,
+    providers: count,
+    sequentialMs: serial.ms,
+    bounded2Ms: bounded2.ms,
+    candidate4Ms: candidate4.ms,
+    bounded2Statuses: bounded2.outcomes.outcomes.map(item => item.status),
+    candidate4Statuses: candidate4.outcomes.map(item => item.status),
+  })
+}
+
+const started = []
+let releaseGate
+const gate = new Promise(resolve => { releaseGate = resolve })
+const controller = new AbortController()
+const cancellationProviders = Array.from({ length: 6 }, (_, index) => ({
+  ...provider('cancel-' + index, 0),
+  discoverSessions: async () => { started.push(index); await gate; return [source('cancel-' + index)] },
+}))
+const cancellation = discoverAllSessionsWithOutcomes('all', cancellationProviders, controller.signal)
+while (started.length < 2) await pause(1)
+controller.abort()
+const cancellationResult = await cancellation
+releaseGate()
+
+console.log(JSON.stringify({ measurements, cancellation: { started, statuses: cancellationResult.outcomes.map(item => item.status) } }, null, 2))

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -299,6 +299,32 @@ export type ProviderDiscoveryRun = {
   sources: SessionSource[]
 }
 
+export const PROVIDER_DISCOVERY_CONCURRENCY = 2 as const
+
+async function discoverProvidersBounded(providers: readonly Provider[], signal?: AbortSignal): Promise<ProviderDiscoveryOutcome[]> {
+  const outcomes: Array<ProviderDiscoveryOutcome | undefined> = new Array(providers.length)
+  let cursor = 0
+  const worker = async (): Promise<void> => {
+    while (true) {
+      const index = cursor++
+      if (index >= providers.length) return
+      const provider = providers[index]!
+      if (signal?.aborted) {
+        outcomes[index] = classifyProviderDiscoveryOutcome(provider.name, { cancelled: true })
+        continue
+      }
+      try {
+        outcomes[index] = await discoverProviderWithOutcome(provider, signal)
+      } catch (error) {
+        outcomes[index] = classifyProviderDiscoveryOutcome(provider.name, { error, cancelled: signal?.aborted === true })
+      }
+    }
+  }
+  const workers = Array.from({ length: Math.min(PROVIDER_DISCOVERY_CONCURRENCY, providers.length) }, () => worker())
+  await Promise.all(workers)
+  return outcomes.map((outcome, index) => outcome ?? classifyProviderDiscoveryOutcome(providers[index]!.name, { cancelled: true }))
+}
+
 export async function discoverAllSessionsWithOutcomes(
   providerFilter?: string,
   providerList?: Provider[],
@@ -306,12 +332,8 @@ export async function discoverAllSessionsWithOutcomes(
 ): Promise<ProviderDiscoveryRun> {
   const allProviders = providerList ?? await getAllProviders()
   const filtered = providerDiscoveryProviderOrder(allProviders.filter(provider => !providerFilter || providerFilter === 'all' || provider.name === providerFilter))
-  const outcomes: ProviderDiscoveryOutcome[] = []
-  for (const provider of filtered) {
-    const outcome = await discoverProviderWithOutcome(provider, signal)
-    outcomes.push(outcome)
-    warnDiscoveryOutcome(outcome)
-  }
+  const outcomes = await discoverProvidersBounded(filtered, signal)
+  for (const outcome of outcomes) warnDiscoveryOutcome(outcome)
   return {
     schemaVersion: PROVIDER_DISCOVERY_OUTCOME_SCHEMA_VERSION,
     complete: outcomes.every(providerDiscoveryIsComplete),

--- a/tests/provider-discovery-outcome.test.ts
+++ b/tests/provider-discovery-outcome.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import {
   ProviderDiscoveryPartialError,
   classifyProviderDiscoveryOutcome,
@@ -89,5 +89,48 @@ describe('provider discovery outcome v1', () => {
     expect(result.sources.map(item => item.path)).toEqual(['/alpha.jsonl', '/zeta.jsonl'])
     expect(result.complete).toBe(false)
     expect(result.outcomes.find(item => item.provider === 'broken')).toMatchObject({ status: 'failed', complete: false })
+  })
+  it('bounds provider discovery at two workers while retaining deterministic order', async () => {
+    const started: string[] = []
+    const releases: Array<() => void> = []
+    let active = 0
+    let maximumActive = 0
+    const provider = (name: string) => fakeProvider(name, async () => {
+      started.push(name)
+      active += 1
+      maximumActive = Math.max(maximumActive, active)
+      await new Promise<void>(resolve => releases.push(resolve))
+      active -= 1
+      return [source(name, '/' + name + '.jsonl')]
+    })
+    const pending = discoverAllSessionsWithOutcomes('all', [provider('zeta'), provider('alpha'), provider('beta'), provider('gamma')])
+    await vi.waitFor(() => expect(started).toHaveLength(2))
+    expect(maximumActive).toBe(2)
+    releases.splice(0, 2).forEach(resolve => resolve())
+    await vi.waitFor(() => expect(started).toHaveLength(4))
+    releases.splice(0, 2).forEach(resolve => resolve())
+    const result = await pending
+    expect(maximumActive).toBe(2)
+    expect(result.outcomes.map(item => item.provider)).toEqual(['alpha', 'beta', 'gamma', 'zeta'])
+    expect(result.sources.map(item => item.path)).toEqual(['/alpha.jsonl', '/beta.jsonl', '/gamma.jsonl', '/zeta.jsonl'])
+  })
+
+  it('stops launching providers after cancellation and preserves cancelled outcomes', async () => {
+    const started: string[] = []
+    const controller = new AbortController()
+    let releaseGate!: () => void
+    const gate = new Promise<void>(resolve => { releaseGate = resolve })
+    const provider = (name: string) => fakeProvider(name, async () => {
+      started.push(name)
+      await gate
+      return [source(name, '/' + name + '.jsonl')]
+    })
+    const pending = discoverAllSessionsWithOutcomes('all', [provider('alpha'), provider('beta'), provider('gamma'), provider('delta')], controller.signal)
+    await vi.waitFor(() => expect(started).toHaveLength(2))
+    controller.abort()
+    const result = await pending
+    releaseGate()
+    expect(started).toHaveLength(2)
+    expect(result.outcomes.every(item => item.status === 'cancelled')).toBe(true)
   })
 })


### PR DESCRIPTION
## Summary

Adds a conservative concurrency bound of 2 to provider discovery now that Discovery Completeness V1 can truthfully distinguish complete and incomplete outcomes.

The implementation preserves deterministic provider/source ordering and the existing `success / empty / unavailable / failed / partial / cancelled` authority. Cancellation stops scheduling additional providers; current provider APIs do not support physical cancellation of already-started discovery I/O.

## Evidence

Disposable local-I/O benchmark compares sequential discovery with the production bound of 2 on the same synthetic physical corpus using filesystem `readdir`, `stat`, JSONL reads and SQLite/WAL-shaped metadata files. Five alternating-order iterations are used per scale to reduce cache/order bias.

Observed Founder-review evidence:

- small: 65.7 ms → 35.9 ms (~45.4%)
- medium: 315.2 ms → 167.4 ms (~46.9%)
- large: 925.8 ms → 479.9 ms (~48.2%)
- exact outcome/source identity preserved in the benchmark corpus

These numbers are synthetic local-I/O evidence, not a claim of equivalent speedup for every real provider or real SQLite workload.

## Safety boundary

- concurrency is fixed/bounded at 2;
- no unbounded `Promise.all` over providers;
- failed/partial/cancelled never become factual empty;
- completion order does not determine output order;
- retained-history reconciliation semantics remain governed by Discovery Completeness V1;
- no provider-level AbortSignal migration is introduced here.

## Validation

Focused discovery/registry/reconciliation/cancellation tests and root typecheck were green before push. Remote CI is required on the exact PR head before merge consideration.

No merge is authorized by this draft PR.