### PR TITLE
docs: define ecosystem surfaces and interoperability direction

### DIFF
--- a/docs/ECOSYSTEM_SURFACES.md
+++ b/docs/ECOSYSTEM_SURFACES.md
@@ -1,0 +1,238 @@
+# Metrora ecosystem surfaces
+
+**Status:** public product direction and implementation-status guide  
+**Decision revision:** 2026-08-30  
+**Authority reviewed:** `maikolsiragusaa/metrora@e0e2a8a6308880ebe2c794f04c54bc2c2fff5fbd`
+
+Metrora is a local-first control and intelligence system for AI-assisted development. Its product surfaces should compose around shared facts and contracts rather than grow into separate products that each calculate their own version of the truth.
+
+This page distinguishes what exists now from what is being built or remains planned.
+
+## How the ecosystem fits together
+
+```text
+Usage · Activity · Models · Capacity · Projects
+                  ↓
+             Metrora Tools
+        ┌─────────┼───────────┐
+        ↓         ↓           ↓
+     Harness     MCP      integrations
+        │
+        └─ state-changing request
+                  ↓
+             proposal only
+                  ↓
+                 ACT
+                  ↓
+          bounded execution
+
+Bench   = methodology-bound test/evidence system
+Widgets = shareable presentation of canonical evidence
+Wrapped = recap/share experience built on canonical evidence + Widgets
+Swarm   = future coordinated Harness capability behind trusted authority
+```
+
+Canonical rule:
+
+> **Tools expose capability. Harness and MCP consume capability. ACT grants execution authority.**
+
+ACT is not a chat mode and an MCP client is not trusted execution authority simply because it can discover a Metrora tool.
+
+## Current status
+
+| Surface | Product job | Status |
+| --- | --- | --- |
+| **Usage / Activity / Models / Capacity** | Factual local evidence, history, economics and provider-reported capacity | **Available** |
+| **Projects** | User-controlled context and scope across relevant evidence | **Available** |
+| **Tools** | Typed factual access to Metrora evidence | **Foundation available** — current implementation still contains `Advisor*` compatibility naming that will migrate |
+| **Harness** | Chat-first investigation, reasoning and Metrora-aware tool use | **Building** — current conversational foundation exists and is being converged from the older Advisor presentation |
+| **Bench** | Performance-first testing plus separate Compatibility / Runtime Health evidence | **Available and expanding** |
+| **ACT** | Trusted authorization/lifecycle for bounded state-changing operations | **Foundation available** — `metrora.action.v1` and `run-core-compatibility`; not a user-facing mode |
+| **MCP** | Standard external access to canonical Metrora Tools | **Planned** |
+| **Widgets** | Shareable visual/statistical presentation of canonical evidence | **Foundation exists through Share Card; broader Widgets family planned** |
+| **Wrapped** | Periodic recap/share experience using canonical evidence and Widgets | **Planned** |
+| **Swarm** | Coordinated multi-agent Harness capability | **Planned** |
+
+Status labels are intentionally conservative. A public direction is not presented as shipped until working product authority exists.
+
+## Tools
+
+Metrora already has typed read-only capabilities for questions such as:
+
+- spend/Usage snapshots;
+- model-efficiency evidence;
+- provider Capacity/quota snapshots;
+- overview evidence;
+- Project drivers;
+- Session highlights;
+- coverage information;
+- Bench evidence.
+
+Today much of this implementation still lives under `Advisor*` names. The product direction is to make these capabilities a reusable canonical Tools layer rather than keep them owned by one UI.
+
+This matters because the same factual capability should be reusable by Harness, a future MCP server and other bounded Metrora integrations without implementing parallel evidence paths.
+
+A tool result remains evidence. A caller or model may explain it, but cannot silently replace Metrora's canonical measurement, scope or unavailable-state semantics.
+
+## Harness
+
+**Metrora Harness** is the product-facing conversational and operational AI surface.
+
+Harness should remain a capable normal chat experience. Metrora-specific facts are read through typed Tools only when needed. Observable tool activity may be shown to the user without exposing private chain-of-thought.
+
+For state-changing requests, the conversational layer may understand the request and prepare a bounded proposal, but it does not authorize itself.
+
+```text
+conversation
+→ optional factual Tools
+→ explanation
+→ action proposal when requested
+→ explicit trusted approval
+→ ACT
+```
+
+The older `Advisor` product name is being retired. Existing `Advisor*` implementation identifiers may survive temporarily while responsibilities are migrated to the correct Harness, Tools, provider/runtime or evidence modules.
+
+## MCP
+
+Metrora adopts the Model Context Protocol as an interoperability direction.
+
+The intended first product is a **local, read-only Metrora MCP Server** that exposes the same canonical factual Tools used by Harness.
+
+A compatible external AI client could then ask a question such as:
+
+> “How much did I spend today?”
+
+and use Metrora's factual evidence instead of guessing or requiring a new Metrora-specific model integration.
+
+Planned Local MCP principles:
+
+- local-first and account-optional;
+- public Community interoperability;
+- read-only first;
+- no duplicate MCP-specific accounting/evidence engine;
+- no arbitrary shell, filesystem, repository or secret access;
+- no ability to bypass Metrora privacy/scope contracts;
+- failure of MCP cannot corrupt canonical Metrora history.
+
+A future hosted MCP surface may be offered separately for managed remote access or other hosted capabilities, but Local MCP is not intended to be crippled merely to create a paid call counter.
+
+### Future actions through MCP
+
+External AI clients may later be able to **propose** bounded Metrora actions. They do not gain direct ACT or Swarm authority.
+
+```text
+external AI
+→ MCP
+→ bounded proposal
+→ Metrora trusted authority
+→ explicit user approval
+→ ACT
+→ bounded execution
+```
+
+Any future Swarm capability follows the same authority rule.
+
+## Bench
+
+Metrora Bench remains a separate evidence system rather than becoming a generic “AI score”.
+
+Primary direction:
+
+- **Performance** — how a declared model/runtime/configuration actually runs on declared hardware.
+
+Separate evidence families:
+
+- **Compatibility / Runtime Health** — including the current deterministic `core-v1` checks;
+- **Coding Evaluation** — future, separately versioned and methodology/licence gated;
+- **Agent / Harness Evaluation** — later, once real coordinated execution exists.
+
+ACT may invoke a supported Bench operation, but Bench remains the canonical owner of Bench evidence/history.
+
+## Widgets and Wrapped
+
+Metrora already has a local **Share Card** foundation. The broader direction is to evolve this into **Widgets**: reusable, privacy-aware visual presentations of canonical Metrora evidence.
+
+Possible future Widgets include:
+
+- Usage/cost cards;
+- model/provider mix;
+- Project or Activity summaries;
+- Bench Performance results;
+- Compatibility results;
+- methodology-labelled comparisons.
+
+Local static sharing should remain useful without requiring an account. Any future hosted/live sharing is a separate service decision.
+
+**Wrapped** is not a second analytics engine. It is a recap/share experience — for example monthly or annual — built from canonical Metrora evidence and Widget presentation primitives.
+
+## Naming
+
+Ordinary pages stay concise:
+
+`Usage · Activity · Models · Capacity · Projects · Settings`
+
+Systems with an independent interaction model or authority can carry a branded name when useful:
+
+- **Metrora Harness**;
+- **Metrora Bench**;
+- **Metrora MCP Server** on first/external mention.
+
+Within an established Metrora context, prefer:
+
+`Harness · Tools · MCP · Bench · Projects · Widgets`
+
+rather than repeating “Metrora” before every noun.
+
+`ACT` remains an execution authority, not a primary navigation item. `Swarm` remains future functionality until it actually ships.
+
+## Public README direction
+
+The repository README should become easier for both users and future contributors to understand at a glance.
+
+The ratified direction is:
+
+- immediate download/install actions near the top;
+- a concise product thesis;
+- an original visual ecosystem map;
+- large visual feature sections instead of long walls of documentation;
+- clear `Available`, `Building` and `Planned` labels;
+- local-first/privacy positioning;
+- supported-tools credibility;
+- obvious routes into documentation and contribution.
+
+Modern visual OSS READMEs such as LobeHub are useful composition references, but Metrora should create original artwork and copy rather than clone another project's images or page pixel-for-pixel.
+
+Conceptual branded illustrations are preferable to screenshots that would immediately become stale while the target Desktop UX is still moving.
+
+## Visual-asset provenance
+
+Metrora inherits source and historical provenance from CodeBurn. A 2026-08-30 audit confirmed that multiple old top-level repository marketing/screenshots in `assets/` are byte-identical to upstream CodeBurn assets.
+
+Those files should be audited before the README visual redesign:
+
+- remove obsolete inherited screenshots when proven unused;
+- do not use inherited marketing imagery as new Metrora brand artwork;
+- do not delete runtime/package assets without proving they are unused;
+- review provider logos/icons separately because trademark/asset rights are independent from repository code licensing;
+- replace README/marketing visuals progressively with original Metrora artwork or current truthful screenshots.
+
+Required upstream provenance and licence notices remain governed by `THIRD_PARTY_NOTICES.md` and `LICENSES/`.
+
+## Near-term progression
+
+This is a dependency-oriented direction, not a rigid roadmap gate:
+
+1. **Harness Productization** — establish Harness as the product identity, extract canonical Tools and connect action requests only through proposal → ACT.
+2. **Local MCP Server V1** — expose the same factual Tools read-only through MCP.
+3. **README / asset refresh** — simplify the repository story and replace stale inherited marketing imagery with original Metrora visuals.
+4. **Widgets V1** — evolve Share Card into reusable static, privacy-aware Widgets.
+5. Continue independent **llama.cpp runtime / Performance Bench** work where it is ready to proceed.
+6. External action proposals and **Swarm** remain later, separately authorized capability work.
+
+See also:
+
+- [`HARNESS_PUBLIC_FOUNDATION.md`](HARNESS_PUBLIC_FOUNDATION.md)
+- [`BENCH_EVIDENCE_FAMILIES.md`](BENCH_EVIDENCE_FAMILIES.md)
+- [`PRODUCT_PRINCIPLES.md`](PRODUCT_PRINCIPLES.md)
+- [`PUBLIC_CONTRACTS_V1.md`](PUBLIC_CONTRACTS_V1.md)

--- a/docs/ECOSYSTEM_SURFACES.md
+++ b/docs/ECOSYSTEM_SURFACES.md
@@ -207,7 +207,7 @@ Conceptual branded illustrations are preferable to screenshots that would immedi
 
 ## Visual-asset provenance
 
-Metrora inherits source and historical provenance from CodeBurn. A 2026-08-30 audit confirmed that multiple old top-level repository marketing/screenshots in `assets/` are byte-identical to upstream CodeBurn assets.
+Metrora contains historical visual material inherited from the incorporated upstream snapshot. A 2026-08-30 audit confirmed that multiple old top-level repository marketing/screenshots in `assets/` are byte-identical to material from that incorporated upstream source.
 
 Those files should be audited before the README visual redesign:
 

--- a/docs/HARNESS_PUBLIC_FOUNDATION.md
+++ b/docs/HARNESS_PUBLIC_FOUNDATION.md
@@ -1,7 +1,9 @@
 # Metrora Harness public foundation
 
 **Status:** public product/architecture direction grounded in current `main`  
-**Implementation compatibility:** the current Desktop/code/contracts still use `Advisor` / `Advisor*` identifiers; a bounded user-facing naming/UX migration is not yet implemented by this document.
+**Implementation compatibility:** the current Desktop/code/contracts still use `Advisor` / `Advisor*` identifiers; a bounded semantic migration into Harness, Tools, provider/runtime and evidence ownership is not yet implemented by this document.
+
+See also [Metrora ecosystem surfaces](ECOSYSTEM_SURFACES.md) for the public composition/status map across Tools, Harness, MCP, ACT, Bench, Widgets, Wrapped and future Swarm.
 
 ## What Metrora Harness means
 
@@ -11,19 +13,19 @@ Canonical interaction rule:
 
 > **Chat first. Tools when useful. Actions only with authority.**
 
-Harness is a normal capable conversational surface. A configured model can help with ordinary conversation, coding, explanations and reasoning. When the user asks for user-specific Metrora facts, the model can use the fixed typed Metrora read tools instead of guessing those facts.
+Harness is a normal capable conversational surface. A configured model can help with ordinary conversation, coding, explanations and reasoning. When the user asks for user-specific Metrora facts, the model can use fixed typed Metrora Tools instead of guessing those facts.
 
 The model is not Metrora's accounting, pricing, quota or action authority.
 
-## Current shipped foundation
+## Current public foundation
 
-Current public `main` already implements the foundation under the existing `Advisor*` names:
+Current public `main` already implements the conversational foundation under existing `Advisor*` names:
 
 - chat-first behavior for capable configured runtimes;
 - ordinary conversation without requiring an evidence read;
 - bounded same-scope conversation history;
 - bounded typed UI context;
-- fixed read-only Metrora tools;
+- fixed read-only Metrora factual tools;
 - canonical fact/evidence verification;
 - proposal-only handling for state-changing requests;
 - Ollama and LM Studio local runtimes;
@@ -31,15 +33,28 @@ Current public `main` already implements the foundation under the existing `Advi
 - explicit hosted evidence-sharing consent;
 - bounded cancellation/error/privacy behavior.
 
-See [Advisor implementation compatibility](ADVISOR_PUBLIC_FOUNDATION.md) for the current public contract names and exact shipped runtime/tool details.
+Current public `main` also now contains the separate **ACT V2 execution foundation**:
+
+- strict `metrora.action.v1` executable authority;
+- first controlled kind `run-core-compatibility`;
+- trusted approval/freshness/digest binding;
+- replay/forgery/restart fail-closed protections;
+- bounded cancellation/timeout/late-result behavior;
+- canonical Bench evidence ownership.
+
+ACT V2 is not yet presented as a general Harness action UI. The conversational proposal layer remains non-executing until a trusted host performs the explicit ACT mapping/confirmation path.
+
+See [Advisor implementation compatibility](ADVISOR_PUBLIC_FOUNDATION.md) for current `Advisor*` contract names and [ACT contract preparation](ACT_CONTRACT_PREP_001.md) for the controlled-action boundary.
 
 This document does **not** add or claim:
 
-- state-changing execution;
 - arbitrary shell or repository access;
+- autonomous model approval;
 - agents or Swarm;
 - managed Metrora inference;
-- new runtime/provider adapters;
+- llama.cpp support;
+- a local MCP server;
+- a hosted MCP service;
 - persistent cloud conversation memory.
 
 ## Conversation vs factual authority
@@ -51,7 +66,7 @@ For user-specific Metrora facts, the desired path is:
 ```text
 user question
 → model decides a bounded read is useful
-→ Metrora validates tool + scope
+→ Metrora validates Tool + scope
 → canonical Metrora evidence
 → model explains/synthesizes
 → Metrora keeps factual claims within accepted evidence
@@ -67,15 +82,15 @@ should not stop at repeating the total when Metrora has bounded breakdown/driver
 
 ## Observable activity, not chain-of-thought
 
-The Harness UX is intended to expose useful **observable work** similar to modern coding harnesses and IDE agents.
+Harness UX is intended to expose useful **observable work** similar to modern coding harnesses and IDE agents.
 
 Examples of safe observable events:
 
-- `Reading spend · Today`;
-- tool started/completed/unavailable;
+- `Reading Usage · Today`;
+- Tool started/completed/unavailable;
 - bounded scope used;
 - evidence freshness/coverage where material;
-- action proposal/progress when the approved ACT path is invoked.
+- action proposal/progress when an approved ACT path is invoked.
 
 Private chain-of-thought, hidden scratchpads and internal model reasoning are not product telemetry and should not be exposed.
 
@@ -86,12 +101,12 @@ A future Harness UX tranche should make prompt processing unmistakable:
 ```text
 message sent
 → immediate visible pending state
-→ optional tool activity
+→ optional Tool activity
 → streamed answer where supported
 → final answer
 ```
 
-Product language should remain simple, for example `Thinking…`, `Reading spend…`, `Checking sessions…` rather than exposing planner/guard/schema terminology.
+Product language should remain simple, for example `Thinking…`, `Reading Usage…`, `Checking Activity…` rather than exposing planner/guard/schema terminology.
 
 The current public foundation already has bounded request/progress mechanics, but this document does not claim the future polished Harness presentation is implemented.
 
@@ -106,54 +121,101 @@ Current local runtime support:
 
 A future llama.cpp / `llama-server` adapter is a planned public Community direction, not current support.
 
-Any new runtime/provider still requires explicit endpoint, privacy, streaming, tool and failure-semantics review. `OpenAI-compatible` by itself is not a compatibility guarantee.
+Any new runtime/provider still requires explicit endpoint, privacy, streaming, Tool and failure-semantics review. `OpenAI-compatible` by itself is not a compatibility guarantee.
 
-## Tools
+## Canonical Tools layer
 
-Current implementation uses the public `AdvisorToolV1` contract. Stable identities remain documented in [Advisor implementation compatibility](ADVISOR_PUBLIC_FOUNDATION.md).
+Current implementation uses the public `AdvisorToolV1` contract and still stores substantial Tool code under `advisor/` namespaces. Stable current identities remain documented in [Advisor implementation compatibility](ADVISOR_PUBLIC_FOUNDATION.md).
 
-The tool boundary stays:
+The ratified product/architecture direction is to extract a reusable canonical **Metrora Tools** layer that is not owned by the Harness UI.
+
+The Tool boundary stays:
 
 - fixed and allowlisted;
-- read-only for the current foundation;
+- read-only for current factual capabilities;
 - scope-bounded;
 - content-minimal;
 - cancellation-aware;
 - explicit about freshness/coverage/unavailable state.
 
-Future tool growth should prefer useful bounded factual drill-downs over unrestricted database/file access.
+Future Tool growth should prefer useful bounded factual drill-downs over unrestricted database/file access.
+
+The same canonical factual Tools are intended to be reusable by:
+
+- Metrora Harness;
+- a future local Metrora MCP Server;
+- bounded CLI/integration surfaces where appropriate.
+
+Do not build a second MCP-specific accounting/evidence implementation.
+
+## MCP relationship
+
+MCP is an adopted interoperability direction, not current shipped functionality.
+
+The intended first product shape is a future **local, read-only Metrora MCP Server** exposing canonical factual Metrora Tools to compatible external AI clients.
+
+Example:
+
+```text
+external AI client
+→ Metrora MCP
+→ get_spend_snapshot / other factual Tool
+→ canonical Metrora evidence
+→ external client explains result
+```
+
+MCP capability discovery does not grant execution authority.
+
+Future state-changing requests from external clients must remain proposal-only until Metrora's trusted authority performs explicit ACT confirmation/authorization.
 
 ## ACT boundary
 
 Harness may understand a state-changing request and prepare a proposal. It is not execution authority.
 
-Canonical relationship for the implemented foundation (not wired to Harness UI):
+Current canonical relationship:
 
 ```text
 Harness intent / proposal
-→ explicit trusted ACT contract + confirmation
+→ trusted host canonicalization
+→ strict ActionContractV1
+→ explicit real-user confirmation
+→ ACT
 → bounded executor
-→ lifecycle + canonical result/evidence
+→ canonical result/evidence owner
 → Harness explanation
 ```
 
 ACT is an execution authority underneath product workflows, not a chat mode the user must select first.
 
-Current public [ACT preparation](ACT_CONTRACT_PREP_001.md) describes the bounded `metrora.action.v1` Core Compatibility executor. Harness/Advisor remains proposal-only; this branch does not add Harness UI or navigation integration.
+Current public ACT V2 implements the first bounded Core Compatibility operation through canonical Bench authority. It deliberately does not make `AdvisorActionProposalV1` or another conversational proposal object executable.
+
+Future MCP callers follow the same authority boundary.
 
 ## Swarm direction
 
-**Swarm** is the name reserved for a future Harness mode that coordinates multiple workers/subagents under explicit policy and action authority.
+**Swarm** is the name reserved for a future Harness mode/capability that coordinates multiple workers/subagents under explicit policy and action authority.
 
 No Swarm implementation is shipped by this document.
 
 A future `Swarm · Soon` UI can be truthful only when clearly disabled/unavailable and must not imply autonomous repository execution already exists.
 
+An external AI/MCP caller may someday propose Swarm work, but it cannot directly authorize or execute the controller.
+
 ## Bench relationship
 
 Harness may read and explain canonical Bench evidence. It may not rescore or reinterpret a Bench family as something it does not measure.
 
+ACT may invoke a supported Bench operation, but Bench remains the canonical evidence/history owner.
+
 Public Bench evidence families are documented in [Bench evidence families](BENCH_EVIDENCE_FAMILIES.md).
+
+## Widgets / sharing relationship
+
+Metrora's existing Share Card foundation is intended to evolve into a broader Widgets family for shareable, privacy-aware presentation of canonical evidence.
+
+Harness may later help explain or prepare a Widget, but it must not calculate a parallel set of totals for sharing.
+
+Wrapped remains a future recap/share experience built on canonical evidence and Widget rendering primitives.
 
 ## Privacy
 
@@ -161,41 +223,55 @@ Current public privacy rules remain:
 
 - local use does not require a Metrora account;
 - direct BYOK credentials remain on the endpoint and use protected local custody;
-- raw prompts/responses/source/patches/secrets/unrestricted paths are outside factual tool outputs;
+- raw prompts/responses/source/patches/secrets/unrestricted paths are outside factual Tool outputs;
 - hosted BYOK requires explicit evidence-sharing consent;
 - conversation state is currently client/session managed;
-- no Metrora managed inference gateway exists in the current public foundation.
+- no Metrora managed inference gateway exists in the current public foundation;
+- no MCP server is currently shipped by this document.
 
-## Naming compatibility
+## Naming compatibility and migration
 
 The product direction is **Metrora Harness**.
 
-Current stable implementation names such as:
+`Advisor` is no longer the long-term product identity.
+
+Current implementation names such as:
 
 - `AdvisorKernel`;
 - `AdvisorToolV1`;
 - `AdvisorActionProposalV1`;
 - current route/file/schema identifiers;
 
-remain valid until a bounded migration demonstrates the compatibility cost is justified.
+remain truthful compatibility names until a bounded migration lands.
 
-Do not mass-rename stable public contracts merely for cosmetic consistency.
+The migration should be semantic rather than cosmetic:
+
+- factual Tool contracts/registry → canonical Tools ownership;
+- conversation/model-flow → Harness ownership;
+- provider/runtime behavior → provider/runtime ownership;
+- evidence helpers → factual evidence/Tool ownership where appropriate;
+- UI product presentation → Harness.
+
+Do not mass-rename a type to `Harness*` when its real responsibility belongs to Tools, runtime transport or evidence.
 
 ## Public/private boundary
 
-This public repository contains the reusable Community foundation: canonical facts, generic conversation/tool mechanics, supported runtime/provider adapters, evidence verification and public safety contracts.
+This public repository contains the reusable Community foundation: canonical facts, generic conversation/Tool mechanics, supported runtime/provider adapters, evidence verification, local interoperability mechanics and public safety contracts.
 
-It does not publish private commercial algorithms, private evaluation/playbook assets, proprietary routing/recommendation systems or managed-service implementation.
+It does not publish private commercial algorithms, private evaluation/playbook assets, proprietary routing/recommendation systems, Swarm controller policy or managed-service implementation.
 
 ## Ratified public principles
 
-1. Product-facing direction: **Metrora Harness**.
-2. Existing `Advisor*` identifiers remain implementation-compatible until bounded migration.
+1. Product-facing conversational/operational identity: **Metrora Harness**.
+2. `Advisor` is compatibility/migration debt, not a second long-term product.
 3. Capable runtimes may converse normally; conversation is not limited to Metrora analytics questions.
-4. User-specific Metrora facts come from bounded typed tools.
-5. Tool results should be explained/synthesized when useful.
-6. Observable tool/action activity may be shown; private chain-of-thought is not.
-7. Factual authority remains with Metrora evidence.
-8. ACT, not the model, owns future state-changing authorization.
-9. Swarm is future and not shipped.
-10. Local Community remains useful without a managed Metrora AI service.
+4. User-specific Metrora facts come from bounded typed Tools.
+5. Canonical Tools should be reusable by Harness and future MCP instead of duplicated per caller.
+6. Tool results should be explained/synthesized when useful.
+7. Observable Tool/action activity may be shown; private chain-of-thought is not.
+8. Factual authority remains with Metrora evidence.
+9. ACT V2 is current trusted execution foundation; the model/proposal layer cannot self-authorize.
+10. ACT is not a user-facing chat mode.
+11. Local MCP is planned, read-only first and cannot bypass ACT.
+12. Swarm is future and not shipped.
+13. Local Community remains useful without a managed Metrora AI service.


### PR DESCRIPTION
## Purpose

Publish the bounded public ecosystem composition after ACT V2 without claiming planned capability as shipped.

## Authority

Base public main: `e0e2a8a6308880ebe2c794f04c54bc2c2fff5fbd`

## Public decisions captured

- Facts/Projects feed a reusable canonical Tools layer;
- Harness and future MCP consume the same factual Tools;
- ACT is execution authority, not a Tool layer or chat mode;
- ACT V2 on current main is reflected truthfully (`metrora.action.v1`, `run-core-compatibility`);
- Local MCP Server is planned, read-only first, Community/local-first and cannot bypass ACT;
- future external action/Swarm requests remain proposal-only until trusted ACT approval;
- Widgets evolve the existing Share Card foundation;
- Wrapped is a future recap/share experience on canonical evidence + Widgets;
- Advisor is compatibility/migration debt, not the long-term product identity;
- README redesign direction is ecosystem-first, visual, original and status-labelled;
- known inherited CodeBurn marketing assets are explicitly treated as provenance/cleanup material, while provider logos/icons remain a separate rights/trademark review.

## Files

- add `docs/ECOSYSTEM_SURFACES.md` with `Available` / `Building` / `Planned` status distinctions;
- update `docs/HARNESS_PUBLIC_FOUNDATION.md` to reflect canonical Tools reuse, future MCP relationship and ACT V2 as current execution foundation.

## Explicit non-scope

- no code or runtime changes;
- no Advisor namespace migration yet;
- no MCP server implementation;
- no Widgets implementation;
- no README visual rewrite or asset deletion;
- no Swarm implementation;
- no release or merge in this mission.

Keep Draft pending review.