### PR TITLE
feat: add privacy-safe local share cards

### DIFF
--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -1,9 +1,11 @@
 import { app, BrowserWindow, dialog, ipcMain, Menu, nativeTheme, safeStorage, shell } from 'electron'
+import { writeFile } from 'node:fs/promises'
 import path from 'node:path'
 
 import { resolveMetroraPath, shutdownCli, spawnCli, spawnCliAction } from './cli'
 import { createApplicationMenuTemplate } from './menu'
 import { getQuota } from './quota'
+import { saveShareCardPng } from './share-card-export'
 import { initializeDesktopShareRuntime, stopDesktopShareRuntime } from './share-runtime'
 import { Telemetry } from './telemetry'
 import { createUpdateChecker, type UpdateChecker, type UpdateStatus } from './updates'
@@ -156,36 +158,50 @@ function registerHandlers(): void {
     advisorCredentials,
     advisorHostedHandlers,
   })
-  const advisorProtectedIpcChannels = new Set([
+  const trustedRendererIpcChannels = new Set([
     'metrora:advisorHostedProbe',
-  'metrora:advisorHostedChat',
-  'metrora:advisorHostedCancel',
-  'metrora:advisorCredentialStatus',
-  'metrora:advisorCredentialSet',
-  'metrora:advisorCredentialClear',
-])
-function isTrustedAdvisorSender(event: { senderFrame?: { url?: string } | null }): boolean {
-  const frameUrl = event.senderFrame?.url
-  if (!frameUrl) return false
-  try {
-    const parsed = new URL(frameUrl)
-    if (parsed.protocol === 'file:') return true
-    const devUrl = process.env.VITE_DEV_SERVER_URL
-    return Boolean(devUrl && new URL(devUrl).origin === parsed.origin)
-  } catch {
-    return false
+    'metrora:advisorHostedChat',
+    'metrora:advisorHostedCancel',
+    'metrora:advisorCredentialStatus',
+    'metrora:advisorCredentialSet',
+    'metrora:advisorCredentialClear',
+  ])
+  function isTrustedRendererSender(event: { senderFrame?: { url?: string } | null }): boolean {
+    const frameUrl = event.senderFrame?.url
+    if (!frameUrl) return false
+    try {
+      const parsed = new URL(frameUrl)
+      if (parsed.protocol === 'file:') return true
+      const devUrl = process.env.VITE_DEV_SERVER_URL
+      return Boolean(devUrl && new URL(devUrl).origin === parsed.origin)
+    } catch {
+      return false
+    }
   }
-}
   for (const [channel, handler] of Object.entries(handlers)) {
     for (const alias of ipcChannelAliases(channel)) {
       ipcMain.handle(alias, (event, ...args) => {
-        if (advisorProtectedIpcChannels.has(channel) && !isTrustedAdvisorSender(event)) {
+        if (trustedRendererIpcChannels.has(channel) && !isTrustedRendererSender(event)) {
           return { ok: false, error: { kind: 'unauthorized', message: 'Advisor IPC request is not from the trusted renderer.' } }
         }
         return handler(...args)
       })
     }
   }
+  ipcMain.handle('metrora:saveShareCardPng', async (event, suggestedName: string, pngDataUrl: string) => {
+    if (!isTrustedRendererSender(event)) {
+      return { ok: false, error: { kind: 'unauthorized', message: 'Share card export request is not from the trusted renderer.' } }
+    }
+    try {
+      const value = await saveShareCardPng(suggestedName, pngDataUrl, {
+        showSaveDialog: options => dialog.showSaveDialog(options),
+        writeFile: (filePath, data) => writeFile(filePath, data),
+      })
+      return { ok: true, value }
+    } catch {
+      return { ok: false, error: { kind: 'bad-args', message: 'Share card PNG could not be saved.' } }
+    }
+  })
   const chooseDirectory = async () => {
     const res = await dialog.showOpenDialog({ properties: ['openDirectory', 'createDirectory'] })
     return { ok: true, value: res.canceled ? null : (res.filePaths[0] ?? null) }

--- a/app/electron/preload.ts
+++ b/app/electron/preload.ts
@@ -67,6 +67,7 @@ const bridge = {
   setPlan: (id: string, provider: string) => invoke('metrora:setPlan', id, provider),
   resetPlan: (provider: string) => invoke('metrora:resetPlan', provider),
   exportData: (format: string, provider: string, outPath: string) => invoke('metrora:exportData', format, provider, outPath),
+  saveShareCardPng: (suggestedName: string, pngDataUrl: string) => invoke('metrora:saveShareCardPng', suggestedName, pngDataUrl),
   chooseDirectory: () => invoke('metrora:chooseDirectory'),
   cliStatus: () => invoke('metrora:cliStatus'),
 

--- a/app/electron/share-card-export.test.ts
+++ b/app/electron/share-card-export.test.ts
@@ -22,8 +22,9 @@ describe('ShareCard PNG export', () => {
     expect(() => decodeShareCardPngDataUrl('data:image/png;base64,not base64')).toThrow(/encoding is invalid/u)
   })
 
-  it('sanitizes the suggested leaf filename without accepting a renderer path', () => {
+  it('sanitizes POSIX and Windows suggested paths down to a bounded leaf filename', () => {
     expect(sanitizeShareCardFilename('../../Secret Folder/my recap.png')).toBe('my-recap.png')
+    expect(sanitizeShareCardFilename('..\\Secret Folder\\my recap.png')).toBe('my-recap.png')
     expect(sanitizeShareCardFilename('')).toBe('metrora-ai-recap.png')
   })
 

--- a/app/electron/share-card-export.test.ts
+++ b/app/electron/share-card-export.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  decodeShareCardPngDataUrl,
+  sanitizeShareCardFilename,
+  saveShareCardPng,
+} from './share-card-export'
+
+function pngDataUrl(extraBytes = 0): string {
+  const bytes = Buffer.concat([
+    Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+    Buffer.alloc(extraBytes, 0),
+  ])
+  return `data:image/png;base64,${bytes.toString('base64')}`
+}
+
+describe('ShareCard PNG export', () => {
+  it('accepts only bounded PNG payloads with a real PNG signature', () => {
+    expect(decodeShareCardPngDataUrl(pngDataUrl())).toHaveLength(8)
+    expect(() => decodeShareCardPngDataUrl('data:text/plain;base64,SGVsbG8=')).toThrow(/must be a PNG/u)
+    expect(() => decodeShareCardPngDataUrl('data:image/png;base64,SGVsbG8=')).toThrow(/payload is invalid/u)
+    expect(() => decodeShareCardPngDataUrl('data:image/png;base64,not base64')).toThrow(/encoding is invalid/u)
+  })
+
+  it('sanitizes the suggested leaf filename without accepting a renderer path', () => {
+    expect(sanitizeShareCardFilename('../../Secret Folder/my recap.png')).toBe('my-recap.png')
+    expect(sanitizeShareCardFilename('')).toBe('metrora-ai-recap.png')
+  })
+
+  it('writes only after the user accepts the native save dialog and returns no path', async () => {
+    const showSaveDialog = vi.fn().mockResolvedValue({ canceled: false, filePath: 'C:\\Users\\test\\recap' })
+    const writeFile = vi.fn().mockResolvedValue(undefined)
+
+    const saved = await saveShareCardPng('../../private-name.png', pngDataUrl(), { showSaveDialog, writeFile })
+
+    expect(saved).toBe(true)
+    expect(showSaveDialog).toHaveBeenCalledWith(expect.objectContaining({
+      defaultPath: 'private-name.png',
+      filters: [{ name: 'PNG image', extensions: ['png'] }],
+    }))
+    expect(writeFile).toHaveBeenCalledTimes(1)
+    expect(writeFile.mock.calls[0][0]).toBe('C:\\Users\\test\\recap.png')
+    expect(writeFile.mock.calls[0][1]).toBeInstanceOf(Uint8Array)
+  })
+
+  it('does not write when the save dialog is cancelled', async () => {
+    const showSaveDialog = vi.fn().mockResolvedValue({ canceled: true })
+    const writeFile = vi.fn()
+
+    await expect(saveShareCardPng('recap.png', pngDataUrl(), { showSaveDialog, writeFile })).resolves.toBe(false)
+    expect(writeFile).not.toHaveBeenCalled()
+  })
+})

--- a/app/electron/share-card-export.ts
+++ b/app/electron/share-card-export.ts
@@ -33,7 +33,9 @@ export function decodeShareCardPngDataUrl(dataUrl: string): Uint8Array {
 }
 
 export function sanitizeShareCardFilename(input: string): string {
-  const raw = typeof input === 'string' ? input : ''
+  // Bound before splitting so an untrusted renderer cannot turn a harmless
+  // suggested filename into unbounded main-process string work.
+  const raw = (typeof input === 'string' ? input : '').slice(-512)
   // Treat both path separators as untrusted renderer input regardless of the
   // host OS. The renderer may suggest a leaf name; it never chooses a path.
   const leaf = raw.split(/[\\/]/u).at(-1) ?? ''

--- a/app/electron/share-card-export.ts
+++ b/app/electron/share-card-export.ts
@@ -1,5 +1,3 @@
-import path from 'node:path'
-
 export const SHARE_CARD_MAX_PNG_BYTES = 5 * 1024 * 1024
 
 export type ShareCardSaveDialogOptions = {
@@ -35,7 +33,10 @@ export function decodeShareCardPngDataUrl(dataUrl: string): Uint8Array {
 }
 
 export function sanitizeShareCardFilename(input: string): string {
-  const leaf = path.basename(typeof input === 'string' ? input : '')
+  const raw = typeof input === 'string' ? input : ''
+  // Treat both path separators as untrusted renderer input regardless of the
+  // host OS. The renderer may suggest a leaf name; it never chooses a path.
+  const leaf = raw.split(/[\\/]/u).at(-1) ?? ''
   const normalized = leaf
     .replace(/\.png$/iu, '')
     .replace(/[^A-Za-z0-9._-]+/gu, '-')

--- a/app/electron/share-card-export.ts
+++ b/app/electron/share-card-export.ts
@@ -1,0 +1,63 @@
+import path from 'node:path'
+
+export const SHARE_CARD_MAX_PNG_BYTES = 5 * 1024 * 1024
+
+export type ShareCardSaveDialogOptions = {
+  title: string
+  defaultPath: string
+  filters: Array<{ name: string; extensions: string[] }>
+}
+
+export type ShareCardExportDeps = {
+  showSaveDialog(options: ShareCardSaveDialogOptions): Promise<{ canceled: boolean; filePath?: string }>
+  writeFile(filePath: string, data: Uint8Array): Promise<void>
+}
+
+function hasPngSignature(bytes: Uint8Array): boolean {
+  const signature = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]
+  return bytes.length >= signature.length && signature.every((byte, index) => bytes[index] === byte)
+}
+
+export function decodeShareCardPngDataUrl(dataUrl: string): Uint8Array {
+  if (typeof dataUrl !== 'string' || !dataUrl.startsWith('data:image/png;base64,')) {
+    throw new Error('Share card export must be a PNG data URL.')
+  }
+  const encoded = dataUrl.slice('data:image/png;base64,'.length)
+  if (!encoded || encoded.length > Math.ceil(SHARE_CARD_MAX_PNG_BYTES * 4 / 3) + 8) {
+    throw new Error('Share card PNG is empty or too large.')
+  }
+  if (!/^[A-Za-z0-9+/]+={0,2}$/u.test(encoded)) throw new Error('Share card PNG encoding is invalid.')
+  const decoded = Buffer.from(encoded, 'base64')
+  if (decoded.length === 0 || decoded.length > SHARE_CARD_MAX_PNG_BYTES || !hasPngSignature(decoded)) {
+    throw new Error('Share card PNG payload is invalid.')
+  }
+  return decoded
+}
+
+export function sanitizeShareCardFilename(input: string): string {
+  const leaf = path.basename(typeof input === 'string' ? input : '')
+  const normalized = leaf
+    .replace(/\.png$/iu, '')
+    .replace(/[^A-Za-z0-9._-]+/gu, '-')
+    .replace(/^-+|-+$/gu, '')
+    .slice(0, 80)
+  return `${normalized || 'metrora-ai-recap'}.png`
+}
+
+export async function saveShareCardPng(
+  suggestedName: string,
+  dataUrl: string,
+  deps: ShareCardExportDeps,
+): Promise<boolean> {
+  const png = decodeShareCardPngDataUrl(dataUrl)
+  const safeName = sanitizeShareCardFilename(suggestedName)
+  const result = await deps.showSaveDialog({
+    title: 'Save Metrora share card',
+    defaultPath: safeName,
+    filters: [{ name: 'PNG image', extensions: ['png'] }],
+  })
+  if (result.canceled || !result.filePath) return false
+  const target = result.filePath.toLowerCase().endsWith('.png') ? result.filePath : `${result.filePath}.png`
+  await deps.writeFile(target, png)
+  return true
+}

--- a/app/renderer/components/ShareCardModal.test.tsx
+++ b/app/renderer/components/ShareCardModal.test.tsx
@@ -1,0 +1,103 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { MenubarPayload } from '../lib/types'
+
+const { saveShareCardPng, rasterizeShareCardPngDataUrl } = vi.hoisted(() => ({
+  saveShareCardPng: vi.fn(),
+  rasterizeShareCardPngDataUrl: vi.fn(),
+}))
+
+vi.mock('../lib/ipc', () => ({
+  metrora: { saveShareCardPng },
+}))
+
+vi.mock('../share-card', async original => {
+  const actual = await original<typeof import('../share-card')>()
+  return {
+    ...actual,
+    rasterizeShareCardPngDataUrl,
+  }
+})
+
+import { ShareCardModal } from './ShareCardModal'
+
+function payload(): MenubarPayload {
+  return {
+    freshness: { readMode: 'snapshot', reconciliation: 'complete', durableThrough: null },
+    current: {
+      calls: 640,
+      sessions: 22,
+      cost: 41.25,
+      topModels: [{ name: 'gpt-5.6-sol', calls: 480, cost: 32, savingsUSD: 0, savingsBaselineModel: '' }],
+      pricingCoverage: 1,
+    },
+  } as unknown as MenubarPayload
+}
+
+function previewSvg(): string {
+  const src = (screen.getByAltText('Metrora AI recap share card preview') as HTMLImageElement).src
+  const encoded = src.slice(src.indexOf(',') + 1)
+  return decodeURIComponent(encoded)
+}
+
+describe('ShareCardModal', () => {
+  beforeEach(() => {
+    saveShareCardPng.mockReset().mockResolvedValue(true)
+    rasterizeShareCardPngDataUrl.mockReset().mockResolvedValue('data:image/png;base64,iVBORw0KGgo=')
+  })
+
+  it('shows the exact disclosure with cost and Project name hidden by default', () => {
+    render(<ShareCardModal
+      payload={payload()}
+      period="week"
+      providerLabel="Codex"
+      projectScopeActive
+      projectScopeName="Private launch"
+      onClose={vi.fn()}
+    />)
+
+    expect(screen.getByText('Current Project scope (name hidden)')).toBeTruthy()
+    expect(screen.getByLabelText('Include exact spend')).not.toBeChecked()
+    expect(screen.getByLabelText('Include Project name')).not.toBeChecked()
+    expect(previewSvg()).toContain('Current Project scope')
+    expect(previewSvg()).not.toContain('Private launch')
+    expect(previewSvg()).not.toContain('$41.25')
+  })
+
+  it('updates the same preview when optional disclosure is explicitly enabled', () => {
+    render(<ShareCardModal
+      payload={payload()}
+      period="week"
+      providerLabel="Codex"
+      projectScopeActive
+      projectScopeName="Private launch"
+      onClose={vi.fn()}
+    />)
+
+    fireEvent.click(screen.getByLabelText('Include exact spend'))
+    fireEvent.click(screen.getByLabelText('Include Project name'))
+
+    expect(previewSvg()).toContain('Project: Private launch')
+    expect(previewSvg()).toContain('$41.25')
+  })
+
+  it('renders and saves only after the explicit Save PNG action', async () => {
+    render(<ShareCardModal
+      payload={payload()}
+      period="30days"
+      providerLabel="All providers"
+      onClose={vi.fn()}
+    />)
+
+    expect(rasterizeShareCardPngDataUrl).not.toHaveBeenCalled()
+    expect(saveShareCardPng).not.toHaveBeenCalled()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save PNG' }))
+
+    await waitFor(() => expect(saveShareCardPng).toHaveBeenCalledWith('metrora-ai-recap.png', 'data:image/png;base64,iVBORw0KGgo='))
+    expect(rasterizeShareCardPngDataUrl).toHaveBeenCalledTimes(1)
+    expect(screen.getByText('PNG saved.')).toBeTruthy()
+  })
+})

--- a/app/renderer/components/ShareCardModal.tsx
+++ b/app/renderer/components/ShareCardModal.tsx
@@ -109,10 +109,16 @@ export function ShareCardModal({
             </ul>
 
             <label className="share-card-option">
-              <input type="checkbox" checked={includeCost} onChange={event => setIncludeCost(event.target.checked)} />
+              <input
+                type="checkbox"
+                aria-label="Include exact spend"
+                aria-describedby="share-card-cost-help"
+                checked={includeCost}
+                onChange={event => setIncludeCost(event.target.checked)}
+              />
               <div>
                 Include exact spend
-                <span>Off by default. Pricing coverage is shown when it is incomplete.</span>
+                <span id="share-card-cost-help">Off by default. Pricing coverage is shown when it is incomplete.</span>
               </div>
             </label>
 
@@ -120,13 +126,15 @@ export function ShareCardModal({
               <label className="share-card-option">
                 <input
                   type="checkbox"
+                  aria-label="Include Project name"
+                  aria-describedby="share-card-project-help"
                   checked={includeProjectName}
                   disabled={!projectScopeName}
                   onChange={event => setIncludeProjectName(event.target.checked)}
                 />
                 <div>
                   Include Project name
-                  <span>{projectScopeName ? 'Off by default.' : 'Project name is unavailable for this scope.'}</span>
+                  <span id="share-card-project-help">{projectScopeName ? 'Off by default.' : 'Project name is unavailable for this scope.'}</span>
                 </div>
               </label>
             )}

--- a/app/renderer/components/ShareCardModal.tsx
+++ b/app/renderer/components/ShareCardModal.tsx
@@ -1,0 +1,151 @@
+import { useEffect, useMemo, useState } from 'react'
+import { createPortal } from 'react-dom'
+
+import { metrora } from '../lib/ipc'
+import type { DateRange, MenubarPayload, Period } from '../lib/types'
+import {
+  buildShareCardV1,
+  rasterizeShareCardPngDataUrl,
+  shareCardSvgDataUrl,
+} from '../share-card'
+import '../styles/share-card.css'
+
+export type ShareCardModalProps = {
+  payload: MenubarPayload
+  period: Period
+  range?: DateRange | null
+  providerLabel: string
+  projectScopeActive?: boolean
+  projectScopeName?: string | null
+  stale?: boolean
+  onClose: () => void
+}
+
+export function ShareCardModal({
+  payload,
+  period,
+  range = null,
+  providerLabel,
+  projectScopeActive = false,
+  projectScopeName = null,
+  stale = false,
+  onClose,
+}: ShareCardModalProps) {
+  const [includeCost, setIncludeCost] = useState(false)
+  const [includeProjectName, setIncludeProjectName] = useState(false)
+  const [saving, setSaving] = useState(false)
+  const [status, setStatus] = useState<{ text: string; error: boolean }>({ text: '', error: false })
+
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') onClose()
+    }
+    document.addEventListener('keydown', onKeyDown)
+    return () => document.removeEventListener('keydown', onKeyDown)
+  }, [onClose])
+
+  const card = useMemo(() => buildShareCardV1({
+    payload,
+    period,
+    range,
+    providerLabel,
+    projectScopeActive,
+    projectScopeName,
+    includeProjectName,
+    includeCost,
+    stale,
+  }), [includeCost, includeProjectName, payload, period, projectScopeActive, projectScopeName, providerLabel, range, stale])
+
+  const save = async () => {
+    setSaving(true)
+    setStatus({ text: '', error: false })
+    try {
+      const pngDataUrl = await rasterizeShareCardPngDataUrl(card)
+      const saved = await metrora.saveShareCardPng('metrora-ai-recap.png', pngDataUrl)
+      setStatus({ text: saved ? 'PNG saved.' : 'Save cancelled.', error: false })
+    } catch (cause) {
+      setStatus({ text: cause instanceof Error ? cause.message : 'Share card could not be saved.', error: true })
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const disclosureProject = projectScopeActive
+    ? includeProjectName && projectScopeName ? projectScopeName : 'Current Project scope (name hidden)'
+    : 'All Projects'
+
+  return createPortal(
+    <div className="share-card-backdrop" onClick={onClose}>
+      <div
+        className="share-card-modal"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="share-card-title"
+        onClick={event => event.stopPropagation()}
+      >
+        <div className="share-card-head">
+          <div>
+            <h2 id="share-card-title">Create share card</h2>
+            <p>Preview the exact local disclosure before saving a PNG.</p>
+          </div>
+          <button className="share-card-close" type="button" aria-label="Close share card" onClick={onClose}>×</button>
+        </div>
+
+        <div className="share-card-body">
+          <div className="share-card-preview-shell">
+            <img src={shareCardSvgDataUrl(card)} alt="Metrora AI recap share card preview" />
+            <p className="share-card-preview-note">The PNG is rendered from this same local preview. Nothing is uploaded.</p>
+          </div>
+
+          <aside className="share-card-disclosure" aria-label="Share card disclosure">
+            <h3>Included in this card</h3>
+            <ul className="share-card-disclosure-list">
+              <li><span>Period</span><strong>{card.periodLabel}</strong></li>
+              <li><span>Provider scope</span><strong>{card.providerScope}</strong></li>
+              <li><span>Project scope</span><strong>{disclosureProject}</strong></li>
+              <li><span>Calls</span><strong>{card.metrics.calls.toLocaleString('en-US')}</strong></li>
+              <li><span>Sessions</span><strong>{card.metrics.sessions.toLocaleString('en-US')}</strong></li>
+              <li><span>Top model</span><strong>{card.topModel?.name ?? 'Not available'}</strong></li>
+            </ul>
+
+            <label className="share-card-option">
+              <input type="checkbox" checked={includeCost} onChange={event => setIncludeCost(event.target.checked)} />
+              <div>
+                Include exact spend
+                <span>Off by default. Pricing coverage is shown when it is incomplete.</span>
+              </div>
+            </label>
+
+            {projectScopeActive && (
+              <label className="share-card-option">
+                <input
+                  type="checkbox"
+                  checked={includeProjectName}
+                  disabled={!projectScopeName}
+                  onChange={event => setIncludeProjectName(event.target.checked)}
+                />
+                <div>
+                  Include Project name
+                  <span>{projectScopeName ? 'Off by default.' : 'Project name is unavailable for this scope.'}</span>
+                </div>
+              </label>
+            )}
+
+            <div className="share-card-privacy">
+              Prompts, responses, repository identity, local paths, session IDs, provider account labels, quota and credentials are never included in ShareCardV1.
+            </div>
+          </aside>
+        </div>
+
+        <div className="share-card-actions">
+          <div className={`share-card-status${status.error ? ' error' : ''}`} role={status.error ? 'alert' : 'status'}>{status.text}</div>
+          <div>
+            <button className="btn" type="button" onClick={onClose} disabled={saving}>Cancel</button>{' '}
+            <button className="btn btn-p" type="button" onClick={() => void save()} disabled={saving}>{saving ? 'Rendering…' : 'Save PNG'}</button>
+          </div>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  )
+}

--- a/app/renderer/lib/metrora-bridge-types.ts
+++ b/app/renderer/lib/metrora-bridge-types.ts
@@ -134,6 +134,7 @@ export interface MetroraBridge extends ProjectBridge {
   setPlan(id: string, provider: string): Promise<ActionResult>
   resetPlan(provider: string): Promise<ActionResult>
   exportData(format: string, provider: string, outPath: string): Promise<ActionResult>
+  saveShareCardPng(suggestedName: string, pngDataUrl: string): Promise<boolean>
   chooseDirectory(): Promise<string | null>
   cliStatus(): Promise<{ found: boolean; path: string | null; error?: string }>
   telemetryStatus(): Promise<TelemetryStatus | null>

--- a/app/renderer/sections/Overview.tsx
+++ b/app/renderer/sections/Overview.tsx
@@ -5,6 +5,7 @@ import { ActivityHeatmap } from '../components/ActivityHeatmap'
 import { EmptyNote } from '../components/EmptyState'
 import { ListRow } from '../components/ListRow'
 import { SectionSkeleton } from '../components/Skeleton'
+import { ShareCardModal } from '../components/ShareCardModal'
 import { StaleBanner } from '../components/StaleBanner'
 import { useBarGrowIn } from '../lib/motion'
 import { type Polled, usePolled } from '../hooks/usePolled'
@@ -326,6 +327,7 @@ export function OverviewContent({
 }) {
   const actReport = usePolled<ActReportJson>(() => metrora.getActReport(), [], { enabled: ready, memoKey: 'overview-act' })
   const yieldReport = usePolled<YieldJsonReport>(() => metrora.getYield(period, provider), [period, provider], { enabled: ready, memoKey: `overview-yield|${period}|${provider}` })
+  const [shareOpen, setShareOpen] = useState(false)
   const { data, error } = overview
   const modelIndex = useMemo(() => data ? buildModelIndex(data) : new Map<string, string>(), [data])
 
@@ -359,6 +361,14 @@ export function OverviewContent({
   const signals = deriveSignals(data, now, rangeActive)
   const decision = deriveOverviewDecision(data, signals, rangeActive)
   const streak = streakDays(data.history.daily, now)
+  const providerLabel = provider === 'all'
+    ? 'All providers'
+    : data.current.providerDetails?.find(item => item.id === provider)?.label ?? provider
+  const selectedProjectId = data.projectScope?.selectedId ?? 'all'
+  const projectScopeActive = selectedProjectId !== 'all'
+  const projectScopeName = projectScopeActive
+    ? data.projectScope?.options.find(option => option.id === selectedProjectId)?.name ?? null
+    : null
   return (
     <div className="ov-dashboard">
       {error && <StaleBanner error={error} />}
@@ -367,6 +377,15 @@ export function OverviewContent({
           Showing canonical last-good data · source reconciliation is incomplete
         </div>
       )}
+
+      <div className="share-card-trigger-row">
+        <div className="share-card-trigger-copy">
+          <strong>Share this recap</strong>
+          <span>Create a privacy-safe PNG from the exact local scope you are viewing.</span>
+        </div>
+        <button className="btn" type="button" onClick={() => setShareOpen(true)}>Create share card</button>
+      </div>
+
       <div className="ov-card ov-home-shell" aria-label="Key performance indicators">
         <OverviewHomeSummary
           current={data.current}
@@ -424,6 +443,19 @@ export function OverviewContent({
           <EfficiencyDiagnostics current={data.current} />
         </div>
       </div>
+
+      {shareOpen && (
+        <ShareCardModal
+          payload={data}
+          period={period}
+          range={range}
+          providerLabel={providerLabel}
+          projectScopeActive={projectScopeActive}
+          projectScopeName={projectScopeName}
+          stale={Boolean(error)}
+          onClose={() => setShareOpen(false)}
+        />
+      )}
     </div>
   )
 }

--- a/app/renderer/share-card.test.ts
+++ b/app/renderer/share-card.test.ts
@@ -64,6 +64,27 @@ describe('ShareCardV1 projection', () => {
     expect(card.dataState).toBe('partial')
     expect(shareCardPeriodLabel('week')).toBe('Last 7 days')
   })
+
+  it('fails closed instead of exporting non-finite or negative evidence', () => {
+    expect(() => buildShareCardV1({
+      payload: payload({ calls: Number.NaN }),
+      period: 'week',
+      providerLabel: 'All providers',
+    })).toThrow(/call-count evidence is invalid/u)
+
+    expect(() => buildShareCardV1({
+      payload: payload({ cost: Number.POSITIVE_INFINITY }),
+      period: 'week',
+      providerLabel: 'All providers',
+      includeCost: true,
+    })).toThrow(/cost evidence is invalid/u)
+
+    expect(() => buildShareCardV1({
+      payload: payload({ sessions: -1 }),
+      period: 'week',
+      providerLabel: 'All providers',
+    })).toThrow(/session-count evidence is invalid/u)
+  })
 })
 
 describe('ShareCardV1 SVG renderer', () => {
@@ -84,6 +105,7 @@ describe('ShareCardV1 SVG renderer', () => {
     expect(svg).toContain('&lt;model&gt;&amp;&quot;')
     expect(svg).not.toContain('<unsafe>')
     expect(svg).toContain('Metrora · metrora.eu')
+    expect(svg).toContain('Spend (USD)')
     expect(svg).toContain('82% of cost-bearing calls priced')
   })
 })

--- a/app/renderer/share-card.test.ts
+++ b/app/renderer/share-card.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest'
+
+import type { MenubarPayload } from './lib/types'
+import { buildShareCardV1, renderShareCardSvg, shareCardPeriodLabel } from './share-card'
+
+function payload(overrides: Partial<MenubarPayload['current']> = {}, reconciliation: 'complete' | 'degraded' = 'complete'): MenubarPayload {
+  return {
+    freshness: { readMode: 'snapshot', reconciliation, durableThrough: null },
+    current: {
+      calls: 1_234,
+      sessions: 48,
+      cost: 67.89,
+      topModels: [{ name: 'gpt-5.6-sol', calls: 812, cost: 50, savingsUSD: 0, savingsBaselineModel: '' }],
+      pricingCoverage: 0.82,
+      ...overrides,
+    },
+  } as unknown as MenubarPayload
+}
+
+describe('ShareCardV1 projection', () => {
+  it('keeps exact cost and Project name private by default', () => {
+    const card = buildShareCardV1({
+      payload: payload(),
+      period: '30days',
+      providerLabel: 'All providers',
+      projectScopeActive: true,
+      projectScopeName: 'Secret launch repo',
+    })
+
+    expect(card.schemaVersion).toBe('metrora.share-card.v1')
+    expect(card.metrics.costUSD).toBeNull()
+    expect(card.pricingCoverage).toBeNull()
+    expect(card.projectScope).toEqual({ active: true, name: null })
+    expect(card.metrics.calls).toBe(1234)
+    expect(card.metrics.sessions).toBe(48)
+    expect(card.topModel).toEqual({ name: 'gpt-5.6-sol', calls: 812 })
+  })
+
+  it('discloses optional sensitive aggregates only after explicit selection', () => {
+    const card = buildShareCardV1({
+      payload: payload(),
+      period: 'week',
+      providerLabel: 'Codex',
+      projectScopeActive: true,
+      projectScopeName: 'Launch & growth',
+      includeProjectName: true,
+      includeCost: true,
+    })
+
+    expect(card.metrics.costUSD).toBe(67.89)
+    expect(card.pricingCoverage).toBe(0.82)
+    expect(card.projectScope.name).toBe('Launch & growth')
+  })
+
+  it('keeps custom ranges explicit and marks degraded evidence', () => {
+    const card = buildShareCardV1({
+      payload: payload({}, 'degraded'),
+      period: '30days',
+      range: { from: '2026-08-01', to: '2026-08-25' },
+      providerLabel: 'All providers',
+    })
+
+    expect(card.periodLabel).toBe('2026-08-01 – 2026-08-25')
+    expect(card.dataState).toBe('partial')
+    expect(shareCardPeriodLabel('week')).toBe('Last 7 days')
+  })
+})
+
+describe('ShareCardV1 SVG renderer', () => {
+  it('escapes user-controlled labels and carries stable Metrora attribution', () => {
+    const card = buildShareCardV1({
+      payload: payload({ topModels: [{ name: '<model>&"', calls: 4, cost: 1, savingsUSD: 0, savingsBaselineModel: '' }] }),
+      period: 'week',
+      providerLabel: 'Provider <unsafe>',
+      projectScopeActive: true,
+      projectScopeName: 'Project & <private>',
+      includeProjectName: true,
+      includeCost: true,
+    })
+    const svg = renderShareCardSvg(card)
+
+    expect(svg).toContain('Provider &lt;unsafe&gt;')
+    expect(svg).toContain('Project: Project &amp; &lt;private&gt;')
+    expect(svg).toContain('&lt;model&gt;&amp;&quot;')
+    expect(svg).not.toContain('<unsafe>')
+    expect(svg).toContain('Metrora · metrora.eu')
+    expect(svg).toContain('82% of cost-bearing calls priced')
+  })
+})

--- a/app/renderer/share-card.ts
+++ b/app/renderer/share-card.ts
@@ -1,0 +1,211 @@
+import { PERIOD_LABELS } from './lib/desktopSections'
+import type { DateRange, MenubarPayload, Period } from './lib/types'
+
+export const SHARE_CARD_V1_SCHEMA = 'metrora.share-card.v1' as const
+export const SHARE_CARD_V1_FAMILY = 'ai-recap' as const
+export const SHARE_CARD_WIDTH = 1200
+export const SHARE_CARD_HEIGHT = 630
+
+export type ShareCardDataState = 'current' | 'last-good' | 'partial'
+
+export type ShareCardV1 = {
+  schemaVersion: typeof SHARE_CARD_V1_SCHEMA
+  family: typeof SHARE_CARD_V1_FAMILY
+  periodLabel: string
+  providerScope: string
+  projectScope: {
+    active: boolean
+    name: string | null
+  }
+  metrics: {
+    calls: number
+    sessions: number
+    costUSD: number | null
+  }
+  topModel: {
+    name: string
+    calls: number
+  } | null
+  pricingCoverage: number | null
+  dataState: ShareCardDataState
+  attribution: 'Metrora · metrora.eu'
+}
+
+export type BuildShareCardV1Input = {
+  payload: MenubarPayload
+  period: Period
+  range?: DateRange | null
+  providerLabel: string
+  projectScopeActive?: boolean
+  projectScopeName?: string | null
+  includeProjectName?: boolean
+  includeCost?: boolean
+  stale?: boolean
+}
+
+function boundedText(value: string, max = 80): string {
+  return value.replace(/[\u0000-\u001f\u007f]/gu, ' ').replace(/\s+/gu, ' ').trim().slice(0, max)
+}
+
+function xml(value: string): string {
+  return value
+    .replace(/&/gu, '&amp;')
+    .replace(/</gu, '&lt;')
+    .replace(/>/gu, '&gt;')
+    .replace(/"/gu, '&quot;')
+    .replace(/'/gu, '&apos;')
+}
+
+function displayText(value: string, max = 42): string {
+  const normalized = boundedText(value, max + 1)
+  return normalized.length > max ? normalized.slice(0, max - 1) + '…' : normalized
+}
+
+export function shareCardPeriodLabel(period: Period, range?: DateRange | null): string {
+  if (range) return range.from === range.to ? range.from : `${range.from} – ${range.to}`
+  return PERIOD_LABELS[period]
+}
+
+export function buildShareCardV1(input: BuildShareCardV1Input): ShareCardV1 {
+  const current = input.payload.current
+  const includeCost = Boolean(input.includeCost)
+  const reconciliation = input.payload.freshness?.reconciliation
+  const dataState: ShareCardDataState = input.stale
+    ? 'last-good'
+    : reconciliation === 'degraded'
+      ? 'partial'
+      : 'current'
+  const topModel = current.topModels[0]
+  const projectActive = Boolean(input.projectScopeActive)
+  const disclosedProject = projectActive && input.includeProjectName && input.projectScopeName
+    ? boundedText(input.projectScopeName)
+    : null
+
+  return {
+    schemaVersion: SHARE_CARD_V1_SCHEMA,
+    family: SHARE_CARD_V1_FAMILY,
+    periodLabel: boundedText(shareCardPeriodLabel(input.period, input.range), 64),
+    providerScope: boundedText(input.providerLabel || 'All providers', 64),
+    projectScope: {
+      active: projectActive,
+      name: disclosedProject,
+    },
+    metrics: {
+      calls: Math.max(0, current.calls),
+      sessions: Math.max(0, current.sessions),
+      costUSD: includeCost ? Math.max(0, current.cost) : null,
+    },
+    topModel: topModel ? {
+      name: boundedText(topModel.name, 96),
+      calls: Math.max(0, topModel.calls),
+    } : null,
+    pricingCoverage: includeCost && typeof current.pricingCoverage === 'number'
+      ? Math.max(0, Math.min(1, current.pricingCoverage))
+      : null,
+    dataState,
+    attribution: 'Metrora · metrora.eu',
+  }
+}
+
+function formatInteger(value: number): string {
+  return Math.round(value).toLocaleString('en-US')
+}
+
+function formatCost(value: number): string {
+  return '$' + value.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })
+}
+
+function metricBlock(x: number, label: string, value: string, detail = ''): string {
+  return `<g transform="translate(${x} 0)">
+    <rect x="0" y="242" width="300" height="142" rx="22" fill="#15191f" stroke="#27313a"/>
+    <text x="24" y="280" fill="#91a0aa" font-size="18" font-weight="600">${xml(label)}</text>
+    <text x="24" y="332" fill="#f7fbfd" font-size="42" font-weight="700">${xml(value)}</text>
+    ${detail ? `<text x="24" y="360" fill="#7f909a" font-size="16">${xml(detail)}</text>` : ''}
+  </g>`
+}
+
+function metroraMark(): string {
+  return `<g fill="#f7fbfd" transform="translate(0 2) scale(.22)">
+    <rect x="8" y="8" width="14" height="104" rx="2"/>
+    <rect x="38" y="40" width="14" height="88" rx="2"/>
+    <rect x="68" y="68" width="14" height="76" rx="2"/>
+    <rect x="98" y="68" width="14" height="76" rx="2"/>
+    <rect x="128" y="40" width="14" height="88" rx="2"/>
+    <rect x="158" y="8" width="14" height="104" rx="2"/>
+  </g>`
+}
+
+export function renderShareCardSvg(card: ShareCardV1): string {
+  const projectScope = card.projectScope.active
+    ? card.projectScope.name ? `Project: ${displayText(card.projectScope.name, 34)}` : 'Current Project scope'
+    : 'All Projects'
+  const topModel = card.topModel ? displayText(card.topModel.name, 34) : 'Not available'
+  const stateNote = card.dataState === 'last-good'
+    ? 'Last-good data · latest refresh unavailable'
+    : card.dataState === 'partial'
+      ? 'Incomplete source reconciliation'
+      : ''
+  const coverageNote = card.metrics.costUSD !== null && card.pricingCoverage !== null && card.pricingCoverage < 1
+    ? `${Math.round(card.pricingCoverage * 100)}% of cost-bearing calls priced`
+    : ''
+  const notice = [stateNote, coverageNote].filter(Boolean).join(' · ')
+  const thirdMetric = card.metrics.costUSD === null
+    ? metricBlock(828, 'Top model', topModel, card.topModel ? `${formatInteger(card.topModel.calls)} calls` : '')
+    : metricBlock(828, 'Spend', formatCost(card.metrics.costUSD), coverageNote)
+
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="${SHARE_CARD_WIDTH}" height="${SHARE_CARD_HEIGHT}" viewBox="0 0 ${SHARE_CARD_WIDTH} ${SHARE_CARD_HEIGHT}">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#0d0f13"/>
+      <stop offset="1" stop-color="#111a20"/>
+    </linearGradient>
+    <radialGradient id="glow" cx="0" cy="0" r="1" gradientTransform="translate(1030 38) rotate(136) scale(460 360)">
+      <stop offset="0" stop-color="#00d4ff" stop-opacity=".18"/>
+      <stop offset="1" stop-color="#00d4ff" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+  <rect width="1200" height="630" rx="28" fill="url(#bg)"/>
+  <rect width="1200" height="630" rx="28" fill="url(#glow)"/>
+  <rect x="1" y="1" width="1198" height="628" rx="27" fill="none" stroke="#26313a"/>
+  <g font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif">
+    <g transform="translate(54 44)">
+      ${metroraMark()}
+      <text x="48" y="30" fill="#f7fbfd" font-size="25" font-weight="700">Metrora</text>
+      <text x="48" y="55" fill="#7f909a" font-size="14" letter-spacing="1.4">LOCAL AI USAGE INTELLIGENCE</text>
+    </g>
+    <text x="54" y="156" fill="#66e6ff" font-size="18" font-weight="700" letter-spacing="2">AI RECAP</text>
+    <text x="54" y="205" fill="#f7fbfd" font-size="44" font-weight="750">${xml(displayText(card.periodLabel, 38))}</text>
+    ${metricBlock(54, 'Calls', formatInteger(card.metrics.calls))}
+    ${metricBlock(441, 'Sessions', formatInteger(card.metrics.sessions))}
+    ${thirdMetric}
+    <text x="54" y="442" fill="#7f909a" font-size="16" font-weight="600">SCOPE</text>
+    <text x="54" y="477" fill="#dbe5ea" font-size="22">${xml(displayText(card.providerScope, 34))} · ${xml(projectScope)}</text>
+    ${card.metrics.costUSD !== null && card.topModel ? `<text x="54" y="515" fill="#91a0aa" font-size="18">Top model: ${xml(topModel)} · ${formatInteger(card.topModel.calls)} calls</text>` : ''}
+    ${notice ? `<text x="54" y="552" fill="#f0b86e" font-size="16">${xml(displayText(notice, 90))}</text>` : ''}
+    <line x1="54" x2="1146" y1="578" y2="578" stroke="#26313a"/>
+    <text x="54" y="608" fill="#82929c" font-size="16">${xml(card.attribution)}</text>
+    <text x="1146" y="608" text-anchor="end" fill="#586872" font-size="14">Measured locally · shared by you</text>
+  </g>
+</svg>`
+}
+
+export function shareCardSvgDataUrl(card: ShareCardV1): string {
+  return `data:image/svg+xml;charset=utf-8,${encodeURIComponent(renderShareCardSvg(card))}`
+}
+
+export async function rasterizeShareCardPngDataUrl(card: ShareCardV1): Promise<string> {
+  const image = new Image()
+  const src = shareCardSvgDataUrl(card)
+  await new Promise<void>((resolve, reject) => {
+    image.onload = () => resolve()
+    image.onerror = () => reject(new Error('Share card preview could not be rendered.'))
+    image.src = src
+  })
+  const canvas = document.createElement('canvas')
+  canvas.width = SHARE_CARD_WIDTH
+  canvas.height = SHARE_CARD_HEIGHT
+  const context = canvas.getContext('2d')
+  if (!context) throw new Error('PNG rendering is unavailable on this device.')
+  context.drawImage(image, 0, 0, SHARE_CARD_WIDTH, SHARE_CARD_HEIGHT)
+  return canvas.toDataURL('image/png')
+}

--- a/app/renderer/share-card.ts
+++ b/app/renderer/share-card.ts
@@ -163,7 +163,7 @@ export function renderShareCardSvg(card: ShareCardV1): string {
     : ''
   const thirdMetric = card.metrics.costUSD === null
     ? metricBlock(828, 'Top model', topModel, card.topModel ? `${formatInteger(card.topModel.calls)} calls` : '')
-    : metricBlock(828, 'Spend', formatCost(card.metrics.costUSD), coverageNote)
+    : metricBlock(828, 'Spend (USD)', formatCost(card.metrics.costUSD), coverageNote)
 
   return `<svg xmlns="http://www.w3.org/2000/svg" width="${SHARE_CARD_WIDTH}" height="${SHARE_CARD_HEIGHT}" viewBox="0 0 ${SHARE_CARD_WIDTH} ${SHARE_CARD_HEIGHT}">
   <defs>

--- a/app/renderer/share-card.ts
+++ b/app/renderer/share-card.ts
@@ -47,6 +47,16 @@ function boundedText(value: string, max = 80): string {
   return value.replace(/[\u0000-\u001f\u007f]/gu, ' ').replace(/\s+/gu, ' ').trim().slice(0, max)
 }
 
+function finiteNonNegative(value: number): number | null {
+  return Number.isFinite(value) && value >= 0 ? value : null
+}
+
+function requiredCount(value: number, label: string): number {
+  const safe = finiteNonNegative(value)
+  if (safe === null) throw new Error(`Share card ${label} evidence is invalid.`)
+  return safe
+}
+
 function xml(value: string): string {
   return value
     .replace(/&/gu, '&amp;')
@@ -80,6 +90,11 @@ export function buildShareCardV1(input: BuildShareCardV1Input): ShareCardV1 {
   const disclosedProject = projectActive && input.includeProjectName && input.projectScopeName
     ? boundedText(input.projectScopeName)
     : null
+  const cost = includeCost ? finiteNonNegative(current.cost) : null
+  if (includeCost && cost === null) throw new Error('Share card cost evidence is invalid.')
+  const coverage = includeCost && typeof current.pricingCoverage === 'number'
+    ? finiteNonNegative(current.pricingCoverage)
+    : null
 
   return {
     schemaVersion: SHARE_CARD_V1_SCHEMA,
@@ -91,17 +106,15 @@ export function buildShareCardV1(input: BuildShareCardV1Input): ShareCardV1 {
       name: disclosedProject,
     },
     metrics: {
-      calls: Math.max(0, current.calls),
-      sessions: Math.max(0, current.sessions),
-      costUSD: includeCost ? Math.max(0, current.cost) : null,
+      calls: requiredCount(current.calls, 'call-count'),
+      sessions: requiredCount(current.sessions, 'session-count'),
+      costUSD: cost,
     },
     topModel: topModel ? {
       name: boundedText(topModel.name, 96),
-      calls: Math.max(0, topModel.calls),
+      calls: requiredCount(topModel.calls, 'top-model call-count'),
     } : null,
-    pricingCoverage: includeCost && typeof current.pricingCoverage === 'number'
-      ? Math.max(0, Math.min(1, current.pricingCoverage))
-      : null,
+    pricingCoverage: coverage === null ? null : Math.min(1, coverage),
     dataState,
     attribution: 'Metrora · metrora.eu',
   }
@@ -148,7 +161,6 @@ export function renderShareCardSvg(card: ShareCardV1): string {
   const coverageNote = card.metrics.costUSD !== null && card.pricingCoverage !== null && card.pricingCoverage < 1
     ? `${Math.round(card.pricingCoverage * 100)}% of cost-bearing calls priced`
     : ''
-  const notice = [stateNote, coverageNote].filter(Boolean).join(' · ')
   const thirdMetric = card.metrics.costUSD === null
     ? metricBlock(828, 'Top model', topModel, card.topModel ? `${formatInteger(card.topModel.calls)} calls` : '')
     : metricBlock(828, 'Spend', formatCost(card.metrics.costUSD), coverageNote)
@@ -181,7 +193,7 @@ export function renderShareCardSvg(card: ShareCardV1): string {
     <text x="54" y="442" fill="#7f909a" font-size="16" font-weight="600">SCOPE</text>
     <text x="54" y="477" fill="#dbe5ea" font-size="22">${xml(displayText(card.providerScope, 34))} · ${xml(projectScope)}</text>
     ${card.metrics.costUSD !== null && card.topModel ? `<text x="54" y="515" fill="#91a0aa" font-size="18">Top model: ${xml(topModel)} · ${formatInteger(card.topModel.calls)} calls</text>` : ''}
-    ${notice ? `<text x="54" y="552" fill="#f0b86e" font-size="16">${xml(displayText(notice, 90))}</text>` : ''}
+    ${stateNote ? `<text x="54" y="552" fill="#f0b86e" font-size="16">${xml(displayText(stateNote, 90))}</text>` : ''}
     <line x1="54" x2="1146" y1="578" y2="578" stroke="#26313a"/>
     <text x="54" y="608" fill="#82929c" font-size="16">${xml(card.attribution)}</text>
     <text x="1146" y="608" text-anchor="end" fill="#586872" font-size="14">Measured locally · shared by you</text>

--- a/app/renderer/styles/share-card.css
+++ b/app/renderer/styles/share-card.css
@@ -1,0 +1,209 @@
+.share-card-trigger-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  margin: 0 0 12px;
+  padding: 10px 12px;
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  background: color-mix(in srgb, var(--panel) 94%, var(--accent) 6%);
+}
+
+.share-card-trigger-copy {
+  min-width: 0;
+}
+
+.share-card-trigger-copy strong {
+  display: block;
+  color: var(--ink);
+  font-size: 13px;
+}
+
+.share-card-trigger-copy span {
+  display: block;
+  margin-top: 2px;
+  color: var(--muted);
+  font-size: 11px;
+}
+
+.share-card-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 1200;
+  display: grid;
+  place-items: center;
+  padding: 24px;
+  background: rgba(4, 7, 10, .72);
+  backdrop-filter: blur(10px);
+}
+
+.share-card-modal {
+  width: min(980px, calc(100vw - 40px));
+  max-height: min(760px, calc(100vh - 40px));
+  overflow: auto;
+  border: 1px solid var(--line);
+  border-radius: 20px;
+  background: var(--panel);
+  box-shadow: 0 28px 90px rgba(0, 0, 0, .42);
+}
+
+.share-card-head,
+.share-card-actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.share-card-head {
+  padding: 20px 22px 14px;
+  border-bottom: 1px solid var(--line2);
+}
+
+.share-card-head h2 {
+  margin: 0;
+  color: var(--ink);
+  font-size: 18px;
+}
+
+.share-card-head p {
+  margin: 4px 0 0;
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.share-card-close {
+  width: 34px;
+  height: 34px;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  background: var(--fill);
+  color: var(--ink);
+  font-size: 20px;
+  cursor: pointer;
+}
+
+.share-card-body {
+  display: grid;
+  grid-template-columns: minmax(0, 1.45fr) minmax(250px, .75fr);
+  gap: 20px;
+  padding: 20px 22px;
+}
+
+.share-card-preview-shell {
+  min-width: 0;
+}
+
+.share-card-preview-shell img {
+  display: block;
+  width: 100%;
+  height: auto;
+  border: 1px solid var(--line);
+  border-radius: 16px;
+  background: #0d0f13;
+  box-shadow: 0 14px 34px rgba(0, 0, 0, .22);
+}
+
+.share-card-preview-note {
+  margin: 10px 2px 0;
+  color: var(--muted);
+  font-size: 11px;
+}
+
+.share-card-disclosure {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.share-card-disclosure h3 {
+  margin: 0;
+  color: var(--ink);
+  font-size: 13px;
+}
+
+.share-card-disclosure-list {
+  display: grid;
+  gap: 8px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.share-card-disclosure-list li {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  color: var(--muted);
+  font-size: 11px;
+}
+
+.share-card-disclosure-list strong {
+  max-width: 58%;
+  overflow: hidden;
+  color: var(--ink);
+  font-size: 11px;
+  text-align: right;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.share-card-option {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 10px 0;
+  border-top: 1px solid var(--line2);
+  color: var(--ink);
+  font-size: 12px;
+}
+
+.share-card-option input {
+  margin-top: 2px;
+}
+
+.share-card-option span {
+  display: block;
+  margin-top: 2px;
+  color: var(--muted);
+  font-size: 10px;
+}
+
+.share-card-privacy {
+  padding: 10px 12px;
+  border: 1px solid color-mix(in srgb, var(--accent) 24%, var(--line));
+  border-radius: 10px;
+  background: color-mix(in srgb, var(--accent) 7%, transparent);
+  color: var(--muted);
+  font-size: 11px;
+  line-height: 1.45;
+}
+
+.share-card-actions {
+  padding: 14px 22px 20px;
+  border-top: 1px solid var(--line2);
+}
+
+.share-card-status {
+  min-height: 18px;
+  color: var(--muted);
+  font-size: 11px;
+}
+
+.share-card-status.error {
+  color: #d96c6c;
+}
+
+@media (max-width: 760px) {
+  .share-card-body {
+    grid-template-columns: 1fr;
+  }
+
+  .share-card-trigger-row,
+  .share-card-actions {
+    align-items: stretch;
+    flex-direction: column;
+  }
+}


### PR DESCRIPTION
## Summary

Adds the first bounded ShareCardV1 product surface to Metrora Desktop.

- adds a typed `metrora.share-card.v1` AI recap projection from the already-loaded canonical Overview snapshot;
- adds an exact local disclosure preview and 1200×630 branded PNG export;
- keeps exact spend and Project name off by default and requires explicit user selection to include them;
- keeps provider/period/Project scope truthful, including last-good or incomplete reconciliation state;
- exports locally through a narrow trusted IPC: renderer supplies only a sanitized suggested filename plus bounded PNG data, while the main process owns the native save dialog and never returns the selected path;
- includes no prompts, responses, repository identity, local paths, session IDs, provider account labels, quota, credentials, account, cloud upload or tracking.

## Scope

V1 intentionally implements only the `AI recap` family. It does not add a generic card editor, hosted profile, direct social posting, quota cards, Bench cards, new analytics, new measurement authority or a second sharing backend.

## Validation intent

New coverage checks:
- default disclosure privacy;
- explicit cost/Project-name opt-in;
- custom period and degraded/last-good semantics;
- XML escaping and numeric fail-closed behavior;
- cross-platform filename sanitization;
- PNG MIME/base64/signature/size bounds;
- no filesystem write before native save acceptance;
- preview and saved PNG derive from the same local SVG representation.

No release, signing or publication is part of this PR.