### PR TITLE
feat(act): add Core Compatibility foundation v2

### DIFF
--- a/docs/ACT_CONTRACT_PREP_001.md
+++ b/docs/ACT_CONTRACT_PREP_001.md
@@ -1,6 +1,6 @@
 # ACT Contract Preparation 001
 
-**Status:** public design contract on current `main`; a separate Draft PR may implement part of this direction, but this document does not make that draft current product authority.
+**Status:** current-main-native ACT foundation v2 contract and implementation note; the bounded first executor is implemented on this branch for review.
 
 ## Purpose
 
@@ -47,7 +47,7 @@ A proposal is not authorization. A successful process/HTTP call is not proof tha
 
 ## First narrow ACT operation: Core Compatibility
 
-The first safe operation direction is the existing public Core Compatibility workflow previously called `Run Core Conformance Bench`.
+The first safe operation is the existing public Core Compatibility workflow; the historical command name was `Run Core Conformance Bench`.
 
 Product classification:
 
@@ -67,6 +67,14 @@ This remains a useful first ACT proof because its external effect is narrow and 
 It must **not** be treated as the definition of Metrora Bench. Mainstream Bench product direction is Performance-first; see [Bench evidence families](BENCH_EVIDENCE_FAMILIES.md).
 
 A future Performance run may receive its own action kind only after a normalized Performance contract/executor is implemented. Do not broaden the first Core Compatibility action into arbitrary benchmark execution merely for convenience.
+
+## Implemented foundation boundary
+
+The v2 foundation currently binds `metrora.action.v1` to the single `run-core-compatibility` kind. Its strict JSON-safe contract fixes the local Ollama loopback runtime, explicit model, `core-v1` selector, canonical pack identity/digest, fixed generation parameters, bounded timeouts, cancellation precedence, declared journal/history writes, and no rollback capability.
+
+Approval is issued and verified by a trusted process using exact action, proposal, confirmation, execution, target, model, pack, and parameter digests. Stored `ready` authority is revalidated for freshness after restart; stale, malformed, forged, replayed, duplicate, or mismatched actions fail closed.
+
+Execution delegates to the existing canonical task-pack runner and history store. ACT persists lifecycle state, bounded progress/counts, digests and references only; task prompts, generated output, credentials, repository paths and shell operations are not persisted or accepted. Orphaned running state is recovered only from exact existing evidence, otherwise it reaches a terminal failure/cancellation without retry.
 
 ## Confirmation UX
 
@@ -144,9 +152,8 @@ An external agent/harness framework must never bypass ActionContract/ACT authori
 
 No dependency is added by this document.
 
-## Explicitly not implemented by this document
+## Explicitly outside this foundation
 
-- new ACT runtime/executor on current `main`;
 - Harness automatic execution;
 - arbitrary shell/repository writes;
 - mobile write/execute routes;
@@ -158,7 +165,7 @@ No dependency is added by this document.
 
 ## Relationship to current Draft implementation work
 
-A Draft PR may contain a concrete `metrora.action.v1` implementation around Core Compatibility. Until that work is rebased/reviewed/merged against current `main`, public current authority remains the shipped read-only/proposal foundation plus this design contract.
+This branch contains the concrete `metrora.action.v1` implementation around Core Compatibility for review against current `main`. The proposal-only Advisor/Harness surface remains data-only and cannot authorize or execute this operation. The implementation does not add a second runner, change mobile execution, or introduce Harness UI/navigation.
 
 Any acceptance pass must ensure there is one ACT authority rather than separate `AdvisorActionProposal` and ACT execution systems that can diverge.
 

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -84,7 +84,7 @@ Experimental commands label heuristic or incomplete methodology explicitly. Thei
 | --- | --- |
 | `metrora bench models` | Discover bounded local Ollama model names that the Bench runner can execute; reports unavailable and no-model states separately. |
 | `metrora bench local --model <model>` | Run one warmup plus five measured requests against the fixed local Ollama loopback endpoint using the versioned synthetic BenchRunV1 fixture. |
-| `metrora bench task-pack --model <model>` | Run the six-check Core conformance pack and optionally save its bounded evaluation to private history. |
+| `metrora bench task-pack --model <model>` | Run the six-check Core Compatibility pack and optionally save its bounded evaluation to private history. |
 | `metrora bench history` / `metrora bench compare <left> <right>` | Read private task-pack history or compare compatible results using factual deltas only. |
 
 The Bench commands record bounded local runtime or synthetic-task evidence only.

--- a/docs/HARNESS_PUBLIC_FOUNDATION.md
+++ b/docs/HARNESS_PUBLIC_FOUNDATION.md
@@ -75,7 +75,7 @@ Examples of safe observable events:
 - tool started/completed/unavailable;
 - bounded scope used;
 - evidence freshness/coverage where material;
-- action proposal/progress when a real ACT path later exists.
+- action proposal/progress when the approved ACT path is invoked.
 
 Private chain-of-thought, hidden scratchpads and internal model reasoning are not product telemetry and should not be exposed.
 
@@ -127,7 +127,7 @@ Future tool growth should prefer useful bounded factual drill-downs over unrestr
 
 Harness may understand a state-changing request and prepare a proposal. It is not execution authority.
 
-Canonical future relationship:
+Canonical relationship for the implemented foundation (not wired to Harness UI):
 
 ```text
 Harness intent / proposal
@@ -139,7 +139,7 @@ Harness intent / proposal
 
 ACT is an execution authority underneath product workflows, not a chat mode the user must select first.
 
-Current public [ACT preparation](ACT_CONTRACT_PREP_001.md) describes that boundary. Draft implementation work is not current `main` authority until separately accepted.
+Current public [ACT preparation](ACT_CONTRACT_PREP_001.md) describes the bounded `metrora.action.v1` Core Compatibility executor. Harness/Advisor remains proposal-only; this branch does not add Harness UI or navigation integration.
 
 ## Swarm direction
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -29,7 +29,7 @@ This index separates user guidance, current product guarantees, public contracts
 - [Architecture](architecture.md) — current responsibility and authority map for the public codebase.
 - [Metrora Harness public foundation](HARNESS_PUBLIC_FOUNDATION.md) — product-facing chat/tools/ACT/Swarm direction grounded in the current read-only public foundation, with explicit shipped/planned boundaries.
 - [Advisor public foundation](ADVISOR_PUBLIC_FOUNDATION.md) — exact current `Advisor*` conversational/tool/runtime/privacy contracts and license provenance.
-- [ACT contract preparation 001](ACT_CONTRACT_PREP_001.md) — trusted-action design, Core Compatibility first-action semantics and explicit current-main non-implementation limits.
+- [ACT contract preparation 001](ACT_CONTRACT_PREP_001.md) — trusted-action design, the current-main-native Core Compatibility first action, and its bounded implementation limits.
 - [Advisor contextual integration v1](ADVISOR_CONTEXT_INTEGRATION_V1.md) — current factual-surface → Ask Advisor → contextual investigation scope handoff across supported Desktop surfaces.
 - [Provider quota authority](provider-quota-authority.md) — canonical provider-reported Capacity semantics, freshness and separation from measured local usage or budgets.
 - [Canonical history read projection v1](CANONICAL_HISTORY_READ_PROJECTION_V1.md) — shadow observation/activity identity and trusted daily-history boundary.
@@ -50,7 +50,7 @@ The public product direction uses **Metrora Harness** for the conversational/ope
 
 The current implementation still exposes stable names such as `AdvisorKernel`, `AdvisorToolV1`, `AdvisorActionProposalV1`, existing route/file names and the current `Ask Advisor` UI. Those remain truthful current implementation names until a separately reviewed UI/code migration lands.
 
-Do not treat the documentation name as proof that a runtime/UI rename, ACT executor, llama.cpp adapter or Swarm mode already ships.
+Do not treat the documentation name as proof that a runtime/UI rename, llama.cpp adapter or Swarm mode already ships.
 
 ## Bench status
 

--- a/src/act/action-contract-v1.ts
+++ b/src/act/action-contract-v1.ts
@@ -1,0 +1,491 @@
+import { createHmac, randomBytes, randomUUID, timingSafeEqual } from 'node:crypto'
+import { z } from 'zod'
+
+import {
+  DEFAULT_OLLAMA_TIMEOUT_MS,
+  MAX_OUTPUT_BYTES,
+  MAX_RESPONSE_BYTES,
+  MAX_STREAM_CHUNKS,
+  MAX_STREAM_EVENTS,
+  OLLAMA_LOCAL_BASE_URL,
+  validateOllamaModelId,
+} from '../bench/ollama-local.js'
+import { FIXED_GENERATION_PARAMETERS } from '../bench/contract-v1.js'
+import { CORE_TASK_PACK_ID, CORE_TASK_PACK_VERSION, CORE_TASK_PACK_V1 } from '../bench/task-pack-v1.js'
+import { validateBenchTimeoutMs } from '../bench/run-v1.js'
+import { canonicalJson, sha256Json } from '../bench/serialization.js'
+
+export const ACTION_CONTRACT_VERSION = 'metrora.action.v1' as const
+export const ACTION_SCHEMA_VERSION = 1 as const
+export const ACTION_KIND_RUN_CORE_COMPATIBILITY = 'run-core-compatibility' as const
+export const ACTION_KIND_RUN_CORE_COMPATIBILITY_BENCH = ACTION_KIND_RUN_CORE_COMPATIBILITY
+export const ACTION_OPERATION_VERSION = 'metrora.action-operation.v1' as const
+export const ACTION_APPROVAL_TOKEN_VERSION = 'metrora.action-approval.v1' as const
+export const ACTION_APPROVAL_AUTHORITY = 'metrora.trusted-process.v1' as const
+export const ACTION_PROPOSAL_DIGEST_DOMAIN = 'metrora.action.proposal.v1' as const
+export const ACTION_CONFIRMATION_DIGEST_DOMAIN = 'metrora.action.confirmation.v1' as const
+export const ACTION_EXECUTION_DIGEST_DOMAIN = 'metrora.action.execution.v1' as const
+export const CORE_TASK_PACK_SELECTOR = 'core-v1' as const
+export const CORE_CHECK_COUNT = 6 as const
+export const ACTION_APPROVAL_MAX_AGE_MS = 5 * 60_000
+export const ACTION_APPROVAL_MAX_FUTURE_SKEW_MS = 30_000
+export const ACTION_NO_ROLLBACK_REASON = 'bounded local evidence/history append has no reversible external mutation' as const
+
+export const ACTION_OPERATION_STATUSES = [
+  'proposed',
+  'ready',
+  'running',
+  'completed',
+  'failed',
+  'cancelled',
+  'unavailable',
+] as const
+export type ActionOperationStatus = typeof ACTION_OPERATION_STATUSES[number]
+
+export const ACTION_FAILURE_CATEGORIES = [
+  'validation',
+  'approval-invalid',
+  'approval-expired',
+  'duplicate',
+  'replay',
+  'concurrent',
+  'unavailable',
+  'timeout',
+  'cancelled',
+  'malformed-result',
+  'execution',
+  'journal',
+  'identity-mismatch',
+] as const
+export type ActionFailureCategoryV1 = typeof ACTION_FAILURE_CATEGORIES[number]
+export type ActionOriginatingSurfaceV1 = 'cli' | 'desktop'
+
+const ACTION_ID_PATTERN = /^[A-Za-z0-9._:-]{1,128}$/
+const DIGEST_PATTERN = /^[0-9a-f]{64}$/
+const EMPTY_DIGEST = '0'.repeat(64)
+
+const ActionId = z.string().regex(ACTION_ID_PATTERN)
+const Digest = z.string().regex(DIGEST_PATTERN)
+const IsoDate = z.string().max(64).datetime({ offset: true })
+const ModelId = z.string().min(1).max(200).refine(value => {
+  try {
+    validateOllamaModelId(value)
+    return true
+  } catch {
+    return false
+  }
+}, 'invalid Ollama model id')
+
+const ContractShape = z.object({
+  contractVersion: z.literal(ACTION_CONTRACT_VERSION),
+  schemaVersion: z.literal(ACTION_SCHEMA_VERSION),
+  actionId: ActionId,
+  kind: z.literal(ACTION_KIND_RUN_CORE_COMPATIBILITY),
+  originatingSurface: z.enum(['cli', 'desktop']),
+  createdAt: IsoDate,
+  scope: z.object({
+    locality: z.literal('local-only'),
+    filesystem: z.literal('none'),
+    repositoryAccess: z.literal('none'),
+    network: z.literal('loopback-only'),
+  }).strict(),
+  target: z.object({
+    runtime: z.object({
+      id: z.literal('ollama-local'),
+      endpoint: z.literal(OLLAMA_LOCAL_BASE_URL),
+    }).strict(),
+    model: ModelId,
+    pack: z.object({
+      selector: z.literal(CORE_TASK_PACK_SELECTOR),
+      packId: z.literal(CORE_TASK_PACK_ID),
+      version: z.literal(CORE_TASK_PACK_VERSION),
+      digest: z.literal(CORE_TASK_PACK_V1.digest),
+    }).strict(),
+  }).strict(),
+  arguments: z.object({
+    model: ModelId,
+    runId: ActionId,
+    packSelector: z.literal(CORE_TASK_PACK_SELECTOR),
+    promptSource: z.literal('canonical-pack-only'),
+  }).strict(),
+  generation: z.object({
+    parameters: z.object({
+      temperature: z.literal(0),
+      seed: z.literal(1729),
+      numPredict: z.literal(64),
+    }).strict(),
+    policy: z.literal('one-bounded-request-per-task'),
+  }).strict(),
+  methodology: z.object({
+    family: z.literal('compatibility-runtime-health'),
+    runner: z.literal('canonical-task-pack-v1'),
+    scoring: z.literal('deterministic-task-assertions'),
+    evidence: z.literal('canonical-bench-history-v1'),
+  }).strict(),
+  preconditions: z.object({
+    explicitModel: z.literal(true),
+    canonicalPack: z.literal(true),
+    runtime: z.literal('ollama-local-only'),
+    credentials: z.literal('none'),
+    shell: z.literal('none'),
+    arbitraryPrompt: z.literal('rejected'),
+    arbitraryPaths: z.literal('rejected'),
+    arbitraryEndpoints: z.literal('rejected'),
+    arbitraryActionKinds: z.literal('rejected'),
+    repositoryCodeExecution: z.literal('none'),
+  }).strict(),
+  declaredEffects: z.object({
+    network: z.literal('loopback-only'),
+    writes: z.tuple([
+      z.literal('metrora.act.journal.v1'),
+      z.literal('metrora.bench-history.v1'),
+    ]),
+    credentials: z.literal('none'),
+    shell: z.literal('none'),
+    repositoryCodeExecution: z.literal('none'),
+    promptSource: z.literal('canonical-pack-only'),
+    hiddenEffects: z.literal('none'),
+  }).strict(),
+  limits: z.object({
+    checksPlanned: z.literal(CORE_CHECK_COUNT),
+    maxConcurrentOperations: z.literal(1),
+    maxResponseBytes: z.literal(MAX_RESPONSE_BYTES),
+    maxOutputBytes: z.literal(MAX_OUTPUT_BYTES),
+    maxStreamChunks: z.literal(MAX_STREAM_CHUNKS),
+    maxStreamEvents: z.literal(MAX_STREAM_EVENTS),
+  }).strict(),
+  timeout: z.object({
+    perRequestMs: z.number().int().min(50).max(120_000),
+    operationMs: z.number().int().min(50).max(1_000_000),
+  }).strict(),
+  cancellation: z.object({
+    policy: z.literal('abort-signal-propagates'),
+    lateResults: z.literal('discard'),
+    terminalStatePrecedence: z.literal('cancelled-or-timeout'),
+  }).strict(),
+  approval: z.object({
+    required: z.literal('explicit-user-confirmation'),
+    proposalDigest: Digest,
+    confirmationDigest: Digest.nullable(),
+    executionDigest: Digest.nullable(),
+  }).strict(),
+  resultIdentity: z.object({
+    kind: z.literal('metrora.bench-evaluation.v1'),
+    runId: ActionId.nullable(),
+    resultDigest: Digest.nullable(),
+  }).strict(),
+  evidenceReferences: z.object({
+    kind: z.literal('metrora.bench-history.v1'),
+    runId: ActionId.nullable(),
+    resultDigest: Digest.nullable(),
+  }).strict(),
+  failureCategory: z.object({
+    category: z.enum(ACTION_FAILURE_CATEGORIES),
+    message: z.string().min(1).max(240),
+  }).strict().nullable(),
+  rollback: z.object({
+    capability: z.literal('none'),
+    reason: z.literal(ACTION_NO_ROLLBACK_REASON),
+  }).strict(),
+}).strict()
+
+export type ActionContractV1 = z.infer<typeof ContractShape>
+
+const ApprovalTokenShape = z.object({
+  tokenVersion: z.literal(ACTION_APPROVAL_TOKEN_VERSION),
+  actionId: ActionId,
+  proposalDigest: Digest,
+  confirmationDigest: Digest,
+  executionDigest: Digest,
+  issuedAt: IsoDate,
+  authority: z.literal(ACTION_APPROVAL_AUTHORITY),
+  proof: Digest,
+}).strict()
+const ApprovedActionEnvelopeShape = z.object({ contract: z.unknown(), approval: z.unknown() }).strict()
+export type ActionApprovalTokenV1 = z.infer<typeof ApprovalTokenShape>
+export type ApprovedActionV1 = { contract: ActionContractV1; approval: ActionApprovalTokenV1 }
+
+export type ActionResultReferenceV1 = {
+  kind: 'metrora.bench-evaluation.v1'
+  runId: string
+  resultDigest: string
+  history: 'saved' | 'duplicate'
+}
+export type ActionResultCountsV1 = {
+  planned: number
+  attempted: number
+  passed: number
+  failed: number
+  unavailable: number
+  timedOut: number
+  cancelled: number
+}
+export type ActionEvidenceReferenceV1 = {
+  kind: 'metrora.bench-history.v1'
+  runId: string
+  resultDigest: string
+  history: 'saved' | 'duplicate'
+}
+export type ActionOperationFailureV1 = {
+  category: ActionFailureCategoryV1
+  message: string
+}
+export type ActionOperationStateV1 = {
+  operationVersion: typeof ACTION_OPERATION_VERSION
+  actionId: string
+  ownerProcessId: number | null
+  startedAt: string | null
+  completedAt: string | null
+  progress: { planned: typeof CORE_CHECK_COUNT; completed: number }
+  checksPlanned: typeof CORE_CHECK_COUNT
+  checksCompleted: number
+  cancellation: { requested: boolean; requestedAt: string | null }
+  timeout: { perRequestMs: number; operationMs: number; triggered: boolean }
+  approvalIssuedAt: string | null
+  result: ActionResultReferenceV1 | null
+  resultCounts: ActionResultCountsV1 | null
+  evidenceReferences: ActionEvidenceReferenceV1[]
+  failure: ActionOperationFailureV1 | null
+  rollback: { capability: 'none'; reason: typeof ACTION_NO_ROLLBACK_REASON }
+}
+
+export class ActionContractError extends Error {
+  constructor(
+    public readonly code: 'invalid-contract' | 'invalid-approval' | 'stale-approval',
+    message: string,
+  ) {
+    super(message)
+    this.name = 'ActionContractError'
+  }
+}
+
+const FORBIDDEN_JSON_KEYS = new Set(['__proto__', 'constructor', 'prototype'])
+
+function assertJsonSafe(value: unknown, seen = new Set<object>()): void {
+  if (value === null || typeof value === 'string' || typeof value === 'boolean') return
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) throw new ActionContractError('invalid-contract', 'action contract numbers must be finite')
+    return
+  }
+  if (value === undefined || typeof value === 'bigint' || typeof value === 'function' || typeof value === 'symbol') {
+    throw new ActionContractError('invalid-contract', 'action contract must contain JSON-safe values only')
+  }
+  if (typeof value !== 'object') throw new ActionContractError('invalid-contract', 'action contract contains an unsupported value')
+  if (seen.has(value)) throw new ActionContractError('invalid-contract', 'action contract must not contain cycles')
+  seen.add(value)
+  const ownKeys = Reflect.ownKeys(value)
+  if (ownKeys.some(key => typeof key === 'symbol')) throw new ActionContractError('invalid-contract', 'action contract must not contain symbol properties')
+  if (Array.isArray(value)) {
+    for (const key of ownKeys) {
+      if (key === 'length') continue
+      if (typeof key !== 'string' || !/^\d+$/.test(key)) throw new ActionContractError('invalid-contract', 'action contract arrays must not contain named properties')
+      const index = Number(key)
+      if (!Number.isSafeInteger(index) || index < 0 || index >= 2 ** 32 - 1 || String(index) !== key) throw new ActionContractError('invalid-contract', 'action contract arrays must contain only dense indexes')
+      const descriptor = Object.getOwnPropertyDescriptor(value, key)
+      if (!descriptor || !('value' in descriptor)) throw new ActionContractError('invalid-contract', 'action contract must not contain accessor properties')
+      assertJsonSafe(descriptor.value, seen)
+    }
+  } else {
+    const prototype = Object.getPrototypeOf(value)
+    if (prototype !== Object.prototype && prototype !== null) throw new ActionContractError('invalid-contract', 'action contract must contain plain JSON objects only')
+    for (const key of ownKeys) {
+      if (typeof key !== 'string' || FORBIDDEN_JSON_KEYS.has(key)) throw new ActionContractError('invalid-contract', 'action contract contains a forbidden object key')
+      const descriptor = Object.getOwnPropertyDescriptor(value, key)
+      if (!descriptor || !('value' in descriptor)) throw new ActionContractError('invalid-contract', 'action contract must not contain accessor properties')
+      assertJsonSafe(descriptor.value, seen)
+    }
+  }
+  seen.delete(value)
+}
+
+function invalidContract(): ActionContractError {
+  return new ActionContractError('invalid-contract', 'action contract failed strict validation')
+}
+function parseContractShape(input: unknown): ActionContractV1 {
+  try { assertJsonSafe(input) } catch (error) { if (error instanceof ActionContractError) throw error; throw invalidContract() }
+  const parsed = ContractShape.safeParse(input)
+  if (!parsed.success) throw invalidContract()
+  const contract = parsed.data
+  if (contract.target.model !== contract.arguments.model || contract.arguments.runId !== contract.actionId) throw invalidContract()
+  if (contract.timeout.operationMs !== (contract.limits.checksPlanned + 1) * contract.timeout.perRequestMs) throw invalidContract()
+  if ((contract.resultIdentity.runId === null) !== (contract.resultIdentity.resultDigest === null)) throw invalidContract()
+  if ((contract.evidenceReferences.runId === null) !== (contract.evidenceReferences.resultDigest === null)) throw invalidContract()
+  const hasConfirmation = contract.approval.confirmationDigest !== null
+  if (!hasConfirmation && contract.approval.executionDigest !== null) throw invalidContract()
+  if (hasConfirmation && contract.approval.confirmationDigest !== computeActionConfirmationDigest(contract.approval.proposalDigest)) throw invalidContract()
+  if (hasConfirmation && contract.approval.executionDigest !== computeActionExecutionDigest(contract, contract.approval.confirmationDigest!)) throw invalidContract()
+  return contract
+}
+
+function proposalPayload(contract: ActionContractV1): Record<string, unknown> {
+  return {
+    domain: ACTION_PROPOSAL_DIGEST_DOMAIN,
+    contractVersion: contract.contractVersion,
+    schemaVersion: contract.schemaVersion,
+    actionId: contract.actionId,
+    kind: contract.kind,
+    originatingSurface: contract.originatingSurface,
+    createdAt: contract.createdAt,
+    scope: contract.scope,
+    target: contract.target,
+    arguments: contract.arguments,
+    generation: contract.generation,
+    methodology: contract.methodology,
+    preconditions: contract.preconditions,
+    declaredEffects: contract.declaredEffects,
+    limits: contract.limits,
+    timeout: contract.timeout,
+    cancellation: contract.cancellation,
+    approvalRequirement: contract.approval.required,
+    rollback: contract.rollback,
+  }
+}
+
+export function computeActionProposalDigest(input: ActionContractV1): string {
+  return sha256Json(proposalPayload(parseContractShape(input)))
+}
+export function computeActionConfirmationDigest(proposalDigest: string): string {
+  if (!DIGEST_PATTERN.test(proposalDigest)) throw new ActionContractError('invalid-contract', 'proposal digest must be a lowercase SHA-256 digest')
+  return sha256Json({ domain: ACTION_CONFIRMATION_DIGEST_DOMAIN, contractVersion: ACTION_CONTRACT_VERSION, schemaVersion: ACTION_SCHEMA_VERSION, proposalDigest, confirmation: 'explicit-user-confirmation' })
+}
+export function computeActionExecutionDigest(contractInput: ActionContractV1, confirmationDigest: string): string {
+  const contract = parseContractShape({ ...contractInput, approval: { ...contractInput.approval, confirmationDigest: null, executionDigest: null } })
+  if (!DIGEST_PATTERN.test(confirmationDigest)) throw new ActionContractError('invalid-contract', 'confirmation digest must be a lowercase SHA-256 digest')
+  return sha256Json({ domain: ACTION_EXECUTION_DIGEST_DOMAIN, proposalDigest: computeActionProposalDigest(contract), confirmationDigest, actionId: contract.actionId, kind: contract.kind, target: contract.target, arguments: contract.arguments, generation: contract.generation, timeout: contract.timeout, cancellation: contract.cancellation })
+}
+export function validateActionContractV1(input: unknown): ActionContractV1 {
+  const contract = parseContractShape(input)
+  if (contract.approval.proposalDigest !== sha256Json(proposalPayload(contract))) throw invalidContract()
+  return contract
+}
+
+export function parseActionApprovalTokenV1(input: unknown): ActionApprovalTokenV1 {
+  try { assertJsonSafe(input) } catch { throw new ActionContractError('invalid-approval', 'approval token must contain JSON-safe values only') }
+  const parsed = ApprovalTokenShape.safeParse(input)
+  if (!parsed.success) throw new ActionContractError('invalid-approval', 'approval token failed strict validation')
+  return parsed.data
+}
+
+export type CreateCoreCompatibilityActionInput = {
+  model: string
+  originatingSurface: ActionOriginatingSurfaceV1
+  actionId?: string
+  createdAt?: string
+  timeoutMs?: number
+}
+
+export function createCoreCompatibilityAction(input: CreateCoreCompatibilityActionInput): ActionContractV1 {
+  const model = validateOllamaModelId(input.model)
+  const actionId = input.actionId ?? randomUUID()
+  if (!ACTION_ID_PATTERN.test(actionId)) throw new ActionContractError('invalid-contract', 'action id must be bounded and contain no path separators')
+  const createdAt = input.createdAt ?? new Date().toISOString()
+  const perRequestMs = validateBenchTimeoutMs(input.timeoutMs ?? DEFAULT_OLLAMA_TIMEOUT_MS)
+  const draft = {
+    contractVersion: ACTION_CONTRACT_VERSION,
+    schemaVersion: ACTION_SCHEMA_VERSION,
+    actionId,
+    kind: ACTION_KIND_RUN_CORE_COMPATIBILITY,
+    originatingSurface: input.originatingSurface,
+    createdAt,
+    scope: { locality: 'local-only' as const, filesystem: 'none' as const, repositoryAccess: 'none' as const, network: 'loopback-only' as const },
+    target: { runtime: { id: 'ollama-local' as const, endpoint: OLLAMA_LOCAL_BASE_URL }, model, pack: { selector: CORE_TASK_PACK_SELECTOR, packId: CORE_TASK_PACK_ID, version: CORE_TASK_PACK_VERSION, digest: CORE_TASK_PACK_V1.digest } },
+    arguments: { model, runId: actionId, packSelector: CORE_TASK_PACK_SELECTOR, promptSource: 'canonical-pack-only' as const },
+    generation: { parameters: { ...FIXED_GENERATION_PARAMETERS }, policy: 'one-bounded-request-per-task' as const },
+    methodology: { family: 'compatibility-runtime-health' as const, runner: 'canonical-task-pack-v1' as const, scoring: 'deterministic-task-assertions' as const, evidence: 'canonical-bench-history-v1' as const },
+    preconditions: { explicitModel: true as const, canonicalPack: true as const, runtime: 'ollama-local-only' as const, credentials: 'none' as const, shell: 'none' as const, arbitraryPrompt: 'rejected' as const, arbitraryPaths: 'rejected' as const, arbitraryEndpoints: 'rejected' as const, arbitraryActionKinds: 'rejected' as const, repositoryCodeExecution: 'none' as const },
+    declaredEffects: { network: 'loopback-only' as const, writes: ['metrora.act.journal.v1', 'metrora.bench-history.v1'] as ['metrora.act.journal.v1', 'metrora.bench-history.v1'], credentials: 'none' as const, shell: 'none' as const, repositoryCodeExecution: 'none' as const, promptSource: 'canonical-pack-only' as const, hiddenEffects: 'none' as const },
+    limits: { checksPlanned: CORE_CHECK_COUNT, maxConcurrentOperations: 1 as const, maxResponseBytes: MAX_RESPONSE_BYTES, maxOutputBytes: MAX_OUTPUT_BYTES, maxStreamChunks: MAX_STREAM_CHUNKS, maxStreamEvents: MAX_STREAM_EVENTS },
+    timeout: { perRequestMs, operationMs: (CORE_CHECK_COUNT + 1) * perRequestMs },
+    cancellation: { policy: 'abort-signal-propagates' as const, lateResults: 'discard' as const, terminalStatePrecedence: 'cancelled-or-timeout' as const },
+    approval: { required: 'explicit-user-confirmation' as const, proposalDigest: EMPTY_DIGEST, confirmationDigest: null, executionDigest: null },
+    resultIdentity: { kind: 'metrora.bench-evaluation.v1' as const, runId: null, resultDigest: null },
+    evidenceReferences: { kind: 'metrora.bench-history.v1' as const, runId: null, resultDigest: null },
+    failureCategory: null,
+    rollback: { capability: 'none' as const, reason: ACTION_NO_ROLLBACK_REASON },
+  }
+  return validateActionContractV1({ ...draft, approval: { ...draft.approval, proposalDigest: computeActionProposalDigest(draft as ActionContractV1) } })
+}
+
+function signingPayload(token: Omit<ActionApprovalTokenV1, 'proof'>): string { return canonicalJson(token) }
+
+export type TrustedActionAuthorityOptions = {
+  secret?: Uint8Array
+  now?: () => Date
+  maxAgeMs?: number
+  futureSkewMs?: number
+}
+
+export class TrustedActionAuthorityV1 {
+  private readonly secret: Buffer
+  private readonly now: () => Date
+  private readonly maxAgeMs: number
+  private readonly futureSkewMs: number
+
+  constructor(secretOrOptions?: Uint8Array | TrustedActionAuthorityOptions) {
+    const options = secretOrOptions instanceof Uint8Array ? { secret: secretOrOptions } : (secretOrOptions ?? {})
+    if (options.secret !== undefined && options.secret.byteLength < 32) throw new Error('trusted action authority secret must be at least 32 bytes')
+    this.secret = Buffer.from(options.secret ?? randomBytes(32))
+    this.now = options.now ?? (() => new Date())
+    this.maxAgeMs = options.maxAgeMs ?? ACTION_APPROVAL_MAX_AGE_MS
+    this.futureSkewMs = options.futureSkewMs ?? ACTION_APPROVAL_MAX_FUTURE_SKEW_MS
+    if (!Number.isInteger(this.maxAgeMs) || this.maxAgeMs <= 0 || !Number.isInteger(this.futureSkewMs) || this.futureSkewMs < 0) throw new Error('trusted action authority freshness bounds must be positive integers')
+  }
+
+  issueApprovalAfterTrustedUserConfirmation(contractInput: ActionContractV1): ApprovedActionV1 {
+    const contract = validateActionContractV1(contractInput)
+    if (contract.approval.confirmationDigest !== null || contract.approval.executionDigest !== null) throw new ActionContractError('invalid-approval', 'action already contains an approval')
+    const proposalDigest = computeActionProposalDigest(contract)
+    const confirmationDigest = computeActionConfirmationDigest(proposalDigest)
+    const executionDigest = computeActionExecutionDigest(contract, confirmationDigest)
+    const unsigned = { tokenVersion: ACTION_APPROVAL_TOKEN_VERSION, actionId: contract.actionId, proposalDigest, confirmationDigest, executionDigest, issuedAt: this.now().toISOString(), authority: ACTION_APPROVAL_AUTHORITY } satisfies Omit<ActionApprovalTokenV1, 'proof'>
+    const proof = createHmac('sha256', this.secret).update(signingPayload(unsigned), 'utf8').digest('hex')
+    const approval = parseActionApprovalTokenV1({ ...unsigned, proof })
+    const approvedContract = validateActionContractV1({ ...contract, approval: { ...contract.approval, confirmationDigest, executionDigest } })
+    return { contract: approvedContract, approval }
+  }
+
+  verifyApprovedAction(input: unknown): ApprovedActionV1 {
+    let envelope: { contract: unknown; approval: unknown }
+    try {
+      assertJsonSafe(input)
+      const parsed = ApprovedActionEnvelopeShape.safeParse(input)
+      if (!parsed.success) throw new Error('invalid envelope')
+      envelope = parsed.data as { contract: unknown; approval: unknown }
+    } catch { throw new ActionContractError('invalid-approval', 'approved action envelope failed strict validation') }
+    let contract: ActionContractV1
+    let approval: ActionApprovalTokenV1
+    try { contract = validateActionContractV1(envelope.contract); approval = parseActionApprovalTokenV1(envelope.approval) } catch (error) {
+      if (error instanceof ActionContractError) throw new ActionContractError('invalid-approval', error.message)
+      throw new ActionContractError('invalid-approval', 'approved action envelope failed strict validation')
+    }
+    const issuedAtMs = Date.parse(approval.issuedAt)
+    const nowMs = this.now().getTime()
+    if (!Number.isFinite(issuedAtMs) || !Number.isFinite(nowMs) || issuedAtMs > nowMs + this.futureSkewMs) throw new ActionContractError('invalid-approval', 'approval is not yet valid')
+    if (nowMs - issuedAtMs > this.maxAgeMs) throw new ActionContractError('stale-approval', 'approval is expired')
+    const expectedProposalDigest = computeActionProposalDigest(contract)
+    const expectedConfirmationDigest = computeActionConfirmationDigest(expectedProposalDigest)
+    const expectedExecutionDigest = computeActionExecutionDigest(contract, expectedConfirmationDigest)
+    if (approval.actionId !== contract.actionId || approval.proposalDigest !== expectedProposalDigest || approval.confirmationDigest !== expectedConfirmationDigest || approval.executionDigest !== expectedExecutionDigest || contract.approval.confirmationDigest !== expectedConfirmationDigest || contract.approval.executionDigest !== expectedExecutionDigest) throw new ActionContractError('invalid-approval', 'approval is not bound to this exact action proposal')
+    const expectedProof = createHmac('sha256', this.secret).update(signingPayload({ tokenVersion: approval.tokenVersion, actionId: approval.actionId, proposalDigest: approval.proposalDigest, confirmationDigest: approval.confirmationDigest, executionDigest: approval.executionDigest, issuedAt: approval.issuedAt, authority: approval.authority }), 'utf8').digest('hex')
+    const expectedBytes = Buffer.from(expectedProof, 'hex')
+    const actualBytes = Buffer.from(approval.proof, 'hex')
+    if (expectedBytes.length !== actualBytes.length || !timingSafeEqual(expectedBytes, actualBytes)) throw new ActionContractError('invalid-approval', 'approval proof was not issued by the trusted process')
+    return { contract, approval }
+  }
+
+  isFreshIssuedAt(issuedAt: string): boolean {
+    const issuedAtMs = Date.parse(issuedAt)
+    const nowMs = this.now().getTime()
+    return Number.isFinite(issuedAtMs) && Number.isFinite(nowMs) && issuedAtMs <= nowMs + this.futureSkewMs && nowMs - issuedAtMs <= this.maxAgeMs
+  }
+}
+
+export function isFreshApprovalIssuedAt(issuedAt: string, now = new Date(), maxAgeMs = ACTION_APPROVAL_MAX_AGE_MS, futureSkewMs = ACTION_APPROVAL_MAX_FUTURE_SKEW_MS): boolean {
+  const issuedAtMs = Date.parse(issuedAt)
+  const nowMs = now.getTime()
+  return Number.isFinite(issuedAtMs) && Number.isFinite(nowMs) && issuedAtMs <= nowMs + futureSkewMs && nowMs - issuedAtMs <= maxAgeMs
+}
+
+export function coreCompatibilityPackIdentity(): { selector: typeof CORE_TASK_PACK_SELECTOR; packId: typeof CORE_TASK_PACK_ID; version: typeof CORE_TASK_PACK_VERSION; checks: typeof CORE_CHECK_COUNT; digest: string } {
+  return { selector: CORE_TASK_PACK_SELECTOR, packId: CORE_TASK_PACK_ID, version: CORE_TASK_PACK_VERSION, checks: CORE_CHECK_COUNT, digest: CORE_TASK_PACK_V1.digest }
+}

--- a/src/act/apply.ts
+++ b/src/act/apply.ts
@@ -4,12 +4,14 @@ import { randomUUID } from 'crypto'
 import type { ActionPlan, ActionRecord, FileChange } from './types.js'
 import { appendRecord, defaultActionsDir, withLock } from './journal.js'
 import { backupDirFor, relBackupPath, revertChange, sha256File, snapshotFile } from './backup.js'
+import { ACTION_KIND_RUN_CORE_COMPATIBILITY } from './action-contract-v1.js'
 
 // The only mutation path. Order: back up every file the plan touches, apply
 // the mutations, hash the results, then journal. If a mutation or the journal
 // append throws, the steps already applied are rolled back (newest first) and
 // nothing is journaled.
 export async function runAction(plan: ActionPlan, actionsDir: string = defaultActionsDir()): Promise<ActionRecord> {
+  if ((plan as unknown as { kind?: unknown }).kind === ACTION_KIND_RUN_CORE_COMPATIBILITY) throw new Error('run-core-compatibility is a controlled operation; use the trusted ACT executor')
   return withLock(actionsDir, async () => {
     const id = randomUUID()
     const at = new Date().toISOString()

--- a/src/act/core-compatibility-operation-v1.ts
+++ b/src/act/core-compatibility-operation-v1.ts
@@ -1,0 +1,492 @@
+import { defaultActionsDir, withLock } from './journal.js'
+import {
+  ActionContractError,
+  ACTION_NO_ROLLBACK_REASON,
+  CORE_CHECK_COUNT,
+  type ActionContractV1,
+  type ActionFailureCategoryV1,
+  type ActionOperationStateV1,
+  type ActionOperationStatus,
+  type ApprovedActionV1,
+  TrustedActionAuthorityV1,
+  computeActionProposalDigest,
+  isFreshApprovalIssuedAt,
+  validateActionContractV1,
+} from './action-contract-v1.js'
+import {
+  ActionOperationError,
+  appendOperationRecord,
+  assertFreshActionContract,
+  boundedMessage,
+  clearOutcome,
+  countsEqual,
+  evidenceReference,
+  failureFromBench,
+  initialOperationState,
+  isTerminal,
+  latestCoreCompatibilityRecord,
+  nowIso,
+  processIsAlive,
+  proposalContract,
+  readCoreCompatibilityRecords,
+  resultCounts,
+  resultReference,
+  sameActionContract,
+  type CoreCompatibilityActionCancellationResult,
+  type CoreCompatibilityActionRecordV1,
+} from './core-compatibility-state-v1.js'
+import {
+  BENCH_EVALUATION_SCHEMA_VERSION,
+  BENCH_TASK_RUNNER_ID,
+  BENCH_TASK_RUNNER_VERSION,
+  digestBenchEvaluationV1,
+  runBenchTaskPackV1,
+  type BenchEvaluationV1,
+  type BenchTaskPackRunOptions,
+} from '../bench/task-pack-run-v1.js'
+import { parseBenchEvaluationV1, saveBenchEvaluationV1, scanBenchHistoryV1 } from '../bench/history-v1.js'
+import { CORE_TASK_PACK_V1 } from '../bench/task-pack-v1.js'
+import { OLLAMA_LOCAL_BASE_URL, type BenchFetch } from '../bench/ollama-local.js'
+
+export { ACTION_RECORD_VERSION, ActionOperationError } from './core-compatibility-state-v1.js'
+export type { CoreCompatibilityActionCancellationResult, CoreCompatibilityActionRecordV1 } from './core-compatibility-state-v1.js'
+
+export type CoreCompatibilityActionExecutionOptions = {
+  authority: TrustedActionAuthorityV1
+  actionsDir?: string
+  dataDir?: string
+  fetchImpl?: BenchFetch
+  signal?: AbortSignal
+  now?: () => Date
+  monotonicNow?: () => number
+  /** Internal test seam; the public action surface always uses the canonical runner. */
+  runBench?: (options: BenchTaskPackRunOptions) => Promise<BenchEvaluationV1>
+}
+export type CoreCompatibilityActionCancellationOptions = { actionsDir?: string; dataDir?: string; now?: () => Date }
+
+const LOCK_RETRIES = 120
+const LOCK_RETRY_MS = 25
+const CANCELLATION_POLL_MS = 100
+type ActiveExecution = {
+  actionId: string
+  controller: AbortController
+  cancelled: boolean
+  cancellationRequestedAt: string | null
+  operationTimedOut: boolean
+  journalFailure: ActionOperationError | null
+  finalized: boolean
+  finalizing: boolean
+}
+const activeExecutions = new Map<string, ActiveExecution>()
+
+function sleep(ms: number): Promise<void> { return new Promise(resolve => setTimeout(resolve, ms)) }
+function isLockBusy(error: unknown): boolean {
+  return error instanceof Error && (error.message.includes('another metrora action is in progress') || error.message.includes('could not acquire the metrora action lock'))
+}
+async function withActionLock<T>(actionsDir: string, operation: () => Promise<T>): Promise<T> {
+  let last: unknown
+  for (let attempt = 0; attempt < LOCK_RETRIES; attempt++) {
+    try { return await withLock(actionsDir, operation) } catch (error) {
+      if (!isLockBusy(error)) throw error
+      last = error
+      await sleep(LOCK_RETRY_MS)
+    }
+  }
+  throw new ActionOperationError('concurrent', boundedMessage(last, 'the ACT journal lock remained busy'))
+}
+function failedOperation(operation: ActionOperationStateV1, category: Exclude<ActionFailureCategoryV1, 'cancelled' | 'unavailable'>, message: string, now: () => Date): ActionOperationStateV1 {
+  return { ...clearOutcome(operation), ownerProcessId: null, completedAt: nowIso(now), timeout: { ...operation.timeout, triggered: operation.timeout.triggered || category === 'timeout' }, failure: { category, message: boundedMessage(message, 'Core Compatibility failed.') }, rollback: { capability: 'none', reason: ACTION_NO_ROLLBACK_REASON } }
+}
+function cancelledBeforeStart(record: CoreCompatibilityActionRecordV1, now: () => Date, requestedAt: string, message = 'Core Compatibility was cancelled before execution started.'): ActionOperationStateV1 {
+  return { ...clearOutcome(record.operation), ownerProcessId: null, startedAt: null, completedAt: nowIso(now), progress: { planned: CORE_CHECK_COUNT, completed: 0 }, checksPlanned: CORE_CHECK_COUNT, checksCompleted: 0, cancellation: { requested: true, requestedAt }, failure: { category: 'cancelled', message }, rollback: { capability: 'none', reason: ACTION_NO_ROLLBACK_REASON } }
+}
+function cancellationState(operation: ActionOperationStateV1, now: () => Date, requestedAt: string, message: string): ActionOperationStateV1 {
+  return { ...clearOutcome(operation), ownerProcessId: null, completedAt: nowIso(now), cancellation: { requested: true, requestedAt: operation.cancellation.requestedAt ?? requestedAt }, failure: { category: 'cancelled', message: boundedMessage(message, 'Core Compatibility was cancelled.') }, rollback: { capability: 'none', reason: ACTION_NO_ROLLBACK_REASON } }
+}
+function exactBenchIdentity(result: BenchEvaluationV1, actionId: string, contract: ActionContractV1): boolean {
+  return result.schemaVersion === BENCH_EVALUATION_SCHEMA_VERSION
+    && result.runId === actionId
+    && result.runner.id === BENCH_TASK_RUNNER_ID
+    && result.runner.version === BENCH_TASK_RUNNER_VERSION
+    && result.model.selected === contract.target.model
+    && result.pack.packId === contract.target.pack.packId
+    && result.pack.version === contract.target.pack.version
+    && result.pack.digest === contract.target.pack.digest
+    && result.runtime.id === contract.target.runtime.id
+    && result.runtime.endpoint === contract.target.runtime.endpoint
+    && result.generation.policy === 'one-bounded-request-per-task'
+    && result.generation.parameters.temperature === 0
+    && result.generation.parameters.seed === 1729
+    && result.generation.parameters.numPredict === 64
+    && result.tasks.length === CORE_TASK_COUNT
+    && result.aggregate.planned === CORE_CHECK_COUNT
+    && digestBenchEvaluationV1(result) === result.resultDigest
+}
+const CORE_TASK_COUNT = CORE_TASK_PACK_V1.tasks.length
+async function findEvidence(actionId: string, contract: ActionContractV1, dataDir?: string): Promise<BenchEvaluationV1 | undefined> {
+  const scan = await scanBenchHistoryV1({ dataDir })
+  return scan.records.find(result => exactBenchIdentity(result, actionId, contract))
+}
+function terminalFromResult(record: CoreCompatibilityActionRecordV1, result: BenchEvaluationV1, history: 'saved' | 'duplicate', now: () => Date): { status: ActionOperationStatus; operation: ActionOperationStateV1 } {
+  const counts = resultCounts(result)
+  const reference = resultReference(result, history)
+  const common: ActionOperationStateV1 = {
+    ...record.operation,
+    ownerProcessId: null,
+    completedAt: nowIso(now),
+    progress: { planned: CORE_CHECK_COUNT, completed: counts.attempted },
+    checksPlanned: CORE_CHECK_COUNT,
+    checksCompleted: counts.attempted,
+    timeout: { ...record.operation.timeout, triggered: record.operation.timeout.triggered || counts.timedOut > 0 },
+    result: reference,
+    resultCounts: counts,
+    evidenceReferences: [evidenceReference(result, history)],
+    failure: null,
+    rollback: { capability: 'none', reason: ACTION_NO_ROLLBACK_REASON },
+  }
+  if (record.operation.cancellation.requested || result.status === 'cancelled') {
+    return { status: 'cancelled', operation: { ...clearOutcome(common), cancellation: { requested: true, requestedAt: record.operation.cancellation.requestedAt ?? nowIso(now) }, failure: { category: 'cancelled', message: 'Core Compatibility cancellation was authoritative; the result was discarded.' } } }
+  }
+  if (counts.timedOut > 0) return { status: 'failed', operation: { ...common, failure: { category: 'timeout', message: failureFromBench(result, 'A bounded Core Compatibility request timed out.') } } }
+  if (result.status === 'unavailable') return { status: 'unavailable', operation: { ...common, failure: { category: 'unavailable', message: failureFromBench(result, 'Ollama local runtime was unavailable.') } } }
+  return { status: 'completed', operation: common }
+}
+async function recoverRunningRecord(record: CoreCompatibilityActionRecordV1, actionsDir: string, dataDir: string | undefined, now: () => Date): Promise<CoreCompatibilityActionRecordV1> {
+  const evidence = await findEvidence(record.id, record.contract, dataDir)
+  if (evidence) {
+    const terminal = terminalFromResult(record, evidence, 'duplicate', now)
+    return appendOperationRecord(actionsDir, record.contract, terminal.status, terminal.operation, now)
+  }
+  if (record.operation.cancellation.requested) return appendOperationRecord(actionsDir, record.contract, 'cancelled', cancellationState(record.operation, now, record.operation.cancellation.requestedAt ?? nowIso(now), 'The previous owner exited after cancellation was requested.'), now)
+  const category = record.operation.timeout.triggered ? 'timeout' : 'execution'
+  return appendOperationRecord(actionsDir, record.contract, 'failed', failedOperation(record.operation, category, category === 'timeout' ? 'The previous owner exited after the bounded timeout.' : 'The previous owner exited before completion; a new action is required.', now), now)
+}
+async function verifyStoredEvidence(record: CoreCompatibilityActionRecordV1, dataDir?: string): Promise<CoreCompatibilityActionRecordV1> {
+  if (!record.operation.result) return record
+  const evidence = await findEvidence(record.id, record.contract, dataDir)
+  if (!evidence || record.operation.result.resultDigest !== evidence.resultDigest || !record.operation.resultCounts || !countsEqual(record.operation.resultCounts, resultCounts(evidence))) throw new ActionOperationError('identity-mismatch', 'the ACT journal references missing or mismatched Bench evidence')
+  return record
+}
+export async function recordCoreCompatibilityProposal(contractInput: ActionContractV1, options: { actionsDir?: string; now?: () => Date } = {}): Promise<CoreCompatibilityActionRecordV1> {
+  let contract: ActionContractV1
+  try { contract = validateActionContractV1(contractInput) } catch (error) { throw new ActionOperationError('validation', boundedMessage(error, 'the Core Compatibility action contract is invalid')) }
+  assertFreshActionContract(contract, false)
+  const actionsDir = options.actionsDir ?? defaultActionsDir()
+  const now = options.now ?? (() => new Date())
+  return withActionLock(actionsDir, async () => {
+    if (await latestCoreCompatibilityRecord(actionsDir, contract.actionId)) throw new ActionOperationError('duplicate', 'the action id has already been proposed or executed')
+    const proposal = proposalContract(contract)
+    return appendOperationRecord(actionsDir, proposal, 'proposed', initialOperationState(proposal), now)
+  })
+}
+
+async function prepareExecution(contract: ActionContractV1, approvalIssuedAt: string, active: ActiveExecution, actionsDir: string, dataDir: string | undefined, now: () => Date): Promise<{ kind: 'running'; record: CoreCompatibilityActionRecordV1 } | { kind: 'terminal'; record: CoreCompatibilityActionRecordV1 }> {
+  return withActionLock(actionsDir, async () => {
+    let current = await latestCoreCompatibilityRecord(actionsDir, contract.actionId)
+    if (current && !sameActionContract(current.contract, contract)) throw new ActionOperationError('identity-mismatch', 'the approved action does not match the recorded proposal')
+    if (current?.status === 'running') {
+      if (processIsAlive(current.operation.ownerProcessId)) throw new ActionOperationError('concurrent', 'the Core Compatibility action is already running')
+      return { kind: 'terminal', record: await recoverRunningRecord(current, actionsDir, dataDir, now) }
+    }
+    if (current && isTerminal(current.status)) throw new ActionOperationError('replay', 'the action has already reached a terminal state; replay is rejected')
+
+    let records = await readCoreCompatibilityRecords(actionsDir)
+    for (const record of records) {
+      if (record.id === contract.actionId || record.status !== 'running') continue
+      if (processIsAlive(record.operation.ownerProcessId)) throw new ActionOperationError('concurrent', 'another Core Compatibility action is already running')
+      await recoverRunningRecord(record, actionsDir, dataDir, now)
+    }
+    current = await latestCoreCompatibilityRecord(actionsDir, contract.actionId)
+    if (current?.status === 'running') throw new ActionOperationError('concurrent', 'the Core Compatibility action is already running')
+    if (current && isTerminal(current.status)) throw new ActionOperationError('replay', 'the action has already reached a terminal state; replay is rejected')
+
+    if (!current) {
+      const proposal = proposalContract(contract)
+      await appendOperationRecord(actionsDir, proposal, 'proposed', initialOperationState(proposal), now)
+      current = await latestCoreCompatibilityRecord(actionsDir, contract.actionId)
+    }
+    if (!current) throw new ActionOperationError('journal', 'the action proposal could not be persisted')
+    if (current.status === 'proposed') {
+      const readyOperation: ActionOperationStateV1 = { ...initialOperationState(contract), approvalIssuedAt }
+      current = await appendOperationRecord(actionsDir, contract, 'ready', readyOperation, now)
+    } else if (current.status === 'ready') {
+      if (current.operation.approvalIssuedAt !== approvalIssuedAt) throw new ActionOperationError('approval-invalid', 'the approval is not the exact approval recorded for this action')
+      if (!isFreshApprovalIssuedAt(current.operation.approvalIssuedAt, now())) {
+        const expired = failedOperation(current.operation, 'approval-expired', 'the persisted action approval expired before execution.', now)
+        current = await appendOperationRecord(actionsDir, current.contract, 'failed', expired, now)
+        throw new ActionOperationError('approval-expired', 'the persisted action approval expired before execution')
+      }
+    }
+    if (active.cancelled || active.controller.signal.aborted) {
+      const requestedAt = active.cancellationRequestedAt ?? nowIso(now)
+      active.cancellationRequestedAt ??= requestedAt
+      return { kind: 'terminal', record: await appendOperationRecord(actionsDir, contract, 'cancelled', cancelledBeforeStart(current, now, requestedAt), now) }
+    }
+    const runningOperation: ActionOperationStateV1 = {
+      ...clearOutcome(current.operation),
+      ownerProcessId: process.pid,
+      startedAt: nowIso(now),
+      completedAt: null,
+      progress: { planned: CORE_CHECK_COUNT, completed: current.operation.progress.completed },
+      checksPlanned: CORE_CHECK_COUNT,
+      checksCompleted: current.operation.checksCompleted,
+      cancellation: { requested: false, requestedAt: null },
+      timeout: { ...current.operation.timeout, triggered: false },
+      approvalIssuedAt,
+      rollback: { capability: 'none', reason: ACTION_NO_ROLLBACK_REASON },
+    }
+    return { kind: 'running', record: await appendOperationRecord(actionsDir, contract, 'running', runningOperation, now) }
+  })
+}
+
+function progressCallback(active: ActiveExecution, contract: ActionContractV1, actionsDir: string, now: () => Date): (progress: { planned: number; completed: number }) => Promise<void> {
+  return async progress => {
+    if (active.finalized || active.finalizing || active.controller.signal.aborted) return
+    if (progress.planned !== CORE_CHECK_COUNT || !Number.isInteger(progress.completed) || progress.completed < 0 || progress.completed > CORE_CHECK_COUNT) {
+      active.journalFailure ??= new ActionOperationError('validation', 'the canonical Bench runner reported invalid bounded progress')
+      active.controller.abort()
+      return
+    }
+    await withActionLock(actionsDir, async () => {
+      if (active.finalized || active.finalizing || active.controller.signal.aborted) return
+      const current = await latestCoreCompatibilityRecord(actionsDir, contract.actionId)
+      if (!current || current.status !== 'running' || current.operation.ownerProcessId !== process.pid) throw new ActionOperationError('concurrent', 'the ACT operation owner changed during progress')
+      if (progress.completed < current.operation.progress.completed) throw new ActionOperationError('validation', 'the canonical Bench runner reported regressed progress')
+      if (progress.completed === current.operation.progress.completed) return
+      const operation = { ...current.operation, progress: { planned: CORE_CHECK_COUNT, completed: progress.completed }, checksCompleted: progress.completed }
+      await appendOperationRecord(actionsDir, contract, 'running', operation, now)
+    }).catch(error => {
+      if (!active.finalized && !active.finalizing) {
+        active.journalFailure ??= error instanceof ActionOperationError ? error : new ActionOperationError('journal', boundedMessage(error, 'the ACT journal became unavailable'))
+        active.controller.abort()
+      }
+    })
+  }
+}
+function failureCategory(error: unknown): Exclude<ActionFailureCategoryV1, 'cancelled' | 'unavailable'> {
+  if (error instanceof ActionOperationError && error.code !== 'cancelled' && error.code !== 'unavailable' && error.code !== 'not-found' && error.code !== 'owner-unavailable') return error.code
+  return 'execution'
+}
+type FinalOutcome = { kind: 'result'; result: unknown } | { kind: 'error'; error: unknown } | { kind: 'abort'; category: 'cancelled' | 'timeout' | 'journal' }
+
+async function finalizeOperation(active: ActiveExecution, contract: ActionContractV1, actionsDir: string, dataDir: string | undefined, now: () => Date, outcome: FinalOutcome): Promise<CoreCompatibilityActionRecordV1> {
+  active.finalizing = true
+  try {
+    return await withActionLock(actionsDir, async () => {
+      const current = await latestCoreCompatibilityRecord(actionsDir, active.actionId)
+      if (!current) throw new ActionOperationError('journal', 'the running action disappeared from the ACT journal')
+      if (isTerminal(current.status)) return verifyStoredEvidence(current, dataDir)
+      if (current.status !== 'running' || current.operation.ownerProcessId !== process.pid) throw new ActionOperationError('concurrent', 'the ACT operation owner changed unexpectedly')
+      if (active.cancelled || current.operation.cancellation.requested || (outcome.kind === 'abort' && outcome.category === 'cancelled')) {
+        return appendOperationRecord(actionsDir, contract, 'cancelled', cancellationState(current.operation, now, active.cancellationRequestedAt ?? current.operation.cancellation.requestedAt ?? nowIso(now), 'Core Compatibility cancellation was authoritative; late results were discarded.'), now)
+      }
+      if (active.operationTimedOut || (outcome.kind === 'abort' && outcome.category === 'timeout')) {
+        return appendOperationRecord(actionsDir, contract, 'failed', failedOperation(current.operation, 'timeout', 'Core Compatibility exceeded its bounded operation timeout; late results were discarded.', now), now)
+      }
+      if (active.journalFailure || (outcome.kind === 'abort' && outcome.category === 'journal')) {
+        const message = active.journalFailure?.message ?? 'the ACT journal became unavailable during Core Compatibility.'
+        return appendOperationRecord(actionsDir, contract, 'failed', failedOperation(current.operation, 'journal', message, now), now)
+      }
+      if (outcome.kind === 'error') {
+        return appendOperationRecord(actionsDir, contract, 'failed', failedOperation(current.operation, failureCategory(outcome.error), boundedMessage(outcome.error, 'Core Compatibility execution failed.'), now), now)
+      }
+      if (outcome.kind !== 'result') return appendOperationRecord(actionsDir, contract, 'failed', failedOperation(current.operation, outcome.category === 'timeout' ? 'timeout' : 'journal', 'the controlled operation aborted before producing a result.', now), now)
+      let result: BenchEvaluationV1
+      try { result = parseBenchEvaluationV1(outcome.result) } catch (error) {
+        return appendOperationRecord(actionsDir, contract, 'failed', failedOperation(current.operation, 'malformed-result', boundedMessage(error, 'the canonical Bench runner returned a malformed result.'), now), now)
+      }
+      if (!exactBenchIdentity(result, active.actionId, contract)) {
+        return appendOperationRecord(actionsDir, contract, 'failed', failedOperation(current.operation, 'identity-mismatch', 'Bench result identity did not match the approved action.', now), now)
+      }
+      let saved: Awaited<ReturnType<typeof saveBenchEvaluationV1>>
+      try { saved = await saveBenchEvaluationV1(result, { dataDir }) } catch (error) {
+        return appendOperationRecord(actionsDir, contract, 'failed', failedOperation(current.operation, 'journal', boundedMessage(error, 'Bench evidence could not be saved to canonical history.'), now), now)
+      }
+      if (active.cancelled || active.operationTimedOut || current.operation.cancellation.requested) {
+        return appendOperationRecord(actionsDir, contract, 'cancelled', cancellationState(current.operation, now, active.cancellationRequestedAt ?? current.operation.cancellation.requestedAt ?? nowIso(now), 'Core Compatibility cancellation was authoritative; the late result was discarded.'), now)
+      }
+      const terminal = terminalFromResult(current, saved.record, saved.status, now)
+      return appendOperationRecord(actionsDir, contract, terminal.status, terminal.operation, now)
+    })
+  } finally {
+    active.finalized = true
+    if (activeExecutions.get(active.actionId) === active) activeExecutions.delete(active.actionId)
+  }
+}
+
+function startCancellationPoll(active: ActiveExecution, actionsDir: string, now: () => Date): () => void {
+  let stopped = false
+  let inFlight = false
+  const tick = async (): Promise<void> => {
+    if (stopped || inFlight || active.finalized || active.finalizing) return
+    inFlight = true
+    try {
+      const record = await withActionLock(actionsDir, () => latestCoreCompatibilityRecord(actionsDir, active.actionId))
+      if (!record) throw new ActionOperationError('journal', 'the running action disappeared from the ACT journal')
+      if (record.status !== 'running' || record.operation.ownerProcessId !== process.pid) throw new ActionOperationError('concurrent', 'the ACT operation owner changed unexpectedly')
+      if (record.operation.cancellation.requested) {
+        active.cancelled = true
+        active.cancellationRequestedAt ??= record.operation.cancellation.requestedAt ?? nowIso(now)
+        active.controller.abort()
+      }
+    } catch (error) {
+      if (!stopped && !active.finalized && !active.finalizing) {
+        active.journalFailure ??= error instanceof ActionOperationError ? error : new ActionOperationError('journal', boundedMessage(error, 'the ACT journal became unavailable'))
+        active.controller.abort()
+      }
+    } finally { inFlight = false }
+  }
+  const handle = setInterval(() => { void tick() }, CANCELLATION_POLL_MS)
+  handle.unref?.()
+  void tick()
+  return () => { stopped = true; clearInterval(handle) }
+}
+function abortCategory(active: ActiveExecution): 'cancelled' | 'timeout' | 'journal' {
+  if (active.journalFailure) return 'journal'
+  if (active.cancelled) return 'cancelled'
+  return 'timeout'
+}
+
+export async function executeApprovedCoreCompatibility(approvedInput: ApprovedActionV1 | unknown, options: CoreCompatibilityActionExecutionOptions): Promise<CoreCompatibilityActionRecordV1> {
+  let approved: ApprovedActionV1
+  try { approved = options.authority.verifyApprovedAction(approvedInput) } catch (error) {
+    if (error instanceof ActionOperationError) throw error
+    if (error instanceof ActionContractError) throw new ActionOperationError(error.code === 'stale-approval' ? 'approval-expired' : 'approval-invalid', error.message)
+    throw error
+  }
+  const contract = approved.contract
+  assertFreshActionContract(contract, true)
+  const actionId = contract.actionId
+  if (activeExecutions.has(actionId)) throw new ActionOperationError('concurrent', 'the Core Compatibility action is already running')
+  const actionsDir = options.actionsDir ?? defaultActionsDir()
+  const dataDir = options.dataDir
+  const now = options.now ?? (() => new Date())
+  const active: ActiveExecution = { actionId, controller: new AbortController(), cancelled: false, cancellationRequestedAt: null, operationTimedOut: false, journalFailure: null, finalized: false, finalizing: false }
+  activeExecutions.set(actionId, active)
+  let removeExternalAbort: (() => void) | undefined
+  const requestExternalAbort = (): void => {
+    if (!active.finalized) {
+      active.cancelled = true
+      active.cancellationRequestedAt ??= nowIso(now)
+      active.controller.abort()
+    }
+  }
+  if (options.signal) {
+    if (options.signal.aborted) requestExternalAbort()
+    else {
+      options.signal.addEventListener('abort', requestExternalAbort, { once: true })
+      removeExternalAbort = () => options.signal?.removeEventListener('abort', requestExternalAbort)
+    }
+  }
+  let stopPoll: (() => void) | undefined
+  let timeoutHandle: ReturnType<typeof setTimeout> | undefined
+  let removeAbortListener: (() => void) | undefined
+  try {
+    const prepared = await prepareExecution(contract, approved.approval.issuedAt, active, actionsDir, dataDir, now)
+    if (prepared.kind === 'terminal') return prepared.record
+    stopPoll = startCancellationPoll(active, actionsDir, now)
+    timeoutHandle = setTimeout(() => {
+      if (!active.finalized) {
+        active.operationTimedOut = true
+        active.controller.abort()
+      }
+    }, contract.timeout.operationMs)
+    timeoutHandle.unref?.()
+    const abortPromise = new Promise<FinalOutcome>(resolve => {
+      const onAbort = (): void => resolve({ kind: 'abort', category: abortCategory(active) })
+      active.controller.signal.addEventListener('abort', onAbort, { once: true })
+      removeAbortListener = () => active.controller.signal.removeEventListener('abort', onAbort)
+      if (active.controller.signal.aborted) onAbort()
+    })
+    if (active.controller.signal.aborted) return finalizeOperation(active, contract, actionsDir, dataDir, now, { kind: 'abort', category: abortCategory(active) })
+    const runBench = options.runBench ?? runBenchTaskPackV1
+    const runPromise: Promise<FinalOutcome> = Promise.resolve().then(() => runBench({
+      model: contract.arguments.model,
+      packId: contract.target.pack.selector,
+      runId: actionId,
+      fetchImpl: options.fetchImpl,
+      signal: active.controller.signal,
+      timeoutMs: contract.timeout.perRequestMs,
+      now,
+      monotonicNow: options.monotonicNow,
+      onProgress: progressCallback(active, contract, actionsDir, now),
+    })).then(result => ({ kind: 'result', result }) as FinalOutcome, error => ({ kind: 'error', error }) as FinalOutcome)
+    const outcome = await Promise.race([runPromise, abortPromise])
+    return finalizeOperation(active, contract, actionsDir, dataDir, now, outcome)
+  } finally {
+    if (timeoutHandle) clearTimeout(timeoutHandle)
+    removeAbortListener?.()
+    stopPoll?.()
+    removeExternalAbort?.()
+    active.finalized = true
+    if (activeExecutions.get(actionId) === active) activeExecutions.delete(actionId)
+  }
+}
+async function appendCancellationRequest(record: CoreCompatibilityActionRecordV1, actionsDir: string, now: () => Date, requestedAt: string): Promise<CoreCompatibilityActionCancellationResult> {
+  if (isTerminal(record.status)) return { status: 'already-terminal', record }
+  if (record.status === 'proposed' || record.status === 'ready') {
+    return { status: 'cancelled', record: await appendOperationRecord(actionsDir, record.contract, 'cancelled', cancelledBeforeStart(record, now, requestedAt), now) }
+  }
+  if (record.status !== 'running') return { status: 'owner-unavailable', record }
+  if (record.operation.cancellation.requested) return { status: 'requested' }
+  await appendOperationRecord(actionsDir, record.contract, 'running', { ...record.operation, cancellation: { requested: true, requestedAt } }, now)
+  return { status: 'requested' }
+}
+
+export async function cancelCoreCompatibilityAction(actionId: string, options: CoreCompatibilityActionCancellationOptions = {}): Promise<CoreCompatibilityActionCancellationResult> {
+  const actionsDir = options.actionsDir ?? defaultActionsDir()
+  const dataDir = options.dataDir
+  const now = options.now ?? (() => new Date())
+  const active = activeExecutions.get(actionId)
+  if (active) {
+    active.cancelled = true
+    active.cancellationRequestedAt ??= nowIso(now)
+    active.controller.abort()
+    return withActionLock(actionsDir, async () => {
+      const current = await latestCoreCompatibilityRecord(actionsDir, actionId)
+      if (!current) return { status: 'requested' }
+      if (isTerminal(current.status)) return { status: 'already-terminal', record: current }
+      if (current.status === 'proposed' || current.status === 'ready') return appendCancellationRequest(current, actionsDir, now, active.cancellationRequestedAt!)
+      if (current.status === 'running' && current.operation.ownerProcessId === process.pid && !current.operation.cancellation.requested) {
+        await appendOperationRecord(actionsDir, current.contract, 'running', { ...current.operation, cancellation: { requested: true, requestedAt: active.cancellationRequestedAt! } }, now)
+      }
+      return { status: 'requested' }
+    })
+  }
+  return withActionLock(actionsDir, async () => {
+    const current = await latestCoreCompatibilityRecord(actionsDir, actionId)
+    if (!current) return { status: 'not-found' }
+    if (isTerminal(current.status)) return { status: 'already-terminal', record: current }
+    if (current.status === 'proposed' || current.status === 'ready') return appendCancellationRequest(current, actionsDir, now, nowIso(now))
+    if (current.status !== 'running') return { status: 'owner-unavailable', record: current }
+    const evidence = await findEvidence(actionId, current.contract, dataDir)
+    if (evidence) {
+      const terminal = terminalFromResult(current, evidence, 'duplicate', now)
+      return { status: 'already-terminal', record: await appendOperationRecord(actionsDir, current.contract, terminal.status, terminal.operation, now) }
+    }
+    if (processIsAlive(current.operation.ownerProcessId)) return appendCancellationRequest(current, actionsDir, now, nowIso(now))
+    return { status: 'cancelled', record: await appendOperationRecord(actionsDir, current.contract, 'cancelled', cancellationState(current.operation, now, nowIso(now), 'Core Compatibility was cancelled after its owner became unavailable.'), now) }
+  })
+}
+
+export async function readCoreCompatibilityAction(actionId: string, options: { actionsDir?: string; dataDir?: string; now?: () => Date } = {}): Promise<CoreCompatibilityActionRecordV1 | null> {
+  const actionsDir = options.actionsDir ?? defaultActionsDir()
+  const dataDir = options.dataDir
+  const now = options.now ?? (() => new Date())
+  return withActionLock(actionsDir, async () => {
+    let record = await latestCoreCompatibilityRecord(actionsDir, actionId)
+    if (!record) return null
+    if (record.status === 'ready' && record.operation.approvalIssuedAt !== null && !isFreshApprovalIssuedAt(record.operation.approvalIssuedAt, now())) {
+      record = await appendOperationRecord(actionsDir, record.contract, 'failed', failedOperation(record.operation, 'approval-expired', 'the persisted action approval expired and was not renewed.', now), now)
+    } else if (record.status === 'running' && !processIsAlive(record.operation.ownerProcessId)) {
+      record = await recoverRunningRecord(record, actionsDir, dataDir, now)
+    }
+    return verifyStoredEvidence(record, dataDir)
+  })
+}
+
+export const executeApprovedCoreCompatibilityAction = executeApprovedCoreCompatibility
+export const executeApprovedCoreCompatibilityBench = executeApprovedCoreCompatibility
+export const recordCoreCompatibilityActionProposal = recordCoreCompatibilityProposal
+export const cancelCoreCompatibility = cancelCoreCompatibilityAction
+export const readCoreCompatibility = readCoreCompatibilityAction

--- a/src/act/core-compatibility-state-v1.ts
+++ b/src/act/core-compatibility-state-v1.ts
@@ -16,6 +16,7 @@ import {
   computeActionProposalDigest, validateActionContractV1,
 } from './action-contract-v1.js'
 import { appendRecord, defaultActionsDir, readRecordHistoryStrict } from './journal.js'
+import { isCoreCompatibilityActionRecord } from './core-compatibility-types.js'
 import type { ActionRecord } from './types.js'
 import { BENCH_EVALUATION_SCHEMA_VERSION, type BenchEvaluationV1 } from '../bench/task-pack-run-v1.js'
 
@@ -203,6 +204,37 @@ function strictLegacyRecord(value: unknown): boolean {
   if (!isLegacyRecord(value)) return false
   const rec = value as ActionRecord
   return ['applied', 'undone'].includes(rec.status) && typeof rec.description === 'string' && Array.isArray(rec.changes)
+}
+export type ActJournalRecordClassification = {
+  legacy: ActionRecord[]
+  controlled: CoreCompatibilityActionRecordV1[]
+  malformed: unknown[]
+}
+function isSaneLegacyRecord(value: unknown): value is ActionRecord {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false
+  const record = value as { at?: unknown; status?: unknown }
+  return typeof record.at === 'string' && typeof record.status === 'string' && !Number.isNaN(new Date(record.at).getTime())
+}
+export function classifyActJournalRecords(records: readonly unknown[]): ActJournalRecordClassification {
+  const legacy: ActionRecord[] = []
+  const controlled: CoreCompatibilityActionRecordV1[] = []
+  const malformed: unknown[] = []
+  for (const value of records) {
+    const object = value && typeof value === 'object' && !Array.isArray(value) ? value as { kind?: unknown; recordVersion?: unknown } : null
+    const hasRecordVersion = object !== null && Object.prototype.hasOwnProperty.call(object, 'recordVersion')
+    const controlledMarker = hasRecordVersion || object?.kind === ACTION_KIND_RUN_CORE_COMPATIBILITY
+    if (controlledMarker) {
+      if (!isCoreCompatibilityActionRecord(value)) {
+        malformed.push(value)
+        continue
+      }
+      try { controlled.push(parseCoreCompatibilityRecord(value)) } catch { malformed.push(value) }
+      continue
+    }
+    if (!isSaneLegacyRecord(value)) malformed.push(value)
+    else legacy.push(value)
+  }
+  return { legacy, controlled, malformed }
 }
 
 export async function readCoreCompatibilityRecords(actionsDir = defaultActionsDir()): Promise<CoreCompatibilityActionRecordV1[]> {

--- a/src/act/core-compatibility-state-v1.ts
+++ b/src/act/core-compatibility-state-v1.ts
@@ -1,0 +1,298 @@
+import { z } from 'zod'
+import {
+  ACTION_FAILURE_CATEGORIES,
+  ACTION_KIND_RUN_CORE_COMPATIBILITY,
+  ACTION_NO_ROLLBACK_REASON,
+  ACTION_OPERATION_STATUSES,
+  ACTION_OPERATION_VERSION,
+  CORE_CHECK_COUNT,
+  type ActionContractV1,
+  type ActionEvidenceReferenceV1,
+  type ActionFailureCategoryV1,
+  type ActionOperationStateV1,
+  type ActionOperationStatus,
+  type ActionResultCountsV1,
+  type ActionResultReferenceV1,
+  computeActionProposalDigest, validateActionContractV1,
+} from './action-contract-v1.js'
+import { appendRecord, defaultActionsDir, readRecordHistoryStrict } from './journal.js'
+import type { ActionRecord } from './types.js'
+import { BENCH_EVALUATION_SCHEMA_VERSION, type BenchEvaluationV1 } from '../bench/task-pack-run-v1.js'
+
+export const ACTION_RECORD_VERSION = 'metrora.action-record.v1' as const
+export type CoreCompatibilityActionProposalOptions = { actionsDir?: string; now?: () => Date }
+export type CoreCompatibilityActionCancellationResult =
+  | { status: 'requested' }
+  | { status: 'cancelled'; record: CoreCompatibilityActionRecordV1 }
+  | { status: 'already-terminal'; record: CoreCompatibilityActionRecordV1 }
+  | { status: 'owner-unavailable'; record: CoreCompatibilityActionRecordV1 }
+  | { status: 'not-found' }
+export type ActionOperationErrorCode = ActionFailureCategoryV1 | 'not-found' | 'owner-unavailable'
+export class ActionOperationError extends Error {
+  constructor(public readonly code: ActionOperationErrorCode, message: string) {
+    super(message)
+    this.name = 'ActionOperationError'
+  }
+}
+export type CoreCompatibilityActionRecordV1 = {
+  recordVersion: typeof ACTION_RECORD_VERSION
+  id: string
+  at: string
+  kind: typeof ACTION_KIND_RUN_CORE_COMPATIBILITY
+  originatingSurface: 'cli' | 'desktop'
+  findingId: null
+  description: string
+  changes: []
+  status: ActionOperationStatus
+  contract: ActionContractV1
+  operation: ActionOperationStateV1
+}
+
+const ActionId = z.string().regex(/^[A-Za-z0-9._:-]{1,128}$/)
+const Digest = z.string().regex(/^[0-9a-f]{64}$/)
+const IsoDate = z.string().max(64).datetime({ offset: true })
+const ResultReference = z.object({ kind: z.literal(BENCH_EVALUATION_SCHEMA_VERSION), runId: ActionId, resultDigest: Digest, history: z.enum(['saved', 'duplicate']) }).strict()
+const EvidenceReference = z.object({ kind: z.literal('metrora.bench-history.v1'), runId: ActionId, resultDigest: Digest, history: z.enum(['saved', 'duplicate']) }).strict()
+const ResultCounts = z.object({
+  planned: z.literal(CORE_CHECK_COUNT),
+  attempted: z.number().int().min(0).max(CORE_CHECK_COUNT),
+  passed: z.number().int().min(0).max(CORE_CHECK_COUNT),
+  failed: z.number().int().min(0).max(CORE_CHECK_COUNT),
+  unavailable: z.number().int().min(0).max(CORE_CHECK_COUNT),
+  timedOut: z.number().int().min(0).max(CORE_CHECK_COUNT),
+  cancelled: z.number().int().min(0).max(CORE_CHECK_COUNT),
+}).strict()
+const OperationFailure = z.object({ category: z.enum(ACTION_FAILURE_CATEGORIES), message: z.string().min(1).max(240) }).strict()
+const OperationStateShape = z.object({
+  operationVersion: z.literal(ACTION_OPERATION_VERSION),
+  actionId: ActionId,
+  ownerProcessId: z.number().int().nonnegative().nullable(),
+  startedAt: IsoDate.nullable(),
+  completedAt: IsoDate.nullable(),
+  progress: z.object({ planned: z.literal(CORE_CHECK_COUNT), completed: z.number().int().min(0).max(CORE_CHECK_COUNT) }).strict(),
+  checksPlanned: z.literal(CORE_CHECK_COUNT),
+  checksCompleted: z.number().int().min(0).max(CORE_CHECK_COUNT),
+  cancellation: z.object({ requested: z.boolean(), requestedAt: IsoDate.nullable() }).strict(),
+  timeout: z.object({ perRequestMs: z.number().int().min(50).max(120_000), operationMs: z.number().int().min(50).max(1_000_000), triggered: z.boolean() }).strict(),
+  approvalIssuedAt: IsoDate.nullable(),
+  result: ResultReference.nullable(),
+  resultCounts: ResultCounts.nullable(),
+  evidenceReferences: z.array(EvidenceReference).max(1),
+  failure: OperationFailure.nullable(),
+  rollback: z.object({ capability: z.literal('none'), reason: z.literal(ACTION_NO_ROLLBACK_REASON) }).strict(),
+}).strict()
+const CoreRecordShape = z.object({
+  recordVersion: z.literal(ACTION_RECORD_VERSION),
+  id: ActionId,
+  at: IsoDate,
+  kind: z.literal(ACTION_KIND_RUN_CORE_COMPATIBILITY),
+  originatingSurface: z.enum(['cli', 'desktop']),
+  findingId: z.null(),
+  description: z.string().min(1).max(240),
+  changes: z.tuple([]),
+  status: z.enum(ACTION_OPERATION_STATUSES),
+  contract: z.unknown(),
+  operation: OperationStateShape,
+}).strict()
+
+export function boundedMessage(error: unknown, fallback: string): string {
+  const raw = error instanceof Error ? error.message : String(error)
+  return (raw.replace(/[\r\n]+/g, ' ').slice(0, 240) || fallback)
+}
+export function nowIso(now: () => Date): string { return now().toISOString() }
+export function proposalContract(contract: ActionContractV1): ActionContractV1 {
+  return validateActionContractV1({ ...contract, approval: { ...contract.approval, confirmationDigest: null, executionDigest: null } })
+}
+export function assertFreshActionContract(contract: ActionContractV1, allowConfirmation: boolean): void {
+  const approved = contract.approval.confirmationDigest !== null && contract.approval.executionDigest !== null
+  if (allowConfirmation && !approved) throw new ActionOperationError('approval-invalid', 'execution requires a trusted confirmation')
+  if (!allowConfirmation && approved) throw new ActionOperationError('validation', 'a proposal must not contain a confirmation')
+  if (contract.resultIdentity.runId !== null || contract.resultIdentity.resultDigest !== null || contract.evidenceReferences.runId !== null || contract.evidenceReferences.resultDigest !== null || contract.failureCategory !== null) throw new ActionOperationError('validation', 'action contracts must not carry mutable outcome data')
+}
+export function initialOperationState(contract: ActionContractV1): ActionOperationStateV1 {
+  return {
+    operationVersion: ACTION_OPERATION_VERSION,
+    actionId: contract.actionId,
+    ownerProcessId: null,
+    startedAt: null,
+    completedAt: null,
+    progress: { planned: CORE_CHECK_COUNT, completed: 0 },
+    checksPlanned: CORE_CHECK_COUNT,
+    checksCompleted: 0,
+    cancellation: { requested: false, requestedAt: null },
+    timeout: { perRequestMs: contract.timeout.perRequestMs, operationMs: contract.timeout.operationMs, triggered: false },
+    approvalIssuedAt: null,
+    result: null,
+    resultCounts: null,
+    evidenceReferences: [],
+    failure: null,
+    rollback: { capability: 'none', reason: ACTION_NO_ROLLBACK_REASON },
+  }
+}
+export function makeRecord(contract: ActionContractV1, status: ActionOperationStatus, operation: ActionOperationStateV1, now: () => Date): CoreCompatibilityActionRecordV1 {
+  return { recordVersion: ACTION_RECORD_VERSION, id: contract.actionId, at: nowIso(now), kind: ACTION_KIND_RUN_CORE_COMPATIBILITY, originatingSurface: contract.originatingSurface, findingId: null, description: 'Run Core Compatibility on ' + contract.target.model, changes: [], status, contract, operation }
+}
+function isLegacyRecord(value: unknown): value is ActionRecord {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false
+  const rec = value as { id?: unknown; kind?: unknown; status?: unknown; at?: unknown }
+  return typeof rec.id === 'string' && typeof rec.kind === 'string' && typeof rec.status === 'string' && typeof rec.at === 'string'
+}
+function assertOperationCoherent(status: ActionOperationStatus, operation: ActionOperationStateV1, actionId: string, contract: ActionContractV1): void {
+  if (operation.actionId !== actionId || operation.checksCompleted !== operation.progress.completed || operation.progress.completed > operation.progress.planned || operation.cancellation.requested !== (operation.cancellation.requestedAt !== null)) throw new ActionOperationError('journal', 'the action operation state is inconsistent')
+  if (operation.result === null) {
+    if (operation.resultCounts !== null || operation.evidenceReferences.length !== 0) throw new ActionOperationError('journal', 'the action result references are inconsistent')
+  } else {
+    const evidence = operation.evidenceReferences[0]
+    if (operation.result.runId !== actionId || !evidence || evidence.runId !== actionId || evidence.resultDigest !== operation.result.resultDigest || evidence.history !== operation.result.history || operation.resultCounts === null || operation.progress.completed !== operation.resultCounts.attempted) throw new ActionOperationError('identity-mismatch', 'the action result and evidence identity is inconsistent')
+  }
+  const approved = contract.approval.confirmationDigest !== null && contract.approval.executionDigest !== null
+  switch (status) {
+    case 'proposed':
+      if (approved || operation.approvalIssuedAt !== null || operation.ownerProcessId !== null || operation.startedAt !== null || operation.completedAt !== null || operation.progress.completed !== 0 || operation.failure !== null || operation.result !== null || operation.cancellation.requested) throw new ActionOperationError('journal', 'a proposed action has inconsistent state')
+      return
+    case 'ready':
+      if (!approved || operation.approvalIssuedAt === null || operation.ownerProcessId !== null || operation.startedAt !== null || operation.completedAt !== null || operation.progress.completed !== 0 || operation.failure !== null || operation.result !== null || operation.cancellation.requested) throw new ActionOperationError('journal', 'a ready action has inconsistent state')
+      return
+    case 'running':
+      if (!approved || operation.approvalIssuedAt === null || operation.ownerProcessId === null || operation.startedAt === null || operation.completedAt !== null || operation.result !== null || operation.failure !== null) throw new ActionOperationError('journal', 'a running action has inconsistent state')
+      return
+    case 'completed':
+      if (!approved || operation.ownerProcessId !== null || operation.startedAt === null || operation.completedAt === null || operation.result === null || operation.failure !== null) throw new ActionOperationError('journal', 'a completed action has inconsistent state')
+      return
+    case 'unavailable':
+      if (!approved || operation.ownerProcessId !== null || operation.startedAt === null || operation.completedAt === null || operation.result === null || operation.failure?.category !== 'unavailable') throw new ActionOperationError('journal', 'an unavailable action has inconsistent state')
+      return
+    case 'cancelled':
+      if (operation.ownerProcessId !== null || operation.completedAt === null || operation.result !== null || operation.failure?.category !== 'cancelled' || !operation.cancellation.requested || (operation.startedAt === null && operation.progress.completed !== 0)) throw new ActionOperationError('journal', 'a cancelled action has inconsistent state')
+      return
+    case 'failed':
+      if (operation.ownerProcessId !== null || operation.completedAt === null || operation.failure === null || operation.failure.category === 'cancelled' || operation.failure.category === 'unavailable' || (operation.startedAt === null && operation.failure.category !== 'approval-expired')) throw new ActionOperationError('journal', 'a failed action has inconsistent state')
+      return
+  }
+}
+export function parseCoreCompatibilityRecord(input: unknown): CoreCompatibilityActionRecordV1 {
+  const parsed = CoreRecordShape.safeParse(input)
+  if (!parsed.success) throw new ActionOperationError('journal', 'the ACT journal contains an invalid Core Compatibility record')
+  let contract: ActionContractV1
+  try { contract = validateActionContractV1(parsed.data.contract) } catch {
+    throw new ActionOperationError('journal', 'the ACT journal contains an invalid action contract')
+  }
+  if (parsed.data.id !== contract.actionId || parsed.data.operation.actionId !== parsed.data.id) throw new ActionOperationError('identity-mismatch', 'the ACT record identity does not match its contract')
+  if (parsed.data.status === 'proposed' && (contract.approval.confirmationDigest !== null || contract.approval.executionDigest !== null)) throw new ActionOperationError('journal', 'a proposed action must not contain approval')
+  if (contract.resultIdentity.runId !== null || contract.resultIdentity.resultDigest !== null || contract.evidenceReferences.runId !== null || contract.evidenceReferences.resultDigest !== null || contract.failureCategory !== null) throw new ActionOperationError('journal', 'the ACT contract contains mutable outcome data')
+  const operation = parsed.data.operation as ActionOperationStateV1
+  assertOperationCoherent(parsed.data.status, operation, parsed.data.id, contract)
+  return { ...parsed.data, contract, operation }
+}
+
+const NEXT_STATUSES: Readonly<Record<ActionOperationStatus, readonly ActionOperationStatus[]>> = {
+  proposed: ['proposed', 'ready', 'cancelled'],
+  ready: ['ready', 'running', 'cancelled', 'failed'],
+  running: ['running', 'completed', 'failed', 'cancelled', 'unavailable'],
+  completed: [],
+  failed: [],
+  cancelled: [],
+  unavailable: [],
+}
+function assertTransition(previous: ActionOperationStatus | undefined, current: CoreCompatibilityActionRecordV1): void {
+  if (previous === undefined && current.status !== 'proposed') throw new ActionOperationError('journal', 'a controlled action must begin in proposed state')
+  if (previous !== undefined && !NEXT_STATUSES[previous].includes(current.status)) throw new ActionOperationError('journal', 'the ACT journal contains an invalid lifecycle transition')
+}
+
+function strictLegacyRecord(value: unknown): boolean {
+  if (!isLegacyRecord(value)) return false
+  const rec = value as ActionRecord
+  return ['applied', 'undone'].includes(rec.status) && typeof rec.description === 'string' && Array.isArray(rec.changes)
+}
+
+export async function readCoreCompatibilityRecords(actionsDir = defaultActionsDir()): Promise<CoreCompatibilityActionRecordV1[]> {
+  let history: unknown[]
+  try { history = await readRecordHistoryStrict(actionsDir) } catch (error) {
+    throw new ActionOperationError('journal', boundedMessage(error, 'the ACT journal contains corrupt or malformed JSON'))
+  }
+  const groups = new Map<string, unknown[]>()
+  for (const raw of history) {
+    if (!isLegacyRecord(raw) && !(raw && typeof raw === 'object' && (raw as { recordVersion?: unknown }).recordVersion === ACTION_RECORD_VERSION)) throw new ActionOperationError('journal', 'the ACT journal contains an unknown record shape')
+    if (!strictLegacyRecord(raw) && !((raw as { recordVersion?: unknown }).recordVersion === ACTION_RECORD_VERSION)) throw new ActionOperationError('journal', 'the ACT journal contains an invalid legacy record')
+    const id = (raw as { id: string }).id
+    groups.set(id, [...(groups.get(id) ?? []), raw])
+  }
+  const result: CoreCompatibilityActionRecordV1[] = []
+  for (const entries of groups.values()) {
+    const controlled = entries.filter(item => (item as { recordVersion?: unknown }).recordVersion === ACTION_RECORD_VERSION)
+    if (controlled.length === 0) continue
+    if (controlled.length !== entries.length) throw new ActionOperationError('duplicate', 'an action id is used by multiple ACT record kinds')
+    let previous: ActionOperationStatus | undefined
+    let latest: CoreCompatibilityActionRecordV1 | undefined
+    let proposalDigest: string | undefined
+    for (const entry of controlled) {
+      const record = parseCoreCompatibilityRecord(entry)
+      const digest = computeActionProposalDigest(record.contract)
+      if (proposalDigest === undefined) proposalDigest = digest
+      else if (proposalDigest !== digest) throw new ActionOperationError('identity-mismatch', 'the ACT lifecycle changed the exact action contract')
+      assertTransition(previous, record)
+      previous = record.status
+      latest = record
+    }
+    if (latest) result.push(latest)
+  }
+  return result
+}
+
+export async function latestCoreCompatibilityRecord(actionsDir: string, actionId: string): Promise<CoreCompatibilityActionRecordV1 | null> {
+  const record = (await readCoreCompatibilityRecords(actionsDir)).find(item => item.id === actionId)
+  if (record) return record
+  let history: unknown[]
+  try { history = await readRecordHistoryStrict(actionsDir) } catch (error) { throw new ActionOperationError('journal', boundedMessage(error, 'the ACT journal contains corrupt or malformed JSON')) }
+  if (history.some(item => item && typeof item === 'object' && (item as { id?: unknown }).id === actionId)) throw new ActionOperationError('duplicate', 'the action id is already used by another ACT record')
+  return null
+}
+
+export async function appendOperationRecord(actionsDir: string, contract: ActionContractV1, status: ActionOperationStatus, operation: ActionOperationStateV1, now: () => Date): Promise<CoreCompatibilityActionRecordV1> {
+  const record = makeRecord(contract, status, operation, now)
+  parseCoreCompatibilityRecord(record)
+  const existing = (await readCoreCompatibilityRecords(actionsDir)).find(item => item.id === record.id)
+  if (existing && computeActionProposalDigest(existing.contract) !== computeActionProposalDigest(record.contract)) {
+    throw new ActionOperationError('identity-mismatch', 'the ACT lifecycle changed the exact action contract')
+  }
+  assertTransition(existing?.status, record)
+  await appendRecord(actionsDir, record)
+  return record
+}
+export function processIsAlive(processId: number | null): boolean {
+  if (processId === null || processId <= 0) return false
+  try { process.kill(processId, 0); return true } catch (error) { return (error as NodeJS.ErrnoException).code === 'EPERM' }
+}
+export function resultCounts(result: BenchEvaluationV1): ActionResultCountsV1 {
+  return {
+    planned: result.aggregate.planned,
+    attempted: result.aggregate.attempted,
+    passed: result.aggregate.passed,
+    failed: result.aggregate.failed,
+    unavailable: result.tasks.filter(task => task.status === 'unavailable').length,
+    timedOut: result.tasks.filter(task => task.status === 'timeout').length,
+    cancelled: result.aggregate.cancelled,
+  }
+}
+export function failureFromBench(result: BenchEvaluationV1, fallback: string): string {
+  const failure = result.tasks.find(task => task.failure !== null)?.failure
+  return boundedMessage(failure?.message, fallback)
+}
+export function resultReference(result: BenchEvaluationV1, history: 'saved' | 'duplicate'): ActionResultReferenceV1 {
+  return { kind: BENCH_EVALUATION_SCHEMA_VERSION, runId: result.runId, resultDigest: result.resultDigest, history }
+}
+export function evidenceReference(result: BenchEvaluationV1, history: 'saved' | 'duplicate'): ActionEvidenceReferenceV1 {
+  return { kind: 'metrora.bench-history.v1', runId: result.runId, resultDigest: result.resultDigest, history }
+}
+export function sameActionContract(left: ActionContractV1, right: ActionContractV1): boolean {
+  return computeActionProposalDigest(left) === computeActionProposalDigest(right)
+}
+export function clearOutcome(operation: ActionOperationStateV1): ActionOperationStateV1 {
+  return { ...operation, result: null, resultCounts: null, evidenceReferences: [], failure: null }
+}
+export function isTerminal(status: ActionOperationStatus): boolean {
+  return status === 'completed' || status === 'failed' || status === 'cancelled' || status === 'unavailable'
+}
+export function countsEqual(left: ActionResultCountsV1, right: ActionResultCountsV1): boolean {
+  return left.planned === right.planned && left.attempted === right.attempted && left.passed === right.passed && left.failed === right.failed && left.unavailable === right.unavailable && left.timedOut === right.timedOut && left.cancelled === right.cancelled
+}

--- a/src/act/core-compatibility-types.ts
+++ b/src/act/core-compatibility-types.ts
@@ -1,0 +1,79 @@
+import type {
+  ActionContractV1,
+  ActionOperationFailureV1,
+  ActionOperationStateV1,
+  ActionOperationStatus,
+  ActionResultCountsV1,
+  ActionResultReferenceV1,
+  ActionEvidenceReferenceV1,
+} from './action-contract-v1.js'
+
+export type CoreCompatibilityActionRecordV1 = {
+  recordVersion: 'metrora.action-record.v1'
+  id: string
+  at: string
+  kind: 'run-core-compatibility'
+  originatingSurface: 'cli' | 'desktop'
+  findingId: null
+  description: string
+  changes: readonly []
+  status: ActionOperationStatus
+  contract: ActionContractV1
+  operation: ActionOperationStateV1
+}
+
+export type JournalRecordV1 = import('./types.js').ActionRecord | CoreCompatibilityActionRecordV1
+
+export type CoreCompatibilityReadResultV1 = {
+  record: CoreCompatibilityActionRecordV1
+  history: readonly CoreCompatibilityActionRecordV1[]
+}
+
+export type CoreCompatibilityOperationOptions = {
+  actionsDir?: string
+  dataDir?: string
+  now?: () => Date
+  fetchImpl?: typeof fetch
+  signal?: AbortSignal
+  runBench?: (options: {
+    model: string
+    packId: string
+    runId: string
+    timeoutMs: number
+    fetchImpl?: typeof fetch
+    signal?: AbortSignal
+    now?: () => Date
+    onProgress?: (progress: { planned: number; completed: number }) => void | Promise<void>
+  }) => Promise<unknown>
+}
+
+export type CoreCompatibilityOperationResultV1 = {
+  status: ActionOperationStatus
+  action: CoreCompatibilityActionRecordV1
+  result: unknown | null
+}
+
+export type CoreCompatibilityOutcomeV1 = {
+  status: Extract<ActionOperationStatus, 'completed' | 'unavailable'>
+  result: ActionResultReferenceV1
+  evidence: ActionEvidenceReferenceV1
+  counts: ActionResultCountsV1
+}
+
+export type CoreCompatibilityJournalStateV1 = {
+  status: ActionOperationStatus
+  contract: ActionContractV1
+  operation: ActionOperationStateV1
+}
+
+export function isCoreCompatibilityActionRecord(value: unknown): value is CoreCompatibilityActionRecordV1 {
+  return Boolean(value && typeof value === 'object' && (value as { recordVersion?: unknown }).recordVersion === 'metrora.action-record.v1' && (value as { kind?: unknown }).kind === 'run-core-compatibility')
+}
+
+export function isTerminalActionStatus(status: ActionOperationStatus): boolean {
+  return status === 'completed' || status === 'failed' || status === 'cancelled' || status === 'unavailable'
+}
+
+export function isActiveActionStatus(status: ActionOperationStatus): boolean {
+  return status === 'proposed' || status === 'ready' || status === 'running'
+}

--- a/src/act/index.ts
+++ b/src/act/index.ts
@@ -1,0 +1,10 @@
+export * from './action-contract-v1.js'
+export * from './core-compatibility-operation-v1.js'
+export {
+  appendOperationRecord,
+  assertFreshActionContract,
+  boundedMessage,
+  parseCoreCompatibilityRecord,
+  readCoreCompatibilityRecords,
+} from './core-compatibility-state-v1.js'
+export type { JournalRecordV1, CoreCompatibilityReadResultV1, CoreCompatibilityOperationOptions, CoreCompatibilityOperationResultV1, CoreCompatibilityOutcomeV1, CoreCompatibilityJournalStateV1 } from './core-compatibility-types.js'

--- a/src/act/journal.ts
+++ b/src/act/journal.ts
@@ -1,7 +1,7 @@
 import { appendFile, mkdir, readFile, rm, stat, writeFile } from 'fs/promises'
 import { dirname, join } from 'path'
 import { getConfigFilePath } from '../config.js'
-import type { ActionRecord } from './types.js'
+import type { JournalRecordV1 } from './core-compatibility-types.js'
 
 // Actions live beside config.json under the same Metrora home dir; reuse the
 // config resolver rather than inventing a second location.
@@ -17,15 +17,15 @@ export function shortId(id: string): string {
   return id.slice(0, 8)
 }
 
-export async function appendRecord(actionsDir: string, record: ActionRecord): Promise<void> {
+export async function appendRecord(actionsDir: string, record: JournalRecordV1): Promise<void> {
   await mkdir(actionsDir, { recursive: true })
   await appendFile(journalPath(actionsDir), JSON.stringify(record) + '\n', 'utf-8')
 }
 
-// Append-only JSONL: a status flip is a full replacement line for the same id,
-// so the last line for an id wins. Returns records in creation (first-seen)
-// order. Unparseable lines are skipped so a corrupt journal never crashes.
-export async function readRecords(actionsDir: string): Promise<ActionRecord[]> {
+// Legacy append-only JSONL: a status flip is a full replacement line for the
+// same id, so the last line for an id wins. This forgiving reader remains for
+// legacy list/undo compatibility; controlled ACT reads use the strict reader.
+export async function readRecords(actionsDir: string): Promise<JournalRecordV1[]> {
   let raw: string
   try {
     raw = await readFile(journalPath(actionsDir), 'utf-8')
@@ -34,12 +34,12 @@ export async function readRecords(actionsDir: string): Promise<ActionRecord[]> {
     throw err
   }
   const order: string[] = []
-  const byId = new Map<string, ActionRecord>()
+  const byId = new Map<string, JournalRecordV1>()
   for (const line of raw.split('\n')) {
     if (!line.trim()) continue
-    let rec: ActionRecord
+    let rec: JournalRecordV1
     try {
-      rec = JSON.parse(line) as ActionRecord
+      rec = JSON.parse(line) as JournalRecordV1
     } catch {
       continue
     }
@@ -48,6 +48,35 @@ export async function readRecords(actionsDir: string): Promise<ActionRecord[]> {
     byId.set(rec.id, rec)
   }
   return order.map(id => byId.get(id)!)
+}
+/**
+ * Controlled ACT operations cannot use the legacy journal's forgiving parser.
+ * Every non-empty line is parsed and must at least be an object with an id;
+ * the operation parser performs the stricter schema and lifecycle checks.
+ */
+export async function readRecordHistoryStrict(actionsDir: string): Promise<unknown[]> {
+  let raw: string
+  try {
+    raw = await readFile(journalPath(actionsDir), 'utf-8')
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return []
+    throw err
+  }
+  const records: unknown[] = []
+  for (const line of raw.split('\n')) {
+    if (!line.trim()) continue
+    let value: unknown
+    try {
+      value = JSON.parse(line)
+    } catch {
+      throw new Error('ACT journal is corrupt: malformed JSON')
+    }
+    if (!value || typeof value !== 'object' || Array.isArray(value) || typeof (value as { id?: unknown }).id !== 'string') {
+      throw new Error('ACT journal is corrupt: record identity is malformed')
+    }
+    records.push(value)
+  }
+  return records
 }
 
 const LOCK_STALE_MS = 60_000

--- a/src/act/report.ts
+++ b/src/act/report.ts
@@ -23,7 +23,7 @@ import { ARCHIVE_DEF_TOKENS, HONEST_FOOTER, MCP_KINDS } from './report-policy.js
 import { renderTable } from '../text-table.js'
 import { formatTokens } from '../format.js'
 import { formatCost } from '../currency.js'
-import { isCoreCompatibilityActionRecord } from './core-compatibility-types.js'
+import { classifyActJournalRecords } from './core-compatibility-state-v1.js'
 
 const DAY_MS = 24 * 60 * 60 * 1000
 const WINDOW_CAP_DAYS = 30
@@ -384,18 +384,13 @@ async function computeRow(
 // Report
 // ---------------------------------------------------------------------------
 
-// A journal line can be any JSON; only records with a parseable `at` date and
-// a string status can be dated and filtered. Anything else is skipped and
-// counted, so a corrupt journal can never crash `act report` or optimize.
-function isSaneRecord(r: ActionRecord): boolean {
-  return typeof r.at === 'string' && typeof r.status === 'string' && !Number.isNaN(new Date(r.at).getTime())
-}
+// Journal records are classified by the ACT v2 boundary before legacy reporting.
 
 export async function computeActReport(opts: ActReportOptions = {}): Promise<ActReport> {
   const now = opts.now ?? new Date()
   const rawRecords = await readRecords(opts.actionsDir ?? defaultActionsDir())
-  const records = rawRecords.filter((record): record is ActionRecord => !isCoreCompatibilityActionRecord(record) && isSaneRecord(record))
-  const malformedRecords = rawRecords.length - records.length
+  const { legacy: records, malformed } = classifyActJournalRecords(rawRecords)
+  const malformedRecords = malformed.length
   const active = records.filter(r => r.status === 'applied')
 
   const appliedByFinding: Record<string, string> = {}

--- a/src/act/report.ts
+++ b/src/act/report.ts
@@ -23,6 +23,7 @@ import { ARCHIVE_DEF_TOKENS, HONEST_FOOTER, MCP_KINDS } from './report-policy.js
 import { renderTable } from '../text-table.js'
 import { formatTokens } from '../format.js'
 import { formatCost } from '../currency.js'
+import { isCoreCompatibilityActionRecord } from './core-compatibility-types.js'
 
 const DAY_MS = 24 * 60 * 60 * 1000
 const WINDOW_CAP_DAYS = 30
@@ -393,7 +394,7 @@ function isSaneRecord(r: ActionRecord): boolean {
 export async function computeActReport(opts: ActReportOptions = {}): Promise<ActReport> {
   const now = opts.now ?? new Date()
   const rawRecords = await readRecords(opts.actionsDir ?? defaultActionsDir())
-  const records = rawRecords.filter(isSaneRecord)
+  const records = rawRecords.filter((record): record is ActionRecord => !isCoreCompatibilityActionRecord(record) && isSaneRecord(record))
   const malformedRecords = rawRecords.length - records.length
   const active = records.filter(r => r.status === 'applied')
 

--- a/src/act/undo.ts
+++ b/src/act/undo.ts
@@ -1,4 +1,5 @@
 import type { ActionRecord, FileChange } from './types.js'
+import { isCoreCompatibilityActionRecord } from './core-compatibility-types.js'
 import { appendRecord, defaultActionsDir, readRecords, shortId, withLock } from './journal.js'
 import { pathExists, revertChange, sha256File } from './backup.js'
 
@@ -51,7 +52,7 @@ export async function undoAction(
 ): Promise<ActionRecord> {
   const actionsDir = opts.actionsDir ?? defaultActionsDir()
   return withLock(actionsDir, async () => {
-    const records = await readRecords(actionsDir)
+    const records = (await readRecords(actionsDir)).filter((record): record is ActionRecord => !isCoreCompatibilityActionRecord(record))
     let record: ActionRecord | undefined
     if ('last' in selector) {
       record = records.filter(r => r.status === 'applied').at(-1)

--- a/src/bench/cli.ts
+++ b/src/bench/cli.ts
@@ -55,7 +55,7 @@ function parseHistoryLimit(value: string): number {
 function renderBenchEvaluation(result: BenchEvaluationV1): string {
   const score = result.aggregate.score.value === null ? 'unavailable (no checks scored)' : (result.aggregate.score.value * 100).toFixed(0) + '% of ' + result.aggregate.score.denominator + ' scored checks'
   return [
-    'Core conformance ' + result.status,
+    'Core Compatibility ' + result.status,
     '  runner: ' + result.runner.id + '@' + result.runner.version,
     '  model: ' + result.model.selected,
     '  pack: ' + result.pack.packId + '@' + result.pack.version,
@@ -67,12 +67,12 @@ function renderBenchEvaluation(result: BenchEvaluationV1): string {
 }
 
 export function renderBenchHistory(records: BenchEvaluationV1[]): string {
-  if (records.length === 0) return 'No Core conformance history.\n'
+  if (records.length === 0) return 'No Core Compatibility history.\n'
   return records.map(record => {
     const checks = record.aggregate.score.value === null
       ? record.aggregate.planned + ' planned; no checks scored; ' + record.aggregate.unavailable + ' unavailable; ' + record.aggregate.cancelled + ' cancelled'
       : record.aggregate.passed + ' passed; ' + record.aggregate.failed + ' failed; ' + record.aggregate.unavailable + ' unavailable; ' + record.aggregate.cancelled + ' cancelled; ' + record.aggregate.planned + ' planned; ' + (record.aggregate.score.value * 100).toFixed(0) + '% of ' + record.aggregate.score.denominator + ' scored checks'
-    return record.runId + '  ' + record.model.selected + '  Core conformance ' + record.status + '  ' + checks + '  ' + record.endedAt
+    return record.runId + '  ' + record.model.selected + '  Core Compatibility ' + record.status + '  ' + checks + '  ' + record.endedAt
   }).join('\n') + '\n'
 }
 

--- a/src/bench/history-v1.ts
+++ b/src/bench/history-v1.ts
@@ -51,17 +51,17 @@ const Evaluation = EvaluationShape.superRefine((record, ctx) => {
   const expectedStatus = counts.cancelled > 0 ? 'cancelled' : counts.unavailable > 0 ? 'unavailable' : 'completed'
   if (record.status !== expectedStatus) issue(['status'], 'status does not match retained task outcomes')
   if (Date.parse(record.startedAt) > Date.parse(record.endedAt)) issue(['endedAt'], 'endedAt must not precede startedAt')
-  if (record.pack.digest !== CORE_TASK_PACK_V1.digest) issue(['pack', 'digest'], 'pack digest does not match the canonical Core conformance pack')
-  if (tasks.length !== CORE_TASK_PACK_V1.tasks.length) issue(['tasks'], 'task count does not match the canonical Core conformance pack')
+  if (record.pack.digest !== CORE_TASK_PACK_V1.digest) issue(['pack', 'digest'], 'pack digest does not match the canonical Core Compatibility pack')
+  if (tasks.length !== CORE_TASK_PACK_V1.tasks.length) issue(['tasks'], 'task count does not match the canonical Core Compatibility pack')
   for (const key of ['temperature', 'seed', 'numPredict'] as const) {
-    if (record.generation.parameters[key] !== FIXED_GENERATION_PARAMETERS[key]) issue(['generation', 'parameters', key], 'generation parameter does not match the fixed Core conformance policy')
+    if (record.generation.parameters[key] !== FIXED_GENERATION_PARAMETERS[key]) issue(['generation', 'parameters', key], 'generation parameter does not match the fixed Core Compatibility policy')
   }
 
   const taskIds = new Set<string>()
   tasks.forEach((task, index) => {
     if (taskIds.has(task.taskId)) issue(['tasks', index, 'taskId'], 'task ids must be unique')
     taskIds.add(task.taskId)
-    if (task.taskId !== CORE_TASK_PACK_V1.tasks[index]?.id) issue(['tasks', index, 'taskId'], 'task id or order does not match the canonical Core conformance pack')
+    if (task.taskId !== CORE_TASK_PACK_V1.tasks[index]?.id) issue(['tasks', index, 'taskId'], 'task id or order does not match the canonical Core Compatibility pack')
     if (!task.attempted && task.score !== null) issue(['tasks', index], 'an unattempted task cannot have a score')
     if (task.status === 'passed') {
       if (!task.attempted || task.score !== 1 || task.failure !== null || task.outputDigest === null || task.outputChars === null) issue(['tasks', index], 'passed tasks must contain a scored output')

--- a/src/bench/task-pack-run-v1.ts
+++ b/src/bench/task-pack-run-v1.ts
@@ -43,7 +43,8 @@ export type BenchEvaluationV1 = {
   resultDigest: string
 }
 
-export type BenchTaskPackRunOptions = { model: string; packId?: string; fetchImpl?: BenchFetch; signal?: AbortSignal; timeoutMs?: number; now?: () => Date; monotonicNow?: () => number; runId?: string }
+export type BenchTaskPackProgressV1 = { planned: number; completed: number }
+export type BenchTaskPackRunOptions = { model: string; packId?: string; fetchImpl?: BenchFetch; signal?: AbortSignal; timeoutMs?: number; now?: () => Date; monotonicNow?: () => number; runId?: string; onProgress?: (progress: BenchTaskPackProgressV1) => void | Promise<void> }
 
 const EMPTY_RUNTIME_METRICS: RuntimeReportedMetricsV1 = { totalDurationNs: null, loadDurationNs: null, promptEvalCount: null, promptEvalDurationNs: null, evalCount: null, evalDurationNs: null }
 const isoNow = (now: () => Date): string => now().toISOString()
@@ -94,6 +95,11 @@ export async function runBenchTaskPackV1(options: BenchTaskPackRunOptions): Prom
   try { runtimeVersion = await fetchOllamaVersion({ fetchImpl: options.fetchImpl, signal: options.signal, timeoutMs }) } catch (error) { preflightFailure = asFailure(error) }
 
   const tasks: BenchTaskResultV1[] = []
+  const reportProgress = async (): Promise<void> => {
+    try { await options.onProgress?.({ planned: pack.tasks.length, completed: tasks.length }) } catch {
+      // Progress is advisory and must never change the canonical result.
+    }
+  }
   let reportedModel: string | null = null
   let reportedModelConflict = false
   for (let index = 0; index < pack.tasks.length; index++) {
@@ -102,9 +108,10 @@ export async function runBenchTaskPackV1(options: BenchTaskPackRunOptions): Prom
       const taskStatus: 'unavailable' | 'timeout' | 'cancelled' = preflightFailure.code === 'cancelled' ? 'cancelled' : preflightFailure.code === 'timeout' ? 'timeout' : 'unavailable'
       const taskCode: 'runtime-unavailable' | 'timeout' | 'cancelled' = preflightFailure.code === 'cancelled' ? 'cancelled' : preflightFailure.code === 'timeout' ? 'timeout' : 'runtime-unavailable'
       tasks.push(emptyTask(task.id, taskStatus, taskCode))
+      await reportProgress()
       continue
     }
-    if (options.signal?.aborted) { for (let rest = index; rest < pack.tasks.length; rest++) tasks.push(emptyTask(pack.tasks[rest]!.id, 'cancelled', 'cancelled')); break }
+    if (options.signal?.aborted) { for (let rest = index; rest < pack.tasks.length; rest++) tasks.push(emptyTask(pack.tasks[rest]!.id, 'cancelled', 'cancelled')); await reportProgress(); break }
     try {
       const evidence = await runOllamaGenerate({ model, prompt: task.prompt, includeOutput: true, fetchImpl: options.fetchImpl, signal: options.signal, timeoutMs, monotonicNow })
       if (evidence.reportedModel !== null && !reportedModelConflict) {
@@ -117,12 +124,14 @@ export async function runBenchTaskPackV1(options: BenchTaskPackRunOptions): Prom
       if (evidence.output === undefined) throw new BenchOllamaError('malformed-response', 'The local runtime output was unavailable for transient scoring.')
       const scored = scoreBenchTaskV1(task, evidence.output)
       tasks.push({ taskId: task.id, attempted: true, status: scored.status, score: scored.score, outputDigest: scored.outputDigest, outputChars: scored.outputChars, requestLatencyMs: evidence.observed.requestLatencyMs, timeToFirstContentMs: evidence.observed.timeToFirstContentMs, runtimeReported: evidence.runtimeReported, failure: scored.status === 'passed' ? null : { code: scored.status === 'malformed' ? 'malformed-output' : 'scoring-failed', message: failureMessage(scored.status === 'malformed' ? 'malformed-output' : 'scoring-failed') } })
+      await reportProgress()
     } catch (error) {
       const failure = asFailure(error)
       const status: BenchTaskRunStatusV1 = failure.code === 'cancelled' ? 'cancelled' : failure.code === 'timeout' ? 'timeout' : ['runtime-unavailable', 'transport-error', 'http-error', 'model-not-found', 'runtime-error', 'malformed-response', 'response-limit'].includes(failure.code) ? 'unavailable' : 'failed'
       tasks.push({ taskId: task.id, attempted: true, status, score: null, outputDigest: null, outputChars: null, requestLatencyMs: null, timeToFirstContentMs: null, runtimeReported: { ...EMPTY_RUNTIME_METRICS }, failure })
-      if (status === 'cancelled') { for (let rest = index + 1; rest < pack.tasks.length; rest++) tasks.push(emptyTask(pack.tasks[rest]!.id, 'cancelled', 'cancelled')); break }
-      if (status === 'unavailable') { for (let rest = index + 1; rest < pack.tasks.length; rest++) tasks.push(emptyTask(pack.tasks[rest]!.id, 'unavailable', 'runtime-unavailable')); break }
+      await reportProgress()
+      if (status === 'cancelled') { for (let rest = index + 1; rest < pack.tasks.length; rest++) tasks.push(emptyTask(pack.tasks[rest]!.id, 'cancelled', 'cancelled')); await reportProgress(); break }
+      if (status === 'unavailable') { for (let rest = index + 1; rest < pack.tasks.length; rest++) tasks.push(emptyTask(pack.tasks[rest]!.id, 'unavailable', 'runtime-unavailable')); await reportProgress(); break }
     }
   }
 

--- a/tests/act-foundation-v2.test.ts
+++ b/tests/act-foundation-v2.test.ts
@@ -1,0 +1,522 @@
+import { afterAll, describe, expect, it } from 'vitest'
+import { appendFile, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { runAction } from '../src/act/apply.js'
+import { undoAction } from '../src/act/undo.js'
+import { appendRecord, journalPath, readRecords } from '../src/act/journal.js'
+import {
+  ACTION_KIND_RUN_CORE_COMPATIBILITY,
+  ACTION_NO_ROLLBACK_REASON,
+  CORE_TASK_PACK_SELECTOR,
+  TrustedActionAuthorityV1,
+  createCoreCompatibilityAction,
+  validateActionContractV1,
+  type ActionContractV1,
+  type ApprovedActionV1,
+} from '../src/act/action-contract-v1.js'
+import {
+  cancelCoreCompatibilityAction,
+  executeApprovedCoreCompatibility,
+  readCoreCompatibilityAction,
+  recordCoreCompatibilityProposal,
+} from '../src/act/core-compatibility-operation-v1.js'
+import {
+  appendOperationRecord,
+  initialOperationState,
+} from '../src/act/core-compatibility-state-v1.js'
+import { scanBenchHistoryV1, saveBenchEvaluationV1 } from '../src/bench/history-v1.js'
+import { OLLAMA_GENERATE_URL, OLLAMA_VERSION_URL, type BenchFetch } from '../src/bench/ollama-local.js'
+import { runBenchTaskPackV1, type BenchEvaluationV1, type BenchTaskPackRunOptions } from '../src/bench/task-pack-run-v1.js'
+import type { ActionPlan, ActionRecord } from '../src/act/types.js'
+
+const roots: string[] = []
+const NL = String.fromCharCode(10)
+const BASE_TIME = Date.parse('2026-08-30T12:00:00.000Z')
+
+type Clock = { now: () => Date; advance: (milliseconds: number) => void }
+function clock(start = BASE_TIME): Clock {
+  let current = start
+  return { now: () => new Date(current), advance: milliseconds => { current += milliseconds } }
+}
+async function dirs(): Promise<{ actionsDir: string; dataDir: string }> {
+  const root = await mkdtemp(join(tmpdir(), 'metrora-act-foundation-v2-'))
+  roots.push(root)
+  return { actionsDir: join(root, 'actions'), dataDir: join(root, 'data') }
+}
+function secret(fill = 7): Uint8Array { return new Uint8Array(32).fill(fill) }
+function authority(time: Clock, fill = 7): TrustedActionAuthorityV1 {
+  return new TrustedActionAuthorityV1({ secret: secret(fill), now: time.now })
+}
+function contract(id: string, time: Clock, timeoutMs = 50): ActionContractV1 {
+  return createCoreCompatibilityAction({ model: 'qwen3:8b', originatingSurface: 'cli', actionId: id, createdAt: time.now().toISOString(), timeoutMs })
+}
+function approve(value: ActionContractV1, time: Clock, fill = 7): { authority: TrustedActionAuthorityV1; approved: ApprovedActionV1 } {
+  const trusted = authority(time, fill)
+  return { authority: trusted, approved: trusted.issueApprovalAfterTrustedUserConfirmation(value) }
+}
+function passFetch(calls?: { version: number; generate: number }): BenchFetch {
+  return async (input, init) => {
+    const url = String(input)
+    if (url === OLLAMA_VERSION_URL) {
+      if (calls) calls.version += 1
+      return new Response(JSON.stringify({ version: '0.12.6' }), { status: 200 })
+    }
+    if (url === OLLAMA_GENERATE_URL) {
+      if (calls) calls.generate += 1
+      const body = JSON.parse(String(init?.body)) as { model: string }
+      return new Response(JSON.stringify({ model: body.model, response: 'READY', done: true, eval_count: 1, prompt_eval_count: 1 }) + NL, { status: 200 })
+    }
+    return new Response('not found', { status: 404 })
+  }
+}
+async function validResult(actionId: string, time: Clock, model = 'qwen3:8b'): Promise<BenchEvaluationV1> {
+  return runBenchTaskPackV1({ model, packId: CORE_TASK_PACK_SELECTOR, runId: actionId, timeoutMs: 50, fetchImpl: passFetch(), now: time.now })
+}
+async function expectCode(promise: Promise<unknown>, code: string): Promise<void> {
+  await expect(promise).rejects.toMatchObject({ code })
+}
+function runningState(value: ActionContractV1, time: Clock, ownerProcessId = 999999): ReturnType<typeof initialOperationState> {
+  const ready = { ...initialOperationState(value), approvalIssuedAt: time.now().toISOString() }
+  return { ...ready, ownerProcessId, startedAt: time.now().toISOString() }
+}
+afterAll(async () => { for (const root of roots) await rm(root, { recursive: true, force: true }) })
+
+describe('ACT foundation v2 strict contract and authority', () => {
+  it('accepts one valid current-main-native Core Compatibility contract with exact identity', () => {
+    const time = clock()
+    const value = contract('act-valid', time)
+    expect(validateActionContractV1(value)).toEqual(value)
+    expect(value.contractVersion).toBe('metrora.action.v1')
+    expect(value.kind).toBe('run-core-compatibility')
+    expect(value.target.runtime.endpoint).toBe('http://127.0.0.1:11434')
+    expect(value.arguments.runId).toBe(value.actionId)
+    expect(value.arguments.promptSource).toBe('canonical-pack-only')
+    expect(value.methodology).toMatchObject({ family: 'compatibility-runtime-health', runner: 'canonical-task-pack-v1', scoring: 'deterministic-task-assertions' })
+    expect(value.limits.checksPlanned).toBe(6)
+    expect(value.rollback).toEqual({ capability: 'none', reason: ACTION_NO_ROLLBACK_REASON })
+  })
+
+  it('rejects unknown schema versions and action kinds', () => {
+    const value = contract('act-schema-kind', clock())
+    expect(() => validateActionContractV1({ ...value, schemaVersion: 2 })).toThrow()
+    expect(() => validateActionContractV1({ ...value, kind: 'run-core-conformance-bench' })).toThrow()
+    expect(ACTION_KIND_RUN_CORE_COMPATIBILITY).toBe('run-core-compatibility')
+  })
+
+  it('rejects arbitrary endpoints, filesystem paths, and prompts', () => {
+    const value = contract('act-boundary-inputs', clock())
+    expect(() => validateActionContractV1({ ...value, target: { ...value.target, runtime: { ...value.target.runtime, endpoint: 'http://127.0.0.1:9999' } } })).toThrow()
+    expect(() => validateActionContractV1({ ...value, arguments: { ...value.arguments, prompt: 'execute arbitrary text' } })).toThrow()
+    expect(() => validateActionContractV1({ ...value, preconditions: { ...value.preconditions, arbitraryPaths: 'allowed' } })).toThrow()
+  })
+
+  it('rejects mutation effects and non-canonical timeout bounds', () => {
+    const value = contract('act-effects-timeout', clock())
+    expect(() => validateActionContractV1({ ...value, declaredEffects: { ...value.declaredEffects, writes: ['repository-files', 'secrets'] } })).toThrow()
+    expect(() => validateActionContractV1({ ...value, timeout: { ...value.timeout, operationMs: 51 } })).toThrow()
+    expect(() => createCoreCompatibilityAction({ model: 'qwen3:8b', originatingSurface: 'cli', actionId: 'bad-model', timeoutMs: 49 })).toThrow()
+  })
+
+  it('rejects cycles and accessor-backed contract data before schema parsing', () => {
+    const value = contract('act-json-safety', clock()) as unknown as Record<string, unknown>
+    const cycle: Record<string, unknown> = { ...value }
+    cycle.self = cycle
+    expect(() => validateActionContractV1(cycle)).toThrow()
+    const accessor = { ...value, schemaVersion: 1 } as Record<string, unknown>
+    Object.defineProperty(accessor, 'actionId', { get: () => 'act-json-safety' })
+    expect(() => validateActionContractV1(accessor)).toThrow()
+  })
+
+  it('binds approval to the exact proposal, confirmation, execution, target, and model', () => {
+    const time = clock()
+    const value = contract('act-approval-binding', time)
+    const { authority: trusted, approved } = approve(value, time)
+    expect(trusted.verifyApprovedAction(approved)).toEqual(approved)
+    expect(() => trusted.verifyApprovedAction({ ...approved, contract: { ...approved.contract, target: { ...approved.contract.target, model: 'llama3.2' }, arguments: { ...approved.contract.arguments, model: 'llama3.2' } } })).toThrow()
+    expect(() => trusted.verifyApprovedAction({ ...approved, approval: { ...approved.approval, actionId: 'other-action' } })).toThrow()
+  })
+
+  it('rejects forged approval proofs and approvals issued by a different authority after restart', () => {
+    const time = clock()
+    const value = contract('act-forged-restart', time)
+    const { approved } = approve(value, time)
+    const forged = { ...approved, approval: { ...approved.approval, proof: '0'.repeat(64) } }
+    expect(() => authority(time).verifyApprovedAction(forged as unknown)).toThrow()
+    expect(() => new TrustedActionAuthorityV1({ secret: secret(8), now: time.now }).verifyApprovedAction(approved)).toThrow()
+  })
+
+  it('rejects expired approvals and does not renew them implicitly', () => {
+    const time = clock()
+    const value = contract('act-expired-approval', time)
+    const { authority: trusted, approved } = approve(value, time)
+    time.advance(5 * 60_000 + 1)
+    expect(() => trusted.verifyApprovedAction(approved)).toThrow(/expired/)
+    expect(() => trusted.issueApprovalAfterTrustedUserConfirmation(approved.contract)).toThrow()
+  })
+
+  it('normalizes forged and stale authority failures at the executor boundary', async () => {
+    const time = clock()
+    const { actionsDir } = await dirs()
+    const value = contract('act-executor-approval-errors', time)
+    const { authority: trusted, approved } = approve(value, time)
+    const forged = { ...approved, approval: { ...approved.approval, proof: '0'.repeat(64) } }
+    await expectCode(executeApprovedCoreCompatibility(forged, { authority: trusted, actionsDir, now: time.now }), 'approval-invalid')
+    time.advance(5 * 60_000 + 1)
+    await expectCode(executeApprovedCoreCompatibility(approved, { authority: trusted, actionsDir, now: time.now }), 'approval-expired')
+  })
+})
+
+describe('ACT foundation v2 proposal, lifecycle, and evidence', () => {
+  it('persists a proposal-only record without trusted approval or mutable outcome data', async () => {
+    const time = clock()
+    const { actionsDir } = await dirs()
+    const value = contract('act-proposal-only', time)
+    const record = await recordCoreCompatibilityProposal(value, { actionsDir, now: time.now })
+    expect(record.status).toBe('proposed')
+    expect(record.contract.approval.confirmationDigest).toBeNull()
+    expect(record.operation.approvalIssuedAt).toBeNull()
+    expect(record.operation.result).toBeNull()
+    expect(record.operation.evidenceReferences).toEqual([])
+  })
+
+  it('rejects self-approved contracts at the proposal boundary', async () => {
+    const time = clock()
+    const { actionsDir } = await dirs()
+    const { approved } = approve(contract('act-self-approval', time), time)
+    await expectCode(recordCoreCompatibilityProposal(approved.contract, { actionsDir, now: time.now }), 'validation')
+  })
+
+  it('executes the canonical six-check runner and records exact Bench evidence references', async () => {
+    const time = clock()
+    const { actionsDir, dataDir } = await dirs()
+    const value = contract('act-completed', time)
+    const { authority: trusted, approved } = approve(value, time)
+    const calls = { version: 0, generate: 0 }
+    const record = await executeApprovedCoreCompatibility(approved, { authority: trusted, actionsDir, dataDir, now: time.now, fetchImpl: passFetch(calls) })
+    expect(record.status).toBe('completed')
+    expect(calls).toEqual({ version: 1, generate: 6 })
+    expect(record.operation.result).toMatchObject({ kind: 'metrora.bench-evaluation.v1', runId: value.actionId, history: 'saved' })
+    expect(record.operation.evidenceReferences).toHaveLength(1)
+    expect(record.operation.evidenceReferences[0]).toMatchObject({ kind: 'metrora.bench-history.v1', runId: value.actionId, history: 'saved' })
+    const history = await scanBenchHistoryV1({ dataDir })
+    expect(history.records).toHaveLength(1)
+    expect(history.records[0]?.runId).toBe(value.actionId)
+  })
+
+  it('uses the canonical task-pack runner seam with exact selector and no arbitrary prompt input', async () => {
+    const time = clock()
+    const { actionsDir, dataDir } = await dirs()
+    const value = contract('act-canonical-runner', time)
+    const { authority: trusted, approved } = approve(value, time)
+    let seen: BenchTaskPackRunOptions | null = null
+    const runBench = async (options: BenchTaskPackRunOptions): Promise<BenchEvaluationV1> => {
+      seen = options
+      return runBenchTaskPackV1({ ...options, fetchImpl: passFetch() })
+    }
+    const record = await executeApprovedCoreCompatibility(approved, { authority: trusted, actionsDir, dataDir, now: time.now, runBench })
+    expect(record.status).toBe('completed')
+    expect(seen).toMatchObject({ model: 'qwen3:8b', packId: CORE_TASK_PACK_SELECTOR, runId: value.actionId, timeoutMs: 50 })
+    expect(seen && 'prompt' in seen).toBe(false)
+  })
+
+  it('journals monotonic bounded progress tied to the six canonical task checks', async () => {
+    const time = clock()
+    const { actionsDir, dataDir } = await dirs()
+    const value = contract('act-progress', time)
+    const { authority: trusted, approved } = approve(value, time)
+    const record = await executeApprovedCoreCompatibility(approved, {
+      authority: trusted,
+      actionsDir,
+      dataDir,
+      now: time.now,
+      runBench: async options => {
+        await options.onProgress?.({ planned: 6, completed: 1 })
+        await options.onProgress?.({ planned: 6, completed: 3 })
+        return validResult(value.actionId, time)
+      },
+    })
+    expect(record.status).toBe('completed')
+    const history = (await readFile(journalPath(actionsDir), 'utf8')).trim().split(NL).map(line => JSON.parse(line) as { status: string; operation?: { progress?: { completed: number } } })
+    expect(history.filter(entry => entry.status === 'running').map(entry => entry.operation?.progress?.completed)).toEqual([0, 1, 3])
+    expect(record.operation.progress).toEqual({ planned: 6, completed: 6 })
+  })
+
+  it('rejects terminal replay and leaves one canonical evidence record', async () => {
+    const time = clock()
+    const { actionsDir, dataDir } = await dirs()
+    const { authority: trusted, approved } = approve(contract('act-replay', time), time)
+    const first = await executeApprovedCoreCompatibility(approved, { authority: trusted, actionsDir, dataDir, now: time.now, fetchImpl: passFetch() })
+    expect(first.status).toBe('completed')
+    await expectCode(executeApprovedCoreCompatibility(approved, { authority: trusted, actionsDir, dataDir, now: time.now, fetchImpl: passFetch() }), 'replay')
+    expect((await scanBenchHistoryV1({ dataDir })).records).toHaveLength(1)
+  })
+
+  it('rejects invalid lifecycle entry and transition shapes fail closed', async () => {
+    const time = clock()
+    const { actionsDir } = await dirs()
+    const { approved } = approve(contract('act-invalid-transition', time), time)
+    await expectCode(appendOperationRecord(actionsDir, approved.contract, 'running', runningState(approved.contract, time), time.now), 'journal')
+    expect(await readCoreCompatibilityAction(approved.contract.actionId, { actionsDir, now: time.now })).toBeNull()
+  })
+
+  it('expires a persisted ready state on read and never silently renews its approval', async () => {
+    const time = clock()
+    const { actionsDir } = await dirs()
+    const value = contract('act-ready-expiry', time)
+    const { approved } = approve(value, time)
+    await recordCoreCompatibilityProposal(value, { actionsDir, now: time.now })
+    await appendOperationRecord(actionsDir, approved.contract, 'ready', { ...initialOperationState(approved.contract), approvalIssuedAt: approved.approval.issuedAt }, time.now)
+    time.advance(5 * 60_000 + 1)
+    const expired = await readCoreCompatibilityAction(value.actionId, { actionsDir, now: time.now })
+    expect(expired?.status).toBe('failed')
+    expect(expired?.operation.failure?.category).toBe('approval-expired')
+    expect(expired?.operation.ownerProcessId).toBeNull()
+  })
+})
+
+describe('ACT foundation v2 cancellation, timeout, recovery, and identity', () => {
+  it('cancels before execution starts without invoking the Bench runner', async () => {
+    const time = clock()
+    const { actionsDir, dataDir } = await dirs()
+    const { authority: trusted, approved } = approve(contract('act-cancel-before-start', time), time)
+    const controller = new AbortController()
+    controller.abort()
+    let called = false
+    const record = await executeApprovedCoreCompatibility(approved, {
+      authority: trusted,
+      actionsDir,
+      dataDir,
+      now: time.now,
+      signal: controller.signal,
+      runBench: async () => { called = true; throw new Error('must not run') },
+    })
+    expect(record.status).toBe('cancelled')
+    expect(record.operation.failure?.category).toBe('cancelled')
+    expect(called).toBe(false)
+  })
+
+  it('makes cancellation authoritative over a late result', async () => {
+    const time = clock()
+    const { actionsDir, dataDir } = await dirs()
+    const value = contract('act-cancel-late', time)
+    const { authority: trusted, approved } = approve(value, time)
+    let resolveLate!: (result: BenchEvaluationV1) => void
+    const lateResult = new Promise<BenchEvaluationV1>(resolve => { resolveLate = resolve })
+    const execution = executeApprovedCoreCompatibility(approved, {
+      authority: trusted,
+      actionsDir,
+      dataDir,
+      now: time.now,
+      runBench: async () => lateResult,
+    })
+    let running = false
+    for (let attempt = 0; attempt < 30 && !running; attempt++) {
+      running = (await readCoreCompatibilityAction(value.actionId, { actionsDir, now: time.now }))?.status === 'running'
+      if (!running) await new Promise(resolve => setTimeout(resolve, 10))
+    }
+    expect(running).toBe(true)
+    const requested = await cancelCoreCompatibilityAction(value.actionId, { actionsDir, dataDir, now: time.now })
+    expect(['requested', 'already-terminal']).toContain(requested.status)
+    const cancelled = await execution
+    expect(cancelled.status).toBe('cancelled')
+    resolveLate(await validResult(value.actionId, time))
+    await new Promise(resolve => setTimeout(resolve, 50))
+    const afterLateResult = await readCoreCompatibilityAction(value.actionId, { actionsDir, dataDir, now: time.now })
+    expect(afterLateResult?.status).toBe('cancelled')
+    expect(afterLateResult?.operation.result).toBeNull()
+    expect((await scanBenchHistoryV1({ dataDir })).records).toHaveLength(0)
+  })
+
+  it('records timeout distinctly and discards a late result after the bounded operation deadline', async () => {
+    const time = clock()
+    const { actionsDir, dataDir } = await dirs()
+    const value = contract('act-timeout-late', time)
+    const { authority: trusted, approved } = approve(value, time)
+    const execution = executeApprovedCoreCompatibility(approved, {
+      authority: trusted,
+      actionsDir,
+      dataDir,
+      now: time.now,
+      runBench: async () => {
+        await new Promise(resolve => setTimeout(resolve, 500))
+        return validResult(value.actionId, time)
+      },
+    })
+    const timedOut = await execution
+    expect(timedOut.status).toBe('failed')
+    expect(timedOut.operation.failure?.category).toBe('timeout')
+    expect(timedOut.operation.timeout.triggered).toBe(true)
+    await new Promise(resolve => setTimeout(resolve, 50))
+    expect((await scanBenchHistoryV1({ dataDir })).records).toHaveLength(0)
+    expect((await readCoreCompatibilityAction(value.actionId, { actionsDir, dataDir, now: time }))?.status).toBe('failed')
+  }, 5_000)
+
+  it('recovers an orphaned running action to failed without automatic retry when evidence is absent', async () => {
+    const time = clock()
+    const { actionsDir } = await dirs()
+    const value = contract('act-orphan-fail', time)
+    const { approved } = approve(value, time)
+    await recordCoreCompatibilityProposal(value, { actionsDir, now: time.now })
+    await appendOperationRecord(actionsDir, approved.contract, 'ready', { ...initialOperationState(approved.contract), approvalIssuedAt: approved.approval.issuedAt }, time.now)
+    await appendOperationRecord(actionsDir, approved.contract, 'running', runningState(approved.contract, time), time.now)
+    const recovered = await readCoreCompatibilityAction(value.actionId, { actionsDir, now: time.now })
+    expect(recovered?.status).toBe('failed')
+    expect(recovered?.operation.failure).toMatchObject({ category: 'execution' })
+    expect(recovered?.operation.result).toBeNull()
+  })
+
+  it('recovers an orphaned running action to completed only from exact canonical evidence', async () => {
+    const time = clock()
+    const { actionsDir, dataDir } = await dirs()
+    const value = contract('act-orphan-evidence', time)
+    const { approved } = approve(value, time)
+    const result = await validResult(value.actionId, time)
+    await saveBenchEvaluationV1(result, { dataDir })
+    await recordCoreCompatibilityProposal(value, { actionsDir, now: time.now })
+    await appendOperationRecord(actionsDir, approved.contract, 'ready', { ...initialOperationState(approved.contract), approvalIssuedAt: approved.approval.issuedAt }, time.now)
+    await appendOperationRecord(actionsDir, approved.contract, 'running', runningState(approved.contract, time), time.now)
+    const recovered = await readCoreCompatibilityAction(value.actionId, { actionsDir, dataDir, now: time.now })
+    expect(recovered?.status).toBe('completed')
+    expect(recovered?.operation.result).toMatchObject({ resultDigest: result.resultDigest, history: 'duplicate' })
+    expect(recovered?.operation.evidenceReferences[0]).toMatchObject({ runId: value.actionId, resultDigest: result.resultDigest, history: 'duplicate' })
+  })
+
+  it('fails closed on malformed Bench results and never publishes them as evidence', async () => {
+    const time = clock()
+    const { actionsDir, dataDir } = await dirs()
+    const { authority: trusted, approved } = approve(contract('act-malformed-result', time), time)
+    const record = await executeApprovedCoreCompatibility(approved, {
+      authority: trusted,
+      actionsDir,
+      dataDir,
+      now: time.now,
+      runBench: async () => ({ malformed: true } as unknown as BenchEvaluationV1),
+    })
+    expect(record.status).toBe('failed')
+    expect(record.operation.failure?.category).toBe('malformed-result')
+    expect((await scanBenchHistoryV1({ dataDir })).records).toHaveLength(0)
+  })
+
+  it('fails closed when Bench result identity does not match the approved action', async () => {
+    const time = clock()
+    const { actionsDir, dataDir } = await dirs()
+    const value = contract('act-result-mismatch', time)
+    const { authority: trusted, approved } = approve(value, time)
+    const wrongResult = await validResult('different-run-id', time)
+    const record = await executeApprovedCoreCompatibility(approved, { authority: trusted, actionsDir, dataDir, now: time.now, runBench: async () => wrongResult })
+    expect(record.status).toBe('failed')
+    expect(record.operation.failure?.category).toBe('identity-mismatch')
+    expect((await scanBenchHistoryV1({ dataDir })).records).toHaveLength(0)
+  })
+
+  it('rejects an approved action whose exact identity differs from the recorded proposal', async () => {
+    const time = clock()
+    const { actionsDir, dataDir } = await dirs()
+    const value = contract('act-proposal-identity', time)
+    await recordCoreCompatibilityProposal(value, { actionsDir, now: time.now })
+    const alternate = createCoreCompatibilityAction({ model: 'qwen3:8b', originatingSurface: 'desktop', actionId: value.actionId, createdAt: value.createdAt, timeoutMs: 50 })
+    const { authority: trusted, approved } = approve(alternate, time)
+    await expectCode(executeApprovedCoreCompatibility(approved, { authority: trusted, actionsDir, dataDir, now: time.now, runBench: async () => validResult(value.actionId, time) }), 'identity-mismatch')
+  })
+})
+
+describe('ACT foundation v2 journal strictness and legacy compatibility', () => {
+  it('rejects duplicate proposals for the same action identity', async () => {
+    const time = clock()
+    const { actionsDir } = await dirs()
+    const value = contract('act-duplicate-proposal', time)
+    await recordCoreCompatibilityProposal(value, { actionsDir, now: time.now })
+    await expectCode(recordCoreCompatibilityProposal(value, { actionsDir, now: time.now }), 'duplicate')
+  })
+
+  it('rejects unknown journal record shapes instead of treating them as legacy actions', async () => {
+    const time = clock()
+    const { actionsDir } = await dirs()
+    await mkdir(actionsDir, { recursive: true })
+    await writeFile(journalPath(actionsDir), JSON.stringify({ id: 'unknown-record', kind: 'unknown-kind', status: 'unknown-status', at: time.now().toISOString() }) + NL)
+    await expectCode(readCoreCompatibilityAction('unknown-record', { actionsDir, now: time.now }), 'journal')
+  })
+
+  it('rejects malformed ACT journal JSON fail closed while legacy read remains intentionally compatible', async () => {
+    const { actionsDir } = await dirs()
+    await mkdir(actionsDir, { recursive: true })
+    await appendFile(journalPath(actionsDir), '{not-json' + NL)
+    await expectCode(readCoreCompatibilityAction('any-action', { actionsDir }), 'journal')
+    expect(await readRecords(actionsDir)).toEqual([])
+  })
+
+  it('keeps legacy records readable beside controlled ACT records without mixing their identities', async () => {
+    const time = clock()
+    const { actionsDir } = await dirs()
+    const legacy: ActionRecord = { id: 'legacy-compatible', at: time.now().toISOString(), kind: 'shell-config', findingId: null, description: 'legacy action', changes: [], status: 'applied' }
+    await appendRecord(actionsDir, legacy)
+    const value = contract('act-beside-legacy', time)
+    await recordCoreCompatibilityProposal(value, { actionsDir, now: time.now })
+    const all = await readRecords(actionsDir)
+    expect(all).toHaveLength(2)
+    expect((await readCoreCompatibilityAction(value.actionId, { actionsDir, now: time.now }))?.status).toBe('proposed')
+  })
+
+  it('preserves the legacy file mutation path for ordinary legacy action kinds', async () => {
+    const { actionsDir } = await dirs()
+    const target = join(actionsDir, 'legacy.txt')
+    const result = await runAction({ kind: 'shell-config', description: 'legacy mutation', changes: [{ op: 'create', path: target, content: 'legacy' }] }, actionsDir)
+    expect(result.status).toBe('applied')
+    expect(await readFile(target, 'utf8')).toBe('legacy')
+    expect((await readRecords(actionsDir)).some(record => record.id === result.id && record.status === 'applied')).toBe(true)
+  })
+
+  it('rejects the controlled operation before it can enter runAction or mutate files', async () => {
+    const { actionsDir } = await dirs()
+    const target = join(actionsDir, 'must-not-exist.txt')
+    const controlledPlan = { kind: ACTION_KIND_RUN_CORE_COMPATIBILITY, description: 'controlled', changes: [{ op: 'create', path: target, content: 'nope' }] } as unknown as ActionPlan
+    await expect(runAction(controlledPlan, actionsDir)).rejects.toThrow(/controlled operation/)
+    expect(await readRecords(actionsDir)).toEqual([])
+    await expect(readFile(target, 'utf8')).rejects.toThrow()
+  })
+
+  it('keeps controlled records outside the legacy undo selector', async () => {
+    const time = clock()
+    const { actionsDir } = await dirs()
+    const value = contract('act-not-legacy-undo', time)
+    await recordCoreCompatibilityProposal(value, { actionsDir, now: time.now })
+    await expect(undoAction({ id: value.actionId }, { actionsDir })).rejects.toThrow(/No action matches/)
+  })
+
+  it('does not write prompt text, model output, or secrets into the ACT journal', async () => {
+    const time = clock()
+    const { actionsDir, dataDir } = await dirs()
+    const value = contract('act-journal-minimal', time)
+    const { authority: trusted, approved } = approve(value, time)
+    await executeApprovedCoreCompatibility(approved, { authority: trusted, actionsDir, dataDir, now: time.now, fetchImpl: passFetch() })
+    const raw = await readFile(journalPath(actionsDir), 'utf8')
+    expect(raw).not.toContain('single lowercase word')
+    expect(raw).not.toContain('READY')
+    expect(raw).not.toContain('secret')
+    expect(raw).toContain('metrora.bench-history.v1')
+  })
+
+  it('returns already-terminal for cancellation after completion and never appends duplicate evidence', async () => {
+    const time = clock()
+    const { actionsDir, dataDir } = await dirs()
+    const value = contract('act-terminal-cancel', time)
+    const { authority: trusted, approved } = approve(value, time)
+    const completed = await executeApprovedCoreCompatibility(approved, { authority: trusted, actionsDir, dataDir, now: time.now, fetchImpl: passFetch() })
+    const cancelled = await cancelCoreCompatibilityAction(value.actionId, { actionsDir, dataDir, now: time.now })
+    expect(completed.status).toBe('completed')
+    expect(cancelled.status).toBe('already-terminal')
+    expect((await scanBenchHistoryV1({ dataDir })).records).toHaveLength(1)
+    expect((await readCoreCompatibilityAction(value.actionId, { actionsDir, dataDir, now: time.now }))?.status).toBe('completed')
+  })
+
+  it('rejects duplicate terminal journal entries instead of accepting a second completion', async () => {
+    const time = clock()
+    const { actionsDir, dataDir } = await dirs()
+    const value = contract('act-duplicate-terminal', time)
+    const { authority: trusted, approved } = approve(value, time)
+    const completed = await executeApprovedCoreCompatibility(approved, { authority: trusted, actionsDir, dataDir, now: time.now, fetchImpl: passFetch() })
+    await appendRecord(actionsDir, completed)
+    await expectCode(readCoreCompatibilityAction(value.actionId, { actionsDir, dataDir, now: time.now }), 'journal')
+  })
+})

--- a/tests/act-report.test.ts
+++ b/tests/act-report.test.ts
@@ -4,6 +4,8 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
 import { journalPath } from '../src/act/journal.js'
+import { createCoreCompatibilityAction } from '../src/act/action-contract-v1.js'
+import { initialOperationState, makeRecord } from '../src/act/core-compatibility-state-v1.js'
 import {
   buildActReportJson,
   buildOptimizeAppliedHeader,
@@ -479,6 +481,19 @@ describe('journal robustness', () => {
     expect(report.rows).toHaveLength(1)
     expect(report.rows[0]!.realizedTokens).toBe(40_000)
     expect(renderActReport(report)).toMatch(/1 malformed record skipped/)
+  })
+
+  it('excludes valid Core Compatibility records without counting them as malformed', async () => {
+    const at = daysAgo(10)
+    const controlledContract = createCoreCompatibilityAction({ model: 'qwen3:8b', originatingSurface: 'cli', actionId: 'controlled-report-record', createdAt: at, timeoutMs: 50 })
+    const controlled = makeRecord(controlledContract, 'proposed', initialOperationState(controlledContract), () => NOW)
+    const actionsDir = await writeJournal([mcpRecord(), controlled, missingAt])
+    const report = await computeActReport({ actionsDir, now: NOW, loadProjects: load([projectOf(sessionsAt(20, daysAgo(5)))]) })
+
+    expect(report.rows).toHaveLength(1)
+    expect(report.rows[0]!.id).toBe('a1')
+    expect(report.activeCount).toBe(1)
+    expect(report.malformedRecords).toBe(1)
   })
 })
 

--- a/tests/bench-cli.test.ts
+++ b/tests/bench-cli.test.ts
@@ -43,7 +43,7 @@ describe('metrora bench local CLI', () => {
       endedAt: '2026-08-27T10:00:00.000Z',
     } as BenchEvaluationV1
     const output = renderBenchHistory([record])
-    expect(output).toContain('Core conformance unavailable')
+    expect(output).toContain('Core Compatibility unavailable')
     expect(output).toContain('no checks scored')
     expect(output).not.toContain('0/6 passed')
   })

--- a/tests/bench-history-v1.test.ts
+++ b/tests/bench-history-v1.test.ts
@@ -103,7 +103,7 @@ describe('Bench history v1', () => {
 
     const scan = await scanBenchHistoryV1({ dataDir: dir })
     expect(scan.records).toHaveLength(0)
-    expect(scan.invalid).toEqual([{ file, reason: expect.stringContaining('canonical Core conformance pack') }])
+    expect(scan.invalid).toEqual([{ file, reason: expect.stringContaining('canonical Core Compatibility pack') }])
   })
 
   it('rejects a result digest that does not match retained task evidence', async () => {
@@ -141,7 +141,7 @@ describe('Bench history v1', () => {
 
     const scan = await scanBenchHistoryV1({ dataDir: dir })
     expect(scan.records).toHaveLength(0)
-    expect(scan.invalid).toEqual([{ file, reason: expect.stringContaining('fixed Core conformance policy') }])
+    expect(scan.invalid).toEqual([{ file, reason: expect.stringContaining('fixed Core Compatibility policy') }])
   })
 
   it('bounds oversized corrupt files before parsing', async () => {


### PR DESCRIPTION
## Summary

- Add the current-main-native ACT foundation v2 for the single controlled `run-core-compatibility` operation under strict `metrora.action.v1`.
- Bind exact runtime/model/pack/methodology/parameters/effects/timeout/cancellation and proposal, confirmation, execution, result, and evidence digests.
- Add trusted-process approval with freshness, restart, forgery, replay, duplicate, lifecycle, orphan-recovery, cancellation, timeout, and late-result protections.
- Reuse the canonical six-check Bench task-pack runner and canonical Bench history; ACT journals only bounded lifecycle/progress/counts and evidence references.
- Keep legacy file mutation/undo/report compatible while preventing controlled actions from entering the legacy mutation executor.

## Scope and safety

- Core Compatibility / Runtime Health remains distinct from the Performance-first Bench direction.
- Advisor/Harness proposals remain proposal-only and are not wired to execution, UI, or navigation.
- No Android/mobile execution changes, repository or shell execution, arbitrary prompts/paths/endpoints, provider credentials, llama.cpp, second runner, merge, force-push, or release changes.

## Validation

- Full Vitest: 345 files passed, 2 skipped; 3,367 tests passed, 5 skipped.
- Focused ACT/report + ACT v2: 64/64 passed (29 ACT report, 35 ACT v2).
- `npx tsc --noEmit --pretty false`: passed.
- `npm run build:cli` and `npm run build`: passed; dashboard emitted only the existing >500 KB chunk warning.
- `node scripts/check-source-size-ratchet.mjs`: passed against the Git base; `src/act/report.ts` is 663 lines (667-line baseline; 668 before remediation).
- GitHub CI for `ed2738ba990d4e90beda16b206b7343bbc83e55e`: Metrora CI — green; Metrora Public Identity — green; Metrora Brand Boundary — green; Architecture boundaries — green; Metrora Windows Candidate — skipped as inapplicable.
- Final HEAD: `ed2738ba990d4e90beda16b206b7343bbc83e55e`.

This PR is intentionally Draft for review. Keep existing PR #244 unchanged; do not merge or release as part of this operation.