### PR TITLE
fix: converge named period semantics

### DIFF
--- a/src/cli-date.ts
+++ b/src/cli-date.ts
@@ -8,12 +8,15 @@ const END_OF_DAY_MINUTES = 59
 const END_OF_DAY_SECONDS = 59
 const END_OF_DAY_MS = 999
 
-// The "all" period is intentionally bounded to the last 6 months. Older data
-// is rarely actionable for a cost tracker, and capping the range keeps the
-// parse path bounded so providers like Codex/Cursor with sparse multi-year
-// history still load in seconds. Users who need an unbounded window can use
-// the explicit `lifetime` period or `--from` / `--to`.
+// The "all" period is intentionally bounded to six calendar months, including
+// the anchor month. Older data is rarely actionable for a cost tracker, and
+// capping the range keeps the parse path bounded so providers like
+// Codex/Cursor with sparse multi-year history still load in seconds. Users who
+// need an unbounded window can use the explicit `lifetime` period or
+// `--from` / `--to`.
 const ALL_TIME_MONTHS = 6
+const WEEK_WINDOW_DAYS = 7
+const RECENT_WINDOW_DAYS = 30
 
 export type Period = 'today' | 'week' | '30days' | 'month' | 'all' | 'lifetime'
 
@@ -86,6 +89,22 @@ function endOfLocalDay(date: Date): Date {
   )
 }
 
+function startOfRecentInclusiveWindow(anchor: Date, dayCount: number): Date {
+  return new Date(
+    anchor.getFullYear(),
+    anchor.getMonth(),
+    anchor.getDate() - (dayCount - 1),
+  )
+}
+
+function startOfCalendarMonthWindow(anchor: Date, monthCount: number): Date {
+  return new Date(
+    anchor.getFullYear(),
+    anchor.getMonth() - (monthCount - 1),
+    1,
+  )
+}
+
 export function dayRangeForDate(date: Date): DateRange {
   const start = new Date(date.getFullYear(), date.getMonth(), date.getDate())
   return { start, end: endOfLocalDay(start) }
@@ -121,16 +140,18 @@ export function parseDateRangeFlags(from: string | undefined, to: string | undef
   if (from === undefined && to === undefined) return null
 
   const now = new Date()
-  // When --from is omitted, default to 6 months back (the same window the
-  // dashboard's "all" period uses) instead of epoch. Previously a bare
-  // `--to 2026-01-01` opened a 55-year scan from 1970 which is rarely what
-  // the user meant and is expensive on machines with many session files.
-  const ALL_TIME_FALLBACK_MS = 6 * 31 * 24 * 60 * 60 * 1000
+  const endDate = to !== undefined
+    ? parseLocalDate(to)
+    : new Date(now.getFullYear(), now.getMonth(), now.getDate())
+
+  // When --from is omitted, use the same bounded six-calendar-month window as
+  // the dashboard's "6 Months" period, anchored to the requested end date.
+  // Anchoring to `to` keeps historical `--to` queries bounded and meaningful
+  // instead of deriving their start from the machine's current date.
   const start = from !== undefined
     ? parseLocalDate(from)
-    : new Date(now.getTime() - ALL_TIME_FALLBACK_MS)
+    : startOfCalendarMonthWindow(endDate, ALL_TIME_MONTHS)
 
-  const endDate = to !== undefined ? parseLocalDate(to) : new Date(now.getFullYear(), now.getMonth(), now.getDate())
   const end = endOfLocalDay(endDate)
 
   if (start > end) {
@@ -144,10 +165,10 @@ export function parseDateRangeFlags(from: string | undefined, to: string | undef
  *
  * Accepts a string (rather than the strict `Period` type) because the CLI
  * surfaces a few extra inputs not exposed in the dashboard tab strip
- * (e.g. `'yesterday'`). Unknown values fall back to `'week'`.
+ * (e.g. `'yesterday'`). Unknown values fail loudly.
  *
- * Note: `'all'` is bounded to the last 6 months. Use `'lifetime'` or
- * `--from`/`--to` for an unbounded historical window.
+ * Note: `'all'` is bounded to six calendar months including the current month.
+ * Use `'lifetime'` or `--from`/`--to` for an unbounded historical window.
  */
 export function getDateRange(period: string): { range: DateRange; label: string } {
   const now = new Date()
@@ -171,7 +192,7 @@ export function getDateRange(period: string): { range: DateRange; label: string 
       return { range: dayRangeForDate(start), label: `Yesterday (${toDateString(start)})` }
     }
     case 'week': {
-      const start = new Date(now.getFullYear(), now.getMonth(), now.getDate() - 7)
+      const start = startOfRecentInclusiveWindow(now, WEEK_WINDOW_DAYS)
       return { range: { start, end }, label: 'Last 7 Days' }
     }
     case 'month': {
@@ -179,11 +200,11 @@ export function getDateRange(period: string): { range: DateRange; label: string 
       return { range: { start, end }, label: `${now.toLocaleString('default', { month: 'long' })} ${now.getFullYear()}` }
     }
     case '30days': {
-      const start = new Date(now.getFullYear(), now.getMonth(), now.getDate() - 30)
+      const start = startOfRecentInclusiveWindow(now, RECENT_WINDOW_DAYS)
       return { range: { start, end }, label: 'Last 30 Days' }
     }
     case 'all': {
-      const start = new Date(now.getFullYear(), now.getMonth() - ALL_TIME_MONTHS, 1)
+      const start = startOfCalendarMonthWindow(now, ALL_TIME_MONTHS)
       return { range: { start, end }, label: 'Last 6 months' }
     }
     case 'lifetime': {

--- a/tests/cli-date.test.ts
+++ b/tests/cli-date.test.ts
@@ -14,23 +14,20 @@ afterEach(() => {
 })
 
 describe('getDateRange', () => {
-  it('"all" is bounded to the last 6 months, not epoch', () => {
+  it('"all" spans six calendar months including the current month, not epoch', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(2026, 7, 25, 12, 0, 0))
+
     const { range, label } = getDateRange('all')
-    const now = new Date()
 
     expect(label).toBe('Last 6 months')
-
-    // Regression guard: must never silently fall back to epoch (the old
-    // dashboard bug) or any pre-2000 date.
-    expect(range.start.getFullYear()).toBeGreaterThan(2000)
-
-    const monthsDiff =
-      (now.getFullYear() - range.start.getFullYear()) * 12 +
-      (now.getMonth() - range.start.getMonth())
-    expect(monthsDiff).toBe(6)
+    expect(range.start.getFullYear()).toBe(2026)
+    expect(range.start.getMonth()).toBe(2) // March
     expect(range.start.getDate()).toBe(1)
-
-    // End is today, end of day.
+    expect(range.start.getHours()).toBe(0)
+    expect(range.end.getFullYear()).toBe(2026)
+    expect(range.end.getMonth()).toBe(7) // August
+    expect(range.end.getDate()).toBe(25)
     expect(range.end.getHours()).toBe(23)
     expect(range.end.getMinutes()).toBe(59)
   })
@@ -42,7 +39,7 @@ describe('getDateRange', () => {
     const { range } = getDateRange('all')
 
     expect(range.start.getFullYear()).toBe(2026)
-    expect(range.start.getMonth()).toBe(1)
+    expect(range.start.getMonth()).toBe(2) // March
     expect(range.start.getDate()).toBe(1)
   })
 
@@ -57,13 +54,19 @@ describe('getDateRange', () => {
     expect(range.end.getMinutes()).toBe(59)
   })
 
-  it('"week" returns the last 7 days', () => {
+  it('"week" contains exactly seven inclusive local calendar dates', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(2026, 7, 25, 12, 0, 0))
+
     const { range, label } = getDateRange('week')
+
     expect(label).toBe('Last 7 Days')
-    // start = midnight 7 days ago, end = today 23:59:59.999 -> ~8 days span.
-    const diffDays = (range.end.getTime() - range.start.getTime()) / (1000 * 60 * 60 * 24)
-    expect(diffDays).toBeGreaterThanOrEqual(7)
-    expect(diffDays).toBeLessThanOrEqual(8)
+    expect(range.start.getFullYear()).toBe(2026)
+    expect(range.start.getMonth()).toBe(7)
+    expect(range.start.getDate()).toBe(19)
+    expect(range.start.getHours()).toBe(0)
+    expect(range.end.getDate()).toBe(25)
+    expect(range.end.getHours()).toBe(23)
   })
 
   it('"month" starts on day 1 of the current month', () => {
@@ -72,12 +75,21 @@ describe('getDateRange', () => {
     expect(range.start.getHours()).toBe(0)
   })
 
-  it('"30days" returns 30 days back', () => {
+  it('"30days" contains exactly thirty inclusive local calendar dates', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(2026, 7, 25, 12, 0, 0))
+
     const { range, label } = getDateRange('30days')
+
     expect(label).toBe('Last 30 Days')
-    const diffDays = (range.end.getTime() - range.start.getTime()) / (1000 * 60 * 60 * 24)
-    expect(diffDays).toBeGreaterThanOrEqual(30)
-    expect(diffDays).toBeLessThanOrEqual(31)
+    expect(range.start.getFullYear()).toBe(2026)
+    expect(range.start.getMonth()).toBe(6) // July
+    expect(range.start.getDate()).toBe(27)
+    expect(range.start.getHours()).toBe(0)
+    expect(range.end.getFullYear()).toBe(2026)
+    expect(range.end.getMonth()).toBe(7)
+    expect(range.end.getDate()).toBe(25)
+    expect(range.end.getHours()).toBe(23)
   })
 
   it('"today" starts at local midnight', () => {
@@ -111,8 +123,6 @@ describe('PERIODS / PERIOD_LABELS', () => {
   })
 
   it('"all" tab label reflects the 6-month bound', () => {
-    // Short label used in the dashboard tab strip. The long-form label
-    // ("Last 6 months") comes from getDateRange().label.
     expect(PERIOD_LABELS.all).toBe('6 Months')
   })
 
@@ -166,10 +176,6 @@ describe('toPeriod', () => {
   })
 
   it('exits with an error on unknown input instead of silently falling back', () => {
-    // Previously toPeriod silently fell back to 'week' for any unrecognized
-    // value, which let typos like `-p mounth` produce a quiet 7-day report
-    // while the user thought they were viewing the month. The new behavior
-    // is to fail loudly via process.exit(1) after writing to stderr.
     const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => { throw new Error('exit') }) as unknown as ReturnType<typeof vi.spyOn>
     const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
     try {

--- a/tests/date-range-filter.test.ts
+++ b/tests/date-range-filter.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, it, expect, vi } from 'vitest'
-import { formatDateRangeLabel, formatDayRangeLabel, parseDateRangeFlags, parseDayFlag, shiftDay } from '../src/cli-date.js'
+import { formatDateRangeLabel, formatDayRangeLabel, getDateRange, parseDateRangeFlags, parseDayFlag, shiftDay } from '../src/cli-date.js'
 
 afterEach(() => {
   vi.useRealTimers()
@@ -30,19 +30,48 @@ describe('parseDateRangeFlags', () => {
     expect(range!.end.getHours()).toBe(23)
   })
 
-  it('accepts --to alone with a 6-month default start', () => {
-    // Previously the missing --from defaulted to epoch (1970), opening a
-    // 55-year scan window that was almost never what the user meant. The
-    // default is now 6 months back from now, matching the dashboard's
-    // "6 Months" period boundary.
+  it('accepts --to alone with the same six-calendar-month window anchored to --to', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(2026, 7, 25, 12, 0, 0))
+
     const range = parseDateRangeFlags(undefined, '2026-04-10')
+
     expect(range).not.toBeNull()
-    expect(range!.start.getTime()).toBeGreaterThan(new Date(0).getTime())
-    const sixMonthsMs = 6 * 31 * 24 * 60 * 60 * 1000
-    const ageMs = Date.now() - range!.start.getTime()
-    expect(ageMs).toBeLessThanOrEqual(sixMonthsMs + 1000)
-    expect(ageMs).toBeGreaterThanOrEqual(sixMonthsMs - 1000)
+    expect(range!.start.getFullYear()).toBe(2025)
+    expect(range!.start.getMonth()).toBe(10) // November
+    expect(range!.start.getDate()).toBe(1)
+    expect(range!.start.getHours()).toBe(0)
+    expect(range!.end.getFullYear()).toBe(2026)
+    expect(range!.end.getMonth()).toBe(3) // April
     expect(range!.end.getDate()).toBe(10)
+    expect(range!.end.getHours()).toBe(23)
+  })
+
+  it('matches the named six-month boundary when --to is today', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(2026, 7, 25, 12, 0, 0))
+
+    const explicitEnd = parseDateRangeFlags(undefined, '2026-08-25')
+    const named = getDateRange('all').range
+
+    expect(explicitEnd).not.toBeNull()
+    expect(explicitEnd!.start.getTime()).toBe(named.start.getTime())
+    expect(explicitEnd!.end.getTime()).toBe(named.end.getTime())
+  })
+
+  it('allows a historical --to without deriving the start from the current date', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(2026, 7, 25, 12, 0, 0))
+
+    const range = parseDateRangeFlags(undefined, '2024-01-15')
+
+    expect(range).not.toBeNull()
+    expect(range!.start.getFullYear()).toBe(2023)
+    expect(range!.start.getMonth()).toBe(7) // August
+    expect(range!.start.getDate()).toBe(1)
+    expect(range!.end.getFullYear()).toBe(2024)
+    expect(range!.end.getMonth()).toBe(0)
+    expect(range!.end.getDate()).toBe(15)
   })
 
   it('throws when --from > --to', () => {
@@ -61,9 +90,6 @@ describe('parseDateRangeFlags', () => {
   })
 
   it('rejects month/day overflow instead of silently rolling forward', () => {
-    // Without overflow validation, JS Date silently turns Feb 31 into Mar 3
-    // and 13/32 into 02/01 of the following year. That made `--from
-    // 2026-02-31 --to 2026-03-15` quietly drop sessions on Feb 28 - Mar 2.
     expect(() => parseDateRangeFlags('2026-02-31', '2026-03-15'))
       .toThrow('Invalid date "2026-02-31"')
     expect(() => parseDateRangeFlags('2026-13-01', undefined))
@@ -72,7 +98,6 @@ describe('parseDateRangeFlags', () => {
       .toThrow('Invalid date "2026-04-31"')
     expect(() => parseDateRangeFlags(undefined, '2026-02-30'))
       .toThrow('Invalid date "2026-02-30"')
-    // Leap-day check: 2024 is a leap year, 2025 is not.
     expect(parseDateRangeFlags('2024-02-29', '2024-03-01')).not.toBeNull()
     expect(() => parseDateRangeFlags('2025-02-29', undefined))
       .toThrow('Invalid date "2025-02-29"')


### PR DESCRIPTION
## Summary

Converges the named local period authority so labels and actual date windows match across existing consumers.

- `Last 7 Days` now means exactly seven inclusive local calendar dates ending today.
- `Last 30 Days` now means exactly thirty inclusive local calendar dates ending today.
- `6 Months` now means six calendar months including the anchor/current month, beginning on the first day of the oldest included month.
- `--to` without `--from` uses the same six-calendar-month bound anchored to the requested `--to` date instead of the machine's current date.
- `This Month`, `Today`, explicit ranges and `Lifetime` remain unchanged.

The Android Demo V1 already uses the corrected 7/30-day inclusive convention, so this removes the prior real-vs-demo drift rather than introducing a second interpretation.

## Scope

Only `src/cli-date.ts` and its focused date-range tests are changed. No collector, cache, pricing, Advisor, Android, macOS quota, release or storage authority is modified.

## Validation intent

Focused tests use fixed local calendar dates rather than millisecond-duration assertions, avoiding DST-sensitive expectations. Remote CI on the exact PR head is required before merge consideration.

No merge or release is authorized by this draft PR.