### PR TITLE
feat(advisor): integrate contextual Desktop launch V1

### DIFF
--- a/app/renderer/App.tsx
+++ b/app/renderer/App.tsx
@@ -36,6 +36,7 @@ import { WorkspaceContent } from './sections/Workspace'
 import { Advisor } from './sections/Advisor'
 import { Bench } from './sections/Bench'
 import type { MenubarPayload } from './lib/types'
+import { createAdvisorContextualLaunch, type AdvisorContextualLaunchV1 } from './advisor/context'
 
 export { overviewMemoKey } from './hooks/useProviderPrefetch'
 export { topCategoryByModel, usageSnapshotProps } from './hooks/useDesktopTelemetry'
@@ -72,6 +73,7 @@ export function App() {
 function AppMain() {
   const [section, setSection] = useState<Section>('overview')
   const [settingsPane, setSettingsPane] = useState<SettingsPane>('general')
+  const [advisorLaunch, setAdvisorLaunch] = useState<AdvisorContextualLaunchV1 | null>(null)
   const [detectedProviders, setDetectedProviders] = useState<Array<{ id: string; label: string }>>([])
   const {
     period,
@@ -120,8 +122,16 @@ function AppMain() {
 
   const navigate = useCallback((next: Section, pane: SettingsPane = 'general') => {
     setSettingsPane(pane)
+    setAdvisorLaunch(null)
     setSection(next)
     trackEvent('section_view', { section: next })
+  }, [trackEvent])
+
+  const openAdvisor = useCallback((launch: AdvisorContextualLaunchV1) => {
+    setSettingsPane('general')
+    setAdvisorLaunch(launch)
+    setSection('advisor')
+    trackEvent('section_view', { section: 'advisor' })
   }, [trackEvent])
 
   useDesktopShortcuts({ navigate, refresh: refreshVisible })
@@ -132,6 +142,19 @@ function AppMain() {
     : null
   const scope = `${customRange ? rangeLabel(customRange) : PERIOD_LABELS[period]} · ${providerLabel}${activeConfigLabel ? ` · ${activeConfigLabel}` : ''}`
   const projectScope = overview.data?.projectScope
+  const projectName = metroraProjectId === 'all'
+    ? 'All projects'
+    : projectScope?.options.find(option => option.id === metroraProjectId)?.name ?? null
+  const contextualAdvisorLaunch = projectName
+    ? createAdvisorContextualLaunch({
+        originatingSection: section,
+        period,
+        range: customRange,
+        provider,
+        projectId: metroraProjectId,
+        projectName,
+      })
+    : null
   useEffect(() => {
     if (!projectScope || projectScope.options.some(option => option.id === metroraProjectId)) return
     onProjectScopeSelect('all')
@@ -151,9 +174,9 @@ function AppMain() {
         {section === 'bench' ? (
           <Bench />
         ) : section === 'advisor' ? (
-          <Advisor period={period} provider={provider} projectScopeId={metroraProjectId} range={customRange} overview={overview} detectedProviders={detectedProviders} />
+          <Advisor period={period} provider={provider} projectScopeId={metroraProjectId} range={customRange} overview={overview} detectedProviders={detectedProviders} contextualLaunch={advisorLaunch} />
         ) : section === 'plans' ? (
-          <Plans period={period} refreshToken={refreshToken} onNavigate={navigate} ready={ready} />
+          <Plans period={period} refreshToken={refreshToken} onNavigate={navigate} onAskAdvisor={contextualAdvisorLaunch ? () => openAdvisor(contextualAdvisorLaunch) : undefined} ready={ready} />
         ) : section === 'settings' ? (
           <Settings period={period} refreshToken={refreshToken} onNavigate={navigate} initialPane={settingsPane} claudeConfigs={claudeConfigs} claudeConfigSource={claudeConfigSource} onConfigMutated={onConfigMutated} />
         ) : (
@@ -176,6 +199,7 @@ function AppMain() {
               projectScopeId={metroraProjectId}
               onProjectScopeSelect={onProjectScopeSelect}
               capabilities={sectionCapabilities}
+              onAskAdvisor={contextualAdvisorLaunch ? () => openAdvisor(contextualAdvisorLaunch) : undefined}
             />
             <div className={motionClass('body', 'section-fade')}>
               {section === 'overview' ? (

--- a/app/renderer/App.tsx
+++ b/app/renderer/App.tsx
@@ -145,16 +145,14 @@ function AppMain() {
   const projectName = metroraProjectId === 'all'
     ? 'All projects'
     : projectScope?.options.find(option => option.id === metroraProjectId)?.name ?? null
-  const contextualAdvisorLaunch = projectName
-    ? createAdvisorContextualLaunch({
-        originatingSection: section,
-        period,
-        range: customRange,
-        provider,
-        projectId: metroraProjectId,
-        projectName,
-      })
-    : null
+  const contextualAdvisorLaunch = createAdvisorContextualLaunch({
+    originatingSection: section,
+    period,
+    range: customRange,
+    provider,
+    projectId: metroraProjectId,
+    projectName,
+  })
   useEffect(() => {
     if (!projectScope || projectScope.options.some(option => option.id === metroraProjectId)) return
     onProjectScopeSelect('all')

--- a/app/renderer/advisor/context.test.ts
+++ b/app/renderer/advisor/context.test.ts
@@ -26,6 +26,7 @@ describe('Advisor contextual launch contract', () => {
       contractVersion: ADVISOR_CONTEXTUAL_LAUNCH_CONTRACT_VERSION,
       schemaVersion: ADVISOR_CONTEXTUAL_LAUNCH_SCHEMA_VERSION,
       originatingSection: 'models',
+      scopeMode: 'analytics',
       period: '30days',
       range: { from: '2026-08-01', to: '2026-08-25' },
       provider: 'codex',
@@ -57,6 +58,7 @@ describe('Advisor contextual launch contract', () => {
       'contractVersion',
       'schemaVersion',
       'originatingSection',
+      'scopeMode',
       'period',
       'range',
       'provider',
@@ -78,6 +80,64 @@ describe('Advisor contextual launch contract', () => {
 
     const malformedModel = createAdvisorContextualLaunch({ ...base, model: { kind: 'session', id: 'session-1' } as never })
     expect(malformedModel?.model).toBeNull()
+  })
+
+  it('projects analytics surfaces with every dimension they actually consume', () => {
+    for (const originatingSection of ['overview', 'sessions', 'spend', 'models'] as const) {
+      const launch = createAdvisorContextualLaunch({ ...base, originatingSection, model: 'gpt-safe' })
+
+      expect(launch).toMatchObject({
+        originatingSection,
+        scopeMode: 'analytics',
+        period: '30days',
+        range: { from: '2026-08-01', to: '2026-08-25' },
+        provider: 'codex',
+        projectId: 'project-a',
+        projectName: 'Project A',
+        model: 'gpt-safe',
+      })
+    }
+  })
+
+  it('drops Compare dimensions that the page does not consume', () => {
+    const launch = createAdvisorContextualLaunch({ ...base, originatingSection: 'compare', model: 'gpt-pair' })
+
+    expect(launch).toMatchObject({
+      originatingSection: 'compare',
+      scopeMode: 'compare',
+      period: '30days',
+      range: null,
+      provider: 'codex',
+      projectId: 'all',
+      projectName: 'All projects',
+      model: null,
+      suggestedPrompt: 'Investigate the observed model-efficiency evidence for the selected period and provider.',
+    })
+  })
+
+  it('does not inherit hidden provider, Project, range, period, or model state for Plans capacity', () => {
+    const launch = createAdvisorContextualLaunch({
+      ...base,
+      originatingSection: 'plans',
+      period: 'not-a-period' as never,
+      range: { from: 'not-a-date', to: 'also-not-a-date' },
+      provider: 'codex',
+      projectId: 'private-project',
+      projectName: 'Private project',
+      model: 'gpt-hidden',
+    })
+
+    expect(launch).toMatchObject({
+      originatingSection: 'plans',
+      scopeMode: 'capacity',
+      period: 'today',
+      range: null,
+      provider: 'all',
+      projectId: 'all',
+      projectName: 'All projects',
+      model: null,
+      suggestedPrompt: 'What current provider-reported capacity and reset windows are available across the connected providers?',
+    })
   })
 
   it('revalidates a launch and replaces arbitrary suggested prose with Metrora-owned copy', () => {

--- a/app/renderer/advisor/context.test.ts
+++ b/app/renderer/advisor/context.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  ADVISOR_CONTEXTUAL_LAUNCH_CONTRACT_VERSION,
+  ADVISOR_CONTEXTUAL_LAUNCH_SCHEMA_VERSION,
+  advisorScopeFromContextualLaunch,
+  createAdvisorContextualLaunch,
+  normalizeAdvisorContextualLaunch,
+} from './context'
+import { advisorScopeFingerprint } from './types'
+
+const base = {
+  originatingSection: 'models' as const,
+  period: '30days' as const,
+  range: { from: '2026-08-01', to: '2026-08-25' },
+  provider: 'codex',
+  projectId: 'project-a',
+  projectName: 'Project A',
+}
+
+describe('Advisor contextual launch contract', () => {
+  it('hands off the canonical period, range, provider, Project, and factual model scope', () => {
+    const launch = createAdvisorContextualLaunch({ ...base, model: 'gpt-safe' })
+
+    expect(launch).toMatchObject({
+      contractVersion: ADVISOR_CONTEXTUAL_LAUNCH_CONTRACT_VERSION,
+      schemaVersion: ADVISOR_CONTEXTUAL_LAUNCH_SCHEMA_VERSION,
+      originatingSection: 'models',
+      period: '30days',
+      range: { from: '2026-08-01', to: '2026-08-25' },
+      provider: 'codex',
+      projectId: 'project-a',
+      projectName: 'Project A',
+      model: 'gpt-safe',
+      suggestedPrompt: 'Which models have the lowest observed cost per call in this scope?',
+    })
+
+    const scope = advisorScopeFromContextualLaunch(launch)
+    expect(scope).not.toBeNull()
+    expect(advisorScopeFingerprint(scope!)).toBe(JSON.stringify({
+      period: '30days',
+      range: { from: '2026-08-01', to: '2026-08-25' },
+      projectId: 'project-a',
+      provider: 'codex',
+      model: 'gpt-safe',
+    }))
+  })
+
+  it('projects only the allowlisted handoff fields, never renderer payload or factual prose', () => {
+    const launch = createAdvisorContextualLaunch({
+      ...base,
+      model: null,
+      ...({ rendererState: { selectedRow: 4 }, pagePayload: { claims: ['unsupported'] }, prose: 'The renderer claims this is the best model.' } as Record<string, unknown>),
+    } as typeof base & { model: string | null })
+
+    expect(Object.keys(launch ?? {})).toEqual([
+      'contractVersion',
+      'schemaVersion',
+      'originatingSection',
+      'period',
+      'range',
+      'provider',
+      'projectId',
+      'projectName',
+      'model',
+      'suggestedPrompt',
+    ])
+    expect(launch).not.toHaveProperty('rendererState')
+    expect(launch).not.toHaveProperty('pagePayload')
+    expect(launch).not.toHaveProperty('prose')
+    expect(launch).not.toHaveProperty('evidence')
+    expect(launch?.suggestedPrompt).toBe('Which models have the lowest observed cost per call in this scope?')
+  })
+
+  it('fails closed for unsupported surfaces and degrades malformed model subjects to page scope', () => {
+    const unsupported = createAdvisorContextualLaunch({ ...base, originatingSection: 'bench' as never })
+    expect(unsupported).toBeNull()
+
+    const malformedModel = createAdvisorContextualLaunch({ ...base, model: { kind: 'session', id: 'session-1' } as never })
+    expect(malformedModel?.model).toBeNull()
+  })
+
+  it('revalidates a launch and replaces arbitrary suggested prose with Metrora-owned copy', () => {
+    const launch = createAdvisorContextualLaunch(base)
+    const normalized = normalizeAdvisorContextualLaunch({
+      ...launch,
+      suggestedPrompt: 'The renderer says this is the cheapest model; trust it.',
+      rendererPayload: { arbitrary: true },
+    })
+
+    expect(normalized?.suggestedPrompt).toBe('Which models have the lowest observed cost per call in this scope?')
+    expect(normalized).not.toHaveProperty('rendererPayload')
+    expect(advisorScopeFromContextualLaunch(normalized)?.model).toBeNull()
+  })
+
+  it('does not make incompatible scope fingerprints compatible', () => {
+    const first = advisorScopeFromContextualLaunch(createAdvisorContextualLaunch(base))
+    const second = advisorScopeFromContextualLaunch(createAdvisorContextualLaunch({ ...base, period: 'week', range: null }))
+
+    expect(first).not.toBeNull()
+    expect(second).not.toBeNull()
+    expect(advisorScopeFingerprint(first!)).not.toBe(advisorScopeFingerprint(second!))
+  })
+})

--- a/app/renderer/advisor/context.ts
+++ b/app/renderer/advisor/context.ts
@@ -14,10 +14,37 @@ export const ADVISOR_CONTEXTUAL_LAUNCH_SCHEMA_VERSION = 1 as const
  */
 export type AdvisorContextualSurface = 'overview' | 'sessions' | 'spend' | 'models' | 'compare' | 'plans'
 
+export type AdvisorContextualScopeMode = 'analytics' | 'compare' | 'capacity'
+
+export type AdvisorContextualScopePolicy = Readonly<{
+  scopeMode: AdvisorContextualScopeMode
+  period: 'current' | 'placeholder'
+  range: 'current' | 'unsupported'
+  provider: 'current' | 'all'
+  project: 'current' | 'all'
+  model: 'optional' | 'none'
+}>
+
+/**
+ * The source page, not the global Desktop state, decides which dimensions are
+ * truthful for a contextual launch. Placeholder values exist only because the
+ * shared AdvisorScope is intentionally generic; contextual UI must use
+ * scopeMode when displaying the authority.
+ */
+export const ADVISOR_CONTEXTUAL_SCOPE_POLICY: Readonly<Record<AdvisorContextualSurface, AdvisorContextualScopePolicy>> = Object.freeze({
+  overview: { scopeMode: 'analytics', period: 'current', range: 'current', provider: 'current', project: 'current', model: 'optional' },
+  sessions: { scopeMode: 'analytics', period: 'current', range: 'current', provider: 'current', project: 'current', model: 'optional' },
+  spend: { scopeMode: 'analytics', period: 'current', range: 'current', provider: 'current', project: 'current', model: 'optional' },
+  models: { scopeMode: 'analytics', period: 'current', range: 'current', provider: 'current', project: 'current', model: 'optional' },
+  compare: { scopeMode: 'compare', period: 'current', range: 'unsupported', provider: 'current', project: 'all', model: 'none' },
+  plans: { scopeMode: 'capacity', period: 'placeholder', range: 'unsupported', provider: 'all', project: 'all', model: 'none' },
+})
+
 export type AdvisorContextualLaunchV1 = {
   contractVersion: typeof ADVISOR_CONTEXTUAL_LAUNCH_CONTRACT_VERSION
   schemaVersion: typeof ADVISOR_CONTEXTUAL_LAUNCH_SCHEMA_VERSION
   originatingSection: AdvisorContextualSurface
+  scopeMode: AdvisorContextualScopeMode
   period: Period
   range: DateRange | null
   provider: string
@@ -35,7 +62,7 @@ export type AdvisorContextualLaunchInput = {
   range: DateRange | null
   provider: string
   projectId: string
-  projectName: string
+  projectName: string | null
   model?: string | null
 }
 
@@ -44,8 +71,8 @@ const SURFACE_PROMPTS: Readonly<Record<AdvisorContextualSurface, string>> = Obje
   sessions: 'Which sessions or Projects explain the most measured spend in this scope?',
   spend: 'What changed in measured spend in this scope, and which drivers are visible?',
   models: 'Which models have the lowest observed cost per call in this scope?',
-  compare: 'Investigate the observed model-efficiency evidence in this scope.',
-  plans: 'What provider quota remains and when does it reset in this scope?',
+  compare: 'Investigate the observed model-efficiency evidence for the selected period and provider.',
+  plans: 'What current provider-reported capacity and reset windows are available across the connected providers?',
 })
 
 const SURFACES: readonly AdvisorContextualSurface[] = Object.freeze([
@@ -96,19 +123,24 @@ export function createAdvisorContextualLaunch(input: AdvisorContextualLaunchInpu
   if (!isContextualSurface(input.originatingSection)) return null
 
   try {
+    const policy = ADVISOR_CONTEXTUAL_SCOPE_POLICY[input.originatingSection]
     const scope = snapshotAdvisorScope({
-      period: input.period,
-      range: input.range ? { from: input.range.from, to: input.range.to } : null,
-      provider: input.provider,
-      projectId: input.projectId,
-      projectName: input.projectName,
-      model: boundedModel(input.model),
+      // Plans/Capacity has no historical period. `today` is an internal
+      // placeholder for the generic AdvisorScope and is never presented as
+      // the capacity authority.
+      period: policy.period === 'current' ? input.period : 'today',
+      range: policy.range === 'current' && input.range ? { from: input.range.from, to: input.range.to } : null,
+      provider: policy.provider === 'current' ? input.provider : 'all',
+      projectId: policy.project === 'current' ? input.projectId : 'all',
+      projectName: policy.project === 'current' ? input.projectName ?? '' : 'All projects',
+      model: policy.model === 'optional' ? boundedModel(input.model) : null,
     })
 
     return Object.freeze({
       contractVersion: ADVISOR_CONTEXTUAL_LAUNCH_CONTRACT_VERSION,
       schemaVersion: ADVISOR_CONTEXTUAL_LAUNCH_SCHEMA_VERSION,
       originatingSection: input.originatingSection,
+      scopeMode: policy.scopeMode,
       period: scope.period,
       range: scope.range,
       provider: scope.provider,

--- a/app/renderer/advisor/context.ts
+++ b/app/renderer/advisor/context.ts
@@ -1,0 +1,159 @@
+import type { Section } from '../lib/desktopNavigation'
+import type { DateRange, Period } from '../lib/types'
+import { snapshotAdvisorScope } from './contract'
+import type { AdvisorScope } from './types'
+
+export const ADVISOR_CONTEXTUAL_LAUNCH_CONTRACT_VERSION = 'advisor-contextual-launch-v1' as const
+export const ADVISOR_CONTEXTUAL_LAUNCH_SCHEMA_VERSION = 1 as const
+
+/**
+ * These are the only Desktop surfaces that currently have a truthful,
+ * page-level investigation in the Advisor contract. The other destinations
+ * either have no shared accounting scope or expose object state that Advisor
+ * cannot represent without inventing another evidence contract.
+ */
+export type AdvisorContextualSurface = 'overview' | 'sessions' | 'spend' | 'models' | 'compare' | 'plans'
+
+export type AdvisorContextualLaunchV1 = {
+  contractVersion: typeof ADVISOR_CONTEXTUAL_LAUNCH_CONTRACT_VERSION
+  schemaVersion: typeof ADVISOR_CONTEXTUAL_LAUNCH_SCHEMA_VERSION
+  originatingSection: AdvisorContextualSurface
+  period: Period
+  range: DateRange | null
+  provider: string
+  projectId: string
+  projectName: string
+  /** Exact model identity only. `null` means page scope, not “all renderer models”. */
+  model: string | null
+  /** Metrora-owned copy; this is a prompt seed, never an answer or claim. */
+  suggestedPrompt: string | null
+}
+
+export type AdvisorContextualLaunchInput = {
+  originatingSection: Section
+  period: Period
+  range: DateRange | null
+  provider: string
+  projectId: string
+  projectName: string
+  model?: string | null
+}
+
+const SURFACE_PROMPTS: Readonly<Record<AdvisorContextualSurface, string>> = Object.freeze({
+  overview: 'Give me a measured overview of this scope and what changed most.',
+  sessions: 'Which sessions or Projects explain the most measured spend in this scope?',
+  spend: 'What changed in measured spend in this scope, and which drivers are visible?',
+  models: 'Which models have the lowest observed cost per call in this scope?',
+  compare: 'Investigate the observed model-efficiency evidence in this scope.',
+  plans: 'What provider quota remains and when does it reset in this scope?',
+})
+
+const SURFACES: readonly AdvisorContextualSurface[] = Object.freeze([
+  'overview',
+  'sessions',
+  'spend',
+  'models',
+  'compare',
+  'plans',
+])
+
+const CONTROL_CHARACTERS = /[\u0000-\u001f\u007f]/
+const MAX_IDENTIFIER_LENGTH = 256
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value)
+}
+
+function isContextualSurface(value: unknown): value is AdvisorContextualSurface {
+  return typeof value === 'string' && (SURFACES as readonly string[]).includes(value)
+}
+
+function boundedModel(value: unknown): string | null {
+  if (value === undefined || value === null) return null
+  if (typeof value !== 'string') return null
+  const normalized = value.trim()
+  if (!normalized || normalized.length > MAX_IDENTIFIER_LENGTH || CONTROL_CHARACTERS.test(normalized)) return null
+  return normalized
+}
+
+/** Returns whether a Desktop section can safely expose the page-level launch. */
+export function isAdvisorContextualSurface(section: Section | string): section is AdvisorContextualSurface {
+  return isContextualSurface(section)
+}
+
+/** Human-readable origin label used only by the Advisor shell. */
+export function advisorContextualSurfaceLabel(surface: AdvisorContextualSurface): string {
+  if (surface === 'overview') return 'Home'
+  return surface.charAt(0).toUpperCase() + surface.slice(1)
+}
+
+/**
+ * Projects Desktop state into the narrow contextual handoff. No page payload,
+ * renderer selection state, factual prose, or evidence is accepted here.
+ * Invalid optional model state degrades to the nearest truthful page scope.
+ */
+export function createAdvisorContextualLaunch(input: AdvisorContextualLaunchInput): AdvisorContextualLaunchV1 | null {
+  if (!isContextualSurface(input.originatingSection)) return null
+
+  try {
+    const scope = snapshotAdvisorScope({
+      period: input.period,
+      range: input.range ? { from: input.range.from, to: input.range.to } : null,
+      provider: input.provider,
+      projectId: input.projectId,
+      projectName: input.projectName,
+      model: boundedModel(input.model),
+    })
+
+    return Object.freeze({
+      contractVersion: ADVISOR_CONTEXTUAL_LAUNCH_CONTRACT_VERSION,
+      schemaVersion: ADVISOR_CONTEXTUAL_LAUNCH_SCHEMA_VERSION,
+      originatingSection: input.originatingSection,
+      period: scope.period,
+      range: scope.range,
+      provider: scope.provider,
+      projectId: scope.projectId,
+      projectName: scope.projectName,
+      model: scope.model,
+      suggestedPrompt: SURFACE_PROMPTS[input.originatingSection] ?? null,
+    })
+  } catch {
+    // A malformed handoff must not create an Advisor scope from partial UI
+    // state. The page simply has no contextual affordance in that case.
+    return null
+  }
+}
+
+/**
+ * Re-validates a launch at the Advisor boundary and reconstructs it from the
+ * allowlisted fields. This also prevents a future caller from smuggling a
+ * renderer payload or arbitrary prose through a structurally compatible cast.
+ */
+export function normalizeAdvisorContextualLaunch(value: unknown): AdvisorContextualLaunchV1 | null {
+  if (!isRecord(value)) return null
+  if (value.contractVersion !== ADVISOR_CONTEXTUAL_LAUNCH_CONTRACT_VERSION || value.schemaVersion !== ADVISOR_CONTEXTUAL_LAUNCH_SCHEMA_VERSION) return null
+  if (!isContextualSurface(value.originatingSection)) return null
+
+  return createAdvisorContextualLaunch({
+    originatingSection: value.originatingSection,
+    period: value.period as Period,
+    range: value.range as DateRange | null,
+    provider: value.provider as string,
+    projectId: value.projectId as string,
+    projectName: value.projectName as string,
+    model: value.model as string | null,
+  })
+}
+
+export function advisorScopeFromContextualLaunch(value: unknown): AdvisorScope | null {
+  const launch = normalizeAdvisorContextualLaunch(value)
+  if (!launch) return null
+  return snapshotAdvisorScope({
+    period: launch.period,
+    range: launch.range ? { from: launch.range.from, to: launch.range.to } : null,
+    provider: launch.provider,
+    projectId: launch.projectId,
+    projectName: launch.projectName,
+    model: launch.model,
+  })
+}

--- a/app/renderer/components/TopBar.test.tsx
+++ b/app/renderer/components/TopBar.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { render, screen } from '@testing-library/react'
+import { fireEvent, render, screen } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
 
 import type { DesktopSectionCapabilities } from '../lib/desktopSections'
@@ -13,7 +13,7 @@ const full: DesktopSectionCapabilities = {
   globalRefresh: true,
 }
 
-function renderTopBar(capabilities: DesktopSectionCapabilities) {
+function renderTopBar(capabilities: DesktopSectionCapabilities, onAskAdvisor?: () => void) {
   render(
     <TopBar
       title="Workspace"
@@ -33,6 +33,7 @@ function renderTopBar(capabilities: DesktopSectionCapabilities) {
       configSource={null}
       onConfigSelect={vi.fn()}
       capabilities={capabilities}
+      onAskAdvisor={onAskAdvisor}
     />,
   )
 }
@@ -58,5 +59,15 @@ describe('TopBar scope capabilities', () => {
     expect(screen.queryByText('7D')).not.toBeInTheDocument()
     expect(screen.queryByLabelText('Choose date range')).not.toBeInTheDocument()
     expect(screen.queryByLabelText('Claude config source')).not.toBeInTheDocument()
+  })
+
+  it('renders one page-level Ask Advisor action without adding card-level advice controls', () => {
+    const onAskAdvisor = vi.fn()
+    renderTopBar(full, onAskAdvisor)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Ask Advisor' }))
+
+    expect(onAskAdvisor).toHaveBeenCalledTimes(1)
+    expect(screen.getAllByRole('button', { name: 'Ask Advisor' })).toHaveLength(1)
   })
 })

--- a/app/renderer/components/TopBar.tsx
+++ b/app/renderer/components/TopBar.tsx
@@ -47,6 +47,7 @@ export function TopBar({
   projectScopeId,
   onProjectScopeSelect,
   capabilities = DEFAULT_CAPABILITIES,
+  onAskAdvisor,
 }: {
   title: ReactNode
   scope?: ReactNode
@@ -65,12 +66,18 @@ export function TopBar({
   projectScopeId?: string
   onProjectScopeSelect?: (id: string) => void
   capabilities?: DesktopSectionCapabilities
+  onAskAdvisor?: () => void
 }) {
   return (
     <div className="bar">
       <div className="t">{title}</div>
       {scope !== undefined && <span className="scope">{scope}</span>}
       <div className="sp" />
+      {onAskAdvisor && (
+        <button type="button" className="btn btn-s ask-advisor-button" onClick={onAskAdvisor}>
+          Ask Advisor <span aria-hidden="true">↗</span>
+        </button>
+      )}
       {capabilities.period && (
         <SegTabs options={PERIOD_OPTIONS} value={customRange ? '' : period} onChange={onPeriodChange} />
       )}

--- a/app/renderer/sections/Advisor.test.tsx
+++ b/app/renderer/sections/Advisor.test.tsx
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { Polled } from '../hooks/usePolled'
 import type { MenubarPayload } from '../lib/types'
+import { createAdvisorContextualLaunch } from '../advisor/context'
 import type { AdvisorAnswer } from '../advisor/types'
 import { Advisor } from './Advisor'
 
@@ -86,6 +87,39 @@ describe('Advisor workspace', () => {
     expect(screen.getByRole('complementary', { name: 'Advisor evidence' })).toHaveTextContent('Ask a question to pin its evidence')
     await waitFor(() => expect(screen.getByText('Offline evidence fallback')).toBeInTheDocument())
     expect(advisorProbe).toHaveBeenCalledTimes(1)
+  })
+  it('loads a contextual scope and suggested investigation without auto-executing it', async () => {
+    const contextualLaunch = createAdvisorContextualLaunch({
+      originatingSection: 'spend',
+      period: '30days',
+      range: { from: '2026-08-01', to: '2026-08-25' },
+      provider: 'codex',
+      projectId: 'project-a',
+      projectName: 'Project A',
+      model: 'gpt-safe',
+    })
+
+    render(
+      <Advisor
+        period="week"
+        provider="all"
+        projectScopeId="all"
+        range={null}
+        overview={overviewWithOptions}
+        detectedProviders={[{ id: 'codex', label: 'Codex' }]}
+        contextualLaunch={contextualLaunch}
+      />,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByRole('textbox', { name: 'Ask Metrora Advisor' })).toHaveValue('What changed in measured spend in this scope, and which drivers are visible?')
+      expect(screen.getByLabelText('Advisor period')).toHaveValue('30days')
+      expect(screen.getByLabelText('Advisor provider')).toHaveValue('codex')
+      expect(screen.getByLabelText('Advisor Project')).toHaveValue('project-a')
+      expect(screen.getByLabelText('Advisor model')).toHaveValue('gpt-safe')
+    })
+    expect(screen.getByText('From Spend')).toBeInTheDocument()
+    expect(investigate).not.toHaveBeenCalled()
   })
   it('renders direct answer hierarchy while keeping deeper evidence in progressive disclosure', async () => {
     render(<Advisor period="week" provider="all" projectScopeId="all" range={null} overview={overview} detectedProviders={[]} />)

--- a/app/renderer/sections/Advisor.test.tsx
+++ b/app/renderer/sections/Advisor.test.tsx
@@ -121,6 +121,38 @@ describe('Advisor workspace', () => {
     expect(screen.getByText('From Spend')).toBeInTheDocument()
     expect(investigate).not.toHaveBeenCalled()
   })
+  it('shows Capacity as current provider authority without exposing hidden Desktop scope', async () => {
+    const contextualLaunch = createAdvisorContextualLaunch({
+      originatingSection: 'plans',
+      period: '30days',
+      range: { from: '2026-08-01', to: '2026-08-25' },
+      provider: 'codex',
+      projectId: 'project-a',
+      projectName: 'Project A',
+      model: 'gpt-safe',
+    })
+
+    render(
+      <Advisor
+        period="week"
+        provider="codex"
+        projectScopeId="project-a"
+        range={{ from: '2026-08-01', to: '2026-08-25' }}
+        overview={overviewWithOptions}
+        detectedProviders={[{ id: 'codex', label: 'Codex' }]}
+        contextualLaunch={contextualLaunch}
+      />,
+    )
+
+    await waitFor(() => expect(screen.getByRole('textbox', { name: 'Ask Metrora Advisor' })).toHaveValue('What current provider-reported capacity and reset windows are available across the connected providers?'))
+    expect(screen.getByText('From Plans')).toBeInTheDocument()
+    expect(screen.getByText(/Provider-reported now · All providers; Project and history do not scope Capacity/)).toBeInTheDocument()
+    expect(screen.queryByLabelText('Advisor period')).not.toBeInTheDocument()
+    expect(screen.queryByLabelText('Advisor Project')).not.toBeInTheDocument()
+    expect(screen.queryByLabelText('Advisor provider')).not.toBeInTheDocument()
+    expect(screen.queryByLabelText('Advisor model')).not.toBeInTheDocument()
+    expect(investigate).not.toHaveBeenCalled()
+  })
   it('renders direct answer hierarchy while keeping deeper evidence in progressive disclosure', async () => {
     render(<Advisor period="week" provider="all" projectScopeId="all" range={null} overview={overview} detectedProviders={[]} />)
     await submitQuestion('Inspect spend behavior')

--- a/app/renderer/sections/Advisor.tsx
+++ b/app/renderer/sections/Advisor.tsx
@@ -11,6 +11,7 @@ import { LMStudioAdvisorRuntime, probeLMStudio } from '../advisor/lmstudio'
 import { OllamaAdvisorRuntime, probeOllama } from '../advisor/ollama'
 import { HostedAdvisorRuntime, probeHostedAdvisor } from '../advisor/hosted'
 import { scopeLabel } from '../advisor/evidence'
+import { advisorContextualSurfaceLabel, advisorScopeFromContextualLaunch, normalizeAdvisorContextualLaunch, type AdvisorContextualLaunchV1 } from '../advisor/context'
 import { advisorScopeFingerprint, type AdvisorAnswer, type AdvisorConversationTurn, type AdvisorLocalRuntimeId, type AdvisorPresentationBlockV1, type AdvisorPresentationChartSeries, type AdvisorScope } from '../advisor/types'
 
 type DetectedProvider = { id: string; label: string }
@@ -160,6 +161,7 @@ export function Advisor({
   range = null,
   overview,
   detectedProviders,
+  contextualLaunch = null,
 }: {
   period: Period
   provider: string
@@ -167,6 +169,7 @@ export function Advisor({
   range?: DateRange | null
   overview: Polled<MenubarPayload>
   detectedProviders: DetectedProvider[]
+  contextualLaunch?: AdvisorContextualLaunchV1 | null
 }) {
   const projectOptions = overview.data?.projectScope?.options ?? []
   const projectName = projectScopeId === 'all'
@@ -178,7 +181,15 @@ export function Advisor({
   ])].filter(Boolean).slice(0, 40)
   const providerOptions = [{ id: 'all', label: 'All providers' }, ...detectedProviders.filter(item => item.id !== 'all')]
 
-  const [scope, setScope] = useState<AdvisorScope>(() => ({
+  const normalizedContextualLaunch = useMemo(
+    () => contextualLaunch ? normalizeAdvisorContextualLaunch(contextualLaunch) : null,
+    [contextualLaunch],
+  )
+  const contextualScope = useMemo(
+    () => normalizedContextualLaunch ? advisorScopeFromContextualLaunch(normalizedContextualLaunch) : null,
+    [normalizedContextualLaunch],
+  )
+  const [scope, setScope] = useState<AdvisorScope>(() => contextualScope ?? ({
     period,
     range,
     provider,
@@ -187,8 +198,9 @@ export function Advisor({
     model: null,
   }))
   useEffect(() => {
+    if (normalizedContextualLaunch) return
     setScope(current => ({ ...current, period, range, provider, projectId: projectScopeId, projectName }))
-  }, [period, provider, projectScopeId, projectName, range])
+  }, [normalizedContextualLaunch, period, provider, projectScopeId, projectName, range])
   useEffect(() => {
     if (scope.model && !modelOptions.includes(scope.model)) setScope(current => ({ ...current, model: null }))
   }, [modelOptions, scope.model])
@@ -298,6 +310,14 @@ export function Advisor({
   const [notice, setNotice] = useState<string | null>(null)
   const [selectedAnswerId, setSelectedAnswerId] = useState<string | null>(null)
   const requestController = useRef<AbortController | null>(null)
+
+  useEffect(() => {
+    if (!normalizedContextualLaunch || !contextualScope) return
+    setScope(contextualScope)
+    setComposer(normalizedContextualLaunch.suggestedPrompt ?? '')
+    setNotice(`Context from ${advisorContextualSurfaceLabel(normalizedContextualLaunch.originatingSection)} loaded. Review the suggested investigation before sending.`)
+    setSelectedAnswerId(null)
+  }, [contextualScope, normalizedContextualLaunch])
 
   const activeConversation = conversations.find(conversation => conversation.id === activeConversationId) ?? conversations[0]!
   const messages = activeConversation.messages
@@ -513,6 +533,7 @@ export function Advisor({
         </header>
         <div className="advisor-scope-bar" aria-label="Advisor context">
           <span className="advisor-scope-label">Context</span>
+          {normalizedContextualLaunch ? <span className="advisor-contextual-origin">From {advisorContextualSurfaceLabel(normalizedContextualLaunch.originatingSection)}</span> : null}
           <label>Period<select aria-label="Advisor period" value={scope.period} onChange={event => setScope(current => ({ ...current, period: event.target.value as Period }))}>{PERIODS.map(option => <option key={option.value} value={option.value}>{option.label}</option>)}</select></label>
           <label>Project<select aria-label="Advisor Project" value={scope.projectId} onChange={event => { const id = event.target.value; setScope(current => ({ ...current, projectId: id, projectName: id === 'all' ? 'All projects' : projectOptions.find(option => option.id === id)?.name ?? id })) }}><option value="all">All projects</option>{projectOptions.map(option => <option key={option.id} value={option.id}>{option.name}</option>)}</select></label>
           <label>Provider<select aria-label="Advisor provider" value={scope.provider} onChange={event => setScope(current => ({ ...current, provider: event.target.value }))}>{providerOptions.map(option => <option key={option.id} value={option.id}>{option.label}</option>)}</select></label>

--- a/app/renderer/sections/Advisor.tsx
+++ b/app/renderer/sections/Advisor.tsx
@@ -10,8 +10,8 @@ import { createAdvisorRuntime } from '../advisor/runtime'
 import { LMStudioAdvisorRuntime, probeLMStudio } from '../advisor/lmstudio'
 import { OllamaAdvisorRuntime, probeOllama } from '../advisor/ollama'
 import { HostedAdvisorRuntime, probeHostedAdvisor } from '../advisor/hosted'
-import { scopeLabel } from '../advisor/evidence'
-import { advisorContextualSurfaceLabel, advisorScopeFromContextualLaunch, normalizeAdvisorContextualLaunch, type AdvisorContextualLaunchV1 } from '../advisor/context'
+import { periodLabel, scopeLabel } from '../advisor/evidence'
+import { advisorContextualSurfaceLabel, advisorScopeFromContextualLaunch, normalizeAdvisorContextualLaunch, type AdvisorContextualLaunchV1, type AdvisorContextualScopeMode } from '../advisor/context'
 import { advisorScopeFingerprint, type AdvisorAnswer, type AdvisorConversationTurn, type AdvisorLocalRuntimeId, type AdvisorPresentationBlockV1, type AdvisorPresentationChartSeries, type AdvisorScope } from '../advisor/types'
 
 type DetectedProvider = { id: string; label: string }
@@ -42,6 +42,11 @@ function isCancelled(error: unknown): boolean {
 function providerLabel(provider: string): string {
   if (provider === 'all') return 'All providers'
   return provider.split(/[-\s]+/).filter(Boolean).map(part => part.charAt(0).toUpperCase() + part.slice(1)).join(' ')
+}
+function contextualScopeLabel(scope: AdvisorScope, mode: AdvisorContextualScopeMode | null): string {
+  if (mode === 'capacity') return 'Provider-reported current capacity · All providers'
+  if (mode === 'compare') return `Compare page scope · ${periodLabel(scope)} · ${providerLabel(scope.provider)}`
+  return scopeLabel(scope)
 }
 function displayAnswer(answer: AdvisorAnswer): string {
   return answer.conclusion
@@ -189,6 +194,7 @@ export function Advisor({
     () => normalizedContextualLaunch ? advisorScopeFromContextualLaunch(normalizedContextualLaunch) : null,
     [normalizedContextualLaunch],
   )
+  const contextualScopeMode = normalizedContextualLaunch?.scopeMode ?? null
   const [scope, setScope] = useState<AdvisorScope>(() => contextualScope ?? ({
     period,
     range,
@@ -365,7 +371,8 @@ export function Advisor({
       const answer = await kernel.investigate({
         question,
         scope: requestedScope,
-        overview: requestedScope.period === period
+        overview: contextualScopeMode !== 'capacity'
+          && requestedScope.period === period
           && requestedScope.provider === provider
           && requestedScope.projectId === projectScopeId
           && requestedScope.range?.from === range?.from
@@ -399,7 +406,7 @@ export function Advisor({
       setStreamPreview('')
       setToolStatus(null)
     }
-  }, [activeConversationId, conversations, kernel, loadingQuestion, overview.data, overview.loading, overview.switching, period, projectScopeId, provider, range?.from, range?.to, scope, updateConversation])
+  }, [activeConversationId, contextualScopeMode, conversations, kernel, loadingQuestion, overview.data, overview.loading, overview.switching, period, projectScopeId, provider, range?.from, range?.to, scope, updateConversation])
 
   const submit = (event: FormEvent) => {
     event.preventDefault()
@@ -534,11 +541,17 @@ export function Advisor({
         <div className="advisor-scope-bar" aria-label="Advisor context">
           <span className="advisor-scope-label">Context</span>
           {normalizedContextualLaunch ? <span className="advisor-contextual-origin">From {advisorContextualSurfaceLabel(normalizedContextualLaunch.originatingSection)}</span> : null}
-          <label>Period<select aria-label="Advisor period" value={scope.period} onChange={event => setScope(current => ({ ...current, period: event.target.value as Period }))}>{PERIODS.map(option => <option key={option.value} value={option.value}>{option.label}</option>)}</select></label>
-          <label>Project<select aria-label="Advisor Project" value={scope.projectId} onChange={event => { const id = event.target.value; setScope(current => ({ ...current, projectId: id, projectName: id === 'all' ? 'All projects' : projectOptions.find(option => option.id === id)?.name ?? id })) }}><option value="all">All projects</option>{projectOptions.map(option => <option key={option.id} value={option.id}>{option.name}</option>)}</select></label>
-          <label>Provider<select aria-label="Advisor provider" value={scope.provider} onChange={event => setScope(current => ({ ...current, provider: event.target.value }))}>{providerOptions.map(option => <option key={option.id} value={option.id}>{option.label}</option>)}</select></label>
-          <label>Model<select aria-label="Advisor model" value={scope.model ?? ''} onChange={event => setScope(current => ({ ...current, model: event.target.value || null }))}><option value="">All models</option>{modelOptions.map(model => <option key={model} value={model}>{model}</option>)}</select></label>
-          <span className="advisor-read-only">Read-only · {scopeLabel(scope)}</span>
+          {contextualScopeMode === 'capacity' ? (
+            <span className="advisor-contextual-authority">Provider-reported now · All providers; Project and history do not scope Capacity.</span>
+          ) : (
+            <>
+              <label>Period<select aria-label="Advisor period" value={scope.period} onChange={event => setScope(current => ({ ...current, period: event.target.value as Period }))}>{PERIODS.map(option => <option key={option.value} value={option.value}>{option.label}</option>)}</select></label>
+              {contextualScopeMode === 'compare' ? <span className="advisor-contextual-authority">Compare uses period + provider; custom dates and Project are not part of Compare.</span> : <label>Project<select aria-label="Advisor Project" value={scope.projectId} onChange={event => { const id = event.target.value; setScope(current => ({ ...current, projectId: id, projectName: id === 'all' ? 'All projects' : projectOptions.find(option => option.id === id)?.name ?? id })) }}><option value="all">All projects</option>{projectOptions.map(option => <option key={option.id} value={option.id}>{option.name}</option>)}</select></label>}
+              <label>Provider<select aria-label="Advisor provider" value={scope.provider} onChange={event => setScope(current => ({ ...current, provider: event.target.value }))}>{providerOptions.map(option => <option key={option.id} value={option.id}>{option.label}</option>)}</select></label>
+              <label>Model<select aria-label="Advisor model" value={scope.model ?? ''} onChange={event => setScope(current => ({ ...current, model: event.target.value || null }))}><option value="">All models</option>{modelOptions.map(model => <option key={model} value={model}>{model}</option>)}</select></label>
+            </>
+          )}
+          <span className="advisor-read-only">Read-only · {contextualScopeLabel(scope, contextualScopeMode)}</span>
         </div>
         {runtimeChoice !== 'hosted' && runtimeState.status === 'unavailable' ? <div className="advisor-runtime-note"><strong>No local model connected.</strong> You can still use the explicit offline evidence fallback; connect a supported local runtime to unlock free-form model conversation and tool calls. <button type="button" onClick={() => void checkLocalRuntime()}>Try again</button></div> : null}
         {overview.error && !overview.data ? <div className="advisor-runtime-note warning"><strong>Canonical Metrora data is unavailable.</strong> {overview.error.message}</div> : null}

--- a/app/renderer/sections/Plans.tsx
+++ b/app/renderer/sections/Plans.tsx
@@ -73,7 +73,7 @@ function manualPlanSummaries(status: StatusJson): JsonPlanSummary[] {
   return planSummaries(status).filter(plan => plan.provider !== 'claude' && plan.provider !== 'codex')
 }
 
-export function Plans({ period, refreshToken = 0, onNavigate, ready = true }: { period: Period; refreshToken?: number; onNavigate?: (section: Section, pane?: SettingsPane) => void; ready?: boolean }) {
+export function Plans({ period, refreshToken = 0, onNavigate, onAskAdvisor, ready = true }: { period: Period; refreshToken?: number; onNavigate?: (section: Section, pane?: SettingsPane) => void; onAskAdvisor?: () => void; ready?: boolean }) {
   // Force a fresh fetch (bypassing QuotaService's 5-min cache, and its keychain
   // guard) when the user hits ⌘R or clicks Refresh in the Connect affordance;
   // the steady 30s poll keeps serving cached quota.
@@ -94,6 +94,7 @@ export function Plans({ period, refreshToken = 0, onNavigate, ready = true }: { 
       <div className="bar">
         <div className="t">Plans</div>
         <div className="sp" />
+        {onAskAdvisor && <button type="button" className="btn btn-s ask-advisor-button" onClick={onAskAdvisor}>Ask Advisor <span aria-hidden="true">↗</span></button>}
         <button type="button" className="btn btn-s" onClick={() => onNavigate?.('settings', 'plans')}>
           Add plan…
         </button>

--- a/app/renderer/styles/advisor.css
+++ b/app/renderer/styles/advisor.css
@@ -201,6 +201,7 @@
   background: var(--advisor-surface);
 }
 .advisor-scope-label { margin-right: 4px; color: var(--advisor-ink); font-size: 10px; font-weight: 750; }
+.advisor-contextual-origin { padding: 4px 7px; border: 1px solid var(--advisor-accent-soft); border-radius: 5px; color: var(--advisor-accent); background: var(--advisor-accent-soft); font-size: 9px; font-weight: 700; }
 .advisor-scope-bar label { display: inline-flex; align-items: center; gap: 5px; font-size: 9px; }
 .advisor-scope-bar select {
   max-width: 128px;

--- a/app/renderer/styles/advisor.css
+++ b/app/renderer/styles/advisor.css
@@ -202,6 +202,7 @@
 }
 .advisor-scope-label { margin-right: 4px; color: var(--advisor-ink); font-size: 10px; font-weight: 750; }
 .advisor-contextual-origin { padding: 4px 7px; border: 1px solid var(--advisor-accent-soft); border-radius: 5px; color: var(--advisor-accent); background: var(--advisor-accent-soft); font-size: 9px; font-weight: 700; }
+.advisor-contextual-authority { color: var(--muted); font-size: 9px; font-weight: 600; white-space: nowrap; }
 .advisor-scope-bar label { display: inline-flex; align-items: center; gap: 5px; font-size: 9px; }
 .advisor-scope-bar select {
   max-width: 128px;

--- a/app/renderer/styles/brand.css
+++ b/app/renderer/styles/brand.css
@@ -105,6 +105,11 @@ body {
   color: var(--accent-control-ink);
   box-shadow: 0 2px 12px color-mix(in srgb, var(--accent) 28%, transparent), inset 0 1px 0 rgba(255,255,255,.22);
 }
+.ask-advisor-button {
+  border-color: color-mix(in srgb, var(--accent) 42%, var(--line2));
+  color: var(--accent-text);
+}
+.ask-advisor-button span { margin-left: 3px; }
 .tglon { box-shadow: 0 1px 8px color-mix(in srgb, var(--accent) 28%, transparent); }
 
 .metrora-mark {

--- a/docs/ADVISOR_CONTEXT_INTEGRATION_V1.md
+++ b/docs/ADVISOR_CONTEXT_INTEGRATION_V1.md
@@ -9,24 +9,22 @@ The public renderer contract is `advisor-contextual-launch-v1`, schema version `
 It carries only:
 
 - the originating supported Desktop section;
-- the canonical period and optional custom date range;
-- the canonical provider filter;
-- the Metrora Project id and canonical display name;
-- an optional exact model identity when the source has one that Advisor can investigate;
+- the surface-aware `scopeMode`;
+- only the canonical scope dimensions consumed by that surface;
 - a Metrora-owned suggested investigation prompt.
 
-The builder projects fields explicitly and snapshots them through the existing `AdvisorScope` validator. It does not accept evidence, claims, renderer state, page payloads, selection collections, or arbitrary prose. Invalid optional model state degrades to page scope; malformed required scope fails closed.
+The builder applies `ADVISOR_CONTEXTUAL_SCOPE_POLICY` before snapshotting through the existing `AdvisorScope` validator. It does not accept evidence, claims, renderer state, page payloads, selection collections, or arbitrary prose. Invalid optional model state degrades to page scope; malformed required scope fails closed. Compare and Plans deliberately discard unsupported incoming dimensions instead of validating or carrying them.
 
-## Surface matrix
+## Surface matrix: before and after remediation
 
-| Surface | V1 behavior | Contextual investigation |
+| Surface | Before remediation | After remediation |
 | --- | --- | --- |
-| Home / Overview | Supported | Current period/range, provider, Project; measured overview prompt |
-| Spend | Supported | Current period/range, provider, Project; measured spend drivers prompt |
-| Models | Supported | Current period/range, provider, Project; observed cost-per-call prompt |
-| Sessions / Activity | Supported | Page-scope period/range, provider, Project; session/Project spend prompt |
-| Compare | Supported at page scope | Does not pass the selected pair; asks about canonical observed model-efficiency evidence |
-| Capacity / Plans | Supported | Uses the existing provider-reported quota evidence path |
+| Home / Overview | Inherited global period/range/provider/Project | Supported; current period/range/provider/Project only |
+| Spend | Inherited global period/range/provider/Project | Supported; current period/range/provider/Project only |
+| Models | Inherited global period/range/provider/Project | Supported; current period/range/provider/Project only |
+| Sessions / Activity | Inherited global period/range/provider/Project | Supported; current period/range/provider/Project only |
+| Compare | Could inherit custom range and Project | Supported at page scope; current period/provider only; custom dates, Project, and the selected pair are dropped |
+| Capacity / Plans | Could inherit hidden provider/Project/range state | Supported as current provider-reported capacity across all providers; no Project/history/custom-range authority and no model |
 | Bench | Unsupported in V1 | Bench evidence is truthful only for its own compatible all-provider/all-Project scope; the page has no matching shared scope handoff |
 | Pull requests, Insights, Workspace, Settings | Unsupported in V1 | No current Advisor evidence contract makes a truthful page-level investigation for these surfaces |
 
@@ -34,7 +32,9 @@ The contextual affordance is one page/header action: `Ask Advisor`. It is shared
 
 ## UX and safety behavior
 
-Selecting `Ask Advisor` navigates to Advisor with the canonical handoff. Advisor shows the originating surface, preselects the supported scope dimensions, and loads the suggested question into the composer. It never submits the question automatically; the user can edit, send, or discard it.
+Selecting `Ask Advisor` navigates to Advisor with the canonical handoff. Advisor shows the originating surface, preselects only the supported scope dimensions, and loads the suggested question into the composer. Compare explains that custom dates and Project are not part of its page scope. Capacity shows `Provider-reported now · All providers` and keeps the generic Advisor placeholder dimensions out of the contextual UI. It never submits the question automatically; the user can edit, send, or discard it.
+
+The Capacity placeholder `today / all providers / all projects / no model` exists only because the shared `AdvisorScope` contract is generic. Provider quota windows, reset timestamps, freshness, and credits remain the authority; Metrora history and Project scope do not silently scope Capacity.
 
 Advisor remains the authority for conversation scope. Existing scope fingerprints filter follow-up history, so changing period, range, provider, Project, or model cannot reuse incompatible factual conversation context. Returning to a product section does not mutate its accounting scope.
 

--- a/docs/ADVISOR_CONTEXT_INTEGRATION_V1.md
+++ b/docs/ADVISOR_CONTEXT_INTEGRATION_V1.md
@@ -1,0 +1,45 @@
+# Metrora Advisor contextual launch V1
+
+Metrora Desktop keeps factual accounting and capacity details in product sections. A contextual launch gives the existing Advisor one bounded entry point for interpreting the current page scope.
+
+## Contract
+
+The public renderer contract is `advisor-contextual-launch-v1`, schema version `1`, implemented in `app/renderer/advisor/context.ts`.
+
+It carries only:
+
+- the originating supported Desktop section;
+- the canonical period and optional custom date range;
+- the canonical provider filter;
+- the Metrora Project id and canonical display name;
+- an optional exact model identity when the source has one that Advisor can investigate;
+- a Metrora-owned suggested investigation prompt.
+
+The builder projects fields explicitly and snapshots them through the existing `AdvisorScope` validator. It does not accept evidence, claims, renderer state, page payloads, selection collections, or arbitrary prose. Invalid optional model state degrades to page scope; malformed required scope fails closed.
+
+## Surface matrix
+
+| Surface | V1 behavior | Contextual investigation |
+| --- | --- | --- |
+| Home / Overview | Supported | Current period/range, provider, Project; measured overview prompt |
+| Spend | Supported | Current period/range, provider, Project; measured spend drivers prompt |
+| Models | Supported | Current period/range, provider, Project; observed cost-per-call prompt |
+| Sessions / Activity | Supported | Page-scope period/range, provider, Project; session/Project spend prompt |
+| Compare | Supported at page scope | Does not pass the selected pair; asks about canonical observed model-efficiency evidence |
+| Capacity / Plans | Supported | Uses the existing provider-reported quota evidence path |
+| Bench | Unsupported in V1 | Bench evidence is truthful only for its own compatible all-provider/all-Project scope; the page has no matching shared scope handoff |
+| Pull requests, Insights, Workspace, Settings | Unsupported in V1 | No current Advisor evidence contract makes a truthful page-level investigation for these surfaces |
+
+The contextual affordance is one page/header action: `Ask Advisor`. It is shared by the analytics `TopBar` and the existing Plans header. It is not repeated on metric cards or deterministic Details/Evidence blocks.
+
+## UX and safety behavior
+
+Selecting `Ask Advisor` navigates to Advisor with the canonical handoff. Advisor shows the originating surface, preselects the supported scope dimensions, and loads the suggested question into the composer. It never submits the question automatically; the user can edit, send, or discard it.
+
+Advisor remains the authority for conversation scope. Existing scope fingerprints filter follow-up history, so changing period, range, provider, Project, or model cannot reuse incompatible factual conversation context. Returning to a product section does not mutate its accounting scope.
+
+The handoff does not add an executor. Provider settings, optimization application, benchmark execution, agent launching, routing changes, and policy changes remain outside Advisor's read-only boundary.
+
+## Public/private and provenance boundary
+
+This is Metrora-owned MIT implementation using the existing Advisor Kernel, seven-tool contract, canonical evidence, privacy projection, and session-local conversation. No dependency was added. No proprietary ranking, forecasting, workload allocation, managed routing, private evaluation, team policy intelligence, or managed inference logic is included.


### PR DESCRIPTION
## Scope-truth remediation

- Centralizes surface-aware projection in `ADVISOR_CONTEXTUAL_SCOPE_POLICY`.
- Overview, Sessions, Spend, and Models retain current period/range/provider/Project scope.
- Compare retains only current period/provider; custom range, Project, and the selected model pair are not carried.
- Plans/Capacity uses current provider-reported capacity across all providers; hidden provider/Project/range/model state is discarded and kept out of the contextual UI.

## Surface matrix

| Surface | Before | After |
| --- | --- | --- |
| Home / Overview | Global scope for every surface | Current period/range/provider/Project |
| Sessions / Spend / Models | Global scope for every surface | Current period/range/provider/Project |
| Compare | Could inherit custom range and Project | Current period/provider only; no pair handoff |
| Plans / Capacity | Could inherit hidden provider/Project/range | All-provider current quota authority; no Project/history/range/model |
| Bench and unsupported destinations | No truthful handoff | Still fail closed |

## UX and boundary

- Advisor shows the originating surface and does not auto-send.
- Capacity shows provider-reported current authority and hides generic placeholder dimensions.
- Existing scope fingerprints continue to filter incompatible conversation history.
- Existing Advisor Kernel, seven-tool contract, evidence path, local runtimes/BYOK, and read-only boundary are unchanged. No executor, second Advisor, dependency, or CI gate was added.

## Validation

- Focused regression tests: 4 files, 54 tests passed.
- Full Desktop suite: 103 files, 880 tests passed; the Electron CLI watchdog test passed on an isolated rerun after one transient timing miss.
- `npm run typecheck`: passed.
- `npm run build`: passed; existing non-blocking Vite chunk-size warning only.

## Remote CI

- 6 checks successful, 4 intentionally skipped; GitHub reports all checks passed.
- No merge conflicts.

## Closeout

- START_HEAD: `14690a67ac88c3aa429d3be4dbfecbaedf055152`
- FINAL_HEAD: `02c79a9a37059e9a0a7492d3cf60a7b43340bfb5`
- BASE_SHA: `dc80c87a138bf98394ba40dc13091a639338c2b6`
- Commits: `14690a67` contextual launch; `02c79a9a` scope-truth remediation.
- Files: 7 remediation files; no unrelated changes.
- Same remote branch `feat/advisor-context-integration-v1`, same PR #228, Draft, no merge.