### PR TITLE
fix(desktop): expose Capacity in Control navigation

### DIFF
--- a/app/renderer/components/Sidebar.test.tsx
+++ b/app/renderer/components/Sidebar.test.tsx
@@ -26,9 +26,9 @@ describe('Sidebar', () => {
       'Advisor⌘',
       'Bench⌘',
     ])
-    expect(within(control).getAllByRole('button').map(item => item.textContent)).toEqual(['Workspace⌘8'])
+    expect(within(control).getAllByRole('button').map(item => item.textContent)).toEqual(['Capacity⌘', 'Workspace⌘8'])
     expect(within(product).getByRole('button', { name: /Settings.*⌘,/ })).toBeInTheDocument()
-    expect(screen.getAllByRole('button')).toHaveLength(11)
+    expect(screen.getAllByRole('button')).toHaveLength(12)
   })
 
   it('routes by click and keyboard without changing section ids', async () => {
@@ -52,7 +52,7 @@ describe('Sidebar', () => {
     expect(screen.getByRole('button', { name: /Home/ })).not.toHaveClass('on')
   })
 
-  it('opens About without competing with the ten product destinations', () => {
+  it('opens About without competing with the visible product destinations', () => {
     render(<Sidebar active="overview" onNavigate={() => {}} />)
     fireEvent.click(screen.getByRole('link', { name: 'About' }))
     expect(screen.getByRole('dialog')).toBeInTheDocument()

--- a/app/renderer/lib/desktopNavigation.test.ts
+++ b/app/renderer/lib/desktopNavigation.test.ts
@@ -13,7 +13,7 @@ describe('desktop navigation authority', () => {
   it('keeps every visible destination unique while allowing internal routable sections', () => {
     expect(new Set(DESKTOP_NAVIGATION_ORDER).size).toBe(DESKTOP_NAVIGATION_ORDER.length)
     expect(DESKTOP_NAVIGATION_ORDER.every(id => SECTION_IDS.includes(id))).toBe(true)
-    expect(DESKTOP_NAVIGATION_ORDER).not.toContain('plans')
+    expect(DESKTOP_NAVIGATION_ORDER).toContain('plans')
     expect(SECTION_IDS).toContain('plans')
   })
 
@@ -28,20 +28,22 @@ describe('desktop navigation authority', () => {
     }
   })
 
-  it('keeps Advisor in the Analyze hierarchy without exposing Plans as a shortcut', () => {
+  it('keeps Advisor in Analyze and Capacity in Control without exposing Capacity as a shortcut', () => {
     expect(DESKTOP_NAVIGATION_GROUPS).toEqual([
       { id: 'home', label: null, placement: 'primary', sections: ['overview'] },
       { id: 'activity', label: 'Activity', placement: 'primary', sections: ['sessions', 'pullRequests'] },
       { id: 'analyze', label: 'Analyze', placement: 'primary', sections: ['spend', 'optimize', 'models', 'compare', 'advisor', 'bench'] },
-      { id: 'control', label: 'Control', placement: 'primary', sections: ['workspace'] },
+      { id: 'control', label: 'Control', placement: 'primary', sections: ['plans', 'workspace'] },
       { id: 'product', label: 'Product', placement: 'utility', sections: ['settings'] },
     ])
     expect(DESKTOP_NAVIGATION_ORDER).toEqual([
-      'overview', 'sessions', 'pullRequests', 'spend', 'optimize', 'models', 'compare', 'advisor', 'bench', 'workspace', 'settings',
+      'overview', 'sessions', 'pullRequests', 'spend', 'optimize', 'models', 'compare', 'advisor', 'bench', 'plans', 'workspace', 'settings',
     ])
     expect(DESKTOP_NAVIGATION_ITEMS.optimize.label).toBe('Insights')
     expect(DESKTOP_NAVIGATION_ITEMS.advisor.label).toBe('Advisor')
     expect(DESKTOP_NAVIGATION_ITEMS.bench.title).toBe('Local Bench')
+    expect(DESKTOP_NAVIGATION_ITEMS.plans.id).toBe('plans')
+    expect(DESKTOP_NAVIGATION_ITEMS.plans.label).toBe('Capacity')
     expect(DESKTOP_NAVIGATION_ITEMS.plans.shortcut).toBe('')
     expect(DESKTOP_NAVIGATION_ITEMS.workspace.shortcut).toBe('8')
     expect(DESKTOP_NAVIGATION_ITEMS.settings.shortcut).toBe(',')

--- a/app/renderer/lib/desktopNavigation.ts
+++ b/app/renderer/lib/desktopNavigation.ts
@@ -39,7 +39,7 @@ export const DESKTOP_NAVIGATION_ITEMS: Record<Section, DesktopNavigationItem> = 
   compare: { id: 'compare', label: 'Compare', title: 'Compare', shortcut: '7' },
   advisor: { id: 'advisor', label: 'Advisor', title: 'Advisor', shortcut: '' },
   bench: { id: 'bench', label: 'Bench', title: 'Local Bench', shortcut: '' },
-  plans: { id: 'plans', label: 'Plans', title: 'Provider plans', shortcut: '' },
+  plans: { id: 'plans', label: 'Capacity', title: 'Provider plans', shortcut: '' },
   workspace: { id: 'workspace', label: 'Workspace', title: 'Personal workspace', shortcut: '8' },
   settings: { id: 'settings', label: 'Settings', title: 'Settings', shortcut: ',' },
 }
@@ -48,7 +48,7 @@ export const DESKTOP_NAVIGATION_GROUPS: readonly DesktopNavigationGroup[] = [
   { id: 'home', label: null, placement: 'primary', sections: ['overview'] },
   { id: 'activity', label: 'Activity', placement: 'primary', sections: ['sessions', 'pullRequests'] },
   { id: 'analyze', label: 'Analyze', placement: 'primary', sections: ['spend', 'optimize', 'models', 'compare', 'advisor', 'bench'] },
-  { id: 'control', label: 'Control', placement: 'primary', sections: ['workspace'] },
+  { id: 'control', label: 'Control', placement: 'primary', sections: ['plans', 'workspace'] },
   { id: 'product', label: 'Product', placement: 'utility', sections: ['settings'] },
 ]
 


### PR DESCRIPTION
Refs #234

## Summary
- expose the existing `plans` section as `Capacity` under Desktop Control
- retain `Workspace`, the internal `plans` section ID, and existing shortcut contracts
- update only the navigation authority and directly relevant Sidebar/navigation tests

## Validation
- focused Desktop navigation, Sidebar, and Capacity tests: 27 passed
- Desktop renderer typecheck: passed
- no Capacity runtime, provider, quota/accounting, Advisor, Workspace, or Control dashboard changes