### PR TITLE
fix: simplify model measurement semantics with progressive disclosure (#203)

### DIFF
--- a/app/renderer/sections/Models.test.tsx
+++ b/app/renderer/sections/Models.test.tsx
@@ -1,8 +1,8 @@
 // @vitest-environment jsdom
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import type { AuditRow, DateRange, ModelPricingSummary, ModelReportRow } from '../lib/types'
+import type { AuditRow, DateRange, DurableModelAccountingRow, ModelPricingSummary, ModelReportRow } from '../lib/types'
 import { Models } from './Models'
 
 const { getModels, getAudit } = vi.hoisted(() => ({
@@ -92,6 +92,21 @@ const auditRows: AuditRow[] = [{
   attributedCostUSD: 252,
 }]
 
+function durableRow(name: string, cost: number, calls: number, savingsUSD: number | undefined, overrides: Partial<DurableModelAccountingRow> = {}): DurableModelAccountingRow {
+  return {
+    name,
+    cost,
+    savingsUSD: savingsUSD as number,
+    calls,
+    inputTokens: 0,
+    outputTokens: 0,
+    cacheReadTokens: 0,
+    cacheWriteTokens: 0,
+    tokenDetail: true,
+    ...overrides,
+  }
+}
+
 function loadedOverview(overrides: Record<string, unknown> = {}) {
   return {
     data: {
@@ -144,44 +159,62 @@ function loadedOverview(overrides: Record<string, unknown> = {}) {
   } as any
 }
 
+async function openDetails() {
+  const details = screen.getByTestId('models-details')
+  fireEvent.click(within(details).getByText('Details'))
+  await waitFor(() => expect(details).toHaveAttribute('open'))
+  return { details, evidence: within(details).getByRole('table', { name: 'Model usage details' }) }
+}
+
 describe('Models', () => {
   beforeEach(() => {
     getModels.mockReset()
     getAudit.mockReset()
   })
 
-  it('renders one durable model table with shared token/cache/unit-cost/performance metrics without spawning the detail report', () => {
+  it('renders only Model, Calls, Cost, and Saved by default', () => {
     render(<Models period="lifetime" provider="all" overview={loadedOverview()} />)
 
-    expect(screen.getByText('Model usage')).toBeInTheDocument()
+    const primary = screen.getByRole('table', { name: 'Model usage' })
+    expect(within(primary).getAllByRole('columnheader').map(header => header.textContent)).toEqual(['Model', 'Calls', 'Cost', 'Saved'])
     expect(screen.getByText('GPT-5.4')).toBeInTheDocument()
     expect(screen.getByText('Claude Opus 4.8')).toBeInTheDocument()
-    expect(screen.getByRole('columnheader', { name: 'Cache ×' })).toBeInTheDocument()
-    expect(screen.getByRole('columnheader', { name: 'Active ms / 1K' })).toBeInTheDocument()
-    expect(screen.getByRole('columnheader', { name: 'Cost / 1M' })).toBeInTheDocument()
-    expect(screen.getByText('9×')).toBeInTheDocument()
-    expect(screen.getByText('5.1M')).toBeInTheDocument()
-    expect(screen.getByText('250.0ms')).toBeInTheDocument()
-    expect(screen.getByText('300.0ms')).toBeInTheDocument()
-    expect(screen.getByText(/observed active-generation timing/i)).toBeInTheDocument()
-    expect(screen.queryByText(/Detailed token breakdown/i)).not.toBeInTheDocument()
+    expect(screen.getByTestId('models-details')).not.toHaveAttribute('open')
+    expect(screen.queryByRole('columnheader', { name: 'Reasoning' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('columnheader', { name: 'Cache ×' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('tab', { name: 'Total tokens' })).not.toBeInTheDocument()
+    expect(screen.queryByText(/durable accounting values/i)).not.toBeInTheDocument()
     expect(getModels).not.toHaveBeenCalled()
   })
 
-  it('shows unavailable token-derived and timing metrics instead of fake zeros for legacy durable rows', () => {
+  it('opens and closes the native Details disclosure while preserving advanced evidence', async () => {
+    render(<Models period="lifetime" provider="all" overview={loadedOverview()} />)
+
+    const details = screen.getByTestId('models-details')
+    const summary = within(details).getByText('Details')
+    expect(summary.tagName).toBe('SUMMARY')
+    summary.focus()
+    expect(document.activeElement).toBe(summary)
+
+    const opened = await openDetails()
+    expect(opened.details.firstElementChild?.tagName).toBe('SUMMARY')
+    expect(within(opened.evidence).getByRole('columnheader', { name: 'Reasoning' })).toBeInTheDocument()
+    expect(within(opened.evidence).getByRole('columnheader', { name: 'Cost / 1M' })).toBeInTheDocument()
+    expect(within(opened.details).getByText('5.1M')).toBeInTheDocument()
+    expect(within(opened.evidence).getByRole('columnheader', { name: 'Generated tok/s' })).toBeInTheDocument()
+    expect(within(opened.evidence).getByRole('columnheader', { name: 'Timing' })).toBeInTheDocument()
+    expect(within(opened.evidence).getAllByText('observed')).toHaveLength(2)
+    expect(within(opened.evidence).getByText('250.0ms')).toBeInTheDocument()
+
+    fireEvent.click(summary)
+    await waitFor(() => expect(opened.details).not.toHaveAttribute('open'))
+    expect(screen.queryByRole('table', { name: 'Model usage details' })).not.toBeInTheDocument()
+  })
+
+  it('shows unavailable token-derived and timing metrics instead of fake zeros for legacy durable rows', async () => {
     const overview = loadedOverview({
       modelAccounting: {
-        rows: [{
-          name: 'Legacy model',
-          cost: 12,
-          savingsUSD: 0,
-          calls: 9,
-          inputTokens: 0,
-          outputTokens: 0,
-          cacheReadTokens: 0,
-          cacheWriteTokens: 0,
-          tokenDetail: false,
-        }],
+        rows: [durableRow('Legacy model', 12, 9, 0, { tokenDetail: false })],
         gap: { cost: 0, savingsUSD: 0, calls: 0 },
         coverage: { cost: 1, calls: 1 },
         tokenCoverage: { cost: 0, calls: 0 },
@@ -189,39 +222,83 @@ describe('Models', () => {
     })
 
     const { container } = render(<Models period="lifetime" provider="all" overview={overview} />)
-
-    expect(screen.getByText(/Legacy rows without a durable token split show/i)).toBeInTheDocument()
-    const row = screen.getByText('Legacy model').closest('tr')!
-    expect(row.textContent?.match(/—/g)?.length).toBeGreaterThanOrEqual(8)
+    expect(screen.getByText('Legacy model')).toBeInTheDocument()
+    const { details, evidence } = await openDetails()
+    expect(within(details).getByText(/Rows without a durable token split show/i)).toBeInTheDocument()
+    const row = within(evidence).getByRole('row', { name: /Legacy model/ })
+    expect(row.querySelectorAll('.models-unavailable').length).toBeGreaterThanOrEqual(9)
     expect(container.querySelector('.provider-mono')).toBeInTheDocument()
   })
 
-  it('sorts the durable model table by total observed tokens on demand', () => {
+  it('sorts the durable evidence table by total observed tokens on demand', async () => {
     render(<Models period="lifetime" provider="all" overview={loadedOverview()} />)
+    const { details, evidence } = await openDetails()
 
-    fireEvent.click(screen.getByRole('tab', { name: 'Total tokens' }))
-    const modelRows = screen.getAllByRole('row').filter(row => row.querySelector('tbody') == null).slice(1)
+    fireEvent.click(within(details).getByRole('tab', { name: 'Total tokens' }))
+    const modelRows = within(evidence).getAllByRole('row').slice(1)
     expect(modelRows[0]).toHaveTextContent('GPT-5.4')
   })
 
-  it('sorts observed ms per 1K fastest-first and leaves untimed rows at the bottom', () => {
+  it('sorts observed ms per 1K fastest-first and leaves untimed rows at the bottom', async () => {
     const overview = loadedOverview({
       modelAccounting: {
         rows: [
-          {
-            name: 'Untimed model', cost: 9, savingsUSD: 0, calls: 9,
-            inputTokens: 1, outputTokens: 1, cacheReadTokens: 0, cacheWriteTokens: 0, tokenDetail: true,
-          },
-          {
-            name: 'Slower model', cost: 8, savingsUSD: 0, calls: 8,
-            inputTokens: 1, outputTokens: 1, cacheReadTokens: 0, cacheWriteTokens: 0, tokenDetail: true,
-            activeDurationMs: 4000, activeGeneratedTokens: 10_000,
-          },
-          {
-            name: 'Faster model', cost: 7, savingsUSD: 0, calls: 7,
-            inputTokens: 1, outputTokens: 1, cacheReadTokens: 0, cacheWriteTokens: 0, tokenDetail: true,
-            activeDurationMs: 2000, activeGeneratedTokens: 10_000,
-          },
+          durableRow('Untimed model', 9, 9, 0, { inputTokens: 1, outputTokens: 1 }),
+          durableRow('Slower model', 8, 8, 0, { inputTokens: 1, outputTokens: 1, activeDurationMs: 4000, activeGeneratedTokens: 10_000 }),
+          durableRow('Faster model', 7, 7, 0, { inputTokens: 1, outputTokens: 1, activeDurationMs: 2000, activeGeneratedTokens: 10_000 }),
+        ],
+        gap: { cost: 0, savingsUSD: 0, calls: 0 },
+        coverage: { cost: 1, calls: 1 },
+        tokenCoverage: { cost: 1, calls: 1 },
+      },
+    })
+    render(<Models period="lifetime" provider="all" overview={overview} />)
+    const { details, evidence } = await openDetails()
+
+    fireEvent.click(within(details).getByRole('tab', { name: 'Active ms / 1K' }))
+    const bodyRows = within(evidence).getAllByRole('row').slice(1)
+    expect(bodyRows[0]).toHaveTextContent('Faster model')
+    expect(bodyRows[1]).toHaveTextContent('Slower model')
+    expect(bodyRows[2]).toHaveTextContent('Untimed model')
+  })
+
+  it('keeps positive, explicit-zero, and unavailable Saved values distinct', () => {
+    const overview = loadedOverview({
+      modelAccounting: {
+        rows: [
+          durableRow('Saved model', 3, 3, 1.25),
+          durableRow('Free model', 0, 2, 0),
+          durableRow('Missing saved model', 2, 1, undefined),
+        ],
+        gap: { cost: 0, savingsUSD: 0, calls: 0 },
+        coverage: { cost: 1, calls: 1 },
+        tokenCoverage: { cost: 1, calls: 1 },
+      },
+    })
+    render(<Models period="lifetime" provider="all" overview={overview} />)
+    const primary = screen.getByRole('table', { name: 'Model usage' })
+    const savedRow = within(primary).getByRole('row', { name: /Saved model/ })
+    const freeRow = within(primary).getByRole('row', { name: /Free model/ })
+    const missingRow = within(primary).getByRole('row', { name: /Missing saved model/ })
+
+    expect(within(savedRow).getAllByRole('cell')[3]).toHaveTextContent('$1.25')
+    expect(within(freeRow).getAllByRole('cell')[3]).toHaveTextContent('$0.00')
+    expect(within(within(missingRow).getAllByRole('cell')[3]).getByLabelText(/Saved is unavailable/)).toBeInTheDocument()
+    expect(within(missingRow).getAllByRole('cell')[3]).toHaveTextContent('—')
+  })
+
+  it('qualifies estimated and unpriced Cost while keeping known zero Cost numeric', () => {
+    const overview = loadedOverview({
+      unpricedModels: [
+        { model: 'Unpriced model', calls: 2, tokens: 0 },
+        { model: 'Partially unpriced model', calls: 1, tokens: 0 },
+      ],
+      modelAccounting: {
+        rows: [
+          durableRow('Explicit free model', 0, 2, 0),
+          durableRow('Estimated model', 4, 2, 0, { costIsEstimated: true, estimatedCostUSD: 1 }),
+          durableRow('Unpriced model', 0, 2, 0),
+          durableRow('Partially unpriced model', 5, 1, 0),
         ],
         gap: { cost: 0, savingsUSD: 0, calls: 0 },
         coverage: { cost: 1, calls: 1 },
@@ -230,11 +307,40 @@ describe('Models', () => {
     })
     render(<Models period="lifetime" provider="all" overview={overview} />)
 
-    fireEvent.click(screen.getByRole('tab', { name: 'Active ms / 1K' }))
-    const bodyRows = screen.getAllByRole('row').slice(1)
-    expect(bodyRows[0]).toHaveTextContent('Faster model')
-    expect(bodyRows[1]).toHaveTextContent('Slower model')
-    expect(bodyRows[2]).toHaveTextContent('Untimed model')
+    const primary = screen.getByRole('table', { name: 'Model usage' })
+    const freeRow = within(primary).getByRole('row', { name: /Explicit free model/ })
+    const estimatedRow = within(primary).getByRole('row', { name: /Estimated model/ })
+    const unpricedRow = within(primary).getByRole('row', { name: /Unpriced model/ })
+    const partialUnpricedRow = within(primary).getByRole('row', { name: /Partially unpriced model/ })
+    expect(within(freeRow).getAllByRole('cell')[2]).toHaveTextContent('$0.00')
+    expect(within(freeRow).getAllByRole('cell')[2]).not.toHaveTextContent(/unpriced|est\.|partial/i)
+    expect(within(estimatedRow).getAllByRole('cell')[2]).toHaveTextContent('$4.00')
+    expect(within(estimatedRow).getAllByRole('cell')[2]).toHaveTextContent('est.')
+    expect(within(unpricedRow).getAllByRole('cell')[2]).toHaveTextContent('unpriced')
+    expect(within(within(unpricedRow).getAllByRole('cell')[2]).getByLabelText(/Cost unavailable/)).toBeInTheDocument()
+    expect(within(partialUnpricedRow).getAllByRole('cell')[2]).toHaveTextContent('$5.00')
+    expect(within(partialUnpricedRow).getAllByRole('cell')[2]).toHaveTextContent('partial')
+  })
+
+  it('keeps Other models visible when durable reconciliation has a remainder', () => {
+    const overview = loadedOverview({
+      cost: 35,
+      calls: 35,
+      modelAccounting: {
+        rows: [durableRow('Named model', 20, 20, 0)],
+        gap: { cost: 15, savingsUSD: 0, calls: 15 },
+        coverage: { cost: 20 / 35, calls: 20 / 35 },
+        tokenCoverage: { cost: 1, calls: 1 },
+      },
+    })
+    render(<Models period="lifetime" provider="all" overview={overview} />)
+
+    const primary = screen.getByRole('table', { name: 'Model usage' })
+    const otherRow = within(primary).getByRole('row', { name: /Other models/ })
+    expect(otherRow).toHaveTextContent('Other models')
+    expect(within(otherRow).getAllByRole('cell')[1]).toHaveTextContent('15')
+    expect(within(otherRow).getAllByRole('cell')[2]).toHaveTextContent('$15.00')
+    expect(within(otherRow).getAllByRole('cell')[3]).toHaveTextContent('$0.00')
   })
 
   it('loads surviving session detail only when By task is requested', async () => {
@@ -264,12 +370,12 @@ describe('Models', () => {
     expect(screen.getAllByText('230').length).toBeGreaterThan(0)
   })
 
-  it('keeps Audit as an explicit on-demand diagnostic lens', async () => {
+  it('keeps Evidence as an explicit on-demand diagnostic lens', async () => {
     getAudit.mockResolvedValue(auditRows)
     render(<Models period="30days" provider="all" overview={loadedOverview()} />)
 
     expect(getAudit).not.toHaveBeenCalled()
-    fireEvent.click(screen.getByRole('tab', { name: 'Audit' }))
+    fireEvent.click(screen.getByRole('tab', { name: 'Evidence' }))
 
     await waitFor(() => expect(getAudit).toHaveBeenCalledWith('30days', 'all'))
     expect(await screen.findByText('3.1M')).toBeInTheDocument()

--- a/app/renderer/sections/Models.tsx
+++ b/app/renderer/sections/Models.tsx
@@ -23,7 +23,7 @@ type DurableModelAccounting = ModelAccounting
 const LENSES = [
   { value: 'model', label: 'By model' },
   { value: 'task', label: 'By task' },
-  { value: 'audit', label: 'Audit' },
+  { value: 'audit', label: 'Evidence' },
 ]
 
 function fmtInt(n: number): string {
@@ -214,23 +214,21 @@ function ModelsUsage({
 
   const accounting = durableAccounting(overview.data)
   const presentation = durablePresentation(overview.data, accounting)
-  const incomplete = accounting.coverage.cost < 0.999999 || accounting.coverage.calls < 0.999999
-  const tokenIncomplete = (accounting.tokenCoverage?.cost ?? 0) < 0.999999 || (accounting.tokenCoverage?.calls ?? 0) < 0.999999
-
   return (
     <>
       {overview.error && <StaleBanner error={overview.error} />}
-      <Panel className="scroll-x">
-          <div style={{ padding: '12px 14px 4px' }}>
-            <strong>Model usage</strong>
-            <div style={authorityNoteStyle}>Historical cost, calls and retained token detail from Metrora&apos;s durable local ledger.</div>
-            <div style={authorityNoteStyle}>Generated tok/s uses retained active-generation evidence only. Observed active-generation timing is shown where the source provides it; Active ms / 1K is the inverse secondary view and unavailable routes remain —.</div>
-            <div style={authorityNoteStyle}>Total includes Input, Output, Cache R, Cache W, and only reasoning reported as additive. Reasoning shows observed evidence; mixed rows can include reasoning already inside Output.</div>
-          {incomplete ? <div style={authorityNoteStyle}>Some older usage no longer has a reliable model identity; that remainder is shown as Other models.</div> : null}
-          {tokenIncomplete ? <div style={authorityNoteStyle}>Legacy rows without a durable token split show — for token-derived metrics instead of guessing.</div> : null}
+      <Panel className="models-panel">
+        <div style={{ padding: '12px 14px 4px' }}>
+          <strong>Model usage</strong>
+          <div style={authorityNoteStyle}>Calls, cost, and savings by model for the selected scope.</div>
         </div>
         {hasAccountingValue(accounting) ? (
-          <DurableModelsTable accounting={accounting} presentation={presentation} legacyPresentationRow={legacyPresentationRow} />
+          <DurableModelsTable
+            accounting={accounting}
+            presentation={presentation}
+            legacyPresentationRow={legacyPresentationRow}
+            unpricedModels={overview.data.current.unpricedModels}
+          />
         ) : (
           <EmptyNote>No model usage in this range yet.</EmptyNote>
         )}
@@ -267,8 +265,8 @@ function AuditLens({
   )
 
   if (!report.data) {
-    if (report.error) return <CliErrorPanel error={report.error} subject="the token audit" />
-    return <SectionSkeleton label="Auditing token usage…" rows={5} />
+    if (report.error) return <CliErrorPanel error={report.error} subject="model usage evidence" />
+    return <SectionSkeleton label="Loading usage evidence…" rows={5} />
   }
 
   return (
@@ -278,7 +276,7 @@ function AuditLens({
         {report.data.length ? (
           <AuditTable rows={report.data} />
         ) : (
-          <EmptyNote>No model usage to audit in this range yet.</EmptyNote>
+          <EmptyNote>No usage evidence is available for this range yet.</EmptyNote>
         )}
       </Panel>
     </>
@@ -287,18 +285,19 @@ function AuditLens({
 
 function AuditTable({ rows }: { rows: AuditRow[] }) {
   return (
-    <table className="audit-table">
+    <table className="audit-table" aria-label="Model usage evidence">
+      <caption className="sr-only">Model usage evidence</caption>
       <thead>
         <tr>
-          <th>Model</th>
-          <th>Calls</th>
-          <th>Input</th>
-          <th>Output</th>
-          <th>Reasoning</th>
-          <th>Norm out</th>
-          <th>Cache wr</th>
-          <th>Cache rd</th>
-          <th>Cost</th>
+          <th scope="col">Model</th>
+          <th scope="col">Calls</th>
+          <th scope="col">Input</th>
+          <th scope="col">Output</th>
+          <th scope="col">Reasoning</th>
+          <th scope="col">Norm out</th>
+          <th scope="col">Cache wr</th>
+          <th scope="col">Cache rd</th>
+          <th scope="col">Cost</th>
         </tr>
       </thead>
       <tbody>

--- a/app/renderer/sections/ModelsDurableTable.test.tsx
+++ b/app/renderer/sections/ModelsDurableTable.test.tsx
@@ -1,11 +1,11 @@
 // @vitest-environment jsdom
-import { render, screen } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import { describe, expect, it } from 'vitest'
 
 import type { DurableModelAccountingRow, DurableModelPresentationRow, ModelAccounting, ModelPresentation } from '../lib/types'
 import { DurableModelsTable } from './ModelsDurableTable'
 
-function delivery(): DurableModelAccountingRow {
+function delivery(overrides: Partial<DurableModelAccountingRow> = {}): DurableModelAccountingRow {
   return {
     name: 'Mixed evidence model',
     cost: 1,
@@ -21,10 +21,11 @@ function delivery(): DurableModelAccountingRow {
     reasoningSemantics: 'mixed',
     provider: 'mixed-route',
     sourceProviders: ['codex', 'zed'],
+    ...overrides,
   }
 }
 
-function presentationRow(row: DurableModelAccountingRow): DurableModelPresentationRow {
+function presentationRow(row: DurableModelAccountingRow, overrides: Partial<DurableModelPresentationRow> = {}): DurableModelPresentationRow {
   return {
     ...row,
     presentationIdentity: 'mixed-evidence-model',
@@ -37,45 +38,207 @@ function presentationRow(row: DurableModelAccountingRow): DurableModelPresentati
     timingCoverage: 'unavailable',
     deliveryRows: [row],
     deliveryStatus: 'exact',
+    ...overrides,
   }
 }
 
-describe('durable Models table reasoning presentation', () => {
-  it('shows observed mixed reasoning and adds only the explicit subtotal to Total', () => {
-    const row = delivery()
-    const accounting: ModelAccounting = {
-      rows: [row],
-      gap: { cost: 0, savingsUSD: 0, calls: 0 },
-      coverage: { cost: 1, calls: 1 },
-      tokenCoverage: { cost: 1, calls: 1 },
-    }
-    const presentation: ModelPresentation = {
-      rows: [presentationRow(row)],
-      accountingRowCount: 1,
-    }
+function accounting(rows: DurableModelAccountingRow[], overrides: Partial<ModelAccounting> = {}): ModelAccounting {
+  return {
+    rows,
+    gap: { cost: 0, savingsUSD: 0, calls: 0 },
+    coverage: { cost: 1, calls: 1 },
+    tokenCoverage: { cost: 1, calls: 1 },
+    ...overrides,
+  }
+}
 
-    render(
-      <DurableModelsTable
-        accounting={accounting}
-        presentation={presentation}
-        legacyPresentationRow={(legacy, index) => ({
-          ...legacy,
-          presentationIdentity: `legacy-${index}`,
-          providers: [],
-          sourceProviders: [],
-          rawModels: [legacy.name],
-          canonicalIdentities: [],
-          economicVariants: ['default'],
-          reasoningSemantics: 'unavailable',
-          timingCoverage: 'unavailable',
-          deliveryRows: [legacy],
-          deliveryStatus: 'unavailable',
-        })}
-      />,
+function renderTable(
+  rows: DurableModelAccountingRow[],
+  presentationRows: DurableModelPresentationRow[] = [presentationRow(rows[0]!)],
+  accountingOverrides: Partial<ModelAccounting> = {},
+  unpricedModels: Array<{ model: string; calls: number; tokens: number }> = [],
+) {
+  const modelAccounting = accounting(rows, accountingOverrides)
+  const presentation: ModelPresentation = { rows: presentationRows, accountingRowCount: rows.length }
+  return render(
+    <DurableModelsTable
+      accounting={modelAccounting}
+      presentation={presentation}
+      legacyPresentationRow={(legacy, index) => ({
+        ...legacy,
+        presentationIdentity: `legacy-${index}`,
+        providers: [],
+        sourceProviders: [],
+        rawModels: [legacy.name],
+        canonicalIdentities: [],
+        economicVariants: ['default'],
+        reasoningSemantics: 'unavailable',
+        timingCoverage: 'unavailable',
+        deliveryRows: [legacy],
+        deliveryStatus: 'unavailable',
+      })}
+      unpricedModels={unpricedModels}
+    />,
+  )
+}
+
+async function openDetails() {
+  const details = screen.getByTestId('models-details')
+  fireEvent.click(within(details).getByText('Details'))
+  await waitFor(() => expect(details).toHaveAttribute('open'))
+  return { details, evidence: within(details).getByRole('table', { name: 'Model usage details' }) }
+}
+
+describe('durable Models table progressive disclosure', () => {
+  it('keeps advanced token facts closed until Details opens', async () => {
+    const row = delivery()
+    renderTable([row])
+
+    const primary = screen.getByRole('table', { name: 'Model usage' })
+    expect(within(primary).getAllByRole('columnheader').map(header => header.textContent)).toEqual(['Model', 'Calls', 'Cost', 'Saved'])
+    const details = screen.getByTestId('models-details')
+    expect(details.firstElementChild?.tagName).toBe('SUMMARY')
+    expect(screen.queryByText('50')).not.toBeInTheDocument()
+
+    const opened = await openDetails()
+    expect(within(opened.evidence).getByText('50')).toBeInTheDocument()
+    expect(within(opened.evidence).getByText('230')).toBeInTheDocument()
+    expect(within(opened.evidence).getByRole('columnheader', { name: 'Cache ×' })).toBeInTheDocument()
+    expect(within(opened.evidence).getByRole('columnheader', { name: 'Cost / 1M' })).toBeInTheDocument()
+    expect(within(opened.evidence).getByRole('columnheader', { name: 'Pricing' })).toBeInTheDocument()
+  })
+
+  it('keeps known zero token facts distinct from unavailable legacy facts', async () => {
+    const knownZero = delivery({
+      name: 'Known zero model',
+      inputTokens: 0,
+      outputTokens: 0,
+      reasoningTokens: 0,
+      additiveReasoningTokens: 0,
+      cacheReadTokens: 0,
+      cacheWriteTokens: 0,
+      reasoningSemantics: 'separate',
+    })
+    const legacy = delivery({
+      name: 'Legacy token model',
+      inputTokens: 0,
+      outputTokens: 0,
+      reasoningTokens: undefined,
+      additiveReasoningTokens: undefined,
+      cacheReadTokens: 0,
+      cacheWriteTokens: 0,
+      tokenDetail: false,
+      reasoningSemantics: 'unavailable',
+    })
+    const knownPresentation = presentationRow(knownZero, { presentationIdentity: 'known-zero', name: 'Known zero model', rawModels: ['Known zero model'], reasoningSemantics: 'separate', deliveryRows: [knownZero] })
+    const legacyPresentation = presentationRow(legacy, { presentationIdentity: 'legacy-token', name: 'Legacy token model', rawModels: ['Legacy token model'], reasoningSemantics: 'unavailable', deliveryRows: [legacy], deliveryStatus: 'unavailable' })
+    renderTable([knownZero, legacy], [knownPresentation, legacyPresentation])
+
+    const { evidence } = await openDetails()
+    const zeroRow = within(evidence).getByRole('row', { name: /Known zero model/ })
+    const legacyRow = within(evidence).getByRole('row', { name: /Legacy token model/ })
+    const zeroCells = within(zeroRow).getAllByRole('cell')
+    const legacyCells = within(legacyRow).getAllByRole('cell')
+    expect(zeroCells[2]).toHaveTextContent('0')
+    expect(zeroCells[3]).toHaveTextContent('0')
+    expect(zeroCells[4]).toHaveTextContent('0')
+    expect(zeroCells[8]).toHaveTextContent('0')
+    expect(zeroCells[7]).toHaveTextContent('—')
+    expect(zeroCells[7].querySelector('.models-unavailable')).toHaveAttribute('aria-label', expect.stringContaining('Cache reuse is unavailable'))
+    expect(legacyCells[2].querySelector('.models-unavailable')).toHaveAttribute('aria-label', expect.stringContaining('Reasoning token evidence is unavailable'))
+    expect(legacyCells[3].querySelector('.models-unavailable')).toHaveAttribute('aria-label', expect.stringContaining('Input token evidence is unavailable'))
+    expect(legacyCells[8].querySelector('.models-unavailable')).toHaveAttribute('aria-label', expect.stringContaining('Total token evidence is unavailable'))
+  })
+
+  it('qualifies partial pricing without changing the reported cost', async () => {
+    const settled = delivery({ name: 'Partial model', cost: 2, reasoningSemantics: 'separate', reasoningTokens: 0, additiveReasoningTokens: 0 })
+    const estimated = delivery({ name: 'Partial model', cost: 3, costIsEstimated: true, estimatedCostUSD: 1, reasoningSemantics: 'separate', reasoningTokens: 0, additiveReasoningTokens: 0 })
+    const row = presentationRow(settled, {
+      presentationIdentity: 'partial-model',
+      name: 'Partial model',
+      cost: 5,
+      calls: 4,
+      rawModels: ['Partial model'],
+      deliveryRows: [settled, estimated],
+      deliveryStatus: 'exact',
+      pricingState: 'mixed',
+      reasoningSemantics: 'separate',
+    })
+    renderTable([settled, estimated], [row])
+
+    const primary = screen.getByRole('table', { name: 'Model usage' })
+    const primaryRow = within(primary).getByRole('row', { name: /Partial model/ })
+    expect(within(primaryRow).getAllByRole('cell')[2]).toHaveTextContent('$5.00')
+    expect(within(primaryRow).getAllByRole('cell')[2]).toHaveTextContent('partial')
+
+    const { evidence } = await openDetails()
+    const evidenceRow = within(evidence).getByRole('row', { name: /Partial model/ })
+    expect(within(evidenceRow).getAllByRole('cell')[15]).toHaveTextContent('Partial pricing')
+  })
+
+  it('does not attribute aggregate unpriced evidence to every delivery', async () => {
+    const first = delivery({ name: 'Ambiguous model', calls: 1, cost: 1, provider: 'route-a', sourceProviders: ['codex'] })
+    const second = delivery({ name: 'Ambiguous model', calls: 1, cost: 2, provider: 'route-b', sourceProviders: ['zed'] })
+    const row = presentationRow(first, {
+      presentationIdentity: 'ambiguous-model',
+      name: 'Ambiguous model',
+      cost: 3,
+      calls: 2,
+      providers: ['route-a', 'route-b'],
+      sourceProviders: ['codex', 'zed'],
+      rawModels: ['Ambiguous model'],
+      deliveryRows: [first, second],
+      deliveryStatus: 'exact',
+      pricingState: 'settled',
+    })
+    renderTable(
+      [first, second],
+      [row],
+      {},
+      [{ model: 'Ambiguous model', calls: 1, tokens: 200 }],
     )
 
-    expect(screen.getByText('50')).toBeInTheDocument()
-    expect(screen.getByText('230')).toBeInTheDocument()
-    expect(screen.getByTitle(/only the additive subset/)).toBeInTheDocument()
+    const primary = screen.getByRole('table', { name: 'Model usage' })
+    expect(within(primary).getByRole('row', { name: /Ambiguous model/ })).toHaveTextContent('partial')
+
+    const { evidence } = await openDetails()
+    const button = within(evidence).getByRole('button', { name: '2 deliveries' })
+    fireEvent.click(button)
+    const region = document.getElementById(button.getAttribute('aria-controls')!)!
+    const deliveryTable = within(region).getByRole('table', { name: 'Ambiguous model delivery evidence' })
+    const deliveryRows = within(deliveryTable).getAllByRole('row').slice(1)
+    expect(deliveryRows).toHaveLength(2)
+    expect(deliveryRows[0]).toHaveTextContent('Unresolved')
+    expect(deliveryRows[1]).toHaveTextContent('Unresolved')
+    expect(deliveryRows[0]).not.toHaveTextContent('Unpriced')
+    expect(deliveryRows[1]).not.toHaveTextContent('Unpriced')
+  })
+
+  it('keeps delivery expansion linked to its region', async () => {
+    const first = delivery({ name: 'Routed model', provider: 'route-a', sourceProviders: ['codex'] })
+    const second = delivery({ name: 'Routed model', provider: 'route-b', sourceProviders: ['zed'] })
+    const row = presentationRow(first, {
+      presentationIdentity: 'routed-model',
+      name: 'Routed model',
+      providers: ['route-a', 'route-b'],
+      sourceProviders: ['codex', 'zed'],
+      deliveryRows: [first, second],
+      deliveryStatus: 'exact',
+    })
+    renderTable([first, second], [row])
+
+    const { evidence } = await openDetails()
+    const button = within(evidence).getByRole('button', { name: '2 deliveries' })
+    const regionId = button.getAttribute('aria-controls')
+    expect(regionId).toBeTruthy()
+    fireEvent.click(button)
+    const region = document.getElementById(regionId!)
+    expect(region).toHaveAttribute('role', 'region')
+    expect(region).toHaveAttribute('aria-label', 'Routed model delivery breakdown')
+    expect(within(region as HTMLElement).getByRole('table', { name: 'Routed model delivery evidence' })).toBeInTheDocument()
+
+    fireEvent.click(button)
+    expect(button).toHaveAttribute('aria-expanded', 'false')
+    expect(document.getElementById(regionId!)).not.toBeInTheDocument()
   })
 })

--- a/app/renderer/sections/ModelsDurableTable.tsx
+++ b/app/renderer/sections/ModelsDurableTable.tsx
@@ -8,6 +8,9 @@ import type { DurableModelAccountingRow, DurableModelPresentationRow, ModelAccou
 
 type ModelSort = 'cost' | 'tokens' | 'calls' | 'cache' | 'speed' | 'activeMs' | 'unitCost'
 type DurableModelRow = DurableModelPresentationRow
+type UnpricedModel = { model: string; calls: number; tokens: number }
+type CostQualityKind = 'settled' | 'estimated' | 'partial' | 'unpriced' | 'unresolved'
+type CostQuality = { kind: CostQualityKind; label: string; detail: string }
 
 const MODEL_SORTS = [
   { value: 'cost', label: 'Cost' },
@@ -101,6 +104,115 @@ function deliveryPricingState(delivery: DurableModelAccountingRow): 'settled' | 
   return 'settled'
 }
 
+function normalizedModelReference(value: string): string {
+  return value.trim().toLowerCase()
+}
+
+function matchesUnpricedModel(model: Pick<DurableModelRow, 'name' | 'rawModels'>, unpricedModels: UnpricedModel[]): boolean {
+  const names = new Set([model.name, ...model.rawModels].map(normalizedModelReference))
+  return unpricedModels.some(item => names.has(normalizedModelReference(item.model)))
+}
+
+function costQualityForModel(model: DurableModelRow, unpricedModels: UnpricedModel[]): CostQuality {
+  const deliveryStates = model.deliveryRows.map(deliveryPricingState)
+  const hasEstimated = model.pricingState === 'estimated'
+    || model.costIsEstimated === true
+    || (model.estimatedCostUSD ?? 0) > 0
+    || deliveryStates.includes('estimated')
+  const hasUnpricedModel = matchesUnpricedModel(model, unpricedModels)
+  const hasUnpriced = model.pricingState === 'unavailable'
+    || deliveryStates.includes('unavailable')
+    || hasUnpricedModel
+  const hasMixedDeliveryState = deliveryStates.includes('unavailable')
+    && (deliveryStates.includes('estimated') || deliveryStates.includes('settled'))
+
+  if (model.pricingState === 'mixed' || hasMixedDeliveryState || (hasUnpricedModel && model.cost > 0)) {
+    return {
+      kind: 'partial',
+      label: 'partial',
+      detail: 'Cost is partial: some model usage is estimated or unpriced.',
+    }
+  }
+  if (hasUnpriced) {
+    return {
+      kind: 'unpriced',
+      label: 'unpriced',
+      detail: 'Cost is unavailable because no authoritative pricing evidence was resolved for this model.',
+    }
+  }
+  if (hasEstimated) {
+    return {
+      kind: 'estimated',
+      label: 'est.',
+      detail: 'Cost includes usage priced from estimated tokens.',
+    }
+  }
+  return { kind: 'settled', label: '', detail: 'Cost has settled pricing evidence.' }
+}
+
+function costQualityForDelivery(delivery: DurableModelAccountingRow, aggregateUnpriced: boolean, deliveryCount: number): CostQuality {
+  const state = deliveryPricingState(delivery)
+  if (state === 'unavailable') {
+    return {
+      kind: 'unpriced',
+      label: 'unpriced',
+      detail: 'Cost is unavailable because no authoritative pricing evidence was resolved for this delivery.',
+    }
+  }
+  if (state === 'estimated') return { kind: 'estimated', label: 'est.', detail: 'Cost includes usage priced from estimated tokens.' }
+  if (aggregateUnpriced) {
+    if (deliveryCount === 1) {
+      return {
+        kind: 'unpriced',
+        label: 'unpriced',
+        detail: 'Cost is unavailable because aggregate model evidence reports unpriced usage for this single delivery.',
+      }
+    }
+    return {
+      kind: 'unresolved',
+      label: 'unresolved',
+      detail: 'Aggregate model evidence reports unpriced usage, but this payload does not identify which delivery or route it belongs to.',
+    }
+  }
+  return { kind: 'settled', label: '', detail: 'Cost has settled pricing evidence.' }
+}
+
+function unavailableValue(explanation: string) {
+  return <span className="models-unavailable" aria-label={explanation}>—</span>
+}
+
+function savedValue(row: Pick<DurableModelAccountingRow, 'savingsUSD'>): number | null {
+  return typeof row.savingsUSD === 'number' && Number.isFinite(row.savingsUSD) ? row.savingsUSD : null
+}
+
+function SavedCell({ row }: { row: Pick<DurableModelAccountingRow, 'savingsUSD'> }) {
+  const value = savedValue(row)
+  return (
+    <td className={value != null && value > 0 ? 'pos' : undefined}>
+      {value == null ? unavailableValue('Saved is unavailable for this model; no savings value was reported.') : formatUsd(value)}
+    </td>
+  )
+}
+
+function CostContents({ cost, quality, subject }: { cost: number; quality: CostQuality; subject: string }) {
+  return (
+    <span className="models-cost-content" title={quality.kind === 'settled' ? undefined : quality.detail}>
+      {quality.kind === 'unpriced'
+        ? unavailableValue(`Cost unavailable for ${subject}. ${quality.detail}`)
+        : formatUsd(cost)}
+      {quality.kind !== 'settled' ? <span className={`models-cost-quality models-cost-quality-${quality.kind}`} aria-label={quality.detail}>{quality.label}</span> : null}
+    </span>
+  )
+}
+
+function modelCostLabel(quality: CostQuality): string {
+  if (quality.kind === 'estimated') return 'Estimated'
+  if (quality.kind === 'partial') return 'Partial pricing'
+  if (quality.kind === 'unpriced') return 'Unpriced'
+  if (quality.kind === 'unresolved') return 'Unresolved'
+  return 'Settled'
+}
+
 function compareNullableDescending(a: number | null, b: number | null): number {
   if (a == null && b == null) return 0
   if (a == null) return 1
@@ -127,21 +239,57 @@ function sortDurableRows(rows: DurableModelRow[], sort: ModelSort): DurableModel
   })
 }
 
+function coverageText(value: number | undefined): string {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return 'Unavailable'
+  return `${Math.max(0, Math.min(100, Math.round(value * 100)))}%`
+}
+
+function hasAccountingGap(accounting: ModelAccounting): boolean {
+  return accounting.gap.cost > 0.000001 || accounting.gap.calls > 0 || accounting.gap.savingsUSD > 0.000001
+}
+
+function ModelDetailsNotes({ accounting, unpricedModels }: { accounting: ModelAccounting; unpricedModels: UnpricedModel[] }) {
+  const tokenCoverage = accounting.tokenCoverage
+  const tokenIncomplete = !tokenCoverage || tokenCoverage.cost < 0.999999 || tokenCoverage.calls < 0.999999
+  const incomplete = accounting.coverage.cost < 0.999999 || accounting.coverage.calls < 0.999999
+  const hasGap = hasAccountingGap(accounting)
+
+  return (
+    <div className="models-details-notes">
+      <p>These recorded model facts use the existing durable accounting values. Details qualify coverage, pricing, timing, and reconstruction state without recalculating Cost or Saved.</p>
+      <dl className="models-details-coverage">
+        <div><dt>Accounting coverage</dt><dd>{coverageText(accounting.coverage.calls)} calls · {coverageText(accounting.coverage.cost)} cost</dd></div>
+        <div><dt>Token detail coverage</dt><dd>{tokenCoverage ? `${coverageText(tokenCoverage.calls)} calls · ${coverageText(tokenCoverage.cost)} cost` : 'Unavailable'}</dd></div>
+      </dl>
+      {incomplete || hasGap ? <p>Other models is the retained accounting remainder for usage that cannot be assigned to a named model without guessing.</p> : null}
+      {tokenIncomplete ? <p>Rows without a durable token split show unavailable token-derived facts rather than inferred zeros.</p> : null}
+      {unpricedModels.length > 0 ? <p>Unpriced model usage is marked in the relevant Cost rows; its reported amount must not be read as settled pricing.</p> : null}
+    </div>
+  )
+}
+
+function modelDeliveryId(model: DurableModelRow, index: number): string {
+  const safeIdentity = model.presentationIdentity.replace(/[^a-z0-9_-]+/gi, '-') || 'model'
+  return `model-delivery-${index}-${safeIdentity}`
+}
+
 export function DurableModelsTable({
   accounting,
   presentation,
   legacyPresentationRow,
+  unpricedModels = [],
 }: {
   accounting: ModelAccounting
   presentation: ModelPresentation
   legacyPresentationRow: (row: DurableModelAccountingRow, index: number) => DurableModelPresentationRow
+  unpricedModels?: UnpricedModel[]
 }) {
   const [sort, setSort] = useState<ModelSort>('cost')
   const [expanded, setExpanded] = useState<Set<string>>(new Set())
-  const hasSavings = accounting.rows.some(row => row.savingsUSD > 0) || accounting.gap.savingsUSD > 0
+  const [detailsOpen, setDetailsOpen] = useState(false)
   const rows = useMemo(() => {
     const values = [...presentation.rows]
-    if (accounting.gap.cost > 0.000001 || accounting.gap.calls > 0 || accounting.gap.savingsUSD > 0.000001) {
+    if (hasAccountingGap(accounting)) {
       values.push(legacyPresentationRow({
         name: 'Other models',
         ...accounting.gap,
@@ -157,121 +305,207 @@ export function DurableModelsTable({
 
   return (
     <>
-      <div style={{ display: 'flex', justifyContent: 'flex-end', padding: '8px 12px 0' }}>
-        <SegTabs options={MODEL_SORTS} value={sort} onChange={value => setSort(value as ModelSort)} />
-      </div>
-      <table className="models-table" aria-label="Model usage">
+      <table className="models-primary-table" aria-label="Model usage">
+        <caption className="sr-only">Primary model usage summary</caption>
         <colgroup>
-          <col style={{ width: 240 }} /><col style={{ width: 72 }} /><col style={{ width: 100 }} /><col style={{ width: 100 }} />
-          <col style={{ width: 100 }} /><col style={{ width: 100 }} /><col style={{ width: 100 }} /><col style={{ width: 86 }} />
-          <col style={{ width: 116 }} /><col style={{ width: 116 }} /><col style={{ width: 116 }} /><col style={{ width: 94 }} />
-          <col style={{ width: 104 }} />{hasSavings ? <col style={{ width: 90 }} /> : null}
+          <col style={{ width: 300 }} /><col style={{ width: 88 }} /><col style={{ width: 150 }} /><col style={{ width: 110 }} />
         </colgroup>
         <thead>
           <tr>
-            <th>Model</th>
-            <th>Calls</th>
-            <th>Reasoning</th>
-            <th>Input</th>
-            <th>Output</th>
-            <th>Cache R</th>
-            <th>Cache W</th>
-            <th title="Cached input read per uncached input token">Cache ×</th>
-            <th>Total</th>
-            <th title="Observed generated tokens per active second; tool wait is excluded where the collector supplies active timing.">Generated tok/s</th>
-            <th title="Active generation milliseconds per 1,000 generated tokens; lower is faster.">Active ms / 1K</th>
-            <th>Cost</th>
-            <th title="Effective API-equivalent value per 1M safe total tokens">Cost / 1M</th>
-            {hasSavings ? <th>Saved</th> : null}
+            <th scope="col">Model</th>
+            <th scope="col">Calls</th>
+            <th scope="col">Cost</th>
+            <th scope="col">Saved</th>
           </tr>
         </thead>
         <tbody>
           {rows.map((model, index) => {
-            const total = model.tokenDetail ? tokenTotal(model) : null
-            const reuse = modelCacheReuse(model)
-            const share = model.tokenDetail ? cacheShare(model.inputTokens, model.cacheReadTokens) : null
-            const unitCost = modelUnitCost(model)
-            const generatedTps = modelGeneratedTps(model)
-            const activeMs = modelMsPer1K(model)
             const providerLabel = model.providers.length > 0
               ? model.providers.join(', ')
               : model.sourceProviders.length > 0 ? model.sourceProviders.join(', ') : undefined
-            const reasoning = reasoningDisplay(model)
-            const expandable = model.deliveryRows.length > 1 || model.deliveryStatus === 'partial'
-            const isExpanded = expanded.has(model.presentationIdentity)
+            const quality = costQualityForModel(model, unpricedModels)
             return (
-              <Fragment key={`${model.presentationIdentity}-${index}`}>
-                <tr>
-                  <td title={providerLabel ? `${model.name} · ${providerLabel}` : model.name}>
-                    <span style={{ display: 'inline-flex', alignItems: 'center', gap: 8, minWidth: 0 }}>
-                      <ModelIdentity name={model.name} />
-                      {providerLabel ? <span style={providerTagStyle}>{providerLabel}</span> : null}
-                      {expandable ? <button type="button" className="alias" aria-expanded={isExpanded} onClick={() => setExpanded(current => {
-                        const next = new Set(current)
-                        if (next.has(model.presentationIdentity)) next.delete(model.presentationIdentity)
-                        else next.add(model.presentationIdentity)
-                        return next
-                      })}>{isExpanded ? 'hide delivery' : `${model.deliveryRows.length} deliveries`}</button> : null}
-                    </span>
-                  </td>
-                  <td>{fmtInt(model.calls)}</td>
-                  <td title={reasoningTitle(model)}>{model.tokenDetail ? reasoning : '—'}</td>
-                  <td>{model.tokenDetail ? formatCompact(model.inputTokens) : '—'}</td>
-                  <td>{model.tokenDetail ? formatCompact(model.outputTokens) : '—'}</td>
-                  <td>{model.tokenDetail ? formatCompact(model.cacheReadTokens) : '—'}</td>
-                  <td>{model.tokenDetail ? formatCompact(model.cacheWriteTokens) : '—'}</td>
-                  <td title={share == null ? undefined : `${Math.round(share * 1000) / 10}% of input served from cache`}>{formatReuseMultiple(reuse)}</td>
-                  <td>{total == null ? '—' : formatCompact(total)}</td>
-                  <td title={generatedTps == null ? 'No reliable active-generation timing for this delivery.' : `Observed active-generation timing: ${formatCompact(model.activeGeneratedTokens ?? 0)} timed generated tokens from available source sessions; timing coverage is ${model.timingCoverage}.`}>{formatGeneratedTps(generatedTps)}</td>
-                  <td title={activeMs == null ? 'No reliable active-generation timing for this delivery.' : 'Inverse of Generated tok/s.'}>{formatMsPer1K(activeMs)}</td>
-                  <td>{formatUsd(model.cost)}</td>
-                  <td>{unitCost == null ? '—' : formatUsd(unitCost)}</td>
-                  {hasSavings ? <td className={model.savingsUSD > 0 ? 'pos' : undefined}>{model.savingsUSD > 0 ? formatUsd(model.savingsUSD) : '—'}</td> : null}
-                </tr>
-                {isExpanded ? <tr className="model-delivery-row"><td colSpan={hasSavings ? 14 : 13}><DeliveryBreakdown model={model} /></td></tr> : null}
-              </Fragment>
+              <tr key={`primary-${model.presentationIdentity}-${index}`}>
+                <td title={providerLabel ? `${model.name} · ${providerLabel}` : model.name}>
+                  <span className="models-primary-model">
+                    <ModelIdentity name={model.name} />
+                    {providerLabel ? <span style={providerTagStyle}>{providerLabel}</span> : null}
+                  </span>
+                </td>
+                <td>{fmtInt(model.calls)}</td>
+                <td className={quality.kind === 'settled' ? undefined : 'models-cost-quality-cell'}>
+                  <CostContents cost={model.cost} quality={quality} subject={model.name} />
+                </td>
+                <SavedCell row={model} />
+              </tr>
             )
           })}
         </tbody>
       </table>
+
+      <details
+        className="models-details"
+        data-testid="models-details"
+        onToggle={event => setDetailsOpen(event.currentTarget.open)}
+      >
+        <summary>Details</summary>
+        {detailsOpen ? (
+          <div className="models-details-body">
+            <ModelDetailsNotes accounting={accounting} unpricedModels={unpricedModels} />
+            <div className="models-sort-controls">
+              <span>Sort details by</span>
+              <SegTabs options={MODEL_SORTS} value={sort} onChange={value => setSort(value as ModelSort)} />
+            </div>
+            <div className="models-evidence-scroll">
+              <table className="models-evidence-table" aria-label="Model usage details">
+                <caption className="sr-only">Model usage details: token, cache, timing, pricing, delivery, and savings evidence.</caption>
+                <thead>
+                  <tr>
+                    <th scope="col">Model</th>
+                    <th scope="col">Calls</th>
+                    <th scope="col">Reasoning</th>
+                    <th scope="col">Input</th>
+                    <th scope="col">Output</th>
+                    <th scope="col">Cache R</th>
+                    <th scope="col">Cache W</th>
+                    <th scope="col" title="Cached input read per uncached input token">Cache ×</th>
+                    <th scope="col">Total</th>
+                    <th scope="col" title="Observed generated tokens per active second; tool wait is excluded where the collector supplies active timing.">Generated tok/s</th>
+                    <th scope="col" title="Active generation milliseconds per 1,000 generated tokens; lower is faster.">Active ms / 1K</th>
+                    <th scope="col">Cost</th>
+                    <th scope="col" title="Effective API-equivalent value per 1M safe total tokens">Cost / 1M</th>
+                    <th scope="col">Saved</th>
+                    <th scope="col">Timing</th>
+                    <th scope="col">Pricing</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {rows.map((model, index) => {
+                    const total = model.tokenDetail ? tokenTotal(model) : null
+                    const reuse = modelCacheReuse(model)
+                    const share = model.tokenDetail ? cacheShare(model.inputTokens, model.cacheReadTokens) : null
+                    const quality = costQualityForModel(model, unpricedModels)
+                    const unitCost = quality.kind === 'unpriced' ? null : modelUnitCost(model)
+                    const generatedTps = modelGeneratedTps(model)
+                    const activeMs = modelMsPer1K(model)
+                    const providerLabel = model.providers.length > 0
+                      ? model.providers.join(', ')
+                      : model.sourceProviders.length > 0 ? model.sourceProviders.join(', ') : undefined
+                    const expandable = model.deliveryRows.length > 1 || model.deliveryStatus === 'partial'
+                    const isExpanded = expanded.has(model.presentationIdentity)
+                    const deliveryId = modelDeliveryId(model, index)
+                    return (
+                      <Fragment key={`${model.presentationIdentity}-${index}`}>
+                        <tr>
+                          <td title={providerLabel ? `${model.name} · ${providerLabel}` : model.name}>
+                            <span className="models-evidence-model">
+                              <ModelIdentity name={model.name} />
+                              {providerLabel ? <span style={providerTagStyle}>{providerLabel}</span> : null}
+                              {expandable ? (
+                                <button
+                                  type="button"
+                                  className="alias models-delivery-toggle"
+                                  aria-expanded={isExpanded}
+                                  aria-controls={deliveryId}
+                                  onClick={() => setExpanded(current => {
+                                    const next = new Set(current)
+                                    if (next.has(model.presentationIdentity)) next.delete(model.presentationIdentity)
+                                    else next.add(model.presentationIdentity)
+                                    return next
+                                  })}
+                                >{isExpanded ? 'hide delivery' : `${model.deliveryRows.length} deliveries`}</button>
+                              ) : null}
+                            </span>
+                          </td>
+                          <td>{fmtInt(model.calls)}</td>
+                          <td title={reasoningTitle(model)}>{model.tokenDetail && model.reasoningSemantics !== 'unavailable' && model.reasoningTokens !== undefined
+                            ? <span aria-label={`${reasoningDisplay(model)}. ${reasoningTitle(model)}`}>{reasoningDisplay(model)}</span>
+                            : unavailableValue('Reasoning token evidence is unavailable for this model.')}</td>
+                          <td>{model.tokenDetail ? formatCompact(model.inputTokens) : unavailableValue('Input token evidence is unavailable for this model.')}</td>
+                          <td>{model.tokenDetail ? formatCompact(model.outputTokens) : unavailableValue('Output token evidence is unavailable for this model.')}</td>
+                          <td>{model.tokenDetail ? formatCompact(model.cacheReadTokens) : unavailableValue('Cache-read token evidence is unavailable for this model.')}</td>
+                          <td>{model.tokenDetail ? formatCompact(model.cacheWriteTokens) : unavailableValue('Cache-write token evidence is unavailable for this model.')}</td>
+                          <td title={share == null ? undefined : `${Math.round(share * 1000) / 10}% of input served from cache`}>{reuse == null
+                            ? unavailableValue('Cache reuse is unavailable because no valid input denominator is recorded for this model.')
+                            : formatReuseMultiple(reuse)}</td>
+                          <td>{total == null ? unavailableValue('Total token evidence is unavailable for this model.') : formatCompact(total)}</td>
+                          <td title={generatedTps == null ? 'No reliable active-generation timing for this delivery.' : `Observed active-generation timing: ${formatCompact(model.activeGeneratedTokens ?? 0)} timed generated tokens from available source sessions; timing coverage is ${model.timingCoverage}.`}>{generatedTps == null
+                            ? unavailableValue('Generated tok/s is unavailable because reliable active-generation timing is not recorded.')
+                            : formatGeneratedTps(generatedTps)}</td>
+                          <td title={activeMs == null ? 'No reliable active-generation timing for this delivery.' : 'Inverse of Generated tok/s.'}>{activeMs == null
+                            ? unavailableValue('Active ms / 1K is unavailable because reliable active-generation timing is not recorded.')
+                            : formatMsPer1K(activeMs)}</td>
+                          <td className={quality.kind === 'settled' ? undefined : 'models-cost-quality-cell'}><CostContents cost={model.cost} quality={quality} subject={model.name} /></td>
+                          <td>{unitCost == null
+                            ? unavailableValue('Cost / 1M is unavailable because a safe token denominator is not recorded.')
+                            : formatUsd(unitCost)}</td>
+                          <SavedCell row={model} />
+                          <td>{model.timingCoverage}</td>
+                          <td title={quality.detail}>{modelCostLabel(quality)}</td>
+                        </tr>
+                        {isExpanded ? <tr className="model-delivery-row"><td colSpan={16}><DeliveryBreakdown id={deliveryId} model={model} unpricedModels={unpricedModels} /></td></tr> : null}
+                      </Fragment>
+                    )
+                  })}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        ) : null}
+      </details>
     </>
   )
 }
 
-function DeliveryBreakdown({ model }: { model: DurableModelRow }) {
+function DeliveryBreakdown({ id, model, unpricedModels }: { id: string; model: DurableModelRow; unpricedModels: UnpricedModel[] }) {
+  const aggregateUnpriced = matchesUnpricedModel(model, unpricedModels)
   return (
-    <div className="model-delivery-breakdown" role="region" aria-label={`${model.name} delivery breakdown`}>
-      <div className="model-delivery-note">Exact constituent accounting rows. Partial historical delivery detail is shown as unavailable rather than synthesized.</div>
-      <table className="model-delivery-table">
-        <thead><tr><th>Variant</th><th>API provider / route</th><th>Source tool</th><th>Calls</th><th>Input</th><th>Output</th><th>Reasoning</th><th>Cache R</th><th>Cache W</th><th>Total</th><th>Cost</th><th>Cost / 1M</th><th>Generated tok/s</th><th>Timing coverage</th><th>Pricing</th></tr></thead>
-        <tbody>{model.deliveryRows.map((delivery, index) => {
-          const semantics = delivery.reasoningSemantics ?? 'unavailable'
-          const usage = { ...delivery, reasoningSemantics: semantics }
-          const total = delivery.tokenDetail ? totalTokenCount(usage) : null
-          const unit = delivery.tokenDetail ? costPerMillionTotal(delivery.cost, usage) : null
-          const reasoning = reasoningDisplay({ reasoningSemantics: semantics, reasoningTokens: delivery.reasoningTokens })
-          const generated = delivery.activeDurationMs && delivery.activeGeneratedTokens
-            ? delivery.activeGeneratedTokens / (delivery.activeDurationMs / 1000)
-            : null
-          const timingCoverage = delivery.timingCoverage ?? (generated == null ? 'unavailable' : 'observed')
-          return <tr key={`${delivery.name}-${delivery.provider ?? 'unknown'}-${index}`}>
-            <td>{delivery.semanticVariant ?? 'default'}</td>
-            <td>{delivery.provider ?? 'Unavailable'}</td>
-            <td>{delivery.sourceProviders?.join(', ') || 'Unavailable'}</td>
-            <td>{fmtInt(delivery.calls)}</td>
-            <td>{delivery.tokenDetail ? formatCompact(delivery.inputTokens) : '—'}</td>
-            <td>{delivery.tokenDetail ? formatCompact(delivery.outputTokens) : '—'}</td>
-            <td title={reasoningTitle({ reasoningSemantics: semantics, reasoningTokens: delivery.reasoningTokens })}>{delivery.tokenDetail ? reasoning : '—'}</td>
-            <td>{delivery.tokenDetail ? formatCompact(delivery.cacheReadTokens) : '—'}</td>
-            <td>{delivery.tokenDetail ? formatCompact(delivery.cacheWriteTokens) : '—'}</td>
-            <td>{total == null ? '—' : formatCompact(total)}</td>
-            <td>{formatUsd(delivery.cost)}</td>
-            <td>{unit == null ? '—' : formatUsd(unit)}</td>
-            <td>{generated == null ? '—' : `${generated.toFixed(1)} tok/s`}</td>
-            <td>{timingCoverage}</td>
-            <td>{deliveryPricingState(delivery)}</td>
+    <div id={id} className="model-delivery-breakdown" role="region" aria-label={`${model.name} delivery breakdown`}>
+      <div className="model-delivery-note">Recorded constituent delivery rows. Partial historical delivery detail is shown as unavailable rather than synthesized.</div>
+      <table className="model-delivery-table" aria-label={`${model.name} delivery evidence`}>
+        <caption className="sr-only">{model.name} delivery evidence</caption>
+        <thead>
+          <tr>
+            <th scope="col">Variant</th><th scope="col">API provider / route</th><th scope="col">Source tool</th><th scope="col">Calls</th><th scope="col">Input</th><th scope="col">Output</th><th scope="col">Reasoning</th><th scope="col">Cache R</th><th scope="col">Cache W</th><th scope="col">Total</th><th scope="col">Cost</th><th scope="col">Cost / 1M</th><th scope="col">Generated tok/s</th><th scope="col">Timing coverage</th><th scope="col">Pricing</th>
           </tr>
-        })}</tbody>
+        </thead>
+        <tbody>
+          {model.deliveryRows.map((delivery, index) => {
+            const semantics = delivery.reasoningSemantics ?? 'unavailable'
+            const usage = { ...delivery, reasoningSemantics: semantics }
+            const total = delivery.tokenDetail ? totalTokenCount(usage) : null
+            const quality = costQualityForDelivery(delivery, aggregateUnpriced, model.deliveryRows.length)
+            const unit = quality.kind === 'unpriced' || !delivery.tokenDetail ? null : costPerMillionTotal(delivery.cost, usage)
+            const reasoning = reasoningDisplay({ reasoningSemantics: semantics, reasoningTokens: delivery.reasoningTokens })
+            const generated = delivery.activeDurationMs && delivery.activeGeneratedTokens
+              ? delivery.activeGeneratedTokens / (delivery.activeDurationMs / 1000)
+              : null
+            const timingCoverage = delivery.timingCoverage ?? (generated == null ? 'unavailable' : 'observed')
+            return (
+              <tr key={`${delivery.name}-${delivery.provider ?? 'unknown'}-${index}`}>
+                <td>{delivery.semanticVariant ?? 'default'}</td>
+                <td>{delivery.provider ?? 'Unavailable'}</td>
+                <td>{delivery.sourceProviders?.join(', ') || 'Unavailable'}</td>
+                <td>{fmtInt(delivery.calls)}</td>
+                <td>{delivery.tokenDetail ? formatCompact(delivery.inputTokens) : unavailableValue('Input token evidence is unavailable for this delivery.')}</td>
+                <td>{delivery.tokenDetail ? formatCompact(delivery.outputTokens) : unavailableValue('Output token evidence is unavailable for this delivery.')}</td>
+                <td title={reasoningTitle({ reasoningSemantics: semantics, reasoningTokens: delivery.reasoningTokens })}>{delivery.tokenDetail && semantics !== 'unavailable' && delivery.reasoningTokens !== undefined
+                  ? <span aria-label={`${reasoning}. ${reasoningTitle({ reasoningSemantics: semantics, reasoningTokens: delivery.reasoningTokens })}`}>{reasoning}</span>
+                  : unavailableValue('Reasoning token evidence is unavailable for this delivery.')}</td>
+                <td>{delivery.tokenDetail ? formatCompact(delivery.cacheReadTokens) : unavailableValue('Cache-read token evidence is unavailable for this delivery.')}</td>
+                <td>{delivery.tokenDetail ? formatCompact(delivery.cacheWriteTokens) : unavailableValue('Cache-write token evidence is unavailable for this delivery.')}</td>
+                <td>{total == null ? unavailableValue('Total token evidence is unavailable for this delivery.') : formatCompact(total)}</td>
+                <td className={quality.kind === 'settled' ? undefined : 'models-cost-quality-cell'}><CostContents cost={delivery.cost} quality={quality} subject={`${model.name} delivery`} /></td>
+                <td>{unit == null
+                  ? unavailableValue('Cost / 1M is unavailable because a safe token denominator is not recorded for this delivery.')
+                  : formatUsd(unit)}</td>
+                <td>{generated == null ? unavailableValue('Generated tok/s is unavailable because reliable active-generation timing is not recorded for this delivery.') : `${generated.toFixed(1)} tok/s`}</td>
+                <td>{timingCoverage}</td>
+                <td title={quality.detail}>{modelCostLabel(quality)}</td>
+              </tr>
+            )
+          })}
+        </tbody>
       </table>
     </div>
   )

--- a/app/renderer/styles/plain.css
+++ b/app/renderer/styles/plain.css
@@ -449,13 +449,39 @@ td:first-child { font-size: var(--fs-body); font-weight: var(--fw-body); }
 .spend-proj-session .sps-cost { color: var(--ink); font-family: var(--mono); }
 .spend-proj-empty { padding: 4px 0 8px 27px; font-size: 11px; color: var(--mut2); }
 
-/* Models: token audit lens (fixed columns, scrolls inside its panel). */
+/* Models: token evidence lens (fixed columns, scrolls inside its panel). */
 .audit-table { min-width: 720px; }
 .audit-table .mdot { width: 10px; height: 10px; border-radius: 3px; }
-.models-table { min-width: 1444px; table-layout: fixed; }
-.models-table td:first-child { overflow: hidden; text-overflow: ellipsis; }
-.models-table td:first-child > span { min-width: 0; overflow: hidden; }
-.models-table td:first-child .alias { flex: 0 0 auto; }
+.models-primary-table { width: 100%; min-width: 500px; table-layout: fixed; }
+.models-primary-table td:first-child { overflow: hidden; text-overflow: ellipsis; }
+.models-primary-table td:first-child > span { min-width: 0; overflow: hidden; }
+.models-primary-model, .models-evidence-model { display: inline-flex; align-items: center; gap: 8px; min-width: 0; }
+.models-primary-model > span:first-child, .models-evidence-model > span:first-child { min-width: 0; overflow: hidden; }
+.models-primary-model > span:first-child > span:last-child, .models-evidence-model > span:first-child > span:last-child { min-width: 0; overflow: hidden; text-overflow: ellipsis; }
+.models-cost-content { display: inline-flex; align-items: baseline; gap: 6px; white-space: nowrap; }
+.models-cost-quality { color: var(--warn); font-size: var(--fs-label); font-weight: var(--fw-medium); }
+.models-cost-quality-unpriced { color: var(--bad); }
+.models-cost-quality-partial { color: var(--warn); }
+.models-cost-quality-unresolved { color: var(--mut); }
+.models-cost-quality-cell { color: var(--ink); }
+.models-unavailable { color: var(--mut2); }
+.models-details { margin-top: 10px; border-top: 1px solid var(--line2); }
+.models-details > summary { padding: 10px 12px 8px; color: var(--mut); font-size: var(--fs-meta); font-weight: var(--fw-medium); cursor: pointer; }
+.models-details > summary:hover { color: var(--ink); }
+.models-details > summary:focus-visible { outline: 1px solid var(--accent); outline-offset: -1px; border-radius: 4px; }
+.models-details-body { padding: 0 12px 12px; }
+.models-details-notes { color: var(--mut); font-size: var(--fs-meta); line-height: 1.5; }
+.models-details-notes p { margin: 0 0 8px; }
+.models-details-coverage { display: grid; grid-template-columns: auto minmax(0, 1fr); gap: 5px 12px; margin: 8px 0 12px; }
+.models-details-coverage div { display: contents; }
+.models-details-coverage dt { color: var(--mut2); }
+.models-details-coverage dd { margin: 0; color: var(--ink); font-family: var(--mono); font-size: var(--fs-label); font-variant-numeric: tabular-nums; text-align: right; }
+.models-sort-controls { display: flex; align-items: center; justify-content: flex-end; gap: 10px; margin: 6px 0 8px; color: var(--mut); font-size: var(--fs-label); }
+.models-evidence-scroll { overflow-x: auto; }
+.models-evidence-table { min-width: 1640px; table-layout: fixed; }
+.models-evidence-table td:first-child { overflow: hidden; text-overflow: ellipsis; }
+.models-evidence-table td:first-child > span { min-width: 0; overflow: hidden; }
+.models-evidence-table td:first-child .alias { flex: 0 0 auto; }
 .model-delivery-row td { padding: 0 10px 10px; background: var(--phead); }
 .model-delivery-breakdown { min-width: 1820px; overflow-x: auto; padding: 8px 0; }
 .model-delivery-table { min-width: 1820px; table-layout: fixed; }


### PR DESCRIPTION
## Summary

Implements #203 with a bounded renderer-only Models disclosure:

- By model defaults to `Model / Calls / Cost / Saved`.
- Native `Details` contains token, cache, timing, pricing, delivery, provider-route, sort, and accounting evidence.
- Saved preserves positive, explicit-zero, and unavailable values.
- Estimated, partial, and unpriced cost states remain visible in primary rows without changing cost calculations or pricing authority.
- User-facing Audit terminology is now Evidence; internal `getAudit`/`AuditLens` contracts remain unchanged.
- By task and lazy Evidence loading remain unchanged.

## Validation

- `npm test -- --run renderer/sections/Models.test.tsx renderer/sections/ModelsDurableTable.test.tsx`
- `npm run typecheck`

No backend, accounting, IPC, provider schema, persistence, Capacity, Advisor, Bench, navigation, or CI changes. No changes to #238 or #239.