### PR TITLE
feat(desktop): disclose truthful Advisor runtime state

### DIFF
--- a/app/renderer/sections/Advisor.test.tsx
+++ b/app/renderer/sections/Advisor.test.tsx
@@ -85,7 +85,12 @@ describe('Advisor workspace', () => {
     expect(screen.getByRole('button', { name: /What quota remains/ })).toBeInTheDocument()
     expect(screen.getByRole('complementary', { name: 'Advisor conversations' })).toHaveTextContent('Session-local history')
     expect(screen.getByRole('complementary', { name: 'Advisor evidence' })).toHaveTextContent('Ask a question to pin its evidence')
+    expect(screen.getByRole('button', { name: 'Configure runtime' })).toBeInTheDocument()
+    expect(screen.queryByLabelText('Advisor runtime')).not.toBeInTheDocument()
+    expect(screen.queryByLabelText('Advisor hosted provider')).not.toBeInTheDocument()
     await waitFor(() => expect(screen.getByText('Offline evidence fallback')).toBeInTheDocument())
+    expect(screen.getByText('Ollama')).toBeInTheDocument()
+    expect(screen.getByText('Runtime unavailable')).toBeInTheDocument()
     expect(advisorProbe).toHaveBeenCalledTimes(1)
   })
   it('loads a contextual scope and suggested investigation without auto-executing it', async () => {
@@ -190,6 +195,7 @@ describe('Advisor workspace', () => {
   it('switches between supported local runtimes and discovers its models factually', async () => {
     render(<Advisor period="week" provider="all" projectScopeId="all" range={null} overview={overview} detectedProviders={[]} />)
     await waitFor(() => expect(screen.getByText('Offline evidence fallback')).toBeInTheDocument())
+    fireEvent.click(screen.getByRole('button', { name: 'Configure runtime' }))
     fireEvent.change(screen.getByLabelText('Advisor runtime'), { target: { value: 'lmstudio' } })
     await waitFor(() => expect(screen.getByLabelText('Advisor local runtime model')).toHaveValue('qwen/qwen3-8b'))
     expect(screen.getByText(/LM Studio · qwen\/qwen3-8b/)).toBeInTheDocument()
@@ -285,6 +291,7 @@ describe('Advisor workspace', () => {
   })
   it('keeps hosted model and consent coherent across refresh and selection changes', async () => {
     render(<Advisor period="week" provider="all" projectScopeId="all" range={null} overview={overview} detectedProviders={[]} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Configure runtime' }))
     fireEvent.click(screen.getByRole('button', { name: 'Use hosted provider' }))
 
     const model = await screen.findByLabelText('Advisor hosted model') as HTMLSelectElement
@@ -310,5 +317,74 @@ describe('Advisor workspace', () => {
       expect((screen.getByLabelText('Advisor hosted model') as HTMLSelectElement).value).toBe('claude-a')
     })
     expect((screen.getByRole('checkbox') as HTMLInputElement).checked).toBe(false)
+  })
+
+  it('presents an unexpected hosted probe failure as unknown instead of Ready or Not configured', async () => {
+    advisorHostedProbe.mockRejectedValue(new Error('bridge unavailable'))
+    render(<Advisor period="week" provider="all" projectScopeId="all" range={null} overview={overview} detectedProviders={[]} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Configure runtime' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Use hosted provider' }))
+
+    await waitFor(() => expect(screen.getByText('Runtime status unavailable')).toBeInTheDocument())
+    expect(screen.getByText('OpenAI', { selector: 'strong' })).toBeInTheDocument()
+    expect(screen.getByText('Credential: Unknown')).toBeInTheDocument()
+    expect(screen.getByText('Reachability: Unknown')).toBeInTheDocument()
+    expect(screen.queryByText('Credential: Ready')).not.toBeInTheDocument()
+    expect(screen.queryByText('Credential: Not configured')).not.toBeInTheDocument()
+    expect(screen.queryByLabelText('Advisor hosted model')).not.toBeInTheDocument()
+    expect(screen.queryByRole('checkbox')).not.toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Close runtime' }))
+    expect(screen.queryByLabelText('Advisor runtime configuration')).not.toBeInTheDocument()
+    expect(screen.getByText('OpenAI')).toBeInTheDocument()
+    expect(screen.getByText('Runtime status unavailable')).toBeInTheDocument()
+  })
+
+  it('preserves provider-owned credential state and keeps reachability and model state separate', async () => {
+    advisorHostedProbe.mockImplementation(async provider => ({
+      provider,
+      available: false,
+      models: [],
+      detail: 'The provider rejected the saved credential.',
+      credentialState: 'invalid',
+    }))
+    render(<Advisor period="week" provider="all" projectScopeId="all" range={null} overview={overview} detectedProviders={[]} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Configure runtime' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Use hosted provider' }))
+    fireEvent.change(screen.getByLabelText('Advisor hosted provider'), { target: { value: 'anthropic' } })
+
+    await waitFor(() => expect(screen.getByText('Credential: Invalid')).toBeInTheDocument())
+    expect(screen.getByText('Reachability: Reachable')).toBeInTheDocument()
+    expect(screen.getByText('Model: Unavailable')).toBeInTheDocument()
+    expect(screen.getByText('Credential invalid')).toBeInTheDocument()
+  })
+
+  it('shows credential, reachability, and model compatibility as separate hosted states', async () => {
+    advisorHostedProbe.mockImplementation(async provider => ({
+      provider,
+      available: true,
+      models: [{ id: provider + '-model', label: provider + '-model', state: 'unverified', limitation: 'Not verified in this session.' }],
+      detail: provider + ' is reachable.',
+      credentialState: 'ready',
+    }))
+    render(<Advisor period="week" provider="all" projectScopeId="all" range={null} overview={overview} detectedProviders={[]} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Configure runtime' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Use hosted provider' }))
+
+    await waitFor(() => expect(screen.getByLabelText('Advisor hosted model')).toHaveValue('openai-model'))
+    expect(screen.getByText('Credential: Ready')).toBeInTheDocument()
+    expect(screen.getByText('Reachability: Reachable')).toBeInTheDocument()
+    expect(screen.getByText('Model: Unverified')).toBeInTheDocument()
+    expect(screen.getByText('Model unverified')).toBeInTheDocument()
+  })
+
+  it('keeps all hosted BYOK providers available through the disclosed configuration', async () => {
+    render(<Advisor period="week" provider="all" projectScopeId="all" range={null} overview={overview} detectedProviders={[]} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Configure runtime' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Use hosted provider' }))
+    await screen.findByLabelText('Advisor hosted model')
+
+    fireEvent.change(screen.getByLabelText('Advisor hosted provider'), { target: { value: 'gemini' } })
+    await waitFor(() => expect(screen.getByLabelText('Advisor hosted model')).toHaveValue('gemini-a'))
+    expect(screen.getByText('Credential: Ready')).toBeInTheDocument()
   })
 })

--- a/app/renderer/sections/Advisor.test.tsx
+++ b/app/renderer/sections/Advisor.test.tsx
@@ -464,6 +464,41 @@ describe('Advisor workspace', () => {
     expect(screen.queryByText(answer.conclusion)).not.toBeInTheDocument()
   })
 
+  it('does not append a hosted answer after refreshing runtime state during an active request', async () => {
+    let resolveInvestigation: ((value: AdvisorAnswer) => void) | undefined
+    investigate.mockImplementation(() => new Promise(resolve => { resolveInvestigation = resolve }))
+    render(<Advisor period="week" provider="all" projectScopeId="all" range={null} overview={overview} detectedProviders={[]} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Configure runtime' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Use hosted provider' }))
+    await screen.findByLabelText('Advisor hosted model')
+    fireEvent.click(screen.getByRole('checkbox'))
+    await waitFor(() => expect((screen.getByRole('checkbox') as HTMLInputElement).checked).toBe(true))
+    await submitQuestion('Do not retain this stale answer after refresh')
+    const probeCalls = advisorHostedProbe.mock.calls.length
+    fireEvent.click(screen.getByRole('button', { name: 'Refresh hosted models' }))
+    await waitFor(() => expect(advisorHostedProbe.mock.calls.length).toBe(probeCalls + 1))
+    resolveInvestigation?.(answer)
+    await new Promise(resolve => setTimeout(resolve, 0))
+    expect(screen.queryByText(answer.conclusion)).not.toBeInTheDocument()
+  })
+
+  it('does not append a hosted answer after removing the credential during an active request', async () => {
+    let resolveInvestigation: ((value: AdvisorAnswer) => void) | undefined
+    investigate.mockImplementation(() => new Promise(resolve => { resolveInvestigation = resolve }))
+    render(<Advisor period="week" provider="all" projectScopeId="all" range={null} overview={overview} detectedProviders={[]} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Configure runtime' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Use hosted provider' }))
+    await screen.findByLabelText('Advisor hosted model')
+    fireEvent.click(screen.getByRole('checkbox'))
+    await waitFor(() => expect((screen.getByRole('checkbox') as HTMLInputElement).checked).toBe(true))
+    await submitQuestion('Do not retain this stale answer after credential removal')
+    fireEvent.click(screen.getByRole('button', { name: 'Remove key' }))
+    await waitFor(() => expect(advisorCredentialClear).toHaveBeenCalledTimes(1))
+    resolveInvestigation?.(answer)
+    await new Promise(resolve => setTimeout(resolve, 0))
+    expect(screen.queryByText(answer.conclusion)).not.toBeInTheDocument()
+  })
+
   it('keeps all hosted BYOK providers available through the disclosed configuration', async () => {
     render(<Advisor period="week" provider="all" projectScopeId="all" range={null} overview={overview} detectedProviders={[]} />)
     fireEvent.click(screen.getByRole('button', { name: 'Configure runtime' }))

--- a/app/renderer/sections/Advisor.test.tsx
+++ b/app/renderer/sections/Advisor.test.tsx
@@ -8,12 +8,14 @@ import { createAdvisorContextualLaunch } from '../advisor/context'
 import type { AdvisorAnswer, AdvisorHostedModelState } from '../advisor/types'
 import { Advisor } from './Advisor'
 
-const { advisorProbe, advisorHostedProbe, investigate } = vi.hoisted(() => ({
+const { advisorProbe, advisorHostedProbe, advisorCredentialSet, advisorCredentialClear, investigate } = vi.hoisted(() => ({
   advisorProbe: vi.fn(async (runtime: 'ollama' | 'lmstudio' = 'ollama') => runtime === 'lmstudio'
     ? { runtime: 'lmstudio' as const, available: true, models: ['qwen/qwen3-8b'], detail: 'Local LM Studio is reachable.', discoveryState: 'models-discovered' as const, capabilities: [{ schemaVersion: 1 as const, runtime: 'lmstudio' as const, modelId: 'qwen/qwen3-8b', discovery: 'discovered' as const, conversational: 'available' as const, toolCall: 'unknown' as const, streaming: 'supported' as const, limitation: 'Tool support varies by model.' }] }
     : { available: false, models: [], detail: 'Ollama is not running.' }),
   investigate: vi.fn(),
   advisorHostedProbe: vi.fn(),
+  advisorCredentialSet: vi.fn(async (provider: 'openai' | 'anthropic' | 'gemini') => ({ provider, state: 'ready' as const })),
+  advisorCredentialClear: vi.fn(async (provider: 'openai' | 'anthropic' | 'gemini') => ({ provider, state: 'not-configured' as const })),
 }))
 vi.mock('../advisor/kernel', () => ({ createAdvisorKernel: () => ({ investigate }) }))
 vi.mock('../lib/ipc', async importOriginal => {
@@ -24,6 +26,8 @@ vi.mock('../lib/ipc', async importOriginal => {
       ...actual.metrora,
       advisorProbe,
       advisorHostedProbe,
+      advisorCredentialSet,
+      advisorCredentialClear,
       advisorChat: vi.fn(),
       advisorCancel: vi.fn(async () => false),
       onAdvisorDelta: vi.fn(() => () => {}),
@@ -63,6 +67,8 @@ async function submitQuestion(question: string): Promise<void> {
 describe('Advisor workspace', () => {
   beforeEach(() => {
     advisorProbe.mockClear()
+    advisorCredentialSet.mockClear()
+    advisorCredentialClear.mockClear()
     advisorHostedProbe.mockReset().mockImplementation(async (provider: 'openai' | 'anthropic' | 'gemini') => ({
       provider,
       available: true,
@@ -417,6 +423,28 @@ describe('Advisor workspace', () => {
     await waitFor(() => expect(screen.getByText(expectedAvailability, { selector: '.advisor-runtime-availability' })).toBeInTheDocument())
     expect(screen.getByLabelText('Advisor runtime status')).toHaveClass(expectedStatus)
     expect(screen.getByText('Model: ' + expectedModelState)).toBeInTheDocument()
+    if (state === 'failed-conformance') expect(screen.queryByLabelText('Advisor hosted model')).not.toBeInTheDocument()
+  })
+
+  it('ignores a stale credential operation after switching hosted providers', async () => {
+    let resolveCredential: ((value: { provider: 'openai' | 'anthropic' | 'gemini'; state: 'ready' }) => void) | undefined
+    advisorHostedProbe.mockImplementation(async provider => provider === 'openai'
+      ? { provider, available: false, models: [], detail: 'OpenAI credential is not configured.', credentialState: 'not-configured' as const }
+      : { provider, available: true, models: [{ id: 'claude-a', label: 'claude-a', state: 'verified' as const, limitation: null }], detail: 'Anthropic provider is reachable.', credentialState: 'ready' as const })
+    advisorCredentialSet.mockImplementation(() => new Promise(resolve => { resolveCredential = resolve }))
+    render(<Advisor period="week" provider="all" projectScopeId="all" range={null} overview={overview} detectedProviders={[]} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Configure runtime' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Use hosted provider' }))
+    const entry = await screen.findByLabelText('Advisor provider key')
+    fireEvent.change(entry, { target: { value: 'test-key-value' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Save key' }))
+    fireEvent.change(screen.getByLabelText('Advisor hosted provider'), { target: { value: 'anthropic' } })
+    await waitFor(() => expect(screen.getByLabelText('Advisor hosted provider')).toHaveValue('anthropic'))
+    await waitFor(() => expect(screen.getByLabelText('Advisor hosted model')).toHaveValue('claude-a'))
+    resolveCredential?.({ provider: 'openai', state: 'ready' })
+    await waitFor(() => expect(screen.getByLabelText('Advisor hosted provider')).toHaveValue('anthropic'))
+    expect(screen.getByLabelText('Advisor hosted model')).toHaveValue('claude-a')
+    expect(screen.queryByText('OpenAI · gpt-a')).not.toBeInTheDocument()
   })
 
   it('keeps all hosted BYOK providers available through the disclosed configuration', async () => {

--- a/app/renderer/sections/Advisor.test.tsx
+++ b/app/renderer/sections/Advisor.test.tsx
@@ -447,6 +447,23 @@ describe('Advisor workspace', () => {
     expect(screen.queryByText('OpenAI · gpt-a')).not.toBeInTheDocument()
   })
 
+  it('does not append a hosted answer after switching providers during an active request', async () => {
+    let resolveInvestigation: ((value: AdvisorAnswer) => void) | undefined
+    investigate.mockImplementation(() => new Promise(resolve => { resolveInvestigation = resolve }))
+    render(<Advisor period="week" provider="all" projectScopeId="all" range={null} overview={overview} detectedProviders={[]} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Configure runtime' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Use hosted provider' }))
+    await screen.findByLabelText('Advisor hosted model')
+    fireEvent.click(screen.getByRole('checkbox'))
+    await waitFor(() => expect((screen.getByRole('checkbox') as HTMLInputElement).checked).toBe(true))
+    await submitQuestion('Do not retain this stale answer')
+    fireEvent.change(screen.getByLabelText('Advisor hosted provider'), { target: { value: 'anthropic' } })
+    await waitFor(() => expect(screen.getByLabelText('Advisor hosted provider')).toHaveValue('anthropic'))
+    resolveInvestigation?.(answer)
+    await new Promise(resolve => setTimeout(resolve, 0))
+    expect(screen.queryByText(answer.conclusion)).not.toBeInTheDocument()
+  })
+
   it('keeps all hosted BYOK providers available through the disclosed configuration', async () => {
     render(<Advisor period="week" provider="all" projectScopeId="all" range={null} overview={overview} detectedProviders={[]} />)
     fireEvent.click(screen.getByRole('button', { name: 'Configure runtime' }))

--- a/app/renderer/sections/Advisor.test.tsx
+++ b/app/renderer/sections/Advisor.test.tsx
@@ -5,7 +5,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { Polled } from '../hooks/usePolled'
 import type { MenubarPayload } from '../lib/types'
 import { createAdvisorContextualLaunch } from '../advisor/context'
-import type { AdvisorAnswer } from '../advisor/types'
+import type { AdvisorAnswer, AdvisorHostedModelState } from '../advisor/types'
 import { Advisor } from './Advisor'
 
 const { advisorProbe, advisorHostedProbe, investigate } = vi.hoisted(() => ({
@@ -358,6 +358,23 @@ describe('Advisor workspace', () => {
     expect(screen.getByText('Credential invalid')).toBeInTheDocument()
   })
 
+  it('does not infer unreachable from a ready credential without provider reachability evidence', async () => {
+    advisorHostedProbe.mockImplementation(async provider => ({
+      provider,
+      available: false,
+      models: [],
+      detail: 'The provider did not return usable models.',
+      credentialState: 'ready',
+    }))
+    render(<Advisor period="week" provider="all" projectScopeId="all" range={null} overview={overview} detectedProviders={[]} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Configure runtime' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Use hosted provider' }))
+
+    await waitFor(() => expect(screen.getByText('Reachability: Unavailable')).toBeInTheDocument())
+    expect(screen.queryByText('Reachability: Unreachable')).not.toBeInTheDocument()
+    expect(screen.getByText('Provider unavailable')).toBeInTheDocument()
+  })
+
   it('shows credential, reachability, and model compatibility as separate hosted states', async () => {
     advisorHostedProbe.mockImplementation(async provider => ({
       provider,
@@ -374,7 +391,32 @@ describe('Advisor workspace', () => {
     expect(screen.getByText('Credential: Ready')).toBeInTheDocument()
     expect(screen.getByText('Reachability: Reachable')).toBeInTheDocument()
     expect(screen.getByText('Model: Unverified')).toBeInTheDocument()
-    expect(screen.getByText('Model unverified')).toBeInTheDocument()
+    expect(screen.getByText('Compatibility unverified')).toBeInTheDocument()
+    expect(screen.getByLabelText('Advisor runtime status')).toHaveClass('unknown')
+  })
+
+  it.each([
+    ['discovered', 'Compatibility unverified', 'unknown', 'Discovered'],
+    ['unverified', 'Compatibility unverified', 'unknown', 'Unverified'],
+    ['limited', 'Model limited', 'unknown', 'Limited'],
+    ['verified', 'Ready', 'ready', 'Verified'],
+    ['unsupported', 'Model unsupported', 'unavailable', 'Unsupported'],
+    ['failed-conformance', 'Model failed conformance', 'unavailable', 'Failed Conformance'],
+  ] as Array<[AdvisorHostedModelState, string, 'ready' | 'unknown' | 'unavailable', string]>)('keeps hosted %s model compatibility distinct from generic Ready', async (state, expectedAvailability, expectedStatus, expectedModelState) => {
+    advisorHostedProbe.mockImplementation(async provider => ({
+      provider,
+      available: true,
+      models: [{ id: provider + '-model', label: provider + '-model', state, limitation: null }],
+      detail: provider + ' is reachable.',
+      credentialState: 'ready',
+    }))
+    render(<Advisor period="week" provider="all" projectScopeId="all" range={null} overview={overview} detectedProviders={[]} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Configure runtime' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Use hosted provider' }))
+
+    await waitFor(() => expect(screen.getByText(expectedAvailability, { selector: '.advisor-runtime-availability' })).toBeInTheDocument())
+    expect(screen.getByLabelText('Advisor runtime status')).toHaveClass(expectedStatus)
+    expect(screen.getByText('Model: ' + expectedModelState)).toBeInTheDocument()
   })
 
   it('keeps all hosted BYOK providers available through the disclosed configuration', async () => {

--- a/app/renderer/sections/Advisor.tsx
+++ b/app/renderer/sections/Advisor.tsx
@@ -158,9 +158,10 @@ export function Advisor({
   const hostedModelRef = useRef<string | null>(null)
   hostedModelRef.current = hostedModel
   const [hostedConsent, setHostedConsent] = useState(false)
-  const hostedRuntime = useMemo(() => hostedModel ? new HostedAdvisorRuntime({ provider: hostedProvider, model: hostedModel, consent: hostedConsent }) : null, [hostedConsent, hostedModel, hostedProvider])
-  const [runtimeState, setRuntimeState] = useState<AdvisorRuntimeState>({ runtime: 'ollama', status: 'checking', detail: 'Checking for a local Ollama model…', models: [], modelState: 'unavailable', toolCall: 'unknown' })
   const [hostedProbe, setHostedProbe] = useState<AdvisorHostedProbePresentation>(() => createHostedProbeChecking('openai'))
+  const hostedModelForRuntime = hostedModel && hostedProbe.models.some(model => model.id === hostedModel && isSelectableHostedModel(model)) ? hostedModel : null
+  const hostedRuntime = useMemo(() => hostedModelForRuntime ? new HostedAdvisorRuntime({ provider: hostedProvider, model: hostedModelForRuntime, consent: hostedConsent }) : null, [hostedConsent, hostedModelForRuntime, hostedProvider])
+  const [runtimeState, setRuntimeState] = useState<AdvisorRuntimeState>({ runtime: 'ollama', status: 'checking', detail: 'Checking for a local Ollama model…', models: [], modelState: 'unavailable', toolCall: 'unknown' })
   const [configureOpen, setConfigureOpen] = useState(false)
   const [runtimeModel, setRuntimeModel] = useState<string | null>(null)
   const [ollamaRuntime, setOllamaRuntime] = useState<OllamaAdvisorRuntime | null>(null)
@@ -260,6 +261,16 @@ export function Advisor({
   const [notice, setNotice] = useState<string | null>(null)
   const [selectedAnswerId, setSelectedAnswerId] = useState<string | null>(null)
   const requestController = useRef<AbortController | null>(null)
+  const requestGenerationRef = useRef(0)
+  const invalidateAdvisorRequest = useCallback(() => {
+    requestGenerationRef.current += 1
+    requestController.current?.abort()
+    requestController.current = null
+    setLoadingQuestion(null)
+    setStreamPreview('')
+    setToolStatus(null)
+  }, [])
+  useEffect(() => () => invalidateAdvisorRequest(), [invalidateAdvisorRequest])
 
   useEffect(() => {
     if (!normalizedContextualLaunch || !contextualScope) return
@@ -289,9 +300,11 @@ export function Advisor({
       setNotice(currentHosted.hostedRuntime ? 'Confirm the hosted-provider evidence sharing notice before investigating.' : 'Connect a hosted provider credential before investigating.')
       return
     }
-    requestController.current?.abort()
+    invalidateAdvisorRequest()
     const controller = new AbortController()
     requestController.current = controller
+    const requestId = requestGenerationRef.current
+    const isCurrentRequest = () => !controller.signal.aborted && requestGenerationRef.current === requestId
     const requestedScopeFingerprint = advisorScopeFingerprint(requestedScope)
     const history: AdvisorConversationTurn[] = retryRequest?.conversation ?? targetConversation.messages
       .map(message => ({ role: message.role, content: message.role === 'user' ? message.text ?? '' : message.answer?.conclusion ?? '', scopeFingerprint: message.scopeFingerprint }))
@@ -326,14 +339,15 @@ export function Advisor({
           && !overview.switching ? overview.data : null,
         conversation: history,
         signal: controller.signal,
-        onToolEvent: event => setToolStatus(event.status === 'started' ? 'Investigating ' + event.name.replaceAll('_', ' ') + '…' : null),
-        onDelta: text => setStreamPreview(text),
+        onToolEvent: event => { if (isCurrentRequest()) setToolStatus(event.status === 'started' ? 'Investigating ' + event.name.replaceAll('_', ' ') + '…' : null) },
+        onDelta: text => { if (isCurrentRequest()) setStreamPreview(text) },
       })
-      if (controller.signal.aborted) return
+      if (!isCurrentRequest()) return
       const assistantMessage: AdvisorMessage = { id: makeId('assistant'), role: 'assistant', answer, scopeFingerprint: requestedScopeFingerprint }
       updateConversation(conversationId, conversation => ({ ...conversation, messages: [...conversation.messages, assistantMessage] }))
       setSelectedAnswerId(assistantMessage.id)
     } catch (caught) {
+      if (!isCurrentRequest()) return
       if (isCancelled(caught)) setNotice('Investigation cancelled. Your conversation stays local to this session.')
       else {
         setFailedRequest({
@@ -345,12 +359,13 @@ export function Advisor({
         setError(caught instanceof Error ? caught.message : 'Advisor could not complete this investigation.')
       }
     } finally {
+      if (requestGenerationRef.current !== requestId) return
       if (requestController.current === controller) requestController.current = null
       setLoadingQuestion(null)
       setStreamPreview('')
       setToolStatus(null)
     }
-  }, [activeConversationId, contextualScopeMode, conversations, kernel, loadingQuestion, overview.data, overview.loading, overview.switching, period, projectScopeId, provider, range?.from, range?.to, scope, updateConversation])
+  }, [activeConversationId, contextualScopeMode, conversations, invalidateAdvisorRequest, kernel, loadingQuestion, overview.data, overview.loading, overview.switching, period, projectScopeId, provider, range?.from, range?.to, scope, updateConversation])
 
   const submit = (event: FormEvent) => {
     event.preventDefault()
@@ -363,7 +378,7 @@ export function Advisor({
     }
   }
   const cancel = () => {
-    requestController.current?.abort()
+    invalidateAdvisorRequest()
     setNotice('Cancelling investigation…')
   }
   const newConversation = () => {
@@ -375,18 +390,22 @@ export function Advisor({
     setNotice(null)
   }
   const activateHosted = () => {
+    invalidateAdvisorRequest()
     setRuntimeChoice('hosted')
     setHostedConsent(false)
     void checkHostedRuntime()
   }
   const activateLocal = () => {
+    invalidateAdvisorRequest()
     setRuntimeChoice(runtimeId)
     setHostedConsent(false)
   }
   const updateHostedConsent = (consent: boolean) => {
+    invalidateAdvisorRequest()
     setHostedConsent(consent)
   }
   const updateHostedProvider = (next: AdvisorHostedProviderId) => {
+    invalidateAdvisorRequest()
     hostedOperationGuardRef.current.setProvider(next)
     hostedProbeController.current?.abort()
     setHostedProvider(next)
@@ -396,16 +415,19 @@ export function Advisor({
     void checkHostedRuntime(next, true)
   }
   const updateHostedModel = (model: string) => {
+    invalidateAdvisorRequest()
     setHostedModel(model)
     setHostedConsent(false)
   }
   const updateLocalRuntime = (next: AdvisorLocalRuntimeId) => {
+    invalidateAdvisorRequest()
     setRuntimeId(next)
     setRuntimeModel(null)
     setHostedConsent(false)
     void checkLocalRuntime(next)
   }
   const updateLocalModel = (model: string) => {
+    invalidateAdvisorRequest()
     setRuntimeModel(model)
     if (runtimeId === 'lmstudio') setLMStudioRuntime(new LMStudioAdvisorRuntime({ model, availability: 'ready' }))
     else setOllamaRuntime(new OllamaAdvisorRuntime({ model, availability: 'ready' }))

--- a/app/renderer/sections/Advisor.tsx
+++ b/app/renderer/sections/Advisor.tsx
@@ -9,29 +9,15 @@ import { createAdvisorKernel } from '../advisor/kernel'
 import { createAdvisorRuntime } from '../advisor/runtime'
 import { LMStudioAdvisorRuntime, probeLMStudio } from '../advisor/lmstudio'
 import { OllamaAdvisorRuntime, probeOllama } from '../advisor/ollama'
-import { HostedAdvisorRuntime, probeHostedAdvisor, type HostedAdvisorProbeResult } from '../advisor/hosted'
+import { HostedAdvisorRuntime, probeHostedAdvisor } from '../advisor/hosted'
 import { periodLabel, scopeLabel } from '../advisor/evidence'
 import { advisorContextualSurfaceLabel, advisorScopeFromContextualLaunch, normalizeAdvisorContextualLaunch, type AdvisorContextualLaunchV1, type AdvisorContextualScopeMode } from '../advisor/context'
-import { advisorScopeFingerprint, type AdvisorAnswer, type AdvisorConversationTurn, type AdvisorCredentialState, type AdvisorHostedModel, type AdvisorHostedModelState, type AdvisorLocalRuntimeId, type AdvisorPresentationBlockV1, type AdvisorPresentationChartSeries, type AdvisorScope, type AdvisorToolCapability } from '../advisor/types'
-
+import { advisorScopeFingerprint, type AdvisorAnswer, type AdvisorConversationTurn, type AdvisorHostedProviderId, type AdvisorLocalRuntimeId, type AdvisorPresentationBlockV1, type AdvisorPresentationChartSeries, type AdvisorScope } from '../advisor/types'
+import { AdvisorRuntimeControls, createHostedProbeChecking, createHostedProbeFailure, presentHostedProbe, type AdvisorHostedProbePresentation, type AdvisorRuntimeChoice, type AdvisorRuntimeState } from './AdvisorRuntimeControls'
 type DetectedProvider = { id: string; label: string }
 type AdvisorMessage = { id: string; role: 'user' | 'assistant'; text?: string; answer?: AdvisorAnswer; scopeFingerprint: string }
 type AdvisorConversation = { id: string; title: string; messages: AdvisorMessage[] }
 type AdvisorFailedRequest = { question: string; scope: AdvisorScope; conversationId: string; conversation: AdvisorConversationTurn[] }
-type RuntimeState = { runtime: AdvisorLocalRuntimeId; status: 'checking' | 'ready' | 'unavailable'; detail: string; models: string[]; modelState: RuntimeModelState; toolCall: AdvisorToolCapability }
-type RuntimeModelState = AdvisorHostedModelState | 'unavailable'
-type ProviderReachability = 'checking' | 'reachable' | 'unreachable' | 'unknown'
-type HostedCredentialState = AdvisorCredentialState | 'unknown'
-type HostedProbePresentation = {
-  provider: HostedAdvisorProbeResult['provider']
-  available: boolean
-  models: AdvisorHostedModel[]
-  detail: string
-  credentialState: HostedCredentialState
-  reachability: ProviderReachability
-}
-type RuntimeStatusKind = 'checking' | 'ready' | 'unavailable' | 'unknown'
-
 const PERIODS: Array<{ value: Period; label: string }> = PERIOD_OPTIONS.map(option => ({ value: option.value as Period, label: option.label }))
 const PROMPTS = [
   { eyebrow: 'Spend changes', label: 'What changed in my spend recently?', question: 'What changed in my spend recently?' },
@@ -39,7 +25,6 @@ const PROMPTS = [
   { eyebrow: 'Capacity', label: 'What quota remains and when does it reset?', question: 'What provider quota remains and when does it reset?' },
   { eyebrow: 'Projects', label: 'Which Project drove the most spend?', question: 'Which Project drove the most spend in this scope?' },
 ]
-
 function makeId(prefix: string): string {
   return prefix + '-' + Date.now().toString(36) + '-' + Math.random().toString(36).slice(2, 7)
 }
@@ -54,71 +39,6 @@ function isCancelled(error: unknown): boolean {
 function providerLabel(provider: string): string {
   if (provider === 'all') return 'All providers'
   return provider.split(/[-\s]+/).filter(Boolean).map(part => part.charAt(0).toUpperCase() + part.slice(1)).join(' ')
-}
-function hostedProviderLabel(provider: HostedAdvisorProbeResult['provider']): string {
-  if (provider === 'openai') return 'OpenAI'
-  if (provider === 'anthropic') return 'Anthropic'
-  return 'Gemini'
-}
-function stateLabel(value: string): string {
-  return value.split('-').map(part => part.charAt(0).toUpperCase() + part.slice(1)).join(' ')
-}
-function modelStateLabel(value: RuntimeModelState): string {
-  return stateLabel(value)
-}
-function reachabilityLabel(value: ProviderReachability): string {
-  return stateLabel(value)
-}
-function credentialStateLabel(value: HostedCredentialState): string {
-  return stateLabel(value)
-}
-function hostedReachability(result: HostedAdvisorProbeResult): ProviderReachability {
-  // An invalid credential is reported after the official endpoint has
-  // answered, so the provider is reachable even though the credential is not
-  // usable. Other non-ready credential states stop before a provider request.
-  if (result.available || result.credentialState === 'invalid') return 'reachable'
-  return result.credentialState === 'ready' ? 'unreachable' : 'unknown'
-}
-function hostedProbePresentation(result: HostedAdvisorProbeResult): HostedProbePresentation {
-  return { ...result, reachability: hostedReachability(result) }
-}
-function hostedProbeFailure(provider: HostedAdvisorProbeResult['provider']): HostedProbePresentation {
-  return {
-    provider,
-    available: false,
-    models: [],
-    detail: 'Hosted runtime status is unavailable. The provider probe did not complete.',
-    credentialState: 'unknown',
-    reachability: 'unknown',
-  }
-}
-function hostedProbeChecking(provider: HostedAdvisorProbeResult['provider'], previous: HostedProbePresentation | null = null): HostedProbePresentation {
-  const preserveModels = previous?.provider === provider ? previous.models : []
-  return {
-    provider,
-    available: false,
-    models: preserveModels,
-    detail: 'Checking the hosted provider…',
-    credentialState: 'unknown',
-    reachability: 'checking',
-  }
-}
-function hostedRuntimeStatusKind(probe: HostedProbePresentation, model: AdvisorHostedModel | null): RuntimeStatusKind {
-  if (probe.reachability === 'checking') return 'checking'
-  if (probe.reachability === 'unknown') return probe.credentialState === 'unknown' ? 'unknown' : 'unavailable'
-  if (probe.credentialState !== 'ready' || probe.reachability === 'unreachable' || !model || model.state === 'unsupported' || model.state === 'failed-conformance') return 'unavailable'
-  return 'ready'
-}
-function hostedAvailabilityLabel(probe: HostedProbePresentation, model: AdvisorHostedModel | null): string {
-  if (probe.reachability === 'checking') return 'Checking provider'
-  if (probe.credentialState !== 'ready' && probe.credentialState !== 'unknown') return 'Credential ' + credentialStateLabel(probe.credentialState).toLowerCase()
-  if (probe.reachability === 'unknown') return probe.credentialState === 'unknown' ? 'Runtime status unavailable' : 'Credential ' + credentialStateLabel(probe.credentialState).toLowerCase()
-  if (probe.reachability === 'unreachable') return 'Provider unavailable'
-  if (!model) return 'No usable model discovered'
-  if (model.state === 'unsupported') return 'Model unsupported'
-  if (model.state === 'failed-conformance') return 'Model failed conformance'
-  if (model.state === 'unverified' || model.state === 'limited') return 'Model ' + model.state
-  return 'Ready'
 }
 function contextualScopeLabel(scope: AdvisorScope, mode: AdvisorContextualScopeMode | null): string {
   if (mode === 'capacity') return 'Provider-reported current capacity · All providers'
@@ -135,12 +55,10 @@ function answerForMessage(messages: AdvisorMessage[], id: string | null): Adviso
   }
   return [...messages].reverse().find(message => message.answer)?.answer ?? null
 }
-
 function chartValue(value: number | null, unit: string): string {
   if (value === null || !Number.isFinite(value)) return 'Unavailable'
   return (unit === 'USD' ? '$' + value.toFixed(2) : value.toLocaleString('en-US')) + ' ' + unit
 }
-
 function chartSeriesSegments(series: AdvisorPresentationChartSeries, width: number, height: number, max: number): Array<Array<[number, number]>> {
   const segments: Array<Array<[number, number]>> = []
   let current: Array<[number, number]> = []
@@ -291,15 +209,15 @@ export function Advisor({
   const source = useMemo(() => createAdvisorDataSource(metrora), [])
   const fallbackRuntime = useMemo(() => createAdvisorRuntime(), [])
   const [runtimeId, setRuntimeId] = useState<AdvisorLocalRuntimeId>('ollama')
-  const [runtimeChoice, setRuntimeChoice] = useState<RuntimeChoice>('ollama')
+  const [runtimeChoice, setRuntimeChoice] = useState<AdvisorRuntimeChoice>('ollama')
   const [hostedProvider, setHostedProvider] = useState<'openai' | 'anthropic' | 'gemini'>('openai')
   const [hostedModel, setHostedModel] = useState<string | null>(null)
   const hostedModelRef = useRef<string | null>(null)
   hostedModelRef.current = hostedModel
   const [hostedConsent, setHostedConsent] = useState(false)
   const hostedRuntime = useMemo(() => hostedModel ? new HostedAdvisorRuntime({ provider: hostedProvider, model: hostedModel, consent: hostedConsent }) : null, [hostedConsent, hostedModel, hostedProvider])
-  const [runtimeState, setRuntimeState] = useState<RuntimeState>({ runtime: 'ollama', status: 'checking', detail: 'Checking for a local Ollama model…', models: [], modelState: 'unavailable', toolCall: 'unknown' })
-  const [hostedProbe, setHostedProbe] = useState<HostedProbePresentation>(() => hostedProbeChecking('openai'))
+  const [runtimeState, setRuntimeState] = useState<AdvisorRuntimeState>({ runtime: 'ollama', status: 'checking', detail: 'Checking for a local Ollama model…', models: [], modelState: 'unavailable', toolCall: 'unknown' })
+  const [hostedProbe, setHostedProbe] = useState<AdvisorHostedProbePresentation>(() => createHostedProbeChecking('openai'))
   const [configureOpen, setConfigureOpen] = useState(false)
   const [runtimeModel, setRuntimeModel] = useState<string | null>(null)
   const [ollamaRuntime, setOllamaRuntime] = useState<OllamaAdvisorRuntime | null>(null)
@@ -327,7 +245,7 @@ export function Advisor({
           setOllamaRuntime(new OllamaAdvisorRuntime({ model: selected, availability: 'ready' }))
           setLMStudioRuntime(null)
         }
-        const capabilityProfiles = (result as { capabilities?: Array<{ modelId: string; toolCall: RuntimeState['toolCall'] }> }).capabilities ?? []
+        const capabilityProfiles = (result as { capabilities?: Array<{ modelId: string; toolCall: AdvisorRuntimeState['toolCall'] }> }).capabilities ?? []
         const capability = capabilityProfiles.find(profile => profile.modelId === selected)
         setRuntimeState({ runtime: requestedRuntime, status: 'ready', detail: result.detail, models: result.models, modelState: 'discovered', toolCall: capability?.toolCall ?? 'unknown' })
       } else {
@@ -350,11 +268,11 @@ export function Advisor({
     hostedProbeController.current?.abort()
     const controller = new AbortController()
     hostedProbeController.current = controller
-    setHostedProbe(current => hostedProbeChecking(requestedProvider, current))
+    setHostedProbe(current => createHostedProbeChecking(requestedProvider, current))
     try {
       const result = await probeHostedAdvisor(requestedProvider, controller.signal)
       if (controller.signal.aborted) return
-      setHostedProbe(hostedProbePresentation(result))
+      setHostedProbe(presentHostedProbe(result))
       const selectable = result.models.find(model => model.state !== 'unsupported')
       if (result.available && selectable) {
         const currentModel = resetSelection ? null : hostedModelRef.current
@@ -369,7 +287,7 @@ export function Advisor({
       if (!isCancelled(caught)) {
         setHostedModel(null)
         setHostedConsent(false)
-        setHostedProbe(hostedProbeFailure(requestedProvider))
+        setHostedProbe(createHostedProbeFailure(requestedProvider))
       }
     }
   }, [hostedProvider])
@@ -521,6 +439,27 @@ export function Advisor({
   const updateHostedConsent = (consent: boolean) => {
     setHostedConsent(consent)
   }
+  const updateHostedProvider = (next: AdvisorHostedProviderId) => {
+    setHostedProvider(next)
+    setHostedModel(null)
+    setHostedConsent(false)
+    void checkHostedRuntime(next, true)
+  }
+  const updateHostedModel = (model: string) => {
+    setHostedModel(model)
+    setHostedConsent(false)
+  }
+  const updateLocalRuntime = (next: AdvisorLocalRuntimeId) => {
+    setRuntimeId(next)
+    setRuntimeModel(null)
+    setHostedConsent(false)
+    void checkLocalRuntime(next)
+  }
+  const updateLocalModel = (model: string) => {
+    setRuntimeModel(model)
+    if (runtimeId === 'lmstudio') setLMStudioRuntime(new LMStudioAdvisorRuntime({ model, availability: 'ready' }))
+    else setOllamaRuntime(new OllamaAdvisorRuntime({ model, availability: 'ready' }))
+  }
   const saveHostedCredential = async () => {
     if (!credentialEntry.trim() || credentialSaving) return
     setCredentialSaving(true)
@@ -550,30 +489,6 @@ export function Advisor({
     conversation.title,
     ...conversation.messages.map(message => message.text ?? message.answer?.conclusion ?? ''),
   ].some(value => value.toLowerCase().includes(normalizedHistoryQuery)))
-  const selectedModelRuntime = runtimeId === 'lmstudio' ? lmStudioRuntime : ollamaRuntime
-  const selectableHostedModels = hostedProbe.models.filter(model => model.state !== 'unsupported')
-  const selectedHostedModel = hostedProbe.models.find(model => model.id === hostedModel) ?? null
-  const hostedModelState: RuntimeModelState = selectedHostedModel?.state ?? 'unavailable'
-  const hostedStatusKind = hostedRuntimeStatusKind(hostedProbe, selectedHostedModel)
-  const runtimeStatusKind: RuntimeStatusKind = runtimeChoice === 'hosted' ? hostedStatusKind : runtimeState.status
-  const runtimeIdentity = runtimeChoice === 'hosted'
-    ? hostedProviderLabel(hostedProvider) + (selectedHostedModel ? ' · ' + selectedHostedModel.label : '')
-    : (runtimeId === 'lmstudio' ? 'LM Studio' : 'Ollama') + (runtimeModel ? ' · ' + runtimeModel : '')
-  const runtimeAvailability = runtimeChoice === 'hosted'
-    ? hostedAvailabilityLabel(hostedProbe, selectedHostedModel)
-    : runtimeState.status === 'checking'
-      ? 'Checking runtime'
-      : runtimeState.status === 'ready'
-        ? 'Ready'
-        : 'Runtime unavailable'
-  const runtimeDescription = runtimeChoice === 'hosted'
-    ? 'Hosted provider account · minimum evidence sent directly · no Metrora proxy'
-    : runtimeState.status === 'ready' && selectedModelRuntime
-      ? (runtimeId === 'lmstudio' ? 'Local LM Studio model' : 'Local Ollama model') + ' · read-only evidence tools · tool support varies by model'
-      : 'Offline evidence fallback'
-  const runtimeDetail = runtimeChoice === 'hosted'
-    ? hostedProbe.detail
-    : runtimeState.detail
   const latestAnswer = selectedAnswer ?? answerForMessage(messages, null)
   const suppliedOverviewMatchesScope = scope.period === period
     && scope.provider === provider
@@ -605,50 +520,33 @@ export function Advisor({
       <main className="advisor-main">
         <header className="advisor-main-head">
           <div><p className="advisor-kicker">ADVISE · READ ONLY</p><h1>Ask Metrora</h1><p className="advisor-subtitle">Investigate measured usage, model efficiency, Projects, and provider capacity.</p></div>
-          <div className={'advisor-runtime-status ' + runtimeStatusKind} aria-label="Advisor runtime status">
-            <span className={'advisor-status-dot ' + runtimeStatusKind} aria-hidden="true" />
-            <div className="advisor-runtime-summary-copy">
-              <strong>{runtimeIdentity}</strong>
-              <span className={'advisor-runtime-availability ' + runtimeStatusKind}>{runtimeAvailability}</span>
-              <small className="advisor-runtime-description">{runtimeDescription}</small>
-              <small className="advisor-runtime-detail">{runtimeDetail}</small>
-            </div>
-            <button type="button" className="advisor-configure-toggle" aria-expanded={configureOpen} aria-controls={configureOpen ? 'advisor-runtime-config' : undefined} onClick={() => setConfigureOpen(current => !current)}>{configureOpen ? 'Close runtime' : 'Configure runtime'}</button>
-            {configureOpen ? <div className="advisor-runtime-config" id="advisor-runtime-config" aria-label="Advisor runtime configuration">
-              <div className="advisor-runtime-config-head"><strong>Runtime configuration</strong><span>Choose a local or hosted runtime. Technical state stays here while the conversation remains the focus.</span></div>
-              {runtimeChoice === 'hosted' ? <div className="advisor-runtime-config-controls">
-                <div className="advisor-runtime-config-actions">
-                  <button type="button" className="advisor-quiet-button" onClick={() => void checkHostedRuntime()}>{hostedProbe.available ? 'Refresh hosted models' : 'Check hosted provider'}</button>
-                  <button type="button" className="advisor-quiet-button" onClick={activateLocal}>Use local runtime</button>
-                </div>
-                <div className="advisor-runtime-picker-row">
-                  <label className="advisor-runtime-picker">Provider<select aria-label="Advisor hosted provider" value={hostedProvider} onChange={event => { const next = event.target.value as 'openai' | 'anthropic' | 'gemini'; setHostedProvider(next); setHostedModel(null); setHostedConsent(false); void checkHostedRuntime(next, true) }}><option value="openai">OpenAI</option><option value="anthropic">Anthropic</option><option value="gemini">Gemini</option></select></label>
-                  {selectableHostedModels.length ? <label className="advisor-runtime-picker">Hosted model<select aria-label="Advisor hosted model" value={hostedModel ?? selectableHostedModels[0]!.id} onChange={event => { const model = event.target.value; setHostedModel(model); setHostedConsent(false) }}>{selectableHostedModels.map(model => <option key={model.id} value={model.id}>{model.label} · {modelStateLabel(model.state)}</option>)}</select></label> : null}
-                </div>
-                <div className="advisor-runtime-state-grid" aria-label="Hosted runtime state">
-                  <span data-state="credential">Credential: {credentialStateLabel(hostedProbe.credentialState)}</span>
-                  <span data-state="reachability">Reachability: {reachabilityLabel(hostedProbe.reachability)}</span>
-                  <span data-state="model">Model: {modelStateLabel(hostedModelState)}</span>
-                </div>
-                {hostedProbe.credentialState !== 'ready' ? <div className="advisor-credential-entry"><input type="password" aria-label="Advisor provider key" autoComplete="off" placeholder="Provider key (not stored in this form)" value={credentialEntry} onChange={event => setCredentialEntry(event.target.value)} /><button type="button" className="advisor-quiet-button" onClick={() => void saveHostedCredential()} disabled={credentialSaving || !credentialEntry.trim()}>{credentialSaving ? 'Saving…' : 'Save key'}</button></div> : <button type="button" className="advisor-quiet-button" onClick={() => void clearHostedCredential()}>Remove key</button>}
-                {hostedRuntime ? <label className="advisor-hosted-consent"><input type="checkbox" checked={hostedConsent} onChange={event => updateHostedConsent(event.target.checked)} /><span>Before the first hosted investigation, send this question and minimum Metrora evidence directly to the selected provider using your account. Metrora does not proxy it; provider terms, privacy, and retention apply.</span></label> : <p className="advisor-consent-unavailable">Consent appears after a usable hosted model is available. It is always explicit and starts unchecked.</p>}
-              </div> : <div className="advisor-runtime-config-controls">
-                <div className="advisor-runtime-config-actions">
-                  <button type="button" className="advisor-quiet-button" onClick={() => void checkLocalRuntime()}>{runtimeState.status === 'checking' ? 'Checking…' : 'Check local model'}</button>
-                  <button type="button" className="advisor-quiet-button" onClick={activateHosted}>Use hosted provider</button>
-                </div>
-                <div className="advisor-runtime-picker-row">
-                  <label className="advisor-runtime-picker">Runtime<select aria-label="Advisor runtime" value={runtimeId} onChange={event => { const next = event.target.value as AdvisorLocalRuntimeId; setRuntimeId(next); setRuntimeModel(null); setHostedConsent(false); void checkLocalRuntime(next) }}><option value="ollama">Ollama</option><option value="lmstudio">LM Studio</option></select></label>
-                  {runtimeState.models.length ? <label className="advisor-runtime-picker">Local model<select aria-label="Advisor local runtime model" value={runtimeModel ?? runtimeState.models[0]} onChange={event => { const model = event.target.value; setRuntimeModel(model); if (runtimeId === 'lmstudio') setLMStudioRuntime(new LMStudioAdvisorRuntime({ model, availability: 'ready' })); else setOllamaRuntime(new OllamaAdvisorRuntime({ model, availability: 'ready' })) }}>{runtimeState.models.map(model => <option key={model} value={model}>{model}</option>)}</select></label> : null}
-                </div>
-                <div className="advisor-runtime-state-grid" aria-label="Local runtime state">
-                  <span data-state="runtime">Runtime: {stateLabel(runtimeState.status)}</span>
-                  <span data-state="model">Model: {modelStateLabel(runtimeState.modelState)}</span>
-                  <span data-state="tool-call">Tool calls: {stateLabel(runtimeState.toolCall)}</span>
-                </div>
-              </div>}
-            </div> : null}
-          </div>
+          <AdvisorRuntimeControls
+            runtimeChoice={runtimeChoice}
+            runtimeId={runtimeId}
+            runtimeModel={runtimeModel}
+            runtimeState={runtimeState}
+            hostedProvider={hostedProvider}
+            hostedModel={hostedModel}
+            hostedProbe={hostedProbe}
+            hostedConsent={hostedConsent}
+            hasHostedRuntime={Boolean(hostedRuntime)}
+            configureOpen={configureOpen}
+            credentialEntry={credentialEntry}
+            credentialSaving={credentialSaving}
+            onToggleConfigure={() => setConfigureOpen(current => !current)}
+            onCheckHostedRuntime={() => void checkHostedRuntime()}
+            onActivateLocal={activateLocal}
+            onHostedProviderChange={updateHostedProvider}
+            onHostedModelChange={updateHostedModel}
+            onHostedConsentChange={updateHostedConsent}
+            onCredentialEntryChange={setCredentialEntry}
+            onSaveHostedCredential={() => void saveHostedCredential()}
+            onClearHostedCredential={() => void clearHostedCredential()}
+            onCheckLocalRuntime={() => void checkLocalRuntime()}
+            onActivateHosted={activateHosted}
+            onLocalRuntimeChange={updateLocalRuntime}
+            onLocalModelChange={updateLocalModel}
+          />
         </header>
         <div className="advisor-scope-bar" aria-label="Advisor context">
           <span className="advisor-scope-label">Context</span>
@@ -699,4 +597,3 @@ export function Advisor({
     </section>
   )
 }
-type RuntimeChoice = AdvisorLocalRuntimeId | 'hosted'

--- a/app/renderer/sections/Advisor.tsx
+++ b/app/renderer/sections/Advisor.tsx
@@ -207,9 +207,23 @@ export function Advisor({
     return () => probeController.current?.abort()
   }, [checkLocalRuntime])
 
+  const [loadingQuestion, setLoadingQuestion] = useState<string | null>(null)
+  const [streamPreview, setStreamPreview] = useState('')
+  const [toolStatus, setToolStatus] = useState<string | null>(null)
+  const requestController = useRef<AbortController | null>(null)
+  const requestGenerationRef = useRef(0)
+  const invalidateAdvisorRequest = useCallback(() => {
+    requestGenerationRef.current += 1
+    requestController.current?.abort()
+    requestController.current = null
+    setLoadingQuestion(null)
+    setStreamPreview('')
+    setToolStatus(null)
+  }, [])
   const hostedProbeController = useRef<AbortController | null>(null)
   const checkHostedRuntime = useCallback(async (requestedProvider: 'openai' | 'anthropic' | 'gemini' = hostedProvider, resetSelection = false) => {
     if (!hostedOperationGuardRef.current.isCurrentProvider(requestedProvider)) return
+    invalidateAdvisorRequest()
     hostedProbeController.current?.abort()
     const requestId = hostedOperationGuardRef.current.startProbe(requestedProvider)
     if (requestId === null) return
@@ -238,7 +252,7 @@ export function Advisor({
         setHostedProbe(createHostedProbeFailure(requestedProvider))
       }
     }
-  }, [hostedProvider])
+  }, [hostedProvider, invalidateAdvisorRequest])
   useEffect(() => {
     if (runtimeChoice !== 'hosted') return
     void checkHostedRuntime()
@@ -248,28 +262,15 @@ export function Advisor({
   const [activeConversationId, setActiveConversationId] = useState(() => conversations[0]!.id)
   const [historyQuery, setHistoryQuery] = useState('')
   const [composer, setComposer] = useState('')
-  const [loadingQuestion, setLoadingQuestion] = useState<string | null>(null)
   const [credentialEntry, setCredentialEntry] = useState('')
   const [credentialSaving, setCredentialSaving] = useState(false)
   const hostedConfigRef = useRef({ runtimeChoice, hostedRuntime, hostedConsent })
   hostedConfigRef.current = { runtimeChoice, hostedRuntime, hostedConsent }
   useEffect(() => { setCredentialEntry('') }, [hostedProvider])
-  const [streamPreview, setStreamPreview] = useState('')
-  const [toolStatus, setToolStatus] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [failedRequest, setFailedRequest] = useState<AdvisorFailedRequest | null>(null)
   const [notice, setNotice] = useState<string | null>(null)
   const [selectedAnswerId, setSelectedAnswerId] = useState<string | null>(null)
-  const requestController = useRef<AbortController | null>(null)
-  const requestGenerationRef = useRef(0)
-  const invalidateAdvisorRequest = useCallback(() => {
-    requestGenerationRef.current += 1
-    requestController.current?.abort()
-    requestController.current = null
-    setLoadingQuestion(null)
-    setStreamPreview('')
-    setToolStatus(null)
-  }, [])
   useEffect(() => () => invalidateAdvisorRequest(), [invalidateAdvisorRequest])
 
   useEffect(() => {
@@ -441,6 +442,7 @@ export function Advisor({
     try {
       const status = await metrora.advisorCredentialSet(requestedProvider, credentialEntry)
       if (!hostedOperationGuardRef.current.isCurrentCredential(requestedProvider, operationId)) return
+      invalidateAdvisorRequest()
       setNotice(status.state === 'ready' ? 'Provider credential saved in protected local storage.' : 'Provider credential was not saved: ' + status.state + '.')
       await checkHostedRuntime(requestedProvider)
     } catch {
@@ -459,6 +461,7 @@ export function Advisor({
     try {
       await metrora.advisorCredentialClear(requestedProvider)
       if (!hostedOperationGuardRef.current.isCurrentCredential(requestedProvider, operationId)) return
+      invalidateAdvisorRequest()
       setHostedConsent(false)
       setNotice('Provider credential removed from this device.')
       await checkHostedRuntime(requestedProvider)

--- a/app/renderer/sections/Advisor.tsx
+++ b/app/renderer/sections/Advisor.tsx
@@ -9,16 +9,28 @@ import { createAdvisorKernel } from '../advisor/kernel'
 import { createAdvisorRuntime } from '../advisor/runtime'
 import { LMStudioAdvisorRuntime, probeLMStudio } from '../advisor/lmstudio'
 import { OllamaAdvisorRuntime, probeOllama } from '../advisor/ollama'
-import { HostedAdvisorRuntime, probeHostedAdvisor } from '../advisor/hosted'
+import { HostedAdvisorRuntime, probeHostedAdvisor, type HostedAdvisorProbeResult } from '../advisor/hosted'
 import { periodLabel, scopeLabel } from '../advisor/evidence'
 import { advisorContextualSurfaceLabel, advisorScopeFromContextualLaunch, normalizeAdvisorContextualLaunch, type AdvisorContextualLaunchV1, type AdvisorContextualScopeMode } from '../advisor/context'
-import { advisorScopeFingerprint, type AdvisorAnswer, type AdvisorConversationTurn, type AdvisorLocalRuntimeId, type AdvisorPresentationBlockV1, type AdvisorPresentationChartSeries, type AdvisorScope } from '../advisor/types'
+import { advisorScopeFingerprint, type AdvisorAnswer, type AdvisorConversationTurn, type AdvisorCredentialState, type AdvisorHostedModel, type AdvisorHostedModelState, type AdvisorLocalRuntimeId, type AdvisorPresentationBlockV1, type AdvisorPresentationChartSeries, type AdvisorScope, type AdvisorToolCapability } from '../advisor/types'
 
 type DetectedProvider = { id: string; label: string }
 type AdvisorMessage = { id: string; role: 'user' | 'assistant'; text?: string; answer?: AdvisorAnswer; scopeFingerprint: string }
 type AdvisorConversation = { id: string; title: string; messages: AdvisorMessage[] }
 type AdvisorFailedRequest = { question: string; scope: AdvisorScope; conversationId: string; conversation: AdvisorConversationTurn[] }
-type RuntimeState = { runtime: AdvisorLocalRuntimeId; status: 'checking' | 'ready' | 'unavailable'; detail: string; models: string[]; toolCall: 'unknown' | 'supported' | 'unsupported' | 'failed-conformance' }
+type RuntimeState = { runtime: AdvisorLocalRuntimeId; status: 'checking' | 'ready' | 'unavailable'; detail: string; models: string[]; modelState: RuntimeModelState; toolCall: AdvisorToolCapability }
+type RuntimeModelState = AdvisorHostedModelState | 'unavailable'
+type ProviderReachability = 'checking' | 'reachable' | 'unreachable' | 'unknown'
+type HostedCredentialState = AdvisorCredentialState | 'unknown'
+type HostedProbePresentation = {
+  provider: HostedAdvisorProbeResult['provider']
+  available: boolean
+  models: AdvisorHostedModel[]
+  detail: string
+  credentialState: HostedCredentialState
+  reachability: ProviderReachability
+}
+type RuntimeStatusKind = 'checking' | 'ready' | 'unavailable' | 'unknown'
 
 const PERIODS: Array<{ value: Period; label: string }> = PERIOD_OPTIONS.map(option => ({ value: option.value as Period, label: option.label }))
 const PROMPTS = [
@@ -42,6 +54,71 @@ function isCancelled(error: unknown): boolean {
 function providerLabel(provider: string): string {
   if (provider === 'all') return 'All providers'
   return provider.split(/[-\s]+/).filter(Boolean).map(part => part.charAt(0).toUpperCase() + part.slice(1)).join(' ')
+}
+function hostedProviderLabel(provider: HostedAdvisorProbeResult['provider']): string {
+  if (provider === 'openai') return 'OpenAI'
+  if (provider === 'anthropic') return 'Anthropic'
+  return 'Gemini'
+}
+function stateLabel(value: string): string {
+  return value.split('-').map(part => part.charAt(0).toUpperCase() + part.slice(1)).join(' ')
+}
+function modelStateLabel(value: RuntimeModelState): string {
+  return stateLabel(value)
+}
+function reachabilityLabel(value: ProviderReachability): string {
+  return stateLabel(value)
+}
+function credentialStateLabel(value: HostedCredentialState): string {
+  return stateLabel(value)
+}
+function hostedReachability(result: HostedAdvisorProbeResult): ProviderReachability {
+  // An invalid credential is reported after the official endpoint has
+  // answered, so the provider is reachable even though the credential is not
+  // usable. Other non-ready credential states stop before a provider request.
+  if (result.available || result.credentialState === 'invalid') return 'reachable'
+  return result.credentialState === 'ready' ? 'unreachable' : 'unknown'
+}
+function hostedProbePresentation(result: HostedAdvisorProbeResult): HostedProbePresentation {
+  return { ...result, reachability: hostedReachability(result) }
+}
+function hostedProbeFailure(provider: HostedAdvisorProbeResult['provider']): HostedProbePresentation {
+  return {
+    provider,
+    available: false,
+    models: [],
+    detail: 'Hosted runtime status is unavailable. The provider probe did not complete.',
+    credentialState: 'unknown',
+    reachability: 'unknown',
+  }
+}
+function hostedProbeChecking(provider: HostedAdvisorProbeResult['provider'], previous: HostedProbePresentation | null = null): HostedProbePresentation {
+  const preserveModels = previous?.provider === provider ? previous.models : []
+  return {
+    provider,
+    available: false,
+    models: preserveModels,
+    detail: 'Checking the hosted provider…',
+    credentialState: 'unknown',
+    reachability: 'checking',
+  }
+}
+function hostedRuntimeStatusKind(probe: HostedProbePresentation, model: AdvisorHostedModel | null): RuntimeStatusKind {
+  if (probe.reachability === 'checking') return 'checking'
+  if (probe.reachability === 'unknown') return probe.credentialState === 'unknown' ? 'unknown' : 'unavailable'
+  if (probe.credentialState !== 'ready' || probe.reachability === 'unreachable' || !model || model.state === 'unsupported' || model.state === 'failed-conformance') return 'unavailable'
+  return 'ready'
+}
+function hostedAvailabilityLabel(probe: HostedProbePresentation, model: AdvisorHostedModel | null): string {
+  if (probe.reachability === 'checking') return 'Checking provider'
+  if (probe.credentialState !== 'ready' && probe.credentialState !== 'unknown') return 'Credential ' + credentialStateLabel(probe.credentialState).toLowerCase()
+  if (probe.reachability === 'unknown') return probe.credentialState === 'unknown' ? 'Runtime status unavailable' : 'Credential ' + credentialStateLabel(probe.credentialState).toLowerCase()
+  if (probe.reachability === 'unreachable') return 'Provider unavailable'
+  if (!model) return 'No usable model discovered'
+  if (model.state === 'unsupported') return 'Model unsupported'
+  if (model.state === 'failed-conformance') return 'Model failed conformance'
+  if (model.state === 'unverified' || model.state === 'limited') return 'Model ' + model.state
+  return 'Ready'
 }
 function contextualScopeLabel(scope: AdvisorScope, mode: AdvisorContextualScopeMode | null): string {
   if (mode === 'capacity') return 'Provider-reported current capacity · All providers'
@@ -216,13 +293,14 @@ export function Advisor({
   const [runtimeId, setRuntimeId] = useState<AdvisorLocalRuntimeId>('ollama')
   const [runtimeChoice, setRuntimeChoice] = useState<RuntimeChoice>('ollama')
   const [hostedProvider, setHostedProvider] = useState<'openai' | 'anthropic' | 'gemini'>('openai')
-  const [hostedProbe, setHostedProbe] = useState<Awaited<ReturnType<typeof probeHostedAdvisor>> | null>(null)
   const [hostedModel, setHostedModel] = useState<string | null>(null)
   const hostedModelRef = useRef<string | null>(null)
   hostedModelRef.current = hostedModel
   const [hostedConsent, setHostedConsent] = useState(false)
   const hostedRuntime = useMemo(() => hostedModel ? new HostedAdvisorRuntime({ provider: hostedProvider, model: hostedModel, consent: hostedConsent }) : null, [hostedConsent, hostedModel, hostedProvider])
-  const [runtimeState, setRuntimeState] = useState<RuntimeState>({ runtime: 'ollama', status: 'checking', detail: 'Checking for a local Ollama model…', models: [], toolCall: 'unknown' })
+  const [runtimeState, setRuntimeState] = useState<RuntimeState>({ runtime: 'ollama', status: 'checking', detail: 'Checking for a local Ollama model…', models: [], modelState: 'unavailable', toolCall: 'unknown' })
+  const [hostedProbe, setHostedProbe] = useState<HostedProbePresentation>(() => hostedProbeChecking('openai'))
+  const [configureOpen, setConfigureOpen] = useState(false)
   const [runtimeModel, setRuntimeModel] = useState<string | null>(null)
   const [ollamaRuntime, setOllamaRuntime] = useState<OllamaAdvisorRuntime | null>(null)
   const [lmStudioRuntime, setLMStudioRuntime] = useState<LMStudioAdvisorRuntime | null>(null)
@@ -235,7 +313,7 @@ export function Advisor({
     const controller = new AbortController()
     probeController.current = controller
     const runtimeName = requestedRuntime === 'lmstudio' ? 'LM Studio' : 'Ollama'
-    setRuntimeState({ runtime: requestedRuntime, status: 'checking', detail: 'Checking for a local ' + runtimeName + ' model…', models: [], toolCall: 'unknown' })
+    setRuntimeState({ runtime: requestedRuntime, status: 'checking', detail: 'Checking for a local ' + runtimeName + ' model…', models: [], modelState: 'unavailable', toolCall: 'unknown' })
     try {
       const result = requestedRuntime === 'lmstudio' ? await probeLMStudio(controller.signal) : await probeOllama(controller.signal)
       if (controller.signal.aborted) return
@@ -251,15 +329,15 @@ export function Advisor({
         }
         const capabilityProfiles = (result as { capabilities?: Array<{ modelId: string; toolCall: RuntimeState['toolCall'] }> }).capabilities ?? []
         const capability = capabilityProfiles.find(profile => profile.modelId === selected)
-        setRuntimeState({ runtime: requestedRuntime, status: 'ready', detail: result.detail, models: result.models, toolCall: capability?.toolCall ?? 'unknown' })
+        setRuntimeState({ runtime: requestedRuntime, status: 'ready', detail: result.detail, models: result.models, modelState: 'discovered', toolCall: capability?.toolCall ?? 'unknown' })
       } else {
         setRuntimeModel(null)
         if (requestedRuntime === 'lmstudio') setLMStudioRuntime(null)
         else setOllamaRuntime(null)
-        setRuntimeState({ runtime: requestedRuntime, status: 'unavailable', detail: result.detail, models: [], toolCall: 'unknown' })
+        setRuntimeState({ runtime: requestedRuntime, status: 'unavailable', detail: result.detail, models: [], modelState: 'unavailable', toolCall: 'unknown' })
       }
     } catch (error) {
-      if (!isCancelled(error)) setRuntimeState({ runtime: requestedRuntime, status: 'unavailable', detail: 'Local runtime probe was cancelled or failed.', models: [], toolCall: 'unknown' })
+      if (!isCancelled(error)) setRuntimeState({ runtime: requestedRuntime, status: 'unavailable', detail: 'Local runtime probe was cancelled or failed.', models: [], modelState: 'unavailable', toolCall: 'unknown' })
     }
   }, [runtimeId, runtimeModel])
   useEffect(() => {
@@ -272,10 +350,11 @@ export function Advisor({
     hostedProbeController.current?.abort()
     const controller = new AbortController()
     hostedProbeController.current = controller
+    setHostedProbe(current => hostedProbeChecking(requestedProvider, current))
     try {
       const result = await probeHostedAdvisor(requestedProvider, controller.signal)
       if (controller.signal.aborted) return
-      setHostedProbe(result)
+      setHostedProbe(hostedProbePresentation(result))
       const selectable = result.models.find(model => model.state !== 'unsupported')
       if (result.available && selectable) {
         const currentModel = resetSelection ? null : hostedModelRef.current
@@ -290,7 +369,7 @@ export function Advisor({
       if (!isCancelled(caught)) {
         setHostedModel(null)
         setHostedConsent(false)
-        setHostedProbe({ provider: requestedProvider, available: false, models: [], detail: 'Hosted provider probe failed.', credentialState: 'ready' })
+        setHostedProbe(hostedProbeFailure(requestedProvider))
       }
     }
   }, [hostedProvider])
@@ -420,7 +499,7 @@ export function Advisor({
   }
   const cancel = () => {
     requestController.current?.abort()
-    setNotice('Cancelling the local investigation…')
+    setNotice('Cancelling investigation…')
   }
   const newConversation = () => {
     const next: AdvisorConversation = { id: makeId('chat'), title: 'New investigation', messages: [] }
@@ -472,18 +551,28 @@ export function Advisor({
     ...conversation.messages.map(message => message.text ?? message.answer?.conclusion ?? ''),
   ].some(value => value.toLowerCase().includes(normalizedHistoryQuery)))
   const selectedModelRuntime = runtimeId === 'lmstudio' ? lmStudioRuntime : ollamaRuntime
-  const displayedRuntime = runtimeChoice === 'hosted' ? hostedRuntime : selectedModelRuntime
-  const displayedReady = runtimeChoice === 'hosted'
-    ? Boolean(hostedProbe?.available && hostedRuntime)
-    : runtimeState.status === 'ready' && Boolean(selectedModelRuntime)
-  const runtimeLabel = displayedReady && displayedRuntime ? displayedRuntime.label : 'Offline evidence fallback'
+  const selectableHostedModels = hostedProbe.models.filter(model => model.state !== 'unsupported')
+  const selectedHostedModel = hostedProbe.models.find(model => model.id === hostedModel) ?? null
+  const hostedModelState: RuntimeModelState = selectedHostedModel?.state ?? 'unavailable'
+  const hostedStatusKind = hostedRuntimeStatusKind(hostedProbe, selectedHostedModel)
+  const runtimeStatusKind: RuntimeStatusKind = runtimeChoice === 'hosted' ? hostedStatusKind : runtimeState.status
+  const runtimeIdentity = runtimeChoice === 'hosted'
+    ? hostedProviderLabel(hostedProvider) + (selectedHostedModel ? ' · ' + selectedHostedModel.label : '')
+    : (runtimeId === 'lmstudio' ? 'LM Studio' : 'Ollama') + (runtimeModel ? ' · ' + runtimeModel : '')
+  const runtimeAvailability = runtimeChoice === 'hosted'
+    ? hostedAvailabilityLabel(hostedProbe, selectedHostedModel)
+    : runtimeState.status === 'checking'
+      ? 'Checking runtime'
+      : runtimeState.status === 'ready'
+        ? 'Ready'
+        : 'Runtime unavailable'
   const runtimeDescription = runtimeChoice === 'hosted'
     ? 'Hosted provider account · minimum evidence sent directly · no Metrora proxy'
     : runtimeState.status === 'ready' && selectedModelRuntime
       ? (runtimeId === 'lmstudio' ? 'Local LM Studio model' : 'Local Ollama model') + ' · read-only evidence tools · tool support varies by model'
-      : 'Deterministic evidence fallback · no model connected'
+      : 'Offline evidence fallback'
   const runtimeDetail = runtimeChoice === 'hosted'
-    ? hostedProbe?.detail ?? 'Choose a hosted provider and connect a credential.'
+    ? hostedProbe.detail
     : runtimeState.detail
   const latestAnswer = selectedAnswer ?? answerForMessage(messages, null)
   const suppliedOverviewMatchesScope = scope.period === period
@@ -516,26 +605,49 @@ export function Advisor({
       <main className="advisor-main">
         <header className="advisor-main-head">
           <div><p className="advisor-kicker">ADVISE · READ ONLY</p><h1>Ask Metrora</h1><p className="advisor-subtitle">Investigate measured usage, model efficiency, Projects, and provider capacity.</p></div>
-          <div className="advisor-runtime-status">
-            <span className={displayedReady ? 'advisor-status-dot ready' : 'advisor-status-dot'} />
-            <div><strong>{runtimeLabel}</strong><small>{runtimeDescription} · {runtimeDetail}</small></div>
-            {runtimeChoice === 'hosted'
-              ? <button type="button" className="advisor-quiet-button" onClick={() => void checkHostedRuntime()}>{hostedProbe?.available ? 'Refresh hosted models' : 'Check hosted provider'}</button>
-              : <button type="button" className="advisor-quiet-button" onClick={() => void checkLocalRuntime()}>{runtimeState.status === 'checking' ? 'Checking…' : 'Check local model'}</button>}
-            {runtimeChoice === 'hosted' ? <>
-              <button type="button" className="advisor-quiet-button" onClick={activateLocal}>Use local runtime</button>
-              <div className="advisor-hosted-controls">
-                <label className="advisor-runtime-picker">Provider<select aria-label="Advisor hosted provider" value={hostedProvider} onChange={event => { const next = event.target.value as 'openai' | 'anthropic' | 'gemini'; setHostedProvider(next); setHostedProbe(null); setHostedModel(null); setHostedConsent(false); void checkHostedRuntime(next, true) }}><option value="openai">OpenAI</option><option value="anthropic">Anthropic</option><option value="gemini">Gemini</option></select></label>
-                {hostedProbe?.models.filter(model => model.state !== 'unsupported').length ? <label className="advisor-runtime-picker">Hosted model<select aria-label="Advisor hosted model" value={hostedModel ?? hostedProbe.models.find(model => model.state !== 'unsupported')?.id ?? ''} onChange={event => { const model = event.target.value; setHostedModel(model); setHostedConsent(false) }}>{hostedProbe.models.filter(model => model.state !== 'unsupported').map(model => <option key={model.id} value={model.id}>{model.label} · {model.state}</option>)}</select></label> : null}
-                <span className="advisor-credential-status">Credential: {hostedProbe?.credentialState ?? 'not-configured'}</span>
-                {hostedProbe?.credentialState !== 'ready' ? <div className="advisor-credential-entry"><input type="password" aria-label="Advisor provider key" autoComplete="off" placeholder="Provider key (not stored in this form)" value={credentialEntry} onChange={event => setCredentialEntry(event.target.value)} /><button type="button" className="advisor-quiet-button" onClick={() => void saveHostedCredential()} disabled={credentialSaving || !credentialEntry.trim()}>{credentialSaving ? 'Saving…' : 'Save key'}</button></div> : <button type="button" className="advisor-quiet-button" onClick={() => void clearHostedCredential()}>Remove key</button>}
-                {hostedRuntime ? <label className="advisor-hosted-consent"><input type="checkbox" checked={hostedConsent} onChange={event => updateHostedConsent(event.target.checked)} /> Before the first hosted investigation, send this question and minimum Metrora evidence directly to the selected provider using your account. Metrora does not proxy it; provider terms, privacy, and retention apply.</label> : null}
-              </div>
-            </> : <>
-              <button type="button" className="advisor-quiet-button" onClick={activateHosted}>Use hosted provider</button>
-              <label className="advisor-runtime-picker">Runtime<select aria-label="Advisor runtime" value={runtimeId} onChange={event => { const next = event.target.value as AdvisorLocalRuntimeId; setRuntimeId(next); setRuntimeModel(null); setHostedConsent(false); void checkLocalRuntime(next) }}><option value="ollama">Ollama</option><option value="lmstudio">LM Studio</option></select></label>
-              {runtimeState.models.length ? <label className="advisor-runtime-picker">Local model<select aria-label="Advisor local runtime model" value={runtimeModel ?? runtimeState.models[0]} onChange={event => { const model = event.target.value; setRuntimeModel(model); if (runtimeId === 'lmstudio') setLMStudioRuntime(new LMStudioAdvisorRuntime({ model, availability: 'ready' })); else setOllamaRuntime(new OllamaAdvisorRuntime({ model, availability: 'ready' })) }}>{runtimeState.models.map(model => <option key={model} value={model}>{model}</option>)}</select></label> : null}
-            </>}
+          <div className={'advisor-runtime-status ' + runtimeStatusKind} aria-label="Advisor runtime status">
+            <span className={'advisor-status-dot ' + runtimeStatusKind} aria-hidden="true" />
+            <div className="advisor-runtime-summary-copy">
+              <strong>{runtimeIdentity}</strong>
+              <span className={'advisor-runtime-availability ' + runtimeStatusKind}>{runtimeAvailability}</span>
+              <small className="advisor-runtime-description">{runtimeDescription}</small>
+              <small className="advisor-runtime-detail">{runtimeDetail}</small>
+            </div>
+            <button type="button" className="advisor-configure-toggle" aria-expanded={configureOpen} aria-controls={configureOpen ? 'advisor-runtime-config' : undefined} onClick={() => setConfigureOpen(current => !current)}>{configureOpen ? 'Close runtime' : 'Configure runtime'}</button>
+            {configureOpen ? <div className="advisor-runtime-config" id="advisor-runtime-config" aria-label="Advisor runtime configuration">
+              <div className="advisor-runtime-config-head"><strong>Runtime configuration</strong><span>Choose a local or hosted runtime. Technical state stays here while the conversation remains the focus.</span></div>
+              {runtimeChoice === 'hosted' ? <div className="advisor-runtime-config-controls">
+                <div className="advisor-runtime-config-actions">
+                  <button type="button" className="advisor-quiet-button" onClick={() => void checkHostedRuntime()}>{hostedProbe.available ? 'Refresh hosted models' : 'Check hosted provider'}</button>
+                  <button type="button" className="advisor-quiet-button" onClick={activateLocal}>Use local runtime</button>
+                </div>
+                <div className="advisor-runtime-picker-row">
+                  <label className="advisor-runtime-picker">Provider<select aria-label="Advisor hosted provider" value={hostedProvider} onChange={event => { const next = event.target.value as 'openai' | 'anthropic' | 'gemini'; setHostedProvider(next); setHostedModel(null); setHostedConsent(false); void checkHostedRuntime(next, true) }}><option value="openai">OpenAI</option><option value="anthropic">Anthropic</option><option value="gemini">Gemini</option></select></label>
+                  {selectableHostedModels.length ? <label className="advisor-runtime-picker">Hosted model<select aria-label="Advisor hosted model" value={hostedModel ?? selectableHostedModels[0]!.id} onChange={event => { const model = event.target.value; setHostedModel(model); setHostedConsent(false) }}>{selectableHostedModels.map(model => <option key={model.id} value={model.id}>{model.label} · {modelStateLabel(model.state)}</option>)}</select></label> : null}
+                </div>
+                <div className="advisor-runtime-state-grid" aria-label="Hosted runtime state">
+                  <span data-state="credential">Credential: {credentialStateLabel(hostedProbe.credentialState)}</span>
+                  <span data-state="reachability">Reachability: {reachabilityLabel(hostedProbe.reachability)}</span>
+                  <span data-state="model">Model: {modelStateLabel(hostedModelState)}</span>
+                </div>
+                {hostedProbe.credentialState !== 'ready' ? <div className="advisor-credential-entry"><input type="password" aria-label="Advisor provider key" autoComplete="off" placeholder="Provider key (not stored in this form)" value={credentialEntry} onChange={event => setCredentialEntry(event.target.value)} /><button type="button" className="advisor-quiet-button" onClick={() => void saveHostedCredential()} disabled={credentialSaving || !credentialEntry.trim()}>{credentialSaving ? 'Saving…' : 'Save key'}</button></div> : <button type="button" className="advisor-quiet-button" onClick={() => void clearHostedCredential()}>Remove key</button>}
+                {hostedRuntime ? <label className="advisor-hosted-consent"><input type="checkbox" checked={hostedConsent} onChange={event => updateHostedConsent(event.target.checked)} /><span>Before the first hosted investigation, send this question and minimum Metrora evidence directly to the selected provider using your account. Metrora does not proxy it; provider terms, privacy, and retention apply.</span></label> : <p className="advisor-consent-unavailable">Consent appears after a usable hosted model is available. It is always explicit and starts unchecked.</p>}
+              </div> : <div className="advisor-runtime-config-controls">
+                <div className="advisor-runtime-config-actions">
+                  <button type="button" className="advisor-quiet-button" onClick={() => void checkLocalRuntime()}>{runtimeState.status === 'checking' ? 'Checking…' : 'Check local model'}</button>
+                  <button type="button" className="advisor-quiet-button" onClick={activateHosted}>Use hosted provider</button>
+                </div>
+                <div className="advisor-runtime-picker-row">
+                  <label className="advisor-runtime-picker">Runtime<select aria-label="Advisor runtime" value={runtimeId} onChange={event => { const next = event.target.value as AdvisorLocalRuntimeId; setRuntimeId(next); setRuntimeModel(null); setHostedConsent(false); void checkLocalRuntime(next) }}><option value="ollama">Ollama</option><option value="lmstudio">LM Studio</option></select></label>
+                  {runtimeState.models.length ? <label className="advisor-runtime-picker">Local model<select aria-label="Advisor local runtime model" value={runtimeModel ?? runtimeState.models[0]} onChange={event => { const model = event.target.value; setRuntimeModel(model); if (runtimeId === 'lmstudio') setLMStudioRuntime(new LMStudioAdvisorRuntime({ model, availability: 'ready' })); else setOllamaRuntime(new OllamaAdvisorRuntime({ model, availability: 'ready' })) }}>{runtimeState.models.map(model => <option key={model} value={model}>{model}</option>)}</select></label> : null}
+                </div>
+                <div className="advisor-runtime-state-grid" aria-label="Local runtime state">
+                  <span data-state="runtime">Runtime: {stateLabel(runtimeState.status)}</span>
+                  <span data-state="model">Model: {modelStateLabel(runtimeState.modelState)}</span>
+                  <span data-state="tool-call">Tool calls: {stateLabel(runtimeState.toolCall)}</span>
+                </div>
+              </div>}
+            </div> : null}
           </div>
         </header>
         <div className="advisor-scope-bar" aria-label="Advisor context">
@@ -559,9 +671,9 @@ export function Advisor({
           {messages.length === 0 ? (
             <div className="advisor-welcome">
               <span className="advisor-welcome-mark">M</span>
-              <p className="advisor-kicker">LOCAL INVESTIGATION SPACE</p>
+              <p className="advisor-kicker">METRORA INVESTIGATION</p>
               <h2>What should we look into?</h2>
-              <p>Ask naturally. A connected local model can call Metrora evidence tools; every number stays in verified details.</p>
+              <p>Ask naturally. Advisor connects your question to Metrora factual evidence; a configured runtime can help explain it while verified details remain the authority.</p>
               <div className="advisor-prompt-grid">{PROMPTS.map(prompt => <button key={prompt.question} type="button" className="advisor-prompt" onClick={() => void ask(prompt.question)}><small>{prompt.eyebrow}</small><span>{prompt.label}</span><i>↗</i></button>)}</div>
             </div>
           ) : (
@@ -570,7 +682,7 @@ export function Advisor({
               : <AnswerCard key={message.id} answer={message.answer!} selected={selectedAnswerId === message.id} onSelect={() => setSelectedAnswerId(message.id)} onFollowUp={next => void ask(next)} />
             )
           )}
-          {loadingQuestion ? <article className="advisor-message assistant-message pending"><div className="advisor-message-label"><span className="advisor-mini-mark">M</span> Metrora Advisor</div><p className="advisor-tool-progress">{toolStatus ?? 'Thinking with local evidence…'}</p>{streamPreview ? <p className="advisor-stream-preview">{streamPreview}</p> : null}<button type="button" className="advisor-cancel" onClick={cancel}>Cancel</button></article> : null}
+          {loadingQuestion ? <article className="advisor-message assistant-message pending"><div className="advisor-message-label"><span className="advisor-mini-mark">M</span> Metrora Advisor</div><p className="advisor-tool-progress">{toolStatus ?? 'Investigating with Metrora evidence…'}</p>{streamPreview ? <p className="advisor-stream-preview">{streamPreview}</p> : null}<button type="button" className="advisor-cancel" onClick={cancel}>Cancel</button></article> : null}
           {error ? <div className="advisor-error" role="alert"><strong>Investigation unavailable.</strong> {error}<button type="button" onClick={() => { if (failedRequest) { setActiveConversationId(failedRequest.conversationId); void ask(failedRequest.question, failedRequest) } }}>Retry</button></div> : null}
           {notice ? <div className="advisor-notice" role="status">{notice}</div> : null}
         </div>

--- a/app/renderer/sections/Advisor.tsx
+++ b/app/renderer/sections/Advisor.tsx
@@ -12,7 +12,7 @@ import { OllamaAdvisorRuntime, probeOllama } from '../advisor/ollama'
 import { HostedAdvisorRuntime, probeHostedAdvisor } from '../advisor/hosted'
 import { periodLabel, scopeLabel } from '../advisor/evidence'
 import { advisorContextualSurfaceLabel, advisorScopeFromContextualLaunch, normalizeAdvisorContextualLaunch, type AdvisorContextualLaunchV1, type AdvisorContextualScopeMode } from '../advisor/context'
-import { advisorScopeFingerprint, type AdvisorAnswer, type AdvisorConversationTurn, type AdvisorHostedProviderId, type AdvisorLocalRuntimeId, type AdvisorPresentationBlockV1, type AdvisorPresentationChartSeries, type AdvisorScope } from '../advisor/types'
+import { advisorScopeFingerprint, type AdvisorAnswer, type AdvisorConversationTurn, type AdvisorHostedModelState, type AdvisorHostedProviderId, type AdvisorLocalRuntimeId, type AdvisorPresentationBlockV1, type AdvisorPresentationChartSeries, type AdvisorScope } from '../advisor/types'
 import { AdvisorRuntimeControls, createHostedProbeChecking, createHostedProbeFailure, presentHostedProbe, type AdvisorHostedProbePresentation, type AdvisorRuntimeChoice, type AdvisorRuntimeState } from './AdvisorRuntimeControls'
 type DetectedProvider = { id: string; label: string }
 type AdvisorMessage = { id: string; role: 'user' | 'assistant'; text?: string; answer?: AdvisorAnswer; scopeFingerprint: string }
@@ -35,6 +35,9 @@ function isCancelled(error: unknown): boolean {
     return item.kind === 'cancelled' || (typeof item.message === 'string' && /cancel|abort/i.test(item.message))
   }
   return false
+}
+function isSelectableHostedModel(model: { state: AdvisorHostedModelState }): boolean {
+  return model.state !== 'unsupported' && model.state !== 'failed-conformance'
 }
 function providerLabel(provider: string): string {
   if (provider === 'all') return 'All providers'
@@ -211,6 +214,8 @@ export function Advisor({
   const [runtimeId, setRuntimeId] = useState<AdvisorLocalRuntimeId>('ollama')
   const [runtimeChoice, setRuntimeChoice] = useState<AdvisorRuntimeChoice>('ollama')
   const [hostedProvider, setHostedProvider] = useState<'openai' | 'anthropic' | 'gemini'>('openai')
+  const hostedProviderRef = useRef(hostedProvider)
+  hostedProviderRef.current = hostedProvider
   const [hostedModel, setHostedModel] = useState<string | null>(null)
   const hostedModelRef = useRef<string | null>(null)
   hostedModelRef.current = hostedModel
@@ -264,19 +269,24 @@ export function Advisor({
   }, [checkLocalRuntime])
 
   const hostedProbeController = useRef<AbortController | null>(null)
+  const hostedProbeRequestRef = useRef(0)
   const checkHostedRuntime = useCallback(async (requestedProvider: 'openai' | 'anthropic' | 'gemini' = hostedProvider, resetSelection = false) => {
+    if (hostedProviderRef.current !== requestedProvider) return
     hostedProbeController.current?.abort()
+    const requestId = hostedProbeRequestRef.current + 1
+    hostedProbeRequestRef.current = requestId
     const controller = new AbortController()
     hostedProbeController.current = controller
+    const isCurrentRequest = () => !controller.signal.aborted && hostedProviderRef.current === requestedProvider && hostedProbeRequestRef.current === requestId
     setHostedProbe(current => createHostedProbeChecking(requestedProvider, current))
     try {
       const result = await probeHostedAdvisor(requestedProvider, controller.signal)
-      if (controller.signal.aborted) return
+      if (!isCurrentRequest()) return
       setHostedProbe(presentHostedProbe(result))
-      const selectable = result.models.find(model => model.state !== 'unsupported')
+      const selectable = result.models.find(isSelectableHostedModel)
       if (result.available && selectable) {
         const currentModel = resetSelection ? null : hostedModelRef.current
-        const next = currentModel && result.models.some(model => model.id === currentModel && model.state !== 'unsupported') ? currentModel : selectable.id
+        const next = currentModel && result.models.some(model => model.id === currentModel && isSelectableHostedModel(model)) ? currentModel : selectable.id
         setHostedModel(next)
         if (next !== currentModel) setHostedConsent(false)
       } else {
@@ -284,7 +294,7 @@ export function Advisor({
         setHostedConsent(false)
       }
     } catch (caught) {
-      if (!isCancelled(caught)) {
+      if (isCurrentRequest() && !isCancelled(caught)) {
         setHostedModel(null)
         setHostedConsent(false)
         setHostedProbe(createHostedProbeFailure(requestedProvider))
@@ -303,6 +313,7 @@ export function Advisor({
   const [loadingQuestion, setLoadingQuestion] = useState<string | null>(null)
   const [credentialEntry, setCredentialEntry] = useState('')
   const [credentialSaving, setCredentialSaving] = useState(false)
+  const credentialOperationRef = useRef(0)
   const hostedConfigRef = useRef({ runtimeChoice, hostedRuntime, hostedConsent })
   hostedConfigRef.current = { runtimeChoice, hostedRuntime, hostedConsent }
   useEffect(() => { setCredentialEntry('') }, [hostedProvider])
@@ -440,9 +451,14 @@ export function Advisor({
     setHostedConsent(consent)
   }
   const updateHostedProvider = (next: AdvisorHostedProviderId) => {
+    hostedProviderRef.current = next
+    hostedProbeRequestRef.current += 1
+    credentialOperationRef.current += 1
+    hostedProbeController.current?.abort()
     setHostedProvider(next)
     setHostedModel(null)
     setHostedConsent(false)
+    setCredentialSaving(false)
     void checkHostedRuntime(next, true)
   }
   const updateHostedModel = (model: string) => {
@@ -462,26 +478,36 @@ export function Advisor({
   }
   const saveHostedCredential = async () => {
     if (!credentialEntry.trim() || credentialSaving) return
+    const requestedProvider = hostedProvider
+    const operationId = credentialOperationRef.current + 1
+    credentialOperationRef.current = operationId
     setCredentialSaving(true)
     try {
-      const status = await metrora.advisorCredentialSet(hostedProvider, credentialEntry)
+      const status = await metrora.advisorCredentialSet(requestedProvider, credentialEntry)
+      if (credentialOperationRef.current !== operationId || hostedProviderRef.current !== requestedProvider) return
       setNotice(status.state === 'ready' ? 'Provider credential saved in protected local storage.' : 'Provider credential was not saved: ' + status.state + '.')
-      await checkHostedRuntime(hostedProvider)
+      await checkHostedRuntime(requestedProvider)
     } catch {
-      setNotice('Provider credential could not be saved. Enter it again.')
+      if (credentialOperationRef.current === operationId && hostedProviderRef.current === requestedProvider) setNotice('Provider credential could not be saved. Enter it again.')
     } finally {
-      setCredentialEntry('')
-      setCredentialSaving(false)
+      if (credentialOperationRef.current === operationId) {
+        setCredentialEntry('')
+        setCredentialSaving(false)
+      }
     }
   }
   const clearHostedCredential = async () => {
+    const requestedProvider = hostedProvider
+    const operationId = credentialOperationRef.current + 1
+    credentialOperationRef.current = operationId
     try {
-      await metrora.advisorCredentialClear(hostedProvider)
+      await metrora.advisorCredentialClear(requestedProvider)
+      if (credentialOperationRef.current !== operationId || hostedProviderRef.current !== requestedProvider) return
       setHostedConsent(false)
       setNotice('Provider credential removed from this device.')
-      await checkHostedRuntime(hostedProvider)
+      await checkHostedRuntime(requestedProvider)
     } catch {
-      setNotice('Provider credential could not be removed.')
+      if (credentialOperationRef.current === operationId && hostedProviderRef.current === requestedProvider) setNotice('Provider credential could not be removed.')
     }
   }
   const normalizedHistoryQuery = historyQuery.trim().toLowerCase()

--- a/app/renderer/sections/Advisor.tsx
+++ b/app/renderer/sections/Advisor.tsx
@@ -12,8 +12,10 @@ import { OllamaAdvisorRuntime, probeOllama } from '../advisor/ollama'
 import { HostedAdvisorRuntime, probeHostedAdvisor } from '../advisor/hosted'
 import { periodLabel, scopeLabel } from '../advisor/evidence'
 import { advisorContextualSurfaceLabel, advisorScopeFromContextualLaunch, normalizeAdvisorContextualLaunch, type AdvisorContextualLaunchV1, type AdvisorContextualScopeMode } from '../advisor/context'
-import { advisorScopeFingerprint, type AdvisorAnswer, type AdvisorConversationTurn, type AdvisorHostedModelState, type AdvisorHostedProviderId, type AdvisorLocalRuntimeId, type AdvisorPresentationBlockV1, type AdvisorPresentationChartSeries, type AdvisorScope } from '../advisor/types'
+import { advisorScopeFingerprint, type AdvisorAnswer, type AdvisorConversationTurn, type AdvisorHostedProviderId, type AdvisorLocalRuntimeId, type AdvisorPresentationBlockV1, type AdvisorScope } from '../advisor/types'
 import { AdvisorRuntimeControls, createHostedProbeChecking, createHostedProbeFailure, presentHostedProbe, type AdvisorHostedProbePresentation, type AdvisorRuntimeChoice, type AdvisorRuntimeState } from './AdvisorRuntimeControls'
+import { AdvisorHostedOperationGuard, isSelectableHostedModel } from './advisor-hosted-operation-guard'
+import { AdvisorChartBlock } from './advisor-chart'
 type DetectedProvider = { id: string; label: string }
 type AdvisorMessage = { id: string; role: 'user' | 'assistant'; text?: string; answer?: AdvisorAnswer; scopeFingerprint: string }
 type AdvisorConversation = { id: string; title: string; messages: AdvisorMessage[] }
@@ -36,9 +38,6 @@ function isCancelled(error: unknown): boolean {
   }
   return false
 }
-function isSelectableHostedModel(model: { state: AdvisorHostedModelState }): boolean {
-  return model.state !== 'unsupported' && model.state !== 'failed-conformance'
-}
 function providerLabel(provider: string): string {
   if (provider === 'all') return 'All providers'
   return provider.split(/[-\s]+/).filter(Boolean).map(part => part.charAt(0).toUpperCase() + part.slice(1)).join(' ')
@@ -58,71 +57,11 @@ function answerForMessage(messages: AdvisorMessage[], id: string | null): Adviso
   }
   return [...messages].reverse().find(message => message.answer)?.answer ?? null
 }
-function chartValue(value: number | null, unit: string): string {
-  if (value === null || !Number.isFinite(value)) return 'Unavailable'
-  return (unit === 'USD' ? '$' + value.toFixed(2) : value.toLocaleString('en-US')) + ' ' + unit
-}
-function chartSeriesSegments(series: AdvisorPresentationChartSeries, width: number, height: number, max: number): Array<Array<[number, number]>> {
-  const segments: Array<Array<[number, number]>> = []
-  let current: Array<[number, number]> = []
-  const denominator = Math.max(1, series.points.length - 1)
-  series.points.forEach((point, index) => {
-    if (point.value === null || !Number.isFinite(point.value)) {
-      if (current.length) segments.push(current)
-      current = []
-      return
-    }
-    const x = 22 + (index / denominator) * (width - 42)
-    const y = height - 22 - (point.value / max) * (height - 42)
-    current.push([x, y])
-  })
-  if (current.length) segments.push(current)
-  return segments
-}
-
-function ChartBlock({ block }: { block: Extract<AdvisorPresentationBlockV1, { kind: 'line-chart' | 'bar-chart' }> }) {
-  const width = 620
-  const height = 190
-  const values = block.series.flatMap(series => series.points.map(point => point.value).filter((value): value is number => value !== null && Number.isFinite(value)))
-  const max = Math.max(1, ...values)
-  return (
-    <section className="advisor-presentation-block advisor-chart-block">
-      <div className="advisor-presentation-head"><h4>{block.title}</h4><span>{block.scopeLabel} · {block.periodLabel}</span></div>
-      <p className="advisor-presentation-summary">{block.summary}</p>
-      <svg className="advisor-chart" viewBox={'0 0 ' + width + ' ' + height} role="img" aria-label={block.accessibilityLabel}>
-        <line x1="22" y1={height - 22} x2={width - 20} y2={height - 22} />
-        <line x1="22" y1="18" x2="22" y2={height - 22} />
-        {block.kind === 'line-chart'
-          ? block.series.map((series, index) => <g key={series.id} className={'advisor-chart-series series-' + index}>
-              {chartSeriesSegments(series, width, height, max).map((segment, segmentIndex) => segment.length > 1 ? <polyline key={segmentIndex} points={segment.map(([x, y]) => x + ',' + y).join(' ')} /> : null)}
-              {series.points.map((point, pointIndex) => {
-                if (point.value === null || !Number.isFinite(point.value)) return null
-                const denominator = Math.max(1, series.points.length - 1)
-                const x = 22 + (pointIndex / denominator) * (width - 42)
-                const y = height - 22 - (point.value / max) * (height - 42)
-                return <circle key={pointIndex} cx={x} cy={y} r="2.6"><title>{series.label} · {point.label} · {chartValue(point.value, block.unit)}</title></circle>
-              })}
-            </g>)
-          : block.series[0]?.points.map((point, index) => {
-              if (point.value === null || !Number.isFinite(point.value)) return null
-              const slot = (width - 42) / Math.max(1, block.series[0]!.points.length)
-              const barWidth = Math.max(4, slot * .62)
-              const x = 22 + index * slot + (slot - barWidth) / 2
-              const y = height - 22 - (point.value / max) * (height - 42)
-              return <rect key={index} x={x} y={y} width={barWidth} height={Math.max(1, height - 22 - y)}><title>{point.label} · {chartValue(point.value, block.unit)}</title></rect>
-            })}
-      </svg>
-      <div className="advisor-chart-legend">{block.series.map((series, index) => <span key={series.id}><i className={'series-' + index} />{series.label}</span>)}</div>
-      <div className="advisor-chart-data">{block.series.flatMap(series => series.points.filter(point => point.value !== null).slice(-6).map(point => <span key={series.id + '-' + point.label}>{series.label} · {point.label} · {chartValue(point.value, block.unit)}</span>))}</div>
-    </section>
-  )
-}
-
 function PresentationBlocks({ blocks }: { blocks: AdvisorPresentationBlockV1[] }) {
   return <div className="advisor-presentation">{blocks.map((block, index) => {
     if (block.kind === 'text') return <p className="advisor-presentation-text" key={index}>{block.text}</p>
     if (block.kind === 'metric-cards') return <section className="advisor-presentation-block" key={index}><div className="advisor-presentation-head"><h4>{block.title}</h4><span>{block.scopeLabel} · {block.periodLabel}</span></div><div className="advisor-metric-grid">{block.cards.map(card => <div className="advisor-metric-card" key={card.label}><span>{card.label}</span><strong>{card.value}</strong><small>{card.unit}</small><p>{card.detail}</p></div>)}</div></section>
-    if (block.kind === 'line-chart' || block.kind === 'bar-chart') return <ChartBlock block={block} key={index} />
+    if (block.kind === 'line-chart' || block.kind === 'bar-chart') return <AdvisorChartBlock block={block} key={index} />
     if (block.kind === 'comparison-table') return <section className="advisor-presentation-block" key={index}><div className="advisor-presentation-head"><h4>{block.title}</h4><span>{block.scopeLabel} · {block.periodLabel}</span></div><p className="advisor-presentation-summary">{block.summary}</p><div className="advisor-table-wrap"><table><caption className="sr-only">{block.title}</caption><thead><tr>{block.table.columns.map(column => <th key={column} scope="col">{column}</th>)}</tr></thead><tbody>{block.table.rows.map((row, rowIndex) => <tr key={rowIndex}>{row.map((cell, cellIndex) => <td key={cellIndex}>{cell}</td>)}</tr>)}</tbody></table></div></section>
     if (block.kind === 'quota-card') return <section className="advisor-presentation-block" key={index}><div className="advisor-presentation-head"><h4>{block.title}</h4><span>{block.scopeLabel} · {block.periodLabel}</span></div><p className="advisor-presentation-summary">{block.summary}</p><div className="advisor-quota-grid">{block.providers.map(provider => <div className="advisor-quota-item" key={provider.provider}><strong>{provider.provider}</strong>{provider.planLabel ? <span>{provider.planLabel}</span> : null}{provider.windows.map(window => <span key={window.id}>{window.label} · {window.remainingPercent}% remaining{window.resetsAt ? ' · reset ' + window.resetsAt : ''}</span>)}{provider.creditsUSD !== null ? <span>Credits · ${provider.creditsUSD.toFixed(2)}</span> : null}</div>)}</div></section>
     if (block.kind === 'bench-summary') return <section className="advisor-presentation-block" key={index}><div className="advisor-presentation-head"><h4>{block.title}</h4><span>{block.scopeLabel} · {block.periodLabel}</span></div><p className="advisor-presentation-summary">{block.summary}</p>{block.run ? <div className="advisor-bench-summary"><strong>{block.run.model.selected}</strong><span>{block.run.aggregate.passed}/{block.run.aggregate.planned} planned tasks passed</span><span>{block.run.aggregate.scoreValue === null ? 'Score unavailable' : (block.run.aggregate.scoreValue * 100).toFixed(1) + '% score'}</span><span>Status · {block.run.status}</span></div> : <p className="advisor-muted-line">No completed controlled run is available.</p>}</section>
@@ -214,8 +153,7 @@ export function Advisor({
   const [runtimeId, setRuntimeId] = useState<AdvisorLocalRuntimeId>('ollama')
   const [runtimeChoice, setRuntimeChoice] = useState<AdvisorRuntimeChoice>('ollama')
   const [hostedProvider, setHostedProvider] = useState<'openai' | 'anthropic' | 'gemini'>('openai')
-  const hostedProviderRef = useRef(hostedProvider)
-  hostedProviderRef.current = hostedProvider
+  const hostedOperationGuardRef = useRef(new AdvisorHostedOperationGuard(hostedProvider))
   const [hostedModel, setHostedModel] = useState<string | null>(null)
   const hostedModelRef = useRef<string | null>(null)
   hostedModelRef.current = hostedModel
@@ -269,15 +207,14 @@ export function Advisor({
   }, [checkLocalRuntime])
 
   const hostedProbeController = useRef<AbortController | null>(null)
-  const hostedProbeRequestRef = useRef(0)
   const checkHostedRuntime = useCallback(async (requestedProvider: 'openai' | 'anthropic' | 'gemini' = hostedProvider, resetSelection = false) => {
-    if (hostedProviderRef.current !== requestedProvider) return
+    if (!hostedOperationGuardRef.current.isCurrentProvider(requestedProvider)) return
     hostedProbeController.current?.abort()
-    const requestId = hostedProbeRequestRef.current + 1
-    hostedProbeRequestRef.current = requestId
+    const requestId = hostedOperationGuardRef.current.startProbe(requestedProvider)
+    if (requestId === null) return
     const controller = new AbortController()
     hostedProbeController.current = controller
-    const isCurrentRequest = () => !controller.signal.aborted && hostedProviderRef.current === requestedProvider && hostedProbeRequestRef.current === requestId
+    const isCurrentRequest = () => !controller.signal.aborted && hostedOperationGuardRef.current.isCurrentProbe(requestedProvider, requestId)
     setHostedProbe(current => createHostedProbeChecking(requestedProvider, current))
     try {
       const result = await probeHostedAdvisor(requestedProvider, controller.signal)
@@ -313,7 +250,6 @@ export function Advisor({
   const [loadingQuestion, setLoadingQuestion] = useState<string | null>(null)
   const [credentialEntry, setCredentialEntry] = useState('')
   const [credentialSaving, setCredentialSaving] = useState(false)
-  const credentialOperationRef = useRef(0)
   const hostedConfigRef = useRef({ runtimeChoice, hostedRuntime, hostedConsent })
   hostedConfigRef.current = { runtimeChoice, hostedRuntime, hostedConsent }
   useEffect(() => { setCredentialEntry('') }, [hostedProvider])
@@ -451,9 +387,7 @@ export function Advisor({
     setHostedConsent(consent)
   }
   const updateHostedProvider = (next: AdvisorHostedProviderId) => {
-    hostedProviderRef.current = next
-    hostedProbeRequestRef.current += 1
-    credentialOperationRef.current += 1
+    hostedOperationGuardRef.current.setProvider(next)
     hostedProbeController.current?.abort()
     setHostedProvider(next)
     setHostedModel(null)
@@ -479,18 +413,18 @@ export function Advisor({
   const saveHostedCredential = async () => {
     if (!credentialEntry.trim() || credentialSaving) return
     const requestedProvider = hostedProvider
-    const operationId = credentialOperationRef.current + 1
-    credentialOperationRef.current = operationId
+    const operationId = hostedOperationGuardRef.current.startCredential(requestedProvider)
+    if (operationId === null) return
     setCredentialSaving(true)
     try {
       const status = await metrora.advisorCredentialSet(requestedProvider, credentialEntry)
-      if (credentialOperationRef.current !== operationId || hostedProviderRef.current !== requestedProvider) return
+      if (!hostedOperationGuardRef.current.isCurrentCredential(requestedProvider, operationId)) return
       setNotice(status.state === 'ready' ? 'Provider credential saved in protected local storage.' : 'Provider credential was not saved: ' + status.state + '.')
       await checkHostedRuntime(requestedProvider)
     } catch {
-      if (credentialOperationRef.current === operationId && hostedProviderRef.current === requestedProvider) setNotice('Provider credential could not be saved. Enter it again.')
+      if (hostedOperationGuardRef.current.isCurrentCredential(requestedProvider, operationId)) setNotice('Provider credential could not be saved. Enter it again.')
     } finally {
-      if (credentialOperationRef.current === operationId) {
+      if (hostedOperationGuardRef.current.isCurrentCredential(requestedProvider, operationId)) {
         setCredentialEntry('')
         setCredentialSaving(false)
       }
@@ -498,16 +432,16 @@ export function Advisor({
   }
   const clearHostedCredential = async () => {
     const requestedProvider = hostedProvider
-    const operationId = credentialOperationRef.current + 1
-    credentialOperationRef.current = operationId
+    const operationId = hostedOperationGuardRef.current.startCredential(requestedProvider)
+    if (operationId === null) return
     try {
       await metrora.advisorCredentialClear(requestedProvider)
-      if (credentialOperationRef.current !== operationId || hostedProviderRef.current !== requestedProvider) return
+      if (!hostedOperationGuardRef.current.isCurrentCredential(requestedProvider, operationId)) return
       setHostedConsent(false)
       setNotice('Provider credential removed from this device.')
       await checkHostedRuntime(requestedProvider)
     } catch {
-      if (credentialOperationRef.current === operationId && hostedProviderRef.current === requestedProvider) setNotice('Provider credential could not be removed.')
+      if (hostedOperationGuardRef.current.isCurrentCredential(requestedProvider, operationId)) setNotice('Provider credential could not be removed.')
     }
   }
   const normalizedHistoryQuery = historyQuery.trim().toLowerCase()

--- a/app/renderer/sections/AdvisorRuntimeControls.tsx
+++ b/app/renderer/sections/AdvisorRuntimeControls.tsx
@@ -154,7 +154,7 @@ export function AdvisorRuntimeControls({
   onLocalRuntimeChange,
   onLocalModelChange,
 }: AdvisorRuntimeControlsProps) {
-  const selectableHostedModels = hostedProbe.models.filter(model => model.state !== 'unsupported')
+  const selectableHostedModels = hostedProbe.models.filter(model => model.state !== 'unsupported' && model.state !== 'failed-conformance')
   const selectedHostedModel = hostedProbe.models.find(model => model.id === hostedModel) ?? null
   const hostedModelForPresentation = selectedHostedModel ?? (hostedProbe.models.length === 1 ? hostedProbe.models[0]! : null)
   const hostedModelState: AdvisorRuntimeModelState = hostedModelForPresentation?.state ?? 'unavailable'

--- a/app/renderer/sections/AdvisorRuntimeControls.tsx
+++ b/app/renderer/sections/AdvisorRuntimeControls.tsx
@@ -1,0 +1,231 @@
+import type { HostedAdvisorProbeResult } from '../advisor/hosted'
+import type { AdvisorCredentialState, AdvisorHostedModel, AdvisorHostedModelState, AdvisorLocalRuntimeId, AdvisorToolCapability, AdvisorHostedProviderId } from '../advisor/types'
+
+export type AdvisorRuntimeChoice = AdvisorLocalRuntimeId | 'hosted'
+export type AdvisorRuntimeModelState = AdvisorHostedModelState | 'unavailable'
+export type AdvisorProviderReachability = 'checking' | 'reachable' | 'unavailable' | 'unknown'
+export type AdvisorHostedCredentialState = AdvisorCredentialState | 'unknown'
+export type AdvisorRuntimeStatusKind = 'checking' | 'ready' | 'unavailable' | 'unknown'
+
+export type AdvisorRuntimeState = {
+  runtime: AdvisorLocalRuntimeId
+  status: 'checking' | 'ready' | 'unavailable'
+  detail: string
+  models: string[]
+  modelState: AdvisorRuntimeModelState
+  toolCall: AdvisorToolCapability
+}
+
+export type AdvisorHostedProbePresentation = {
+  provider: HostedAdvisorProbeResult['provider']
+  available: boolean
+  models: AdvisorHostedModel[]
+  detail: string
+  credentialState: AdvisorHostedCredentialState
+  reachability: AdvisorProviderReachability
+}
+
+function stateLabel(value: string): string {
+  return value.split('-').map(part => part.charAt(0).toUpperCase() + part.slice(1)).join(' ')
+}
+
+function modelStateLabel(value: AdvisorRuntimeModelState): string {
+  return stateLabel(value)
+}
+
+function reachabilityLabel(value: AdvisorProviderReachability): string {
+  return stateLabel(value)
+}
+
+function credentialStateLabel(value: AdvisorHostedCredentialState): string {
+  return stateLabel(value)
+}
+
+export function hostedReachability(result: HostedAdvisorProbeResult): AdvisorProviderReachability {
+  // Invalid credentials are reported after the official endpoint has answered.
+  // A ready credential with no available models does not prove literal network
+  // reachability, so the weaker Unavailable state is the truthful presentation.
+  if (result.available || result.credentialState === 'invalid') return 'reachable'
+  if (result.credentialState === 'ready') return 'unavailable'
+  return 'unknown'
+}
+
+export function presentHostedProbe(result: HostedAdvisorProbeResult): AdvisorHostedProbePresentation {
+  return { ...result, reachability: hostedReachability(result) }
+}
+
+export function createHostedProbeFailure(provider: HostedAdvisorProbeResult['provider']): AdvisorHostedProbePresentation {
+  return {
+    provider,
+    available: false,
+    models: [],
+    detail: 'Hosted runtime status is unavailable. The provider probe did not complete.',
+    credentialState: 'unknown',
+    reachability: 'unknown',
+  }
+}
+
+export function createHostedProbeChecking(provider: HostedAdvisorProbeResult['provider'], previous: AdvisorHostedProbePresentation | null = null): AdvisorHostedProbePresentation {
+  const preserveModels = previous?.provider === provider ? previous.models : []
+  return {
+    provider,
+    available: false,
+    models: preserveModels,
+    detail: 'Checking the hosted provider…',
+    credentialState: 'unknown',
+    reachability: 'checking',
+  }
+}
+
+function hostedRuntimeStatusKind(probe: AdvisorHostedProbePresentation, model: AdvisorHostedModel | null): AdvisorRuntimeStatusKind {
+  if (probe.reachability === 'checking') return 'checking'
+  if (probe.reachability === 'unknown') return probe.credentialState === 'unknown' ? 'unknown' : 'unavailable'
+  if (probe.credentialState !== 'ready' || probe.reachability !== 'reachable' || !model) return 'unavailable'
+  if (model.state === 'verified') return 'ready'
+  if (model.state === 'discovered' || model.state === 'unverified' || model.state === 'limited') return 'unknown'
+  return 'unavailable'
+}
+
+function hostedAvailabilityLabel(probe: AdvisorHostedProbePresentation, model: AdvisorHostedModel | null): string {
+  if (probe.reachability === 'checking') return 'Checking provider'
+  if (probe.credentialState !== 'ready' && probe.credentialState !== 'unknown') return 'Credential ' + credentialStateLabel(probe.credentialState).toLowerCase()
+  if (probe.reachability === 'unknown') return probe.credentialState === 'unknown' ? 'Runtime status unavailable' : 'Credential ' + credentialStateLabel(probe.credentialState).toLowerCase()
+  if (probe.reachability === 'unavailable') return 'Provider unavailable'
+  if (!model) return 'No usable model discovered'
+  if (model.state === 'unsupported') return 'Model unsupported'
+  if (model.state === 'failed-conformance') return 'Model failed conformance'
+  if (model.state === 'discovered' || model.state === 'unverified') return 'Compatibility unverified'
+  if (model.state === 'limited') return 'Model limited'
+  return 'Ready'
+}
+
+export type AdvisorRuntimeControlsProps = {
+  runtimeChoice: AdvisorRuntimeChoice
+  runtimeId: AdvisorLocalRuntimeId
+  runtimeModel: string | null
+  runtimeState: AdvisorRuntimeState
+  hostedProvider: AdvisorHostedProviderId
+  hostedModel: string | null
+  hostedProbe: AdvisorHostedProbePresentation
+  hostedConsent: boolean
+  hasHostedRuntime: boolean
+  configureOpen: boolean
+  credentialEntry: string
+  credentialSaving: boolean
+  onToggleConfigure: () => void
+  onCheckHostedRuntime: () => void
+  onActivateLocal: () => void
+  onHostedProviderChange: (provider: AdvisorHostedProviderId) => void
+  onHostedModelChange: (model: string) => void
+  onHostedConsentChange: (consent: boolean) => void
+  onCredentialEntryChange: (value: string) => void
+  onSaveHostedCredential: () => void
+  onClearHostedCredential: () => void
+  onCheckLocalRuntime: () => void
+  onActivateHosted: () => void
+  onLocalRuntimeChange: (runtime: AdvisorLocalRuntimeId) => void
+  onLocalModelChange: (model: string) => void
+}
+
+export function AdvisorRuntimeControls({
+  runtimeChoice,
+  runtimeId,
+  runtimeModel,
+  runtimeState,
+  hostedProvider,
+  hostedModel,
+  hostedProbe,
+  hostedConsent,
+  hasHostedRuntime,
+  configureOpen,
+  credentialEntry,
+  credentialSaving,
+  onToggleConfigure,
+  onCheckHostedRuntime,
+  onActivateLocal,
+  onHostedProviderChange,
+  onHostedModelChange,
+  onHostedConsentChange,
+  onCredentialEntryChange,
+  onSaveHostedCredential,
+  onClearHostedCredential,
+  onCheckLocalRuntime,
+  onActivateHosted,
+  onLocalRuntimeChange,
+  onLocalModelChange,
+}: AdvisorRuntimeControlsProps) {
+  const selectableHostedModels = hostedProbe.models.filter(model => model.state !== 'unsupported')
+  const selectedHostedModel = hostedProbe.models.find(model => model.id === hostedModel) ?? null
+  const hostedModelForPresentation = selectedHostedModel ?? (hostedProbe.models.length === 1 ? hostedProbe.models[0]! : null)
+  const hostedModelState: AdvisorRuntimeModelState = hostedModelForPresentation?.state ?? 'unavailable'
+  const runtimeStatusKind = runtimeChoice === 'hosted' ? hostedRuntimeStatusKind(hostedProbe, hostedModelForPresentation) : runtimeState.status
+  const runtimeIdentity = runtimeChoice === 'hosted'
+    ? hostedProviderLabel(hostedProvider) + (selectedHostedModel ? ' · ' + selectedHostedModel.label : '')
+    : (runtimeId === 'lmstudio' ? 'LM Studio' : 'Ollama') + (runtimeModel ? ' · ' + runtimeModel : '')
+  const runtimeAvailability = runtimeChoice === 'hosted'
+    ? hostedAvailabilityLabel(hostedProbe, hostedModelForPresentation)
+    : runtimeState.status === 'checking'
+      ? 'Checking runtime'
+      : runtimeState.status === 'ready'
+        ? 'Ready'
+        : 'Runtime unavailable'
+  const runtimeDescription = runtimeChoice === 'hosted'
+    ? 'Hosted provider account · minimum evidence sent directly · no Metrora proxy'
+    : runtimeState.status === 'ready'
+      ? (runtimeId === 'lmstudio' ? 'Local LM Studio model' : 'Local Ollama model') + ' · read-only evidence tools · tool support varies by model'
+      : 'Offline evidence fallback'
+  const runtimeDetail = runtimeChoice === 'hosted' ? hostedProbe.detail : runtimeState.detail
+
+  return (
+    <div className={'advisor-runtime-status ' + runtimeStatusKind} aria-label="Advisor runtime status">
+      <span className={'advisor-status-dot ' + runtimeStatusKind} aria-hidden="true" />
+      <div className="advisor-runtime-summary-copy">
+        <strong>{runtimeIdentity}</strong>
+        <span className={'advisor-runtime-availability ' + runtimeStatusKind}>{runtimeAvailability}</span>
+        <small className="advisor-runtime-description">{runtimeDescription}</small>
+        <small className="advisor-runtime-detail">{runtimeDetail}</small>
+      </div>
+      <button type="button" className="advisor-configure-toggle" aria-expanded={configureOpen} aria-controls={configureOpen ? 'advisor-runtime-config' : undefined} onClick={onToggleConfigure}>{configureOpen ? 'Close runtime' : 'Configure runtime'}</button>
+      {configureOpen ? <div className="advisor-runtime-config" id="advisor-runtime-config" aria-label="Advisor runtime configuration">
+        <div className="advisor-runtime-config-head"><strong>Runtime configuration</strong><span>Choose a local or hosted runtime. Technical state stays here while the conversation remains the focus.</span></div>
+        {runtimeChoice === 'hosted' ? <div className="advisor-runtime-config-controls">
+          <div className="advisor-runtime-config-actions">
+            <button type="button" className="advisor-quiet-button" onClick={onCheckHostedRuntime}>{hostedProbe.available ? 'Refresh hosted models' : 'Check hosted provider'}</button>
+            <button type="button" className="advisor-quiet-button" onClick={onActivateLocal}>Use local runtime</button>
+          </div>
+          <div className="advisor-runtime-picker-row">
+            <label className="advisor-runtime-picker">Provider<select aria-label="Advisor hosted provider" value={hostedProvider} onChange={event => onHostedProviderChange(event.target.value as AdvisorHostedProviderId)}><option value="openai">OpenAI</option><option value="anthropic">Anthropic</option><option value="gemini">Gemini</option></select></label>
+            {selectableHostedModels.length ? <label className="advisor-runtime-picker">Hosted model<select aria-label="Advisor hosted model" value={hostedModel ?? selectableHostedModels[0]!.id} onChange={event => onHostedModelChange(event.target.value)}>{selectableHostedModels.map(model => <option key={model.id} value={model.id}>{model.label} · {modelStateLabel(model.state)}</option>)}</select></label> : null}
+          </div>
+          <div className="advisor-runtime-state-grid" aria-label="Hosted runtime state">
+            <span data-state="credential">Credential: {credentialStateLabel(hostedProbe.credentialState)}</span>
+            <span data-state="reachability">Reachability: {reachabilityLabel(hostedProbe.reachability)}</span>
+            <span data-state="model">Model: {modelStateLabel(hostedModelState)}</span>
+          </div>
+          {hostedProbe.credentialState !== 'ready' ? <div className="advisor-credential-entry"><input type="password" aria-label="Advisor provider key" autoComplete="off" placeholder="Provider key (not stored in this form)" value={credentialEntry} onChange={event => onCredentialEntryChange(event.target.value)} /><button type="button" className="advisor-quiet-button" onClick={onSaveHostedCredential} disabled={credentialSaving || !credentialEntry.trim()}>{credentialSaving ? 'Saving…' : 'Save key'}</button></div> : <button type="button" className="advisor-quiet-button" onClick={onClearHostedCredential}>Remove key</button>}
+          {hasHostedRuntime ? <label className="advisor-hosted-consent"><input type="checkbox" checked={hostedConsent} onChange={event => onHostedConsentChange(event.target.checked)} /><span>Before the first hosted investigation, send this question and minimum Metrora evidence directly to the selected provider using your account. Metrora does not proxy it; provider terms, privacy, and retention apply.</span></label> : <p className="advisor-consent-unavailable">Consent appears after a usable hosted model is available. It is always explicit and starts unchecked.</p>}
+        </div> : <div className="advisor-runtime-config-controls">
+          <div className="advisor-runtime-config-actions">
+            <button type="button" className="advisor-quiet-button" onClick={onCheckLocalRuntime}>{runtimeState.status === 'checking' ? 'Checking…' : 'Check local model'}</button>
+            <button type="button" className="advisor-quiet-button" onClick={onActivateHosted}>Use hosted provider</button>
+          </div>
+          <div className="advisor-runtime-picker-row">
+            <label className="advisor-runtime-picker">Runtime<select aria-label="Advisor runtime" value={runtimeId} onChange={event => onLocalRuntimeChange(event.target.value as AdvisorLocalRuntimeId)}><option value="ollama">Ollama</option><option value="lmstudio">LM Studio</option></select></label>
+            {runtimeState.models.length ? <label className="advisor-runtime-picker">Local model<select aria-label="Advisor local runtime model" value={runtimeModel ?? runtimeState.models[0]} onChange={event => onLocalModelChange(event.target.value)}>{runtimeState.models.map(model => <option key={model} value={model}>{model}</option>)}</select></label> : null}
+          </div>
+          <div className="advisor-runtime-state-grid" aria-label="Local runtime state">
+            <span data-state="runtime">Runtime: {stateLabel(runtimeState.status)}</span>
+            <span data-state="model">Model: {modelStateLabel(runtimeState.modelState)}</span>
+            <span data-state="tool-call">Tool calls: {stateLabel(runtimeState.toolCall)}</span>
+          </div>
+        </div>}
+      </div> : null}
+    </div>
+  )
+}
+
+function hostedProviderLabel(provider: AdvisorHostedProviderId): string {
+  if (provider === 'openai') return 'OpenAI'
+  if (provider === 'anthropic') return 'Anthropic'
+  return 'Gemini'
+}

--- a/app/renderer/sections/AdvisorRuntimeControls.tsx
+++ b/app/renderer/sections/AdvisorRuntimeControls.tsx
@@ -155,7 +155,7 @@ export function AdvisorRuntimeControls({
   onLocalModelChange,
 }: AdvisorRuntimeControlsProps) {
   const selectableHostedModels = hostedProbe.models.filter(model => model.state !== 'unsupported' && model.state !== 'failed-conformance')
-  const selectedHostedModel = hostedProbe.models.find(model => model.id === hostedModel) ?? null
+  const selectedHostedModel = selectableHostedModels.find(model => model.id === hostedModel) ?? null
   const hostedModelForPresentation = selectedHostedModel ?? (hostedProbe.models.length === 1 ? hostedProbe.models[0]! : null)
   const hostedModelState: AdvisorRuntimeModelState = hostedModelForPresentation?.state ?? 'unavailable'
   const runtimeStatusKind = runtimeChoice === 'hosted' ? hostedRuntimeStatusKind(hostedProbe, hostedModelForPresentation) : runtimeState.status

--- a/app/renderer/sections/advisor-chart.tsx
+++ b/app/renderer/sections/advisor-chart.tsx
@@ -1,0 +1,62 @@
+import type { AdvisorPresentationBlockV1, AdvisorPresentationChartSeries } from '../advisor/types'
+
+function chartValue(value: number | null, unit: string): string {
+  if (value === null || !Number.isFinite(value)) return 'Unavailable'
+  return (unit === 'USD' ? '$' + value.toFixed(2) : value.toLocaleString('en-US')) + ' ' + unit
+}
+
+function chartSeriesSegments(series: AdvisorPresentationChartSeries, width: number, height: number, max: number): Array<Array<[number, number]>> {
+  const segments: Array<Array<[number, number]>> = []
+  let current: Array<[number, number]> = []
+  const denominator = Math.max(1, series.points.length - 1)
+  series.points.forEach((point, index) => {
+    if (point.value === null || !Number.isFinite(point.value)) {
+      if (current.length) segments.push(current)
+      current = []
+      return
+    }
+    const x = 22 + (index / denominator) * (width - 42)
+    const y = height - 22 - (point.value / max) * (height - 42)
+    current.push([x, y])
+  })
+  if (current.length) segments.push(current)
+  return segments
+}
+
+export function AdvisorChartBlock({ block }: { block: Extract<AdvisorPresentationBlockV1, { kind: 'line-chart' | 'bar-chart' }> }) {
+  const width = 620
+  const height = 190
+  const values = block.series.flatMap(series => series.points.map(point => point.value).filter((value): value is number => value !== null && Number.isFinite(value)))
+  const max = Math.max(1, ...values)
+  return (
+    <section className="advisor-presentation-block advisor-chart-block">
+      <div className="advisor-presentation-head"><h4>{block.title}</h4><span>{block.scopeLabel} · {block.periodLabel}</span></div>
+      <p className="advisor-presentation-summary">{block.summary}</p>
+      <svg className="advisor-chart" viewBox={'0 0 ' + width + ' ' + height} role="img" aria-label={block.accessibilityLabel}>
+        <line x1="22" y1={height - 22} x2={width - 20} y2={height - 22} />
+        <line x1="22" y1="18" x2="22" y2={height - 22} />
+        {block.kind === 'line-chart'
+          ? block.series.map((series, index) => <g key={series.id} className={'advisor-chart-series series-' + index}>
+              {chartSeriesSegments(series, width, height, max).map((segment, segmentIndex) => segment.length > 1 ? <polyline key={segmentIndex} points={segment.map(([x, y]) => x + ',' + y).join(' ')} /> : null)}
+              {series.points.map((point, pointIndex) => {
+                if (point.value === null || !Number.isFinite(point.value)) return null
+                const denominator = Math.max(1, series.points.length - 1)
+                const x = 22 + (pointIndex / denominator) * (width - 42)
+                const y = height - 22 - (point.value / max) * (height - 42)
+                return <circle key={pointIndex} cx={x} cy={y} r="2.6"><title>{series.label} · {point.label} · {chartValue(point.value, block.unit)}</title></circle>
+              })}
+            </g>)
+          : block.series[0]?.points.map((point, index) => {
+              if (point.value === null || !Number.isFinite(point.value)) return null
+              const slot = (width - 42) / Math.max(1, block.series[0]!.points.length)
+              const barWidth = Math.max(4, slot * .62)
+              const x = 22 + index * slot + (slot - barWidth) / 2
+              const y = height - 22 - (point.value / max) * (height - 42)
+              return <rect key={index} x={x} y={y} width={barWidth} height={Math.max(1, height - 22 - y)}><title>{point.label} · {chartValue(point.value, block.unit)}</title></rect>
+            })}
+      </svg>
+      <div className="advisor-chart-legend">{block.series.map((series, index) => <span key={series.id}><i className={'series-' + index} />{series.label}</span>)}</div>
+      <div className="advisor-chart-data">{block.series.flatMap(series => series.points.filter(point => point.value !== null).slice(-6).map(point => <span key={series.id + '-' + point.label}>{series.label} · {point.label} · {chartValue(point.value, block.unit)}</span>))}</div>
+    </section>
+  )
+}

--- a/app/renderer/sections/advisor-hosted-operation-guard.ts
+++ b/app/renderer/sections/advisor-hosted-operation-guard.ts
@@ -1,0 +1,47 @@
+import type { AdvisorHostedModelState } from '../advisor/types'
+
+export type AdvisorHostedOperationProvider = 'openai' | 'anthropic' | 'gemini'
+
+export function isSelectableHostedModel(model: { state: AdvisorHostedModelState }): boolean {
+  return model.state !== 'unsupported' && model.state !== 'failed-conformance'
+}
+
+export class AdvisorHostedOperationGuard {
+  private provider: AdvisorHostedOperationProvider
+  private probeRequest = 0
+  private credentialOperation = 0
+
+  constructor(provider: AdvisorHostedOperationProvider) {
+    this.provider = provider
+  }
+
+  setProvider(provider: AdvisorHostedOperationProvider): void {
+    this.provider = provider
+    this.probeRequest += 1
+    this.credentialOperation += 1
+  }
+
+  isCurrentProvider(provider: AdvisorHostedOperationProvider): boolean {
+    return this.provider === provider
+  }
+
+  startProbe(provider: AdvisorHostedOperationProvider): number | null {
+    if (!this.isCurrentProvider(provider)) return null
+    this.probeRequest += 1
+    return this.probeRequest
+  }
+
+  isCurrentProbe(provider: AdvisorHostedOperationProvider, requestId: number): boolean {
+    return this.isCurrentProvider(provider) && this.probeRequest === requestId
+  }
+
+  startCredential(provider: AdvisorHostedOperationProvider): number | null {
+    if (!this.isCurrentProvider(provider)) return null
+    this.credentialOperation += 1
+    return this.credentialOperation
+  }
+
+  isCurrentCredential(provider: AdvisorHostedOperationProvider, operationId: number): boolean {
+    return this.isCurrentProvider(provider) && this.credentialOperation === operationId
+  }
+}

--- a/app/renderer/styles/advisor.css
+++ b/app/renderer/styles/advisor.css
@@ -154,11 +154,42 @@
 .advisor-kicker { margin: 0 0 7px; color: var(--advisor-accent); font-size: 9px; font-weight: 800; letter-spacing: .16em; }
 .advisor-main-head h1 { margin: 0; font-size: 25px; letter-spacing: -.045em; }
 .advisor-subtitle { margin: 6px 0 0; color: var(--advisor-muted); font-size: 11px; }
-.advisor-runtime-status { display: flex; flex-wrap: wrap; align-items: center; gap: 9px; max-width: 520px; color: var(--advisor-muted); }
+.advisor-runtime-status { display: grid; grid-template-columns: auto minmax(0, 1fr) auto; align-items: start; gap: 0 9px; min-width: 260px; max-width: 560px; color: var(--advisor-muted); }
+.advisor-runtime-summary-copy { display: grid; min-width: 0; gap: 3px; }
 .advisor-runtime-status strong { display: block; color: var(--advisor-ink); font-size: 11px; }
-.advisor-runtime-status small { display: block; margin-top: 3px; font-size: 9px; line-height: 1.3; }
-.advisor-status-dot { width: 7px; height: 7px; flex: 0 0 auto; border-radius: 50%; background: var(--advisor-muted); }
+.advisor-runtime-status small { display: block; font-size: 9px; line-height: 1.3; }
+.advisor-runtime-description { color: var(--advisor-muted); }
+.advisor-runtime-detail { overflow: hidden; color: var(--advisor-muted); text-overflow: ellipsis; white-space: nowrap; }
+.advisor-runtime-availability { display: block; width: fit-content; color: var(--advisor-muted); font-size: 9px; font-weight: 750; }
+.advisor-runtime-availability.ready { color: #18704f; }
+.advisor-runtime-availability.unavailable { color: #a23a34; }
+.advisor-runtime-availability.unknown { color: #956000; }
+.advisor-runtime-availability.checking { color: var(--advisor-accent); }
+.advisor-status-dot { width: 8px; height: 8px; flex: 0 0 auto; margin-top: 4px; border-radius: 50%; background: var(--advisor-muted); }
 .advisor-status-dot.ready { background: #22a06b; box-shadow: 0 0 0 4px rgba(34,160,107,.12); }
+.advisor-status-dot.unavailable { background: #c2382f; box-shadow: 0 0 0 4px rgba(194,56,47,.1); }
+.advisor-status-dot.unknown { background: #d29100; box-shadow: 0 0 0 4px rgba(210,145,0,.1); }
+.advisor-status-dot.checking { background: var(--advisor-accent); box-shadow: 0 0 0 4px var(--advisor-accent-soft); }
+.advisor-configure-toggle {
+  border: 1px solid var(--advisor-line);
+  border-radius: 7px;
+  padding: 7px 9px;
+  color: var(--advisor-ink);
+  background: var(--advisor-surface-strong);
+  font: inherit;
+  font-size: 9px;
+  font-weight: 700;
+  cursor: pointer;
+}
+.advisor-configure-toggle:hover { border-color: var(--advisor-accent); color: var(--advisor-accent); }
+.advisor-runtime-config { grid-column: 1 / -1; display: grid; gap: 10px; margin-top: 7px; padding: 12px 0 0 17px; border-top: 1px solid var(--advisor-line); }
+.advisor-runtime-config-head { display: grid; gap: 3px; }
+.advisor-runtime-config-head strong { font-size: 10px; }
+.advisor-runtime-config-head span { color: var(--advisor-muted); font-size: 9px; line-height: 1.35; }
+.advisor-runtime-config-controls { display: grid; gap: 9px; }
+.advisor-runtime-config-actions,
+.advisor-runtime-picker-row { display: flex; flex-wrap: wrap; align-items: flex-end; gap: 8px; }
+.advisor-runtime-picker-row { align-items: start; }
 .advisor-quiet-button {
   flex: 0 0 auto;
   border: 1px solid var(--advisor-line);
@@ -182,13 +213,17 @@
   font: inherit;
   font-size: 9px;
 }
-.advisor-hosted-controls { flex: 1 0 100%; display: flex; flex-wrap: wrap; align-items: flex-end; gap: 8px; padding: 8px 0 0 16px; border-top: 1px solid var(--advisor-line); }
-.advisor-hosted-controls .advisor-runtime-picker select { max-width: 160px; }
-.advisor-credential-status { align-self: center; color: var(--advisor-muted); font-size: 9px; }
+.advisor-runtime-picker-row .advisor-runtime-picker select { max-width: 160px; }
+.advisor-runtime-state-grid { display: flex; flex-wrap: wrap; gap: 6px; }
+.advisor-runtime-state-grid span { padding: 4px 6px; border: 1px solid var(--advisor-line); border-radius: 5px; color: var(--advisor-muted); background: var(--advisor-tint); font-size: 9px; line-height: 1.25; }
+.advisor-runtime-state-grid span[data-state="credential"] { border-color: rgba(230,93,25,.22); }
+.advisor-runtime-state-grid span[data-state="reachability"] { border-color: rgba(45,111,229,.22); }
+.advisor-runtime-state-grid span[data-state="model"] { border-color: rgba(125,91,214,.22); }
 .advisor-credential-entry { display: flex; align-items: center; gap: 6px; }
 .advisor-credential-entry input { width: 165px; border: 1px solid var(--advisor-line); border-radius: 5px; padding: 5px 6px; color: var(--advisor-ink); background: var(--advisor-tint); font: inherit; font-size: 9px; }
-.advisor-hosted-consent { flex: 1 0 100%; display: flex; align-items: flex-start; gap: 6px; max-width: 480px; color: var(--advisor-muted); font-size: 9px; line-height: 1.4; }
+.advisor-hosted-consent { display: flex; align-items: flex-start; gap: 6px; max-width: 480px; color: var(--advisor-muted); font-size: 9px; line-height: 1.4; }
 .advisor-hosted-consent input { flex: 0 0 auto; margin: 1px 0 0; accent-color: var(--advisor-accent); }
+.advisor-consent-unavailable { max-width: 480px; margin: 0; color: var(--advisor-muted); font-size: 9px; line-height: 1.4; }
 .advisor-quiet-button:disabled { opacity: .45; cursor: not-allowed; }
 .advisor-scope-bar {
   display: flex;
@@ -388,7 +423,7 @@
   .advisor-workspace { grid-template-columns: 190px minmax(0, 1fr) 240px; }
   .advisor-main-head, .advisor-scope-bar, .advisor-thread { padding-left: 20px; padding-right: 20px; }
   .advisor-composer { margin-left: 20px; margin-right: 20px; }
-  .advisor-runtime-status { max-width: 280px; }
+  .advisor-runtime-status { min-width: 0; max-width: 360px; }
 }
 @media (max-width: 900px) {
   .advisor-workspace { grid-template-columns: 0 minmax(0, 1fr) 230px; }
@@ -398,7 +433,8 @@
   .advisor-workspace { grid-template-columns: minmax(0, 1fr); }
   .advisor-evidence { display: none; }
   .advisor-main-head { display: block; }
-  .advisor-runtime-status { margin-top: 14px; max-width: none; }
+  .advisor-runtime-status { margin-top: 14px; min-width: 0; max-width: none; }
+  .advisor-runtime-config { padding-left: 0; }
   .advisor-scope-bar { overflow-x: auto; }
   .advisor-scope-label { position: sticky; left: 0; }
   .advisor-prompt-grid { grid-template-columns: 1fr; }


### PR DESCRIPTION
## Summary

- disclose Advisor runtime identity and availability in the primary workbench
- separate credential, provider reachability, and model state in the Configure runtime panel
- render unexpected hosted probe failures as unknown and clear stale hosted model/consent state
- remove local-only investigation copy while preserving the evidence-first architecture

## Validation

- `npm --prefix app test -- --run renderer/sections/Advisor.test.tsx`
- `npm --prefix app test`
- `npm --prefix app run typecheck`
- `git diff --check`

## Scope

- renderer-only changes in Advisor.tsx, advisor.css, and Advisor.test.tsx
- no Electron/provider IPC/schema, persistence, backend, dependency, CI, merge, or release changes
- related to #232