### PR TITLE
fix(capacity): bind stale quota to credential identity

### DIFF
--- a/app/electron/quota/antigravity.ts
+++ b/app/electron/quota/antigravity.ts
@@ -5,6 +5,7 @@ import { promisify } from 'node:util'
 
 import { emptyQuota, markObserved, type QuotaProvider, type QuotaWindow } from './types'
 import { sanitizeError } from './security'
+import { knownIdentity, unknownIdentity, type IdentityObservation } from './identity'
 
 const SOURCE = { kind: 'provider-loopback', stability: 'experimental' } as const
 const SUMMARY_PATH = '/exa.language_server_pb.LanguageServerService/RetrieveUserQuotaSummary'
@@ -250,29 +251,35 @@ async function probe(deps: AntigravityDeps, candidate: Candidate, port: number, 
   return null
 }
 
-export async function fetchAntigravityQuota(options: Partial<AntigravityDeps> & { signal?: AbortSignal } = {}): Promise<{ quota: QuotaProvider }> {
+export type AntigravityResult = { quota: QuotaProvider; identity: IdentityObservation }
+
+export async function fetchAntigravityQuota(options: Partial<AntigravityDeps> & { signal?: AbortSignal; identityOnly?: boolean } = {}): Promise<AntigravityResult> {
   const deps = { ...defaults, ...options }
   try {
-    if (options.signal?.aborted) return { quota: empty('disconnected') }
+    if (options.signal?.aborted) return { quota: empty('disconnected'), identity: unknownIdentity() }
     const candidates = await processCandidates(deps)
-    if (options.signal?.aborted) return { quota: empty('disconnected') }
-    for (const candidate of candidates) {
-      if (options.signal?.aborted) return { quota: empty('disconnected') }
-      const ports = candidate.port ? [candidate.port] : await listeningPorts(deps, candidate.pid)
-      for (const port of ports) {
-        if (options.signal?.aborted) return { quota: empty('disconnected') }
-        const quota = await probe(deps, candidate, port, options.signal)
-        if (quota) return { quota: markObserved(quota, deps.now()) }
-      }
+    if (options.signal?.aborted) return { quota: empty('disconnected'), identity: unknownIdentity() }
+    if (candidates.length === 0) return { quota: empty('disconnected'), identity: unknownIdentity() }
+    // Multiple eligible desktop authorities make the current session ambiguous;
+    // do not select one just to make stale retention appear available.
+    if (candidates.length !== 1) return { quota: empty('transientFailure'), identity: unknownIdentity() }
+    const candidate = candidates[0]!
+    const identity = knownIdentity('antigravity', 'session', candidate.csrf)
+    if (options.identityOnly) return { quota: empty('loading'), identity }
+    const ports = candidate.port ? [candidate.port] : await listeningPorts(deps, candidate.pid)
+    for (const port of ports) {
+      if (options.signal?.aborted) return { quota: empty('disconnected'), identity }
+      const quota = await probe(deps, candidate, port, options.signal)
+      if (quota) return { quota: markObserved(quota, deps.now()), identity }
     }
     // An absent eligible process is a normal disconnected state. Once an
     // eligible provider-owned authority was observed, however, a failed port
     // or protocol probe is a transport failure and may legitimately retain a
     // prior factual snapshot as stale in QuotaService.
-    return { quota: empty(candidates.length > 0 ? 'transientFailure' : 'disconnected') }
+    return { quota: empty('transientFailure'), identity }
   } catch (error) {
-    if (options.signal?.aborted) return { quota: empty('disconnected') }
+    if (options.signal?.aborted) return { quota: empty('disconnected'), identity: unknownIdentity() }
     console.warn(`Antigravity capacity unavailable: ${sanitizeError(error)}`)
-    return { quota: empty('transientFailure') }
+    return { quota: empty('transientFailure'), identity: unknownIdentity() }
   }
 }

--- a/app/electron/quota/antigravity.ts
+++ b/app/electron/quota/antigravity.ts
@@ -5,7 +5,7 @@ import { promisify } from 'node:util'
 
 import { emptyQuota, markObserved, type QuotaProvider, type QuotaWindow } from './types'
 import { sanitizeError } from './security'
-import { knownIdentity, unknownIdentity, type IdentityObservation } from './identity'
+import { knownContinuityIdentity, unknownIdentity, type IdentityObservation } from './identity'
 
 const SOURCE = { kind: 'provider-loopback', stability: 'experimental' } as const
 const SUMMARY_PATH = '/exa.language_server_pb.LanguageServerService/RetrieveUserQuotaSummary'
@@ -264,7 +264,9 @@ export async function fetchAntigravityQuota(options: Partial<AntigravityDeps> & 
     // do not select one just to make stale retention appear available.
     if (candidates.length !== 1) return { quota: empty('transientFailure'), identity: unknownIdentity() }
     const candidate = candidates[0]!
-    const identity = knownIdentity('antigravity', 'session', candidate.csrf)
+    // The local process/CSRF pair proves session continuity only. It is not a
+    // provider-account identity and must never authorize stale factual reuse.
+    const identity = knownContinuityIdentity('antigravity', 'session', candidate.pid, candidate.csrf)
     if (options.identityOnly) return { quota: empty('loading'), identity }
     const ports = candidate.port ? [candidate.port] : await listeningPorts(deps, candidate.pid)
     for (const port of ports) {

--- a/app/electron/quota/capacity-expansion.test.ts
+++ b/app/electron/quota/capacity-expansion.test.ts
@@ -213,6 +213,24 @@ describe('Capacity provider expansion', () => {
     expect(failedProbe.quota.windows).toEqual([])
   })
 
+  it('fails closed when multiple Antigravity authorities are eligible', async () => {
+    const execFile = vi.fn(async (_file: string, args: string[]) => {
+      const command = args.at(-1) ?? ''
+      if (!command.includes('Get-CimInstance')) return { stdout: '' }
+      return {
+        stdout: [
+          JSON.stringify({ PID: 4242, Cmd: 'C:\\Antigravity\\language_server.exe --app_data_dir antigravity --csrf_token abcdefghijklmnop' }),
+          JSON.stringify({ PID: 4343, Cmd: 'C:\\Antigravity\\language_server.exe --app_data_dir antigravity --csrf_token qrstuvwxyzabcdef' }),
+        ].join('\n'),
+      }
+    })
+    const request = vi.fn()
+    const result = await fetchAntigravityQuota({ platform: 'win32', execFile, request })
+    expect(result.quota.connection).toBe('transientFailure')
+    expect(result.identity.state).toBe('unknown')
+    expect(request).not.toHaveBeenCalled()
+  })
+
   it('sanitizes source metadata through the renderer boundary and drops unknown values', () => {
     const base = {
       schemaVersion: 1,

--- a/app/electron/quota/capacity-expansion.test.ts
+++ b/app/electron/quota/capacity-expansion.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from 'vitest'
 import { decodeAntigravitySummary, fetchAntigravityQuota } from './antigravity'
 import { decodeCopilotUsage, fetchCopilotQuota } from './copilot'
 import { decodeKimiUsage, fetchKimiQuota } from './kimi'
+import { sameIdentity } from './identity'
 import { sanitizeQuotaProvider } from './types'
 
 describe('Capacity provider expansion', () => {
@@ -188,6 +189,7 @@ describe('Capacity provider expansion', () => {
       source: { kind: 'provider-loopback', stability: 'experimental' },
     })
     expect(result.quota.windows[0]).toMatchObject({ label: 'Gemini Models · Weekly', usedFraction: 0.25 })
+    expect(result.identity).toMatchObject({ state: 'known', capability: 'continuity' })
     expect(execFile).toHaveBeenCalledTimes(2)
   })
 
@@ -229,6 +231,23 @@ describe('Capacity provider expansion', () => {
     expect(result.quota.connection).toBe('transientFailure')
     expect(result.identity.state).toBe('unknown')
     expect(request).not.toHaveBeenCalled()
+  })
+
+  it('keeps Antigravity continuity bound to the process and CSRF pair', async () => {
+    let pid = '4242'
+    const execFile = vi.fn(async (_file: string, args: string[]) => {
+      const command = args.at(-1) ?? ''
+      if (!command.includes('Get-CimInstance')) return { stdout: '' }
+      return { stdout: `${JSON.stringify({ PID: Number(pid), Cmd: `C:\\Antigravity\\language_server.exe --app_data_dir antigravity --csrf_token abcdefghijklmnop` })}\n` }
+    })
+
+    const first = await fetchAntigravityQuota({ platform: 'win32', execFile, identityOnly: true })
+    pid = '4343'
+    const second = await fetchAntigravityQuota({ platform: 'win32', execFile, identityOnly: true })
+
+    expect(first.identity).toMatchObject({ state: 'known', capability: 'continuity' })
+    expect(second.identity).toMatchObject({ state: 'known', capability: 'continuity' })
+    expect(sameIdentity(first.identity, second.identity)).toBe(false)
   })
 
   it('sanitizes source metadata through the renderer boundary and drops unknown values', () => {

--- a/app/electron/quota/claude.ts
+++ b/app/electron/quota/claude.ts
@@ -4,6 +4,7 @@ import path from 'node:path'
 import { emptyQuota, markObserved, type QuotaProvider, type QuotaWindow } from './types'
 import { fraction, quotaRequestSignal, readKeychainPassword, readSecureFile, sanitizeError } from './security'
 import type { KeychainOutcome } from './security'
+import { knownIdentity, unknownIdentity, type IdentityObservation } from './identity'
 
 const ENDPOINT = 'https://api.anthropic.com/api/oauth/usage'
 const KEYCHAIN_SERVICE = 'Claude Code-credentials'
@@ -168,45 +169,50 @@ async function request(token: string, deps: ClaudeDeps, parent?: AbortSignal): P
   })
 }
 
-export type ClaudeResult = { quota: QuotaProvider; retryAfterSeconds?: number }
+export type ClaudeResult = { quota: QuotaProvider; retryAfterSeconds?: number; identity: IdentityObservation }
 
-export async function fetchClaudeQuota(options: Partial<ClaudeDeps> & { signal?: AbortSignal; allowKeychain?: boolean } = {}): Promise<ClaudeResult> {
+export async function fetchClaudeQuota(options: Partial<ClaudeDeps> & { signal?: AbortSignal; allowKeychain?: boolean; identityOnly?: boolean } = {}): Promise<ClaudeResult> {
   const deps = { ...defaults, ...options }
   try {
     const discovered = await discoverCredential(deps, Boolean(options.allowKeychain))
-    if (discovered === 'accessDenied') return { quota: empty('accessDenied') }
-    if (!discovered) return { quota: empty('disconnected') }
+    if (discovered === 'accessDenied') return { quota: empty('accessDenied'), identity: unknownIdentity() }
+    if (!discovered) return { quota: empty('disconnected'), identity: unknownIdentity() }
     const source = discovered
     let credential = source.credential
+    let identity = knownIdentity('claude', credential.accessToken)
 
     // Claude's CLI owns token rotation. A near-expiry credential gets one
     // bounded reread; Metrora never calls a provider refresh endpoint.
     if (credential.expiresAt !== undefined && credential.expiresAt - deps.now() <= 5 * 60_000) {
       const reread = await source.reread()
-      if (!reread || reread.accessToken === credential.accessToken) return { quota: empty('transientFailure') }
+      if (!reread || reread.accessToken === credential.accessToken) return { quota: empty('transientFailure'), identity }
       credential = reread
+      identity = knownIdentity('claude', credential.accessToken)
     }
+
+    if (options.identityOnly) return { quota: empty('loading'), identity }
 
     let response = await request(credential.accessToken, deps, options.signal)
     if (response.status === 401) {
       const reread = await source.reread()
-      if (!reread || reread.accessToken === credential.accessToken) return { quota: empty('transientFailure') }
+      if (!reread || reread.accessToken === credential.accessToken) return { quota: empty('transientFailure'), identity }
       credential = reread
+      identity = knownIdentity('claude', credential.accessToken)
       response = await request(credential.accessToken, deps, options.signal)
-      if (response.status === 401) return { quota: empty('transientFailure') }
+      if (response.status === 401) return { quota: empty('transientFailure'), identity }
     }
     if (response.status === 429) {
       let hint: unknown
       try { hint = (await response.json() as Record<string, unknown>).retry_after } catch { hint = undefined }
       const parsed = typeof hint === 'number' ? hint : typeof hint === 'string' ? Number(hint) : NaN
-      return { quota: empty('transientFailure'), retryAfterSeconds: Math.max(Number.isFinite(parsed) ? parsed : 300, 60) }
+      return { quota: empty('transientFailure'), retryAfterSeconds: Math.max(Number.isFinite(parsed) ? parsed : 300, 60), identity }
     }
-    if (!response.ok) return { quota: empty(response.status >= 400 && response.status < 500 ? 'terminalFailure' : 'transientFailure') }
-    return { quota: markObserved(decodeClaudeUsage(await response.json(), credential), deps.now()) }
+    if (!response.ok) return { quota: empty(response.status >= 400 && response.status < 500 ? 'terminalFailure' : 'transientFailure'), identity }
+    return { quota: markObserved(decodeClaudeUsage(await response.json(), credential), deps.now()), identity }
   } catch (error) {
     // Deliberately sanitize before the only diagnostic sink. Tokens and
     // provider response bodies are never returned or logged.
     console.warn(`Claude quota unavailable: ${sanitizeError(error)}`)
-    return { quota: empty('transientFailure') }
+    return { quota: empty('transientFailure'), identity: unknownIdentity() }
   }
 }

--- a/app/electron/quota/codex.test.ts
+++ b/app/electron/quota/codex.test.ts
@@ -91,6 +91,25 @@ describe('Codex quota', () => {
     expect(usageInit.headers).toMatchObject({ 'ChatGPT-Account-Id': 'acct_1', 'User-Agent': 'Metrora' })
   })
 
+  it('binds retention identity to Codex account_id rather than token alone', async () => {
+    let accountId = 'acct_1'
+    const readFile = vi.fn(async () => JSON.stringify({
+      ...auth,
+      tokens: { ...auth.tokens, access_token: 'same-token', account_id: accountId },
+    }))
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify({ plan_type: 'pro' }), { status: 200 }))
+
+    const first = await fetchCodexQuota({ fetch: fetchMock, readFile, now: () => now })
+    accountId = 'acct_2'
+    const second = await fetchCodexQuota({ fetch: fetchMock, readFile, now: () => now })
+
+    expect(first.identity.state).toBe('known')
+    expect(second.identity.state).toBe('known')
+    expect(first.identity).not.toEqual(second.identity)
+    expect(JSON.stringify(first.identity)).not.toContain('acct_1')
+    expect(JSON.stringify(second.identity)).not.toContain('acct_2')
+  })
+
   it('never refreshes or writes a stale provider-owned auth document', async () => {
     const stale = { ...auth, last_refresh: '2026-07-01T00:00:00Z' }
     const fetchMock = vi.fn(async () => new Response(JSON.stringify({ plan_type: 'pro', rate_limit: {} }), { status: 200 }))

--- a/app/electron/quota/codex.ts
+++ b/app/electron/quota/codex.ts
@@ -4,6 +4,7 @@ import path from 'node:path'
 import { emptyQuota, markObserved, type QuotaProvider, type QuotaWindow } from './types'
 import { fraction, quotaRequestSignal, readKeychainPassword, readSecureFile, sanitizeError } from './security'
 import type { KeychainOutcome } from './security'
+import { knownIdentity, sameIdentity, unknownIdentity, type IdentityObservation } from './identity'
 
 const USAGE_ENDPOINT = 'https://chatgpt.com/backend-api/wham/usage'
 // The Metrora menubar caches its ChatGPT-mode Codex OAuth here as a
@@ -46,6 +47,13 @@ type CodexSource = {
 
 function empty(connection: QuotaProvider['connection']): QuotaProvider {
   return emptyQuota('codex', connection)
+}
+
+function identityForAuth(auth: AuthDoc): IdentityObservation {
+  const accountId = typeof auth.tokens?.account_id === 'string' ? auth.tokens.account_id.trim() : ''
+  if (accountId) return knownIdentity('codex', 'account', accountId)
+  const token = typeof auth.tokens?.access_token === 'string' ? auth.tokens.access_token : ''
+  return token ? knownIdentity('codex', 'credential', token) : unknownIdentity()
 }
 
 async function readAuth(deps: CodexDeps, filePath: string = deps.authPath): Promise<AuthDoc | null> {
@@ -206,46 +214,50 @@ async function usage(auth: AuthDoc, deps: CodexDeps, signal?: AbortSignal): Prom
   return deps.fetch(USAGE_ENDPOINT, { method: 'GET', headers, signal: quotaRequestSignal(signal) })
 }
 
-export type CodexResult = { quota: QuotaProvider; retryAfterSeconds?: number }
+export type CodexResult = { quota: QuotaProvider; retryAfterSeconds?: number; identity: IdentityObservation }
 
-export async function fetchCodexQuota(options: Partial<CodexDeps> & { signal?: AbortSignal; allowKeychain?: boolean } = {}): Promise<CodexResult> {
+export async function fetchCodexQuota(options: Partial<CodexDeps> & { signal?: AbortSignal; allowKeychain?: boolean; identityOnly?: boolean } = {}): Promise<CodexResult> {
   const deps = { ...defaults, ...options }
   try {
     const discovered = await discoverSource(deps, Boolean(options.allowKeychain))
-    if (discovered === 'accessDenied') return { quota: empty('accessDenied') }
-    if (!discovered) return { quota: empty('disconnected') }
+    if (discovered === 'accessDenied') return { quota: empty('accessDenied'), identity: unknownIdentity() }
+    if (!discovered) return { quota: empty('disconnected'), identity: unknownIdentity() }
     const source = discovered
     let auth = source.auth
-    if (auth.auth_mode !== 'chatgpt') return { quota: empty('terminalFailure') }
-    if (!auth.tokens?.access_token) return { quota: empty('disconnected') }
+    let identity = identityForAuth(auth)
+    if (auth.auth_mode !== 'chatgpt') return { quota: empty('terminalFailure'), identity }
+    if (!auth.tokens?.access_token) return { quota: empty('disconnected'), identity: unknownIdentity() }
+    if (options.identityOnly) return { quota: empty('loading'), identity }
 
     // Provider-owned Codex OAuth is observationally read-only. In particular,
     // a stale refresh_token in auth.json is never spent by this code.
     let response = await usage(auth, deps, options.signal)
-    if (!response) return { quota: empty('disconnected') }
+    if (!response) return { quota: empty('disconnected'), identity }
     if (response.status === 401) {
       // One bounded reread lets the owner win a concurrent rotation. If the
       // access token did not change, truthfully wait rather than refreshing or
       // mutating the provider-owned credential source.
       const reread = await source.reread()
       const nextToken = reread?.tokens?.access_token
-      if (!nextToken || nextToken === auth.tokens?.access_token) return { quota: empty('transientFailure') }
-      if (reread?.auth_mode !== 'chatgpt') return { quota: empty('terminalFailure') }
+      const nextIdentity = reread ? identityForAuth(reread) : unknownIdentity()
+      if (!nextToken || (nextToken === auth.tokens?.access_token && sameIdentity(nextIdentity, identity))) return { quota: empty('transientFailure'), identity }
+      if (reread?.auth_mode !== 'chatgpt') return { quota: empty('terminalFailure'), identity: nextIdentity }
       auth = reread
+      identity = nextIdentity
       response = await usage(auth, deps, options.signal)
-      if (!response) return { quota: empty('transientFailure') }
-      if (response.status === 401) return { quota: empty('transientFailure') }
+      if (!response) return { quota: empty('transientFailure'), identity }
+      if (response.status === 401) return { quota: empty('transientFailure'), identity }
     }
     if (response.status === 429) {
       const raw = response.headers.get('Retry-After')
       let seconds = raw === null ? NaN : Number(raw)
       if (!Number.isFinite(seconds) && raw) seconds = (Date.parse(raw) - deps.now()) / 1000
-      return { quota: empty('transientFailure'), retryAfterSeconds: Math.max(Number.isFinite(seconds) ? Math.ceil(seconds) : 300, 60) }
+      return { quota: empty('transientFailure'), retryAfterSeconds: Math.max(Number.isFinite(seconds) ? Math.ceil(seconds) : 300, 60), identity }
     }
-    if (!response.ok) return { quota: empty(response.status >= 400 && response.status < 500 ? 'terminalFailure' : 'transientFailure') }
-    return { quota: markObserved(decodeCodexUsage(await response.json()), deps.now()) }
+    if (!response.ok) return { quota: empty(response.status >= 400 && response.status < 500 ? 'terminalFailure' : 'transientFailure'), identity }
+    return { quota: markObserved(decodeCodexUsage(await response.json()), deps.now()), identity }
   } catch (error) {
     console.warn(`Codex quota unavailable: ${sanitizeError(error)}`)
-    return { quota: empty('transientFailure') }
+    return { quota: empty('transientFailure'), identity: unknownIdentity() }
   }
 }

--- a/app/electron/quota/copilot.ts
+++ b/app/electron/quota/copilot.ts
@@ -3,6 +3,7 @@ import path from 'node:path'
 
 import { emptyQuota, markObserved, type QuotaProvider, type QuotaWindow } from './types'
 import { quotaRequestSignal, readSecureFile, sanitizeError } from './security'
+import { knownIdentity, unknownIdentity, type IdentityObservation } from './identity'
 
 const USAGE_ENDPOINT = 'https://api.github.com/copilot_internal/user'
 const SOURCE = { kind: 'provider-internal-api', stability: 'experimental' } as const
@@ -210,27 +211,30 @@ function retryAfterSeconds(response: Response, now: number): number {
   return Math.max(60, Number.isFinite(date) ? Math.ceil((date - now) / 1000) : 300)
 }
 
-export type CopilotResult = { quota: QuotaProvider; retryAfterSeconds?: number }
+export type CopilotResult = { quota: QuotaProvider; retryAfterSeconds?: number; identity: IdentityObservation }
 
-export async function fetchCopilotQuota(options: Partial<CopilotDeps> & { signal?: AbortSignal } = {}): Promise<CopilotResult> {
+export async function fetchCopilotQuota(options: Partial<CopilotDeps> & { signal?: AbortSignal; identityOnly?: boolean } = {}): Promise<CopilotResult> {
   const deps = { ...defaults, ...options }
   try {
     let token = await credentialFromFiles(deps)
-    if (!token) return { quota: empty('disconnected') }
+    if (!token) return { quota: empty('disconnected'), identity: unknownIdentity() }
+    let identity = knownIdentity('copilot', 'credential', token)
+    if (options.identityOnly) return { quota: empty('loading'), identity }
 
     let response = await request(token, deps, options.signal)
     if (response.status === 401) {
       const reread = await credentialFromFiles(deps)
-      if (!reread || reread === token) return { quota: empty('transientFailure') }
+      if (!reread || reread === token) return { quota: empty('transientFailure'), identity }
       token = reread
+      identity = knownIdentity('copilot', 'credential', token)
       response = await request(token, deps, options.signal)
-      if (response.status === 401) return { quota: empty('transientFailure') }
+      if (response.status === 401) return { quota: empty('transientFailure'), identity }
     }
-    if (response.status === 429) return { quota: empty('transientFailure'), retryAfterSeconds: retryAfterSeconds(response, deps.now()) }
-    if (!response.ok) return { quota: empty(response.status >= 400 && response.status < 500 ? 'terminalFailure' : 'transientFailure') }
-    return { quota: markObserved(decodeCopilotUsage(await response.json()), deps.now()) }
+    if (response.status === 429) return { quota: empty('transientFailure'), retryAfterSeconds: retryAfterSeconds(response, deps.now()), identity }
+    if (!response.ok) return { quota: empty(response.status >= 400 && response.status < 500 ? 'terminalFailure' : 'transientFailure'), identity }
+    return { quota: markObserved(decodeCopilotUsage(await response.json()), deps.now()), identity }
   } catch (error) {
     console.warn(`GitHub Copilot capacity unavailable: ${sanitizeError(error)}`)
-    return { quota: empty('transientFailure') }
+    return { quota: empty('transientFailure'), identity: unknownIdentity() }
   }
 }

--- a/app/electron/quota/identity.ts
+++ b/app/electron/quota/identity.ts
@@ -2,9 +2,9 @@ import { createHash, randomBytes } from 'node:crypto'
 
 import type { ProviderName } from './types'
 
-/** Process-local identity evidence used only to gate factual retention. */
+/** Process-local identity evidence kept inside the quota service boundary. */
 export type IdentityObservation =
-  | { state: 'known'; key: string }
+  | { state: 'known'; key: string; capability: 'retention' | 'continuity' }
   | { state: 'unknown' }
 
 // A per-process salt keeps the comparison value non-linkable across app runs.
@@ -16,6 +16,14 @@ export function unknownIdentity(): IdentityObservation {
 }
 
 export function knownIdentity(provider: ProviderName, ...parts: readonly string[]): IdentityObservation {
+  return makeIdentity('retention', provider, parts)
+}
+
+export function knownContinuityIdentity(provider: ProviderName, ...parts: readonly string[]): IdentityObservation {
+  return makeIdentity('continuity', provider, parts)
+}
+
+function makeIdentity(capability: 'retention' | 'continuity', provider: ProviderName, parts: readonly string[]): IdentityObservation {
   if (parts.length === 0 || parts.some(part => !part.trim())) return unknownIdentity()
 
   const hash = createHash('sha256')
@@ -23,9 +31,16 @@ export function knownIdentity(provider: ProviderName, ...parts: readonly string[
     .update(PROCESS_SALT)
     .update(`\0${provider}\0`)
   for (const part of parts) hash.update(`${part.length}:`).update(part)
-  return { state: 'known', key: hash.digest('base64url') }
+  return { state: 'known', key: hash.digest('base64url'), capability }
+}
+
+export function isRetentionSafe(identity: IdentityObservation): boolean {
+  return identity.state === 'known' && identity.capability === 'retention'
 }
 
 export function sameIdentity(left: IdentityObservation, right: IdentityObservation): boolean {
-  return left.state === 'known' && right.state === 'known' && left.key === right.key
+  return left.state === 'known'
+    && right.state === 'known'
+    && left.capability === right.capability
+    && left.key === right.key
 }

--- a/app/electron/quota/identity.ts
+++ b/app/electron/quota/identity.ts
@@ -1,0 +1,31 @@
+import { createHash, randomBytes } from 'node:crypto'
+
+import type { ProviderName } from './types'
+
+/** Process-local identity evidence used only to gate factual retention. */
+export type IdentityObservation =
+  | { state: 'known'; key: string }
+  | { state: 'unknown' }
+
+// A per-process salt keeps the comparison value non-linkable across app runs.
+// The value is intentionally never persisted, logged, or exposed to consumers.
+const PROCESS_SALT = randomBytes(32)
+
+export function unknownIdentity(): IdentityObservation {
+  return { state: 'unknown' }
+}
+
+export function knownIdentity(provider: ProviderName, ...parts: readonly string[]): IdentityObservation {
+  if (parts.length === 0 || parts.some(part => !part.trim())) return unknownIdentity()
+
+  const hash = createHash('sha256')
+    .update('metrora-quota-identity-v1\0')
+    .update(PROCESS_SALT)
+    .update(`\0${provider}\0`)
+  for (const part of parts) hash.update(`${part.length}:`).update(part)
+  return { state: 'known', key: hash.digest('base64url') }
+}
+
+export function sameIdentity(left: IdentityObservation, right: IdentityObservation): boolean {
+  return left.state === 'known' && right.state === 'known' && left.key === right.key
+}

--- a/app/electron/quota/index.test.ts
+++ b/app/electron/quota/index.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 
 import { QuotaService } from './index'
+import { knownIdentity, unknownIdentity } from './identity'
 import type { ProviderName, QuotaProvider } from './types'
 
 const quota = (provider: ProviderName, overrides: Partial<QuotaProvider> = {}): QuotaProvider => ({
@@ -18,14 +19,35 @@ const quota = (provider: ProviderName, overrides: Partial<QuotaProvider> = {}): 
   ...overrides,
 })
 
+const result = (provider: ProviderName, value: QuotaProvider = quota(provider), account = 'A', extra: Record<string, unknown> = {}) => ({
+  ...extra,
+  quota: value,
+  identity: knownIdentity(provider, account),
+})
+
 function providerDeps(overrides: Partial<Record<ProviderName, ReturnType<typeof vi.fn>>> = {}) {
   return {
-    claude: overrides.claude ?? vi.fn(async () => ({ quota: quota('claude') })),
-    codex: overrides.codex ?? vi.fn(async () => ({ quota: quota('codex') })),
-    copilot: overrides.copilot ?? vi.fn(async () => ({ quota: quota('copilot') })),
-    kimi: overrides.kimi ?? vi.fn(async () => ({ quota: quota('kimi') })),
-    antigravity: overrides.antigravity ?? vi.fn(async () => ({ quota: quota('antigravity') })),
+    claude: overrides.claude ?? vi.fn(async () => result('claude')),
+    codex: overrides.codex ?? vi.fn(async () => result('codex')),
+    copilot: overrides.copilot ?? vi.fn(async () => result('copilot')),
+    kimi: overrides.kimi ?? vi.fn(async () => result('kimi')),
+    antigravity: overrides.antigravity ?? vi.fn(async () => result('antigravity')),
   }
+}
+
+function actualCalls(fetcher: ReturnType<typeof vi.fn>): number {
+  return fetcher.mock.calls.filter(([options]) => !options?.identityOnly).length
+}
+
+function probe(provider: ProviderName, identity: ReturnType<typeof knownIdentity>) {
+  return { quota: quota(provider, { availability: 'unavailable', connection: 'loading', freshness: 'unavailable', observedAt: null }), identity }
+}
+
+function factual(provider: ProviderName, usedFraction: number, observedAt: string): QuotaProvider {
+  return quota(provider, {
+    observedAt,
+    windows: [{ id: 'window', label: 'Usage', usedFraction, resetsAt: null, windowSeconds: 3600 }],
+  })
 }
 
 describe('QuotaService', () => {
@@ -37,12 +59,12 @@ describe('QuotaService', () => {
     })
     const value = await service.getQuota({ force: true })
     expect(value.map(row => row.provider)).toEqual(['claude', 'codex', 'copilot', 'kimi', 'antigravity'])
-    for (const fetcher of Object.values(deps)) expect(fetcher).toHaveBeenCalledTimes(1)
+    for (const fetcher of Object.values(deps)) expect(actualCalls(fetcher)).toBe(1)
   })
 
   it('persists provider 429 blocked-until and gates only that provider', async () => {
     const writes: string[] = []
-    const claude = vi.fn(async () => ({ quota: quota('claude'), retryAfterSeconds: 60 }))
+    const claude = vi.fn(async () => result('claude', quota('claude'), 'A', { retryAfterSeconds: 60 }))
     const deps = providerDeps({ claude })
     const service = new QuotaService({
       ...deps, now: () => Date.parse('2026-07-12T00:00:00Z'),
@@ -54,11 +76,11 @@ describe('QuotaService', () => {
     const saved = JSON.parse(writes[0]!)
     expect(saved.claude).toBe('2026-07-12T00:01:00.000Z')
     await service.getQuota({ force: true })
-    expect(claude).toHaveBeenCalledTimes(1)
-    expect(deps.codex).toHaveBeenCalledTimes(2)
-    expect(deps.copilot).toHaveBeenCalledTimes(2)
-    expect(deps.kimi).toHaveBeenCalledTimes(2)
-    expect(deps.antigravity).toHaveBeenCalledTimes(2)
+    expect(actualCalls(claude)).toBe(1)
+    expect(actualCalls(deps.codex)).toBe(2)
+    expect(actualCalls(deps.copilot)).toBe(2)
+    expect(actualCalls(deps.kimi)).toBe(2)
+    expect(actualCalls(deps.antigravity)).toBe(2)
   })
 
   it('force re-fetches within the cache window by invalidating first', async () => {
@@ -69,15 +91,15 @@ describe('QuotaService', () => {
     })
     await service.getQuota()
     await service.getQuota()
-    expect(deps.claude).toHaveBeenCalledTimes(1)
+    expect(actualCalls(deps.claude)).toBe(1)
     await service.getQuota({ force: true })
-    expect(deps.claude).toHaveBeenCalledTimes(2)
+    expect(actualCalls(deps.claude)).toBe(2)
   })
 
   it('single-flights simultaneous callers', async () => {
     let release!: () => void
     const pending = new Promise<void>(resolve => { release = resolve })
-    const claude = vi.fn(async () => { await pending; return { quota: quota('claude') } })
+    const claude = vi.fn(async () => { await pending; return result('claude') })
     const deps = providerDeps({ claude })
     const service = new QuotaService({
       ...deps,
@@ -87,7 +109,7 @@ describe('QuotaService', () => {
     const second = service.getQuota({ force: true })
     release()
     expect(await first).toEqual(await second)
-    expect(claude).toHaveBeenCalledTimes(1)
+    expect(actualCalls(claude)).toBe(1)
   })
 
   it('retains one provider last factual snapshot without contaminating peers', async () => {
@@ -97,7 +119,7 @@ describe('QuotaService', () => {
       observedAt: '2026-07-11T23:00:00.000Z',
       windows: [{ id: 'weekly', label: 'Weekly', usedFraction: 0.25, resetsAt: '2026-07-19T00:00:00.000Z', windowSeconds: 604_800 }],
     })
-    const kimi = vi.fn(async () => ({ quota: healthy ? factual : quota('kimi', { connection: 'transientFailure', availability: 'unavailable', freshness: 'unavailable', observedAt: null }) }))
+    const kimi = vi.fn(async () => result('kimi', healthy ? factual : quota('kimi', { connection: 'transientFailure', availability: 'unavailable', freshness: 'unavailable', observedAt: null })))
     const deps = providerDeps({ kimi })
     let now = Date.parse('2026-07-12T00:00:00Z')
     const service = new QuotaService({
@@ -120,7 +142,7 @@ describe('QuotaService', () => {
   })
 
   it('does not fabricate windows when there is no previous factual snapshot', async () => {
-    const claude = vi.fn(async () => ({ quota: quota('claude', { connection: 'transientFailure', availability: 'unavailable', freshness: 'unavailable', observedAt: null }) }))
+    const claude = vi.fn(async () => result('claude', quota('claude', { connection: 'transientFailure', availability: 'unavailable', freshness: 'unavailable', observedAt: null })))
     const service = new QuotaService({
       ...providerDeps({ claude }),
       readFile: vi.fn(async () => null), writeFile: vi.fn(async () => undefined),
@@ -129,5 +151,161 @@ describe('QuotaService', () => {
     expect(value[0]!.windows).toEqual([])
     expect(value[0]!.observedAt).toBeNull()
     expect(value[0]!.freshness).toBe('unavailable')
+  })
+
+  it('reuses stale facts only for the same credential identity and never exposes the key', async () => {
+    let account = 'A'
+    let failure = false
+    const claude = vi.fn(async (options: { identityOnly?: boolean }) => {
+      const identity = knownIdentity('claude', 'credential', account)
+      if (options.identityOnly) return probe('claude', identity)
+      return failure
+        ? { quota: quota('claude', { connection: 'transientFailure', availability: 'unavailable', freshness: 'unavailable', observedAt: null }), identity }
+        : { quota: factual('claude', account === 'A' ? 0.2 : 0.8, account === 'A' ? '2026-07-12T00:00:00.000Z' : '2026-07-12T01:00:00.000Z'), identity }
+    })
+    const service = new QuotaService({
+      ...providerDeps({ claude }),
+      readFile: vi.fn(async () => null), writeFile: vi.fn(async () => undefined),
+    })
+
+    await service.getQuota({ force: true })
+    account = 'B'
+    await service.getQuota({ force: true })
+    failure = true
+    const retained = await service.getQuota({ force: true })
+
+    expect(retained[0]!.windows[0]!.usedFraction).toBe(0.8)
+    expect(JSON.stringify(retained)).not.toContain('credential')
+    expect(JSON.stringify(retained)).not.toContain('account')
+  })
+
+  it('fails closed instead of serving A when switching to B before a transient failure', async () => {
+    let account = 'A'
+    let failure = false
+    const claude = vi.fn(async (options: { identityOnly?: boolean }) => {
+      const identity = knownIdentity('claude', 'credential', account)
+      if (options.identityOnly) return probe('claude', identity)
+      return failure
+        ? { quota: quota('claude', { connection: 'transientFailure', availability: 'unavailable', freshness: 'unavailable', observedAt: null }), identity }
+        : { quota: factual('claude', 0.2, '2026-07-12T00:00:00.000Z'), identity }
+    })
+    const service = new QuotaService({
+      ...providerDeps({ claude }),
+      readFile: vi.fn(async () => null), writeFile: vi.fn(async () => undefined),
+    })
+
+    await service.getQuota({ force: true })
+    account = 'B'
+    failure = true
+    const value = await service.getQuota({ force: true })
+
+    expect(value[0]!.windows).toEqual([])
+    expect(value[0]!.observedAt).toBeNull()
+    expect(value[0]!.freshness).toBe('unavailable')
+  })
+
+  it('checks identity before returning a fresh cache after an account switch', async () => {
+    let account = 'A'
+    const claude = vi.fn(async (options: { identityOnly?: boolean }) => {
+      const identity = knownIdentity('claude', 'credential', account)
+      if (options.identityOnly) return probe('claude', identity)
+      return { quota: factual('claude', account === 'A' ? 0.1 : 0.9, '2026-07-12T00:00:00.000Z'), identity }
+    })
+    const service = new QuotaService({
+      ...providerDeps({ claude }), refreshMs: 60_000,
+      readFile: vi.fn(async () => null), writeFile: vi.fn(async () => undefined),
+    })
+
+    await service.getQuota({ force: true })
+    account = 'B'
+    const value = await service.getQuota()
+
+    expect(value[0]!.windows[0]!.usedFraction).toBe(0.9)
+    expect(actualCalls(claude)).toBe(2)
+  })
+
+  it('discards an A response that completes after the current identity becomes B', async () => {
+    let account = 'A'
+    let release!: () => void
+    let started!: () => void
+    const requestStarted = new Promise<void>(resolve => { started = resolve })
+    const pending = new Promise<void>(resolve => { release = resolve })
+    const claude = vi.fn(async (options: { identityOnly?: boolean }) => {
+      const identityAtCall = knownIdentity('claude', 'credential', account)
+      if (options.identityOnly) return probe('claude', identityAtCall)
+      const accountAtRequest = account
+      started()
+      await pending
+      return { quota: factual('claude', accountAtRequest === 'A' ? 0.2 : 0.8, '2026-07-12T00:00:00.000Z'), identity: identityAtCall }
+    })
+    const service = new QuotaService({
+      ...providerDeps({ claude }),
+      readFile: vi.fn(async () => null), writeFile: vi.fn(async () => undefined),
+    })
+
+    const request = service.getQuota({ force: true })
+    await requestStarted
+    account = 'B'
+    release()
+    const value = await request
+
+    expect(value[0]!.windows).toEqual([])
+    expect(value[0]!.connection).toBe('disconnected')
+  })
+
+  it('drops A backoff and fetches B instead of retaining A', async () => {
+    let account = 'A'
+    let mode: 'success' | 'rateLimit' = 'success'
+    const writes: string[] = []
+    const claude = vi.fn(async (options: { identityOnly?: boolean }) => {
+      const identity = knownIdentity('claude', 'credential', account)
+      if (options.identityOnly) return probe('claude', identity)
+      if (mode === 'rateLimit') return { quota: quota('claude', { connection: 'transientFailure', availability: 'unavailable', freshness: 'unavailable', observedAt: null }), retryAfterSeconds: 600, identity }
+      return { quota: factual('claude', account === 'A' ? 0.2 : 0.8, account === 'A' ? '2026-07-12T00:00:00.000Z' : '2026-07-12T01:00:00.000Z'), identity }
+    })
+    const service = new QuotaService({
+      ...providerDeps({ claude }), now: () => Date.parse('2026-07-12T00:00:00Z'),
+      readFile: vi.fn(async () => writes.at(-1) ?? null),
+      writeFile: vi.fn(async (_path, value) => { writes.push(value) }),
+      statePath: '/mock/backoff.json',
+    })
+
+    await service.getQuota({ force: true })
+    mode = 'rateLimit'
+    const rateLimited = await service.getQuota({ force: true })
+    expect(rateLimited[0]!.freshness).toBe('stale')
+    account = 'B'
+    mode = 'success'
+    const value = await service.getQuota({ force: true })
+
+    expect(value[0]!.windows[0]!.usedFraction).toBe(0.8)
+    expect(actualCalls(claude)).toBe(3)
+  })
+
+  it('does not turn a background keychain restriction into an identity change', async () => {
+    const identity = knownIdentity('claude', 'credential', 'A')
+    let failure = false
+    const claude = vi.fn(async (options: { identityOnly?: boolean; allowKeychain?: boolean }) => {
+      if (!options.allowKeychain) {
+        return options.identityOnly
+          ? probe('claude', unknownIdentity())
+          : { quota: quota('claude', { connection: 'transientFailure', availability: 'unavailable', freshness: 'unavailable', observedAt: null }), identity: unknownIdentity() }
+      }
+      if (options.identityOnly) return probe('claude', identity)
+      if (failure) return { quota: quota('claude', { connection: 'transientFailure', availability: 'unavailable', freshness: 'unavailable', observedAt: null }), identity }
+      return { quota: factual('claude', 0.2, '2026-07-12T00:00:00.000Z'), identity }
+    })
+    const service = new QuotaService({
+      ...providerDeps({ claude }),
+      readFile: vi.fn(async () => null), writeFile: vi.fn(async () => undefined),
+    })
+
+    await service.getQuota({ force: true, allowKeychain: true })
+    const restricted = await service.getQuota({ force: true, allowKeychain: false })
+    expect(restricted[0]!.windows).toEqual([])
+    failure = true
+    const sameAccount = await service.getQuota({ force: true, allowKeychain: true })
+    expect(sameAccount[0]!.freshness).toBe('stale')
+    expect(sameAccount[0]!.windows[0]!.usedFraction).toBe(0.2)
   })
 })

--- a/app/electron/quota/index.test.ts
+++ b/app/electron/quota/index.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 
 import { QuotaService } from './index'
-import { knownIdentity, unknownIdentity } from './identity'
+import { knownContinuityIdentity, knownIdentity, unknownIdentity } from './identity'
 import type { ProviderName, QuotaProvider } from './types'
 
 const quota = (provider: ProviderName, overrides: Partial<QuotaProvider> = {}): QuotaProvider => ({
@@ -25,13 +25,19 @@ const result = (provider: ProviderName, value: QuotaProvider = quota(provider), 
   identity: knownIdentity(provider, account),
 })
 
+const continuityResult = (provider: ProviderName, value: QuotaProvider = quota(provider), session = 'A', extra: Record<string, unknown> = {}) => ({
+  ...extra,
+  quota: value,
+  identity: knownContinuityIdentity(provider, 'session', session),
+})
+
 function providerDeps(overrides: Partial<Record<ProviderName, ReturnType<typeof vi.fn>>> = {}) {
   return {
     claude: overrides.claude ?? vi.fn(async () => result('claude')),
     codex: overrides.codex ?? vi.fn(async () => result('codex')),
     copilot: overrides.copilot ?? vi.fn(async () => result('copilot')),
     kimi: overrides.kimi ?? vi.fn(async () => result('kimi')),
-    antigravity: overrides.antigravity ?? vi.fn(async () => result('antigravity')),
+    antigravity: overrides.antigravity ?? vi.fn(async () => continuityResult('antigravity')),
   }
 }
 
@@ -151,6 +157,91 @@ describe('QuotaService', () => {
     expect(value[0]!.windows).toEqual([])
     expect(value[0]!.observedAt).toBeNull()
     expect(value[0]!.freshness).toBe('unavailable')
+  })
+
+  it('keeps a fresh Antigravity observation usable without making its session retention-safe', async () => {
+    const antigravity = vi.fn(async (options: { identityOnly?: boolean }) => {
+      const identity = knownContinuityIdentity('antigravity', 'session', 'A')
+      if (options.identityOnly) return probe('antigravity', identity)
+      return continuityResult('antigravity', factual('antigravity', 0.25, '2026-07-12T00:00:00.000Z'), 'A')
+    })
+    const service = new QuotaService({
+      ...providerDeps({ antigravity }),
+      readFile: vi.fn(async () => null), writeFile: vi.fn(async () => undefined),
+    })
+
+    const value = await service.getQuota({ force: true })
+
+    expect(value[4]).toMatchObject({ provider: 'antigravity', connection: 'connected', freshness: 'fresh' })
+    expect(value[4]!.windows[0]!.usedFraction).toBe(0.25)
+    const cached = await service.getQuota()
+    expect(cached[4]!.freshness).toBe('fresh')
+    expect(actualCalls(antigravity)).toBe(1)
+  })
+
+  it('does not reuse Antigravity facts after a same-session transient failure', async () => {
+    let healthy = true
+    const antigravity = vi.fn(async (options: { identityOnly?: boolean }) => {
+      const identity = knownContinuityIdentity('antigravity', 'session', 'A')
+      if (options.identityOnly) return probe('antigravity', identity)
+      return healthy
+        ? continuityResult('antigravity', factual('antigravity', 0.25, '2026-07-12T00:00:00.000Z'), 'A')
+        : continuityResult('antigravity', quota('antigravity', { connection: 'transientFailure', availability: 'unavailable', freshness: 'unavailable', observedAt: null }), 'A')
+    })
+    const service = new QuotaService({
+      ...providerDeps({ antigravity }),
+      readFile: vi.fn(async () => null), writeFile: vi.fn(async () => undefined),
+    })
+
+    await service.getQuota({ force: true })
+    healthy = false
+    const value = await service.getQuota({ force: true })
+
+    expect(value[4]).toMatchObject({ provider: 'antigravity', connection: 'transientFailure', freshness: 'unavailable' })
+    expect(value[4]!.windows).toEqual([])
+    expect(value[4]!.observedAt).toBeNull()
+  })
+
+  it('does not let a replacement Antigravity session inherit prior factual quota', async () => {
+    let session = 'A'
+    let healthy = true
+    const antigravity = vi.fn(async (options: { identityOnly?: boolean }) => {
+      const identity = knownContinuityIdentity('antigravity', 'session', session)
+      if (options.identityOnly) return probe('antigravity', identity)
+      return healthy
+        ? continuityResult('antigravity', factual('antigravity', 0.25, '2026-07-12T00:00:00.000Z'), session)
+        : continuityResult('antigravity', quota('antigravity', { connection: 'transientFailure', availability: 'unavailable', freshness: 'unavailable', observedAt: null }), session)
+    })
+    const service = new QuotaService({
+      ...providerDeps({ antigravity }),
+      readFile: vi.fn(async () => null), writeFile: vi.fn(async () => undefined),
+    })
+
+    await service.getQuota({ force: true })
+    session = 'B'
+    healthy = false
+    const value = await service.getQuota({ force: true })
+
+    expect(value[4]).toMatchObject({ provider: 'antigravity', connection: 'transientFailure', freshness: 'unavailable' })
+    expect(value[4]!.windows).toEqual([])
+    expect(value[4]!.observedAt).toBeNull()
+  })
+
+  it('rejects a late Antigravity result when the session changes before postflight verification', async () => {
+    const antigravity = vi.fn(async (options: { identityOnly?: boolean }) => {
+      if (options.identityOnly) return probe('antigravity', knownContinuityIdentity('antigravity', 'session', 'B'))
+      return continuityResult('antigravity', factual('antigravity', 0.25, '2026-07-12T00:00:00.000Z'), 'A')
+    })
+    const service = new QuotaService({
+      ...providerDeps({ antigravity }),
+      readFile: vi.fn(async () => null), writeFile: vi.fn(async () => undefined),
+    })
+
+    const value = await service.getQuota({ force: true })
+
+    expect(value[4]).toMatchObject({ provider: 'antigravity', connection: 'disconnected', freshness: 'unavailable' })
+    expect(value[4]!.windows).toEqual([])
+    expect(value[4]!.observedAt).toBeNull()
   })
 
   it('reuses stale facts only for the same credential identity and never exposes the key', async () => {

--- a/app/electron/quota/index.ts
+++ b/app/electron/quota/index.ts
@@ -7,6 +7,7 @@ import { fetchCodexQuota } from './codex'
 import { fetchCopilotQuota } from './copilot'
 import { fetchKimiQuota } from './kimi'
 import { atomicWriteSecureFile, readSecureFile, sanitizeError } from './security'
+import { sameIdentity, unknownIdentity, type IdentityObservation } from './identity'
 import {
   PROVIDER_NAMES,
   emptyQuota,
@@ -36,8 +37,10 @@ export { hasProviderQuotaFacts } from './types'
 export { sanitizeError } from './security'
 
 type Blocked = Partial<Record<ProviderNameFromQuota, string>>
-type FetchResult = { quota: QuotaProvider; retryAfterSeconds?: number }
-type ProviderFetcher = (options: { signal: AbortSignal; allowKeychain: boolean }) => Promise<FetchResult>
+type FetchResult = { quota: QuotaProvider; retryAfterSeconds?: number; identity: IdentityObservation }
+type ProviderFetcher = (options: { signal: AbortSignal; allowKeychain: boolean; identityOnly?: boolean }) => Promise<FetchResult>
+type RetainedQuota = { quota: QuotaProvider; identity: IdentityObservation }
+type CacheState = { at: number; value: QuotaProvider[]; retained: Partial<Record<ProviderNameFromQuota, RetainedQuota>> }
 type QuotaDeps = {
   claude: ProviderFetcher
   codex: ProviderFetcher
@@ -85,9 +88,9 @@ function generationMap(): Record<ProviderNameFromQuota, number> {
 
 export class QuotaService {
   private readonly deps: QuotaDeps
-  private cache: { at: number; value: QuotaProvider[] } | null = null
+  private cache: CacheState | null = null
   /** Last factual value survives cache invalidation so force failures can be honest. */
-  private readonly lastGood: Partial<Record<ProviderNameFromQuota, QuotaProvider>> = {}
+  private readonly lastGood: Partial<Record<ProviderNameFromQuota, RetainedQuota>> = {}
   private flight: Promise<QuotaProvider[]> | null = null
   private generations: Record<ProviderNameFromQuota, number> = generationMap()
   private controllers: Partial<Record<ProviderNameFromQuota, AbortController>> = {}
@@ -106,10 +109,46 @@ export class QuotaService {
 
   async getQuota(options: { force?: boolean; allowKeychain?: boolean } = {}): Promise<QuotaProvider[]> {
     if (options.force) this.invalidate()
-    if (!options.force && this.cache && this.deps.now() - this.cache.at < this.deps.refreshMs) return this.cache.value
+    const cached = this.cache
+    const cachedGenerations = { ...this.generations }
+    if (!options.force && cached && this.deps.now() - cached.at < this.deps.refreshMs) {
+      const safe = await this.cacheIsIdentitySafe(cached, Boolean(options.allowKeychain))
+      const unchanged = PROVIDER_NAMES.every(provider => cachedGenerations[provider] === this.generations[provider])
+      if (safe && unchanged && this.cache === cached) return cached.value
+    }
     if (this.flight) return this.flight
     this.flight = this.fetchAll(Boolean(options.allowKeychain)).finally(() => { this.flight = null })
     return this.flight
+  }
+
+  private async observeIdentity(provider: ProviderNameFromQuota, allowKeychain: boolean): Promise<FetchResult> {
+    try {
+      const result = await this.fetcher(provider)({
+        signal: new AbortController().signal,
+        allowKeychain,
+        identityOnly: true,
+      })
+      return { ...result, identity: result.identity ?? unknownIdentity() }
+    } catch {
+      return { quota: emptyQuota(provider, 'transientFailure'), identity: unknownIdentity() }
+    }
+  }
+
+  private clearRetained(provider: ProviderNameFromQuota): void {
+    this.lastGood[provider] = undefined
+  }
+
+  private async cacheIsIdentitySafe(cache: CacheState, allowKeychain: boolean): Promise<boolean> {
+    const checks = await Promise.all(PROVIDER_NAMES.map(async provider => {
+      const current = cache.value.find(item => item.provider === provider)
+      if (!current || !hasRetainedFacts(current)) return true
+      const retained = cache.retained[provider]
+      if (!retained) return false
+      const observed = await this.observeIdentity(provider, allowKeychain)
+      if (hasKnownIdentityMismatch(retained.identity, observed.identity)) return false
+      return sameIdentity(retained.identity, observed.identity)
+    }))
+    return checks.every(Boolean)
   }
 
   private async readBlocked(): Promise<Blocked> {
@@ -133,18 +172,19 @@ export class QuotaService {
 
   private async fetchAll(allowKeychain: boolean): Promise<QuotaProvider[]> {
     const startingGenerations = { ...this.generations }
-    const prior = this.cache?.value ?? []
+    const runIdentities: Partial<Record<ProviderNameFromQuota, IdentityObservation>> = {}
     const blocked = await this.readBlocked()
     const run = async (provider: ProviderNameFromQuota): Promise<QuotaProvider> => {
-      const retainOnFailure = (next: QuotaProvider): QuotaProvider => {
-        const candidate = this.lastGood[provider] ?? prior.find(item => item.provider === provider)
-        const previous = candidate
-          && hasProviderQuotaFacts(candidate)
-          && candidate.observedAt !== null
-          && Number.isFinite(Date.parse(candidate.observedAt))
-          ? candidate
-          : undefined
+      const retainOnFailure = (next: QuotaProvider, identity: IdentityObservation): QuotaProvider => {
+        runIdentities[provider] = identity
+        const candidate = this.lastGood[provider] ?? this.cache?.retained[provider]
+        const previous = candidate && hasRetainedFacts(candidate.quota) ? candidate : undefined
         if (!previous) return next
+        if (hasKnownIdentityMismatch(previous.identity, identity)) {
+          this.clearRetained(provider)
+          return next
+        }
+        if (!sameIdentity(previous.identity, identity)) return next
 
         // Background polls deliberately skip keychain reads. Keep the previous
         // factual value, but make the unavailable/stale state explicit. A
@@ -152,16 +192,25 @@ export class QuotaService {
         const backgroundCredentialMiss = !allowKeychain && (next.connection === 'disconnected' || next.connection === 'accessDenied')
         const transient = next.connection === 'transientFailure' || next.connection === 'stale' || backgroundCredentialMiss
         if (!transient) return next
-        return markStale(previous, next.connection === 'stale' ? 'stale' : 'transientFailure', next.rateLimit)
+        return markStale(previous.quota, next.connection === 'stale' ? 'stale' : 'transientFailure', next.rateLimit)
       }
 
       const until = blocked[provider] ? Date.parse(blocked[provider]!) : NaN
       if (Number.isFinite(until) && until > this.deps.now()) {
-        const previous = this.lastGood[provider] ?? prior.find(item => item.provider === provider)
-        return retainOnFailure({
-          ...emptyQuota(provider, 'transientFailure', backoffRateLimit(new Date(until).toISOString())),
-          ...(previous?.source ? { source: previous.source } : {}),
-        })
+        const identityProbe = await this.observeIdentity(provider, allowKeychain)
+        const preflightIdentity = identityProbe.identity
+        const retained = this.lastGood[provider] ?? this.cache?.retained[provider]
+        const identityChanged = retained && hasKnownIdentityMismatch(retained.identity, preflightIdentity)
+        if (!identityChanged) {
+          return retainOnFailure({
+            ...emptyQuota(provider, 'transientFailure', backoffRateLimit(new Date(until).toISOString())),
+          }, preflightIdentity)
+        }
+        // A provider-level backoff belongs to the authority that produced it.
+        // Once a different known authority is observed, remove that boundary
+        // before fetching so the new authority cannot inherit the old pause.
+        delete blocked[provider]
+        await this.writeBlocked(blocked)
       }
 
       const generation = this.generations[provider]
@@ -172,6 +221,22 @@ export class QuotaService {
         if (generation !== this.generations[provider] || controller.signal.aborted) return emptyQuota(provider, 'disconnected')
 
         const quota = sanitizeQuotaProvider(result.quota) ?? emptyQuota(provider, 'transientFailure')
+        const postflight = await this.observeIdentity(provider, allowKeychain)
+        if (hasKnownIdentityMismatch(result.identity, postflight.identity)) {
+          this.clearRetained(provider)
+          runIdentities[provider] = postflight.identity
+          return emptyQuota(provider, 'disconnected')
+        }
+        const resultIdentity = result.identity.state === 'known'
+          ? result.identity
+          : isFactualSnapshot(quota) ? unknownIdentity() : postflight.identity
+        if (resultIdentity.state !== 'known' || postflight.identity.state !== 'known') {
+          // Factual state without a safely comparable identity must never be
+          // accepted or retained. Unknown is not an account-change claim.
+          runIdentities[provider] = postflight.identity
+          return emptyQuota(provider, 'transientFailure')
+        }
+        const identity = postflight.identity
         if (result.retryAfterSeconds !== undefined) {
           const seconds = Number.isFinite(result.retryAfterSeconds) ? Math.max(60, Math.ceil(result.retryAfterSeconds)) : 300
           const retryAt = new Date(this.deps.now() + seconds * 1000).toISOString()
@@ -182,21 +247,21 @@ export class QuotaService {
           // snapshot may supply windows while this backoff is active.
           return retainOnFailure({
             ...emptyQuota(provider, 'transientFailure', backoffRateLimit(retryAt)),
-            ...(quota.source ? { source: quota.source } : {}),
-          })
+          }, identity)
         }
 
         if (blocked[provider]) {
           delete blocked[provider]
           await this.writeBlocked(blocked)
         }
-        if (isFactualSnapshot(quota)) this.lastGood[provider] = quota
-        return retainOnFailure(quota)
+        if (isFactualSnapshot(quota)) this.lastGood[provider] = { quota, identity }
+        return retainOnFailure(quota, identity)
       } catch (error) {
         // Provider adapters normally convert failures to a snapshot. Keep this
         // final guard so one provider's outage cannot reject the all-provider request.
         console.warn(`${provider} quota unavailable: ${sanitizeError(error)}`)
-        return retainOnFailure(emptyQuota(provider, 'transientFailure'))
+        const postflight = await this.observeIdentity(provider, allowKeychain)
+        return retainOnFailure(emptyQuota(provider, 'transientFailure'), postflight.identity)
       } finally {
         if (this.controllers[provider] === controller) this.controllers[provider] = undefined
       }
@@ -204,9 +269,27 @@ export class QuotaService {
 
     const value = await Promise.all(PROVIDER_NAMES.map(run))
     const unchanged = PROVIDER_NAMES.every(provider => startingGenerations[provider] === this.generations[provider])
-    if (unchanged) this.cache = { at: this.deps.now(), value }
+    if (unchanged) {
+      const retained: Partial<Record<ProviderNameFromQuota, RetainedQuota>> = {}
+      for (const provider of PROVIDER_NAMES) {
+        const identity = runIdentities[provider]
+        const quota = value.find(item => item.provider === provider)
+        if (identity?.state === 'known' && quota && hasRetainedFacts(quota)) retained[provider] = { quota, identity }
+      }
+      this.cache = { at: this.deps.now(), value, retained }
+    }
     return value
   }
+}
+
+function hasRetainedFacts(quota: QuotaProvider): boolean {
+  return hasProviderQuotaFacts(quota)
+    && quota.observedAt !== null
+    && Number.isFinite(Date.parse(quota.observedAt))
+}
+
+function hasKnownIdentityMismatch(left: IdentityObservation, right: IdentityObservation): boolean {
+  return left.state === 'known' && right.state === 'known' && !sameIdentity(left, right)
 }
 
 export const quotaService = new QuotaService()

--- a/app/electron/quota/index.ts
+++ b/app/electron/quota/index.ts
@@ -7,7 +7,7 @@ import { fetchCodexQuota } from './codex'
 import { fetchCopilotQuota } from './copilot'
 import { fetchKimiQuota } from './kimi'
 import { atomicWriteSecureFile, readSecureFile, sanitizeError } from './security'
-import { sameIdentity, unknownIdentity, type IdentityObservation } from './identity'
+import { isRetentionSafe, sameIdentity, unknownIdentity, type IdentityObservation } from './identity'
 import {
   PROVIDER_NAMES,
   emptyQuota,
@@ -40,7 +40,12 @@ type Blocked = Partial<Record<ProviderNameFromQuota, string>>
 type FetchResult = { quota: QuotaProvider; retryAfterSeconds?: number; identity: IdentityObservation }
 type ProviderFetcher = (options: { signal: AbortSignal; allowKeychain: boolean; identityOnly?: boolean }) => Promise<FetchResult>
 type RetainedQuota = { quota: QuotaProvider; identity: IdentityObservation }
-type CacheState = { at: number; value: QuotaProvider[]; retained: Partial<Record<ProviderNameFromQuota, RetainedQuota>> }
+type CacheState = {
+  at: number
+  value: QuotaProvider[]
+  cacheIdentity: Partial<Record<ProviderNameFromQuota, IdentityObservation>>
+  retained: Partial<Record<ProviderNameFromQuota, RetainedQuota>>
+}
 type QuotaDeps = {
   claude: ProviderFetcher
   codex: ProviderFetcher
@@ -142,11 +147,11 @@ export class QuotaService {
     const checks = await Promise.all(PROVIDER_NAMES.map(async provider => {
       const current = cache.value.find(item => item.provider === provider)
       if (!current || !hasRetainedFacts(current)) return true
-      const retained = cache.retained[provider]
-      if (!retained) return false
+      const cachedIdentity = cache.cacheIdentity[provider]
+      if (!cachedIdentity || cachedIdentity.state !== 'known') return false
       const observed = await this.observeIdentity(provider, allowKeychain)
-      if (hasKnownIdentityMismatch(retained.identity, observed.identity)) return false
-      return sameIdentity(retained.identity, observed.identity)
+      if (hasKnownIdentityMismatch(cachedIdentity, observed.identity)) return false
+      return sameIdentity(cachedIdentity, observed.identity)
     }))
     return checks.every(Boolean)
   }
@@ -180,6 +185,7 @@ export class QuotaService {
         const candidate = this.lastGood[provider] ?? this.cache?.retained[provider]
         const previous = candidate && hasRetainedFacts(candidate.quota) ? candidate : undefined
         if (!previous) return next
+        if (!isRetentionSafe(previous.identity) || !isRetentionSafe(identity)) return next
         if (hasKnownIdentityMismatch(previous.identity, identity)) {
           this.clearRetained(provider)
           return next
@@ -254,7 +260,7 @@ export class QuotaService {
           delete blocked[provider]
           await this.writeBlocked(blocked)
         }
-        if (isFactualSnapshot(quota)) this.lastGood[provider] = { quota, identity }
+        if (isFactualSnapshot(quota) && isRetentionSafe(identity)) this.lastGood[provider] = { quota, identity }
         return retainOnFailure(quota, identity)
       } catch (error) {
         // Provider adapters normally convert failures to a snapshot. Keep this
@@ -270,13 +276,17 @@ export class QuotaService {
     const value = await Promise.all(PROVIDER_NAMES.map(run))
     const unchanged = PROVIDER_NAMES.every(provider => startingGenerations[provider] === this.generations[provider])
     if (unchanged) {
+      const cacheIdentity: Partial<Record<ProviderNameFromQuota, IdentityObservation>> = {}
       const retained: Partial<Record<ProviderNameFromQuota, RetainedQuota>> = {}
       for (const provider of PROVIDER_NAMES) {
         const identity = runIdentities[provider]
         const quota = value.find(item => item.provider === provider)
-        if (identity?.state === 'known' && quota && hasRetainedFacts(quota)) retained[provider] = { quota, identity }
+        if (identity?.state === 'known' && quota && hasRetainedFacts(quota)) {
+          cacheIdentity[provider] = identity
+          if (isRetentionSafe(identity)) retained[provider] = { quota, identity }
+        }
       }
-      this.cache = { at: this.deps.now(), value, retained }
+      this.cache = { at: this.deps.now(), value, cacheIdentity, retained }
     }
     return value
   }

--- a/app/electron/quota/kimi.ts
+++ b/app/electron/quota/kimi.ts
@@ -3,6 +3,7 @@ import path from 'node:path'
 
 import { emptyQuota, markObserved, type QuotaProvider, type QuotaWindow } from './types'
 import { quotaRequestSignal, readSecureFile, sanitizeError } from './security'
+import { knownIdentity, unknownIdentity, type IdentityObservation } from './identity'
 
 const USAGE_ENDPOINT = 'https://api.kimi.com/coding/v1/usages'
 const SOURCE = { kind: 'provider-api', stability: 'experimental' } as const
@@ -144,14 +145,16 @@ function retryAfterSeconds(response: Response, now: number): number {
   return Math.max(60, Number.isFinite(date) ? Math.ceil((date - now) / 1000) : 300)
 }
 
-export type KimiResult = { quota: QuotaProvider; retryAfterSeconds?: number }
+export type KimiResult = { quota: QuotaProvider; retryAfterSeconds?: number; identity: IdentityObservation }
 
-export async function fetchKimiQuota(options: Partial<KimiDeps> & { signal?: AbortSignal } = {}): Promise<KimiResult> {
+export async function fetchKimiQuota(options: Partial<KimiDeps> & { signal?: AbortSignal; identityOnly?: boolean } = {}): Promise<KimiResult> {
   const deps = { ...defaults, ...options }
   try {
     const token = await freshToken(deps)
-    if (token === null) return { quota: empty('disconnected') }
-    if (token === 'expired') return { quota: empty('terminalFailure') }
+    if (token === null) return { quota: empty('disconnected'), identity: unknownIdentity() }
+    if (token === 'expired') return { quota: empty('terminalFailure'), identity: unknownIdentity() }
+    const identity = knownIdentity('kimi', 'credential', token)
+    if (options.identityOnly) return { quota: empty('loading'), identity }
     const deviceId = await readDeviceId(deps)
     const response = await deps.fetch(USAGE_ENDPOINT, {
       method: 'GET',
@@ -165,13 +168,13 @@ export async function fetchKimiQuota(options: Partial<KimiDeps> & { signal?: Abo
         ...(deviceId ? { 'X-Msh-Device-Id': deviceId } : {}),
       },
     })
-    if (response.status === 401 || response.status === 403) return { quota: empty('terminalFailure') }
-    if (response.status === 429) return { quota: empty('transientFailure'), retryAfterSeconds: retryAfterSeconds(response, deps.now()) }
-    if (!response.ok) return { quota: empty(response.status >= 400 && response.status < 500 ? 'terminalFailure' : 'transientFailure') }
+    if (response.status === 401 || response.status === 403) return { quota: empty('terminalFailure'), identity }
+    if (response.status === 429) return { quota: empty('transientFailure'), retryAfterSeconds: retryAfterSeconds(response, deps.now()), identity }
+    if (!response.ok) return { quota: empty(response.status >= 400 && response.status < 500 ? 'terminalFailure' : 'transientFailure'), identity }
     const quota = decodeKimiUsage(await response.json())
-    return { quota: quota ? markObserved(quota, deps.now()) : empty('transientFailure') }
+    return { quota: quota ? markObserved(quota, deps.now()) : empty('transientFailure'), identity }
   } catch (error) {
     console.warn(`Kimi Code capacity unavailable: ${sanitizeError(error)}`)
-    return { quota: empty('transientFailure') }
+    return { quota: empty('transientFailure'), identity: unknownIdentity() }
   }
 }


### PR DESCRIPTION
## Summary

Fixes #230 by binding retained provider quota facts to backend-only credential identity so stale Capacity cannot cross provider-account/credential boundaries.

- adds process-local opaque identity observations for Capacity providers;
- verifies identity before cache/backoff reuse and again after provider fetches;
- rejects late results when the current identity changes;
- preserves truthful stale retention only when the same retention-safe identity is established;
- treats unknown/ambiguous identity conservatively;
- keeps all identity material out of public quota schemas, renderer/mobile projections, persistence and logs;
- treats Antigravity process/session evidence as **continuity-only**, not provider-account identity, so it may guard fresh-cache/session races but never authorize stale factual reuse.

## Public boundary

- [x] This description contains only information needed to review the public change.
- [x] No personal data, usage totals, credentials, private repository names, administrative documents, internal budgets or unpublished roadmap details are included.
- [x] No public Capacity schema, renderer/mobile identity field or persisted identity key is added.
- [x] Validation claims below were actually performed.

## Validation

- [x] Focused quota tests pass: **63/63**.
- [x] Desktop typecheck passes.
- [x] Electron build passes.
- [x] Renderer build passes (existing non-blocking Vite chunk-size warning only).
- [x] Source-size ratchet passes.
- [x] Public identity boundary passes.
- [x] GitHub `Metrora CI #1245` passes on final HEAD `0b96af81fb57567aa5e795d1f935ed62881b85aa`.
- [x] GitHub `Metrora Brand Boundary #971`, `Architecture boundaries #698` and `Metrora Public Identity #652` pass.
- [x] Windows Candidate workflow is skipped as expected for this change surface.

Local full-suite validation reached **893/894** with one unrelated watchdog timeout in `electron/cli.test.ts`; its isolated rerun passed **48/48**.

## Correctness / privacy evidence

Covered behavior includes:

- same retention-safe credential identity may reuse truthful stale facts after a transient failure;
- credential/account A -> B followed by transient failure cannot surface A facts as B stale Capacity;
- a fresh cache is identity-checked before reuse;
- account switch during persisted 429 backoff drops the old authority boundary and fetches the new authority;
- a late A response is rejected if postflight identity is B;
- background keychain-read restriction does not fabricate an identity change;
- multiple eligible Antigravity authorities fail closed;
- Antigravity fresh facts remain usable in the verified current session, while same-session failure or session replacement cannot reuse prior facts as stale;
- Antigravity continuity is derived from process/session evidence only and is explicitly not retention-safe;
- opaque identity comparison keys are process-local, salted, non-persisted and not exported.

## UI evidence

No user-visible UI or public data-contract shape changes.

## Risks and rollback

The primary behavioral tradeoff is conservative loss of stale continuity when Metrora cannot safely establish the same provider identity. This intentionally prefers unavailable Capacity over cross-account attribution. Antigravity is stricter still: its current process/session evidence can prove continuity but not provider-account identity, so stale factual retention is disabled for that provider.

Rollback is the bounded revert of this PR; no persisted-data migration or public schema migration is introduced.