### PR TITLE
feat: add canonical MCP interoperability foundation

### DIFF
--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -129,7 +129,8 @@ Pairing is explicit and revocable. Combined-device reporting is separate from th
 | Command | Purpose |
 | --- | --- |
 | `metrora web` | Start the local browser dashboard. |
-| `metrora mcp` | Run the local stdio MCP server for supported usage and savings queries. |
+| `metrora mcp serve` | Run the local read-only stdio MCP server for canonical factual Tools. |
+| `metrora mcp info [--json]` | Print MCP V1 transport, contract, limits and discovered tool metadata. |
 | `metrora menubar` | Install the retained macOS menubar development surface. |
 | `metrora antigravity-hook` | Install or remove supported Antigravity CLI usage capture. |
 

--- a/docs/ECOSYSTEM_SURFACES.md
+++ b/docs/ECOSYSTEM_SURFACES.md
@@ -49,7 +49,7 @@ ACT is not a chat mode and an MCP client is not trusted execution authority simp
 | **Harness** | Chat-first investigation, reasoning and Metrora-aware tool use | **Available in this slice** — product-facing Desktop surface, bounded Tool activity and one proposal-only Core Compatibility path |
 | **Bench** | Performance-first testing plus separate Compatibility / Runtime Health evidence | **Available and expanding** |
 | **ACT** | Trusted authorization/lifecycle for bounded state-changing operations | **Available** — `metrora.action.v1`, `run-core-compatibility`, and the trusted Desktop bridge; not a user-facing mode |
-| **MCP** | Standard external access to canonical Metrora Tools | **Planned** |
+| **MCP** | Standard external access to canonical Metrora Tools | **Available** — local read-only MCP Server V1 |
 | **Widgets** | Shareable visual/statistical presentation of canonical evidence | **Foundation exists through Share Card; broader Widgets family planned** |
 | **Wrapped** | Periodic recap/share experience using canonical evidence and Widgets | **Planned** |
 | **Swarm** | Coordinated multi-agent Harness capability | **Planned** |
@@ -71,7 +71,7 @@ Metrora already has typed read-only capabilities for questions such as:
 
 The reusable implementation now lives in `src/tools`. The renderer's `Advisor*` files retain only compatibility adapters and stable contract names; the factual registry is not owned by one UI.
 
-This matters because the same factual capability should be reusable by Harness, a future MCP server and other bounded Metrora integrations without implementing parallel evidence paths.
+This matters because the same factual capability is reused by Harness, the Local MCP Server V1 and other bounded Metrora integrations without implementing parallel evidence paths.
 
 A tool result remains evidence. A caller or model may explain it, but cannot silently replace Metrora's canonical measurement, scope or unavailable-state semantics.
 
@@ -98,7 +98,7 @@ The older `Advisor` product name is being retired. Existing `Advisor*` implement
 
 Metrora adopts the Model Context Protocol as an interoperability direction.
 
-The intended first product is a **local, read-only Metrora MCP Server** that exposes the same canonical factual Tools used by Harness.
+The shipped first product is a **local, read-only Metrora MCP Server V1** that exposes the same canonical factual Tools used by Harness.
 
 A compatible external AI client could then ask a question such as:
 
@@ -106,7 +106,7 @@ A compatible external AI client could then ask a question such as:
 
 and use Metrora's factual evidence instead of guessing or requiring a new Metrora-specific model integration.
 
-Planned Local MCP principles:
+Local MCP V1 principles:
 
 - local-first and account-optional;
 - public Community interoperability;
@@ -116,7 +116,7 @@ Planned Local MCP principles:
 - no ability to bypass Metrora privacy/scope contracts;
 - failure of MCP cannot corrupt canonical Metrora history.
 
-A future hosted MCP surface may be offered separately for managed remote access or other hosted capabilities, but Local MCP is not intended to be crippled merely to create a paid call counter.
+A future hosted MCP surface may be offered separately for managed remote access or other hosted capabilities. Local MCP remains a local read authority and is not a hosted metering product.
 
 ### Future actions through MCP
 
@@ -225,7 +225,7 @@ Required upstream provenance and licence notices remain governed by `THIRD_PARTY
 This is a dependency-oriented direction, not a rigid roadmap gate:
 
 1. **Harness Productization** — establish Harness as the product identity, extract canonical Tools and connect action requests only through proposal → ACT.
-2. **Local MCP Server V1** — expose the same factual Tools read-only through MCP.
+2. **Local MCP Server V1** — shipped in Interoperability Foundation Wave 001; expose the same factual Tools read-only through MCP.
 3. **README / asset refresh** — simplify the repository story and replace stale inherited marketing imagery with original Metrora visuals.
 4. **Widgets V1** — evolve Share Card into reusable static, privacy-aware Widgets.
 5. Continue independent **llama.cpp runtime / Performance Bench** work where it is ready to proceed.

--- a/docs/HARNESS_PUBLIC_FOUNDATION.md
+++ b/docs/HARNESS_PUBLIC_FOUNDATION.md
@@ -57,7 +57,7 @@ This document does **not** add or claim:
 - agents or Swarm;
 - managed Metrora inference;
 - llama.cpp support;
-- a local MCP server;
+- an MCP server that can mutate state or bypass the canonical Tools boundary;
 - a hosted MCP service;
 - persistent cloud conversation memory.
 
@@ -145,16 +145,16 @@ Future Tool growth should prefer useful bounded factual drill-downs over unrestr
 The same canonical factual Tools are reusable by:
 
 - Metrora Harness;
-- a future local Metrora MCP Server;
+- the local Metrora MCP Server V1;
 - bounded CLI/integration surfaces where appropriate.
 
 Do not build a second MCP-specific accounting/evidence implementation.
 
 ## MCP relationship
 
-MCP is an adopted interoperability direction, not current shipped functionality.
+MCP is an adopted interoperability surface with a shipped local V1.
 
-The intended first product shape is a future **local, read-only Metrora MCP Server** exposing canonical factual Metrora Tools to compatible external AI clients.
+The shipped product shape is a **local, read-only Metrora MCP Server V1** exposing canonical factual Metrora Tools to compatible external AI clients.
 
 Example:
 
@@ -233,7 +233,7 @@ Current public privacy rules remain:
 - contract material and ACT approval tokens stay in trusted host/ACT boundaries;
 - conversation state is currently client/session managed;
 - no Metrora managed inference gateway exists in the current public foundation;
-- no MCP server is currently shipped by this document.
+- Local MCP Server V1 is shipped as a read-only stdio surface; hosted MCP remains outside this public wave.
 
 ## Naming compatibility and migration
 
@@ -272,12 +272,12 @@ It does not publish private commercial algorithms, private evaluation/playbook a
 2. `Advisor` is compatibility/migration debt, not a second long-term product.
 3. Capable runtimes may converse normally; conversation is not limited to Metrora analytics questions.
 4. User-specific Metrora facts come from bounded typed Tools.
-5. Canonical Tools should be reusable by Harness and future MCP instead of duplicated per caller.
+5. Canonical Tools are reusable by Harness and the Local MCP Server V1 instead of duplicated per caller.
 6. Tool results should be explained/synthesized when useful.
 7. Observable Tool/action activity may be shown; private chain-of-thought is not.
 8. Factual authority remains with Metrora evidence.
 9. ACT V2 is current trusted execution foundation; the model/proposal layer cannot self-authorize.
 10. ACT is not a user-facing chat mode.
-11. Local MCP is planned, read-only first and cannot bypass ACT.
+11. Local MCP V1 is read-only and cannot bypass ACT.
 12. Swarm is future and not shipped.
 13. Local Community remains useful without a managed Metrora AI service.

--- a/docs/MCP_SERVER_V1.md
+++ b/docs/MCP_SERVER_V1.md
@@ -58,10 +58,11 @@ MCP adapter
 
 Results use the advisor-tool-v1 contract, JSON-safe content-minimal output,
 explicit coverage/freshness/unavailable semantics and a 32 KiB output bound.
-Arguments are bounded to 8 KiB. Provider quota is reported only when a
-provider-reported source exists; Metrora spend is never converted into an
-invented quota or burn-rate estimate. The current public source therefore
-returns quota as unavailable until that provider authority is implemented.
+Arguments are bounded to 8 KiB. Canonical provider-reported Capacity exists in
+the Desktop authority, but Local MCP V1's CLI/core runtime does not yet bind
+that authority through a reusable non-Electron source. `get_quota_snapshot`
+therefore truthfully returns unavailable in Local MCP V1. Metrora spend is
+never converted into an invented quota or burn-rate estimate.
 
 The server excludes raw conversations, prompts, responses, source content,
 credentials, unrestricted session payloads and local filesystem paths. Tool

--- a/docs/MCP_SERVER_V1.md
+++ b/docs/MCP_SERVER_V1.md
@@ -1,0 +1,85 @@
+# Metrora MCP Server V1
+
+**Status:** implemented local interoperability surface
+
+Metrora MCP Server V1 is a local, read-only Model Context Protocol server. It
+publishes the same factual Tools registry used by the rest of Metrora and does
+not maintain a second usage database or evidence calculator.
+
+## Run
+
+~~~text
+metrora mcp serve
+~~~
+
+The server uses the MCP TypeScript SDK already present in the public package
+(@modelcontextprotocol/sdk 1.29.x, MIT) and communicates over stdio.
+JSON-RPC owns stdout; diagnostics go to stderr. No client configuration file
+is edited automatically.
+
+Optional startup scope:
+
+~~~text
+metrora mcp serve --period week --provider claude --project-id <project-id>
+metrora mcp info --json
+~~~
+
+The default period is 'all', bounded to the same six-calendar-month window as
+the canonical CLI. Valid periods are 'today', 'week', '30days', 'month', 'all'
+and 'lifetime'; valid provider filters are 'all', 'claude' and 'codex'.
+
+## Canonical tool surface
+
+Discovery is generated from src/tools and preserves this order:
+
+1. get_spend_snapshot
+2. get_model_efficiency
+3. get_quota_snapshot
+4. get_overview_snapshot
+5. get_project_drivers
+6. get_session_highlights
+7. get_coverage_report
+8. get_bench_evidence
+
+Every tool is annotated read-only, idempotent and closed-world. Arguments are
+limited to the filters declared by the canonical contract. A tool call may
+narrow its startup period or add a model/provider filter where the contract
+allows it; it cannot widen the immutable scope.
+
+## Authority and output
+
+The path is:
+
+~~~text
+MCP adapter
+→ canonical Metrora Tools registry
+→ canonical evidence source
+~~~
+
+Results use the advisor-tool-v1 contract, JSON-safe content-minimal output,
+explicit coverage/freshness/unavailable semantics and a 32 KiB output bound.
+Arguments are bounded to 8 KiB. Provider quota is reported only when a
+provider-reported source exists; Metrora spend is never converted into an
+invented quota or burn-rate estimate. The current public source therefore
+returns quota as unavailable until that provider authority is implemented.
+
+The server excludes raw conversations, prompts, responses, source content,
+credentials, unrestricted session payloads and local filesystem paths. Tool
+calls do not start Bench runs, mutate usage history or invoke actions.
+
+## Non-goals
+
+This V1 is not a shell, filesystem, repository, credential, provider-proxy,
+model-runner or hosted Metrora service. It does not expose ACT, Swarm,
+approval, execution or agent-management operations. External clients receive
+factual evidence only.
+
+OpenHands and ACP remain characterized as replaceable external-agent/runtime
+boundaries. No production adapter for either is included in this wave.
+
+## Verification
+
+The public test suite includes real child-process stdio negotiation, exact
+tool discovery, annotation/schema checks, bounded output, fail-closed invalid
+arguments, privacy markers and a source-boundary check that keeps the
+transport adapter dependent on the canonical Tools registry.

--- a/docs/design/metrora-mcp.md
+++ b/docs/design/metrora-mcp.md
@@ -1,47 +1,66 @@
 # Metrora MCP architecture
 
-**Status:** implemented compatibility surface
+**Status:** implemented Local MCP Server V1
 
 ## Purpose
 
-Metrora exposes selected local usage and optimization evidence to MCP-compatible agents through a stdio server. The MCP surface reuses canonical aggregation and does not create a second analytics authority.
+Metrora exposes bounded local factual evidence to MCP-compatible clients
+through a stdio server. The adapter is intentionally thin: discovery and
+execution are bound to the canonical src/tools registry, so MCP does not
+create a second analytics authority.
 
 ## Runtime model
 
-- The MCP server runs as a long-lived local CLI process over stdio.
+- metrora mcp serve starts the local long-lived server over stdio.
 - JSON-RPC owns stdout; diagnostics use stderr.
-- Aggregation, pricing and optimization remain in the canonical public runtime.
-- In-flight requests and cache use are bounded.
-- No hosted Metrora service is required.
+- Startup scope is immutable and defaults to the bounded six-calendar-month
+  'all' period.
+- Calls may narrow the scope only where the canonical contract permits it.
+- Active and queued calls are bounded.
+- No hosted Metrora service or automatic client configuration is required.
 
-## Tool boundary
+## Canonical surface
 
-Current tools expose structured usage and savings evidence with display-ready summaries. Tool output must preserve:
+The server discovers and registers the eight definitions from
+METRORA_TOOL_DEFINITIONS:
 
-- period, provider and project scope;
-- observed versus derived or estimated evidence;
-- coverage and unavailable states;
-- pricing provenance;
-- privacy-safe project/session handling.
+get_spend_snapshot, get_model_efficiency, get_quota_snapshot,
+get_overview_snapshot, get_project_drivers, get_session_highlights,
+get_coverage_report, and get_bench_evidence.
 
-Absolute local paths, prompts, responses, source code and secrets are excluded.
+Each result is produced by the canonical registry and preserves the
+advisor-tool-v1 envelope, coverage, freshness, unavailable and content-
+minimal privacy semantics. The adapter does not render tables or recalculate
+spend/savings.
 
-## Privacy
+## Privacy and authority
 
-Project and session labels are pseudonymized by default where the tool contract requires it. Real local names are exposed only through an explicit caller option and remain on the user's machine.
+MCP is a local read authority only. It excludes raw conversation content,
+prompts, responses, source content, credentials, unrestricted session payloads
+and filesystem paths. It does not expose action, shell, repository, provider
+proxy or model-runner operations. MCP calls do not mutate usage/session/Bench
+history.
 
-The MCP server must not become a general filesystem, shell or model-proxy tool.
+Provider quota is returned only from a provider-reported source. Until that
+source exists in the public canonical runtime, quota evidence is explicitly
+unavailable rather than inferred from Metrora spend.
 
 ## Compatibility
 
-The canonical command is `metrora mcp`. The current package publishes no
-alternate CLI alias; historical signed-data identifiers are internal protocol
-details, not current product names.
+metrora mcp info --json reports the command, transport, contract version,
+tool names and bounded limits. The public package uses the MIT-licensed MCP
+TypeScript SDK dependency already declared in package.json.
+
+OpenHands and ACP are characterization targets for future replaceable
+external-agent boundaries. This wave does not add production adapters or make
+either system a Metrora authority.
 
 ## Maintenance rules
 
-- Keep transport, schemas, redaction and table formatting in separate modules.
-- Reuse canonical usage/optimization functions rather than copying logic.
-- Keep stdout protocol-clean under every success and failure path.
-- Add fixture-backed tests for schemas, redaction, empty states and concurrency.
-- Do not introduce hosted dependencies or content collection through MCP work.
+- Keep transport, schemas and evidence in separate layers.
+- Generate MCP discovery from the canonical Tools registry.
+- Keep stdout protocol-clean under success and failure paths.
+- Fail closed for unknown/additional arguments without echoing input.
+- Preserve unavailable/stale/fresh/coverage semantics.
+- Keep local MCP read-only and prevent MCP failures from corrupting canonical
+  history.

--- a/docs/design/metrora-mcp.md
+++ b/docs/design/metrora-mcp.md
@@ -41,9 +41,10 @@ and filesystem paths. It does not expose action, shell, repository, provider
 proxy or model-runner operations. MCP calls do not mutate usage/session/Bench
 history.
 
-Provider quota is returned only from a provider-reported source. Until that
-source exists in the public canonical runtime, quota evidence is explicitly
-unavailable rather than inferred from Metrora spend.
+Provider-reported Capacity exists in the public Desktop authority. Local MCP
+V1's CLI/core runtime does not yet bind that authority through a reusable
+non-Electron source, so its empty quota source truthfully produces unavailable
+quota evidence rather than inferring capacity from Metrora spend.
 
 ## Compatibility
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -2291,17 +2291,51 @@ program
     await runAgyStatusLineHook()
   })
 
-program
+const mcp = program
   .command('mcp')
-  .description('Run a Model Context Protocol server (stdio) exposing usage + savings to AI agents')
-  .action(async () => {
-    // stdout MUST carry only JSON-RPC; route stray logs to stderr.
-    // NOTE: only console.log is guarded here. process.stdout.write is left intact
-    // because the MCP StdioServerTransport relies on it for JSON-RPC output.
-    console.log = ((...args: unknown[]) => process.stderr.write(args.join(' ') + '\n')) as typeof console.log
+  .description('Run the local read-only MCP server')
+
+mcp
+  .command('serve')
+  .description('Run the local MCP server over stdio')
+  .option('--period <period>', 'Initial bounded period: today, week, 30days, month, all, lifetime', 'all')
+  .option('--provider <provider>', 'Initial provider scope: all, claude, codex', 'all')
+  .option('--project-id <projectId>', 'Initial user-owned Metrora Project scope', 'all')
+  .action(async opts => {
+    const periods = new Set<Period>(['today', 'week', '30days', 'month', 'all', 'lifetime'])
+    const providers = new Set(['all', 'claude', 'codex'])
+    if (!periods.has(opts.period)) {
+      process.stderr.write('metrora: unsupported MCP period.\n')
+      process.exitCode = 2
+      return
+    }
+    if (!providers.has(opts.provider)) {
+      process.stderr.write('metrora: unsupported MCP provider.\n')
+      process.exitCode = 2
+      return
+    }
     const { startStdioServer } = await import('./mcp/server.js')
-    await startStdioServer(version)
+    await startStdioServer(version, {
+      period: opts.period,
+      provider: opts.provider,
+      projectId: opts.projectId,
+    })
   })
+
+mcp
+  .command('info')
+  .description('Print the local MCP server contract and discovery metadata')
+  .option('--json', 'Output machine-readable JSON')
+  .action(async opts => {
+    const { renderMetroraMcpInfo } = await import('./mcp/info.js')
+    process.stdout.write(renderMetroraMcpInfo(version, Boolean(opts.json)))
+  })
+
+// Preserve the original bare mcp entry point as an alias for serve.
+mcp.action(async () => {
+  const { startStdioServer } = await import('./mcp/server.js')
+  await startStdioServer(version)
+})
 
 program
   .command('doctor')

--- a/src/main.ts
+++ b/src/main.ts
@@ -46,6 +46,7 @@ import { clearPlan, readConfig, readPlan, readPlans, saveConfig, savePlan, getCo
 import { clampResetDay, getPlanUsageOrNull, getPlanUsages, type PlanUsage } from './plan-usage.js'
 import { getPresetPlan, isPlanId, isPlanProvider, PLAN_IDS, PLAN_PROVIDERS, planDisplayName } from './plans.js'
 import { createRequire } from 'node:module'
+import { registerMetroraMcpCommands } from './mcp/cli.js'
 
 const require = createRequire(import.meta.url); const { version } = require('../package.json')
 import { loadCurrency, getCurrency, isValidCurrencyCode } from './currency.js'
@@ -2291,51 +2292,7 @@ program
     await runAgyStatusLineHook()
   })
 
-const mcp = program
-  .command('mcp')
-  .description('Run the local read-only MCP server')
-
-mcp
-  .command('serve')
-  .description('Run the local MCP server over stdio')
-  .option('--period <period>', 'Initial bounded period: today, week, 30days, month, all, lifetime', 'all')
-  .option('--provider <provider>', 'Initial provider scope: all, claude, codex', 'all')
-  .option('--project-id <projectId>', 'Initial user-owned Metrora Project scope', 'all')
-  .action(async opts => {
-    const periods = new Set<Period>(['today', 'week', '30days', 'month', 'all', 'lifetime'])
-    const providers = new Set(['all', 'claude', 'codex'])
-    if (!periods.has(opts.period)) {
-      process.stderr.write('metrora: unsupported MCP period.\n')
-      process.exitCode = 2
-      return
-    }
-    if (!providers.has(opts.provider)) {
-      process.stderr.write('metrora: unsupported MCP provider.\n')
-      process.exitCode = 2
-      return
-    }
-    const { startStdioServer } = await import('./mcp/server.js')
-    await startStdioServer(version, {
-      period: opts.period,
-      provider: opts.provider,
-      projectId: opts.projectId,
-    })
-  })
-
-mcp
-  .command('info')
-  .description('Print the local MCP server contract and discovery metadata')
-  .option('--json', 'Output machine-readable JSON')
-  .action(async opts => {
-    const { renderMetroraMcpInfo } = await import('./mcp/info.js')
-    process.stdout.write(renderMetroraMcpInfo(version, Boolean(opts.json)))
-  })
-
-// Preserve the original bare mcp entry point as an alias for serve.
-mcp.action(async () => {
-  const { startStdioServer } = await import('./mcp/server.js')
-  await startStdioServer(version)
-})
+registerMetroraMcpCommands(program, version)
 
 program
   .command('doctor')

--- a/src/mcp/cli.ts
+++ b/src/mcp/cli.ts
@@ -1,0 +1,100 @@
+import type { Command } from 'commander'
+
+import type { MetroraToolPeriod } from '../tools/types.js'
+import type { MetroraMcpProvider, MetroraMcpStartupOptions } from './runtime.js'
+
+const MCP_PERIODS: ReadonlySet<MetroraToolPeriod> = new Set([
+  'today',
+  'week',
+  '30days',
+  'month',
+  'all',
+  'lifetime',
+])
+const MCP_PROVIDERS: ReadonlySet<MetroraMcpProvider> = new Set(['all', 'claude', 'codex'])
+
+type McpServeOptions = {
+  period: string
+  provider: string
+  projectId: string
+}
+
+type McpInfoOptions = {
+  json?: boolean
+}
+
+function isMcpPeriod(value: string): value is MetroraToolPeriod {
+  return MCP_PERIODS.has(value as MetroraToolPeriod)
+}
+
+function isMcpProvider(value: string): value is MetroraMcpProvider {
+  return MCP_PROVIDERS.has(value as MetroraMcpProvider)
+}
+
+function safeStartupError(error: unknown): string {
+  if (error instanceof Error && error.name === 'MetroraMcpStartupError') return error.message
+  return 'Metrora MCP server could not start.'
+}
+
+async function runMcpServe(version: string, options: McpServeOptions): Promise<void> {
+  if (!isMcpPeriod(options.period)) {
+    process.stderr.write('metrora: unsupported MCP period.\n')
+    process.exitCode = 2
+    return
+  }
+  if (!isMcpProvider(options.provider)) {
+    process.stderr.write('metrora: unsupported MCP provider.\n')
+    process.exitCode = 2
+    return
+  }
+
+  const startup: MetroraMcpStartupOptions = {
+    period: options.period,
+    provider: options.provider,
+    projectId: options.projectId,
+  }
+  try {
+    const { startStdioServer } = await import('./server.js')
+    await startStdioServer(version, startup)
+  } catch (error) {
+    process.stderr.write(`metrora: ${safeStartupError(error)}\n`)
+    process.exitCode = 2
+  }
+}
+
+/** Register the complete MCP CLI surface while keeping main.ts wiring-only. */
+export function registerMetroraMcpCommands(program: Command, version: string): void {
+  const mcp = program
+    .command('mcp')
+    .description('Run the local read-only MCP server')
+
+  mcp
+    .command('serve')
+    .description('Run the local MCP server over stdio')
+    .option('--period <period>', 'Initial bounded period: today, week, 30days, month, all, lifetime', 'all')
+    .option('--provider <provider>', 'Initial provider scope: all, claude, codex', 'all')
+    .option('--project-id <projectId>', 'Initial user-owned Metrora Project scope', 'all')
+    .action(async (options: McpServeOptions) => {
+      await runMcpServe(version, options)
+    })
+
+  mcp
+    .command('info')
+    .description('Print the local MCP server contract and discovery metadata')
+    .option('--json', 'Output machine-readable JSON')
+    .action(async (options: McpInfoOptions) => {
+      const { renderMetroraMcpInfo } = await import('./info.js')
+      process.stdout.write(renderMetroraMcpInfo(version, Boolean(options.json)))
+    })
+
+  // Preserve the original bare mcp entry point as an alias for serve.
+  mcp.action(async () => {
+    try {
+      const { startStdioServer } = await import('./server.js')
+      await startStdioServer(version)
+    } catch (error) {
+      process.stderr.write(`metrora: ${safeStartupError(error)}\n`)
+      process.exitCode = 2
+    }
+  })
+}

--- a/src/mcp/info.ts
+++ b/src/mcp/info.ts
@@ -1,0 +1,50 @@
+import {
+  METRORA_TOOL_ARGUMENT_MAX_BYTES,
+  METRORA_TOOL_CONTRACT_VERSION,
+  METRORA_TOOL_DEFINITIONS,
+  METRORA_TOOL_OUTPUT_MAX_BYTES,
+} from '../tools/contract.js'
+
+export type MetroraMcpInfo = {
+  name: 'metrora'
+  version: string
+  adapterVersion: 'mcp-server-v1'
+  contractVersion: string
+  transport: 'stdio'
+  command: { command: 'metrora'; args: ['mcp', 'serve'] }
+  tools: string[]
+  readOnly: true
+  localOnly: true
+  privacy: 'content-minimal'
+  limits: { argumentBytes: number; outputBytes: number }
+}
+
+export function buildMetroraMcpInfo(version: string): MetroraMcpInfo {
+  return {
+    name: 'metrora',
+    version,
+    adapterVersion: 'mcp-server-v1',
+    contractVersion: METRORA_TOOL_CONTRACT_VERSION,
+    transport: 'stdio',
+    command: { command: 'metrora', args: ['mcp', 'serve'] },
+    tools: METRORA_TOOL_DEFINITIONS.map(definition => definition.function.name),
+    readOnly: true,
+    localOnly: true,
+    privacy: 'content-minimal',
+    limits: { argumentBytes: METRORA_TOOL_ARGUMENT_MAX_BYTES, outputBytes: METRORA_TOOL_OUTPUT_MAX_BYTES },
+  }
+}
+
+export function renderMetroraMcpInfo(version: string, json: boolean): string {
+  const info = buildMetroraMcpInfo(version)
+  if (json) return JSON.stringify(info, null, 2) + '\n'
+  return [
+    'Metrora MCP Server V1',
+    'transport: stdio',
+    'mode: local, read-only',
+    'privacy: content-minimal',
+    'contract: ' + info.contractVersion,
+    'command: metrora mcp serve',
+    'tools: ' + info.tools.join(', '),
+  ].join('\n') + '\n'
+}

--- a/src/mcp/runtime.ts
+++ b/src/mcp/runtime.ts
@@ -255,9 +255,11 @@ export async function createMetroraToolRuntime(options: MetroraMcpStartupOptions
       throwIfAborted(signal)
       return rows.slice(0, 64).map(modelReportRow)
     },
-    // No canonical provider-reported quota source exists yet. Returning an
-    // empty source is intentional: the registry will label quota unavailable
-    // instead of turning Metrora spend into an invented capacity estimate.
+    // Desktop owns canonical provider-reported Capacity collectors and a
+    // sanitized quota projection. Local MCP V1's CLI/core runtime does not
+    // yet bind that authority through a reusable non-Electron source. Keep
+    // this source empty so MCP reports quota unavailable rather than turning
+    // Metrora spend into an invented capacity estimate.
     getQuota: async signal => {
       throwIfAborted(signal)
       return []

--- a/src/mcp/runtime.ts
+++ b/src/mcp/runtime.ts
@@ -1,0 +1,269 @@
+import type { DateRange } from '../types.js'
+import { getDateRange } from '../cli-date.js'
+import { aggregateModels } from '../models-report.js'
+import type { ModelAccountingRow } from '../model-accounting-types.js'
+import type { MenubarPayload } from '../menubar-json.js'
+import { parseProjectsForMetroraScope } from '../project-scope-cli.js'
+import { readProjectRegistry } from '../project-registry.js'
+import { compareBenchEvaluationsV1 } from '../bench/compare-v1.js'
+import { scanBenchHistoryV1 } from '../bench/history-v1.js'
+import { createMetroraToolRegistry } from '../tools/registry.js'
+import type {
+  MetroraModelReportRow,
+  MetroraOverview,
+  MetroraToolBenchEvidence,
+  MetroraToolDataSource,
+  MetroraToolJsonObject,
+  MetroraToolJsonValue,
+  MetroraToolPeriod,
+  MetroraToolScope,
+  MetroraToolRegistry,
+  MetroraOverviewModelAccountingRow,
+} from '../tools/types.js'
+import { ALL_PROJECTS_SCOPE_ID } from '../project-scope.js'
+import { buildMenubarPayloadForRange } from '../usage-aggregator.js'
+
+export type MetroraMcpProvider = 'all' | 'claude' | 'codex'
+export type MetroraMcpStartupOptions = {
+  period?: MetroraToolPeriod
+  provider?: MetroraMcpProvider
+  projectId?: string
+}
+
+const PERIODS: readonly MetroraToolPeriod[] = ['today', 'week', '30days', 'month', 'all', 'lifetime']
+const PROVIDERS: readonly MetroraMcpProvider[] = ['all', 'claude', 'codex']
+
+export class MetroraMcpStartupError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'MetroraMcpStartupError'
+  }
+}
+
+function isPeriod(value: unknown): value is MetroraToolPeriod {
+  return typeof value === 'string' && (PERIODS as readonly string[]).includes(value)
+}
+
+function isProvider(value: unknown): value is MetroraMcpProvider {
+  return typeof value === 'string' && (PROVIDERS as readonly string[]).includes(value)
+}
+
+function localDate(value: string): Date {
+  const [year, month, day] = value.split('-').map(Number)
+  return new Date(year!, month! - 1, day!)
+}
+
+function endOfDay(value: Date): Date {
+  return new Date(value.getFullYear(), value.getMonth(), value.getDate(), 23, 59, 59, 999)
+}
+
+function throwIfAborted(signal?: AbortSignal): void {
+  if (!signal?.aborted) return
+  const error = new Error('Metrora tool call cancelled')
+  error.name = 'AbortError'
+  throw error
+}
+
+type RuntimePeriodInfo = { range: DateRange; label: string }
+
+function periodInfoForScope(scope: MetroraToolScope): RuntimePeriodInfo {
+  if (!scope.range) return getDateRange(scope.period)
+  const start = localDate(scope.range.from)
+  const end = endOfDay(localDate(scope.range.to))
+  const label = scope.range.from === scope.range.to
+    ? 'Selected day (' + scope.range.from + ')'
+    : scope.range.from + ' to ' + scope.range.to
+  return { range: { start, end }, label }
+}
+
+function mapAccountingRow(row: ModelAccountingRow): MetroraOverviewModelAccountingRow {
+  return {
+    name: row.name,
+    cost: row.cost,
+    calls: row.calls,
+    inputTokens: row.inputTokens,
+    outputTokens: row.outputTokens,
+    cacheReadTokens: row.cacheReadTokens,
+    cacheWriteTokens: row.cacheWriteTokens,
+    ...(typeof row.reasoningTokens === 'number' ? { reasoningTokens: row.reasoningTokens } : {}),
+    ...(typeof row.additiveReasoningTokens === 'number' ? { additiveReasoningTokens: row.additiveReasoningTokens } : {}),
+  }
+}
+
+/** Project the rich CLI payload into the transport-neutral Overview shape. */
+function overviewFromPayload(payload: MenubarPayload): MetroraOverview {
+  const current = payload.current
+  return {
+    generated: payload.generated,
+    freshness: payload.freshness,
+    current: {
+      label: current.label,
+      cost: current.cost,
+      calls: current.calls,
+      sessions: current.sessions,
+      inputTokens: current.inputTokens,
+      outputTokens: current.outputTokens,
+      cacheReadTokens: current.cacheReadTokens,
+      cacheWriteTokens: current.cacheWriteTokens,
+      pricingCoverage: current.pricingCoverage ?? null,
+      providers: current.providers,
+      providerDetails: current.providerDetails,
+      topModels: current.topModels.map(row => ({ name: row.name, cost: row.cost, calls: row.calls })),
+      topProjects: current.topProjects.map(row => ({ name: row.name, cost: row.cost, sessions: row.sessions })),
+      topSessions: current.topSessions.map(row => ({ project: row.project, cost: row.cost, calls: row.calls, date: row.date })),
+      modelAccounting: current.modelAccounting
+        ? {
+            rows: current.modelAccounting.rows.map(row => mapAccountingRow(row)),
+            coverage: { cost: current.modelAccounting.coverage.cost },
+          }
+        : undefined,
+    },
+    history: {
+      daily: (payload.history?.daily ?? []).map(row => ({
+        date: row.date,
+        cost: row.cost,
+        calls: row.calls,
+        inputTokens: row.inputTokens,
+        outputTokens: row.outputTokens,
+        cacheReadTokens: row.cacheReadTokens,
+        cacheWriteTokens: row.cacheWriteTokens,
+        topModels: (row.topModels ?? []).map(model => ({ name: model.name, cost: model.cost, calls: model.calls })),
+      })),
+    },
+  }
+}
+
+function modelReportRow(row: Awaited<ReturnType<typeof aggregateModels>>[number]): MetroraModelReportRow {
+  return {
+    provider: row.provider,
+    providerDisplayName: row.providerDisplayName,
+    model: row.model,
+    inputTokens: row.inputTokens,
+    outputTokens: row.outputTokens,
+    reasoningTokens: row.reasoningTokens,
+    additiveReasoningTokens: row.additiveReasoningTokens,
+    cacheWriteTokens: row.cacheWriteTokens,
+    cacheReadTokens: row.cacheReadTokens,
+    totalTokens: row.totalTokens,
+    costUSD: row.costUSD,
+    calls: row.calls,
+    pricing: { state: row.pricing.state },
+  }
+}
+
+function safeBenchRecord(record: {
+  runId: string
+  model: { selected: string; reported: string | null }
+  pack: { packId: string; version: string; digest: string }
+  startedAt: string
+  endedAt: string
+  status: string
+  aggregate: unknown
+  resultDigest: string
+}): MetroraToolJsonObject {
+  return {
+    runId: record.runId,
+    model: record.model.selected,
+    reportedModel: record.model.reported,
+    packId: record.pack.packId,
+    packVersion: record.pack.version,
+    packDigest: record.pack.digest,
+    startedAt: record.startedAt,
+    endedAt: record.endedAt,
+    status: record.status,
+    aggregate: record.aggregate as MetroraToolJsonValue,
+    resultDigest: record.resultDigest,
+  }
+}
+
+async function benchEvidence(scope: MetroraToolScope, signal?: AbortSignal): Promise<MetroraToolBenchEvidence> {
+  throwIfAborted(signal)
+  const scan = await scanBenchHistoryV1()
+  throwIfAborted(signal)
+  const info = periodInfoForScope(scope)
+  const start = info.range.start.getTime()
+  const end = info.range.end.getTime()
+  const records = scan.records
+    .filter(record => {
+      const ended = Date.parse(record.endedAt)
+      return Number.isFinite(ended) && ended >= start && ended <= end
+    })
+    .slice(0, 10)
+  const latest = records[0]
+  const previous = records[1]
+  const comparison = latest && previous ? compareBenchEvaluationsV1(previous, latest) : null
+  return {
+    state: latest ? 'AVAILABLE' : 'UNAVAILABLE',
+    latest: latest ? safeBenchRecord(latest) : null,
+    history: records.map(safeBenchRecord),
+    comparison: comparison as unknown as MetroraToolJsonValue,
+    invalidCount: scan.invalid.length,
+  }
+}
+
+function scopeProjectId(value: string): string | null {
+  return value === ALL_PROJECTS_SCOPE_ID ? null : value
+}
+
+function dateRangeForScope(scope: MetroraToolScope): DateRange {
+  return periodInfoForScope(scope).range
+}
+
+export async function createMetroraToolRuntime(options: MetroraMcpStartupOptions = {}): Promise<MetroraToolRegistry> {
+  const period = options.period ?? 'all'
+  const provider = options.provider ?? 'all'
+  const projectId = options.projectId ?? ALL_PROJECTS_SCOPE_ID
+  if (!isPeriod(period)) throw new MetroraMcpStartupError('Metrora MCP period is unsupported.')
+  if (!isProvider(provider)) throw new MetroraMcpStartupError('Metrora MCP provider is unsupported.')
+  if (typeof projectId !== 'string' || !projectId.trim() || projectId.length > 256 || /[\u0000-\u001f\u007f]/u.test(projectId)) {
+    throw new MetroraMcpStartupError('Metrora MCP Project scope is invalid.')
+  }
+
+  const projectRegistry = await readProjectRegistry()
+  const project = projectId === ALL_PROJECTS_SCOPE_ID
+    ? null
+    : projectRegistry.registry.projects.find(candidate => candidate.id === projectId) ?? null
+  if (projectId !== ALL_PROJECTS_SCOPE_ID && !project) throw new MetroraMcpStartupError('Metrora MCP Project scope was not found.')
+
+  const scope: MetroraToolScope = {
+    period,
+    // A named period remains narrowable by the canonical contract. A relative
+    // date range is materialized only when a tool requests yesterday.
+    range: null,
+    provider,
+    projectId,
+    projectName: project?.name ?? 'All projects',
+    model: null,
+  }
+
+  const source: MetroraToolDataSource = {
+    getOverview: async (context, signal) => {
+      throwIfAborted(signal)
+      const payload = await buildMenubarPayloadForRange(periodInfoForScope(context), {
+        provider: context.provider,
+        metroraProjectId: scopeProjectId(context.projectId),
+        optimize: false,
+        timeline: false,
+      })
+      throwIfAborted(signal)
+      return overviewFromPayload(payload)
+    },
+    getModels: async (context, signal) => {
+      throwIfAborted(signal)
+      const projects = await parseProjectsForMetroraScope(dateRangeForScope(context), context.provider, scopeProjectId(context.projectId))
+      const rows = await aggregateModels(projects)
+      throwIfAborted(signal)
+      return rows.slice(0, 64).map(modelReportRow)
+    },
+    // No canonical provider-reported quota source exists yet. Returning an
+    // empty source is intentional: the registry will label quota unavailable
+    // instead of turning Metrora spend into an invented capacity estimate.
+    getQuota: async signal => {
+      throwIfAborted(signal)
+      return []
+    },
+    getBenchEvidence: (context, signal) => benchEvidence(context, signal),
+  }
+
+  return createMetroraToolRegistry(source, scope)
+}

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -1,136 +1,195 @@
-import { z } from 'zod'
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
-import { getDateRange } from '../cli-date.js'
+import { z } from 'zod'
+
 import { loadPricing } from '../models.js'
-import { buildMenubarPayloadForRange, type PeriodInfo } from '../usage-aggregator.js'
-import type { MenubarPayload } from '../menubar-json.js'
-import { redactProjectNames } from './redact.js'
-import { renderSummaryTable, renderBreakdownTable, renderSavingsTable, type BreakdownBy } from './tables.js'
-
-const PERIOD = { today: 'today', last_7_days: 'week', last_30_days: '30days', month_to_date: 'month', last_6_months: 'all' } as const
-type McpPeriod = keyof typeof PERIOD
-const periodSchema = z.enum(['today', 'last_7_days', 'last_30_days', 'month_to_date', 'last_6_months'])
-
-type Aggregate = (periodInfo: PeriodInfo, opts: { provider?: string; optimize?: boolean }) => Promise<MenubarPayload>
+import { boundedMetroraToolJson, MetroraToolContractError } from '../tools/contract.js'
+import { METRORA_TOOL_MODEL_FILTER_MAX_LENGTH } from '../tools/contract.js'
+import type { MetroraToolDefinition, MetroraToolRegistry } from '../tools/types.js'
+import { createMetroraToolRuntime, type MetroraMcpStartupOptions } from './runtime.js'
 
 const INSTRUCTIONS =
-  'Metrora exposes local AI-coding spend data. Use get_usage for spend/usage and breakdowns (fast); ' +
-  'use get_savings to find cost reductions (slower — runs a deeper analysis). Project names are pseudonymized ' +
-  'unless include_project_names is true. All data is read locally from this machine; last_6_months is the widest ' +
-  'window. Numbers reflect the most recent scan and may lag the current session by up to a few minutes.'
+  'Metrora provides local, read-only, content-minimal factual evidence from its canonical Tools registry. ' +
+  'The server uses stdio, keeps the selected scope bounded, and never exposes raw conversation content, ' +
+  'credentials, unrestricted session payloads, or provider proxy capability. Unavailable and stale evidence ' +
+  'remains labeled as such.'
 
-function breakdownRows(p: MenubarPayload, by: BreakdownBy, limit: number): Array<{ name: string; costUSD: number; estimatedCostUSD?: number }> {
-  const c = p.current
-  if (by === 'model') return c.topModels.slice(0, limit).map(m => ({ name: m.name, costUSD: m.cost, estimatedCostUSD: m.estimatedCostUSD ?? 0 }))
-  if (by === 'project') return c.topProjects.slice(0, limit).map(x => ({ name: x.name, costUSD: x.cost }))
-  if (by === 'task') return c.topActivities.slice(0, limit).map(a => ({ name: a.name, costUSD: a.cost }))
-  return Object.entries(c.providers).sort(([, a], [, b]) => b - a).slice(0, limit).map(([name, cost]) => ({ name, costUSD: cost }))
+const MAX_ACTIVE_CALLS = 2
+const MAX_QUEUED_CALLS = 8
+
+type JsonSchemaProperty = { type?: unknown; enum?: unknown[] }
+type ZodShape = Record<string, z.ZodTypeAny>
+
+function shapeFromDefinition(definition: MetroraToolDefinition): z.ZodObject<ZodShape> {
+  const properties = definition.function.parameters.properties
+  const shape: ZodShape = {}
+  if (!properties || typeof properties !== 'object' || Array.isArray(properties)) return z.object(shape).strict()
+
+  for (const [name, raw] of Object.entries(properties as Record<string, JsonSchemaProperty>)) {
+    if (Array.isArray(raw?.enum) && raw.enum.every(value => typeof value === 'string') && raw.enum.length > 0) {
+      const values = raw.enum as [string, ...string[]]
+      shape[name] = z.enum(values).optional()
+      continue
+    }
+    if (raw?.type === 'string') {
+      shape[name] = z.string().max(name === 'model' ? METRORA_TOOL_MODEL_FILTER_MAX_LENGTH : 256).optional()
+      continue
+    }
+    shape[name] = z.unknown().optional()
+  }
+  return z.object(shape).strict()
 }
 
-export function createServer(deps: { version: string; aggregate?: Aggregate }): McpServer {
-  const aggregate = deps.aggregate ?? buildMenubarPayloadForRange
-  const inflight = new Map<string, Promise<MenubarPayload>>()
+function abortError(): Error {
+  const error = new Error('Metrora tool call cancelled')
+  error.name = 'AbortError'
+  return error
+}
 
-  const getPayload = (period: McpPeriod, optimize: boolean): Promise<MenubarPayload> => {
-    const key = `${optimize ? 'sav' : 'use'}:${period}`
-    const existing = inflight.get(key)
-    if (existing) return existing
-    const { range, label } = getDateRange(PERIOD[period])
-    const p = aggregate({ range, label }, { provider: 'all', optimize }).finally(() => inflight.delete(key))
-    inflight.set(key, p)
-    return p
+type PendingCall<T> = {
+  signal?: AbortSignal
+  run: () => Promise<T>
+  resolve: (value: T | PromiseLike<T>) => void
+  reject: (reason?: unknown) => void
+  cleanup?: () => void
+}
+
+/** Keep a local stdio server from creating an unbounded parser backlog. */
+function createCallLimiter() {
+  let active = 0
+  const pending: Array<PendingCall<unknown>> = []
+
+  const start = <T>(call: PendingCall<T>): void => {
+    call.cleanup?.()
+    active += 1
+    void call.run().then(call.resolve, call.reject).finally(() => {
+      active -= 1
+      pump()
+    })
   }
 
+  const pump = (): void => {
+    while (active < MAX_ACTIVE_CALLS && pending.length > 0) {
+      const call = pending.shift()!
+      call.cleanup?.()
+      if (call.signal?.aborted) {
+        call.reject(abortError())
+        continue
+      }
+      start(call)
+    }
+  }
+
+  const run = <T>(task: () => Promise<T>, signal?: AbortSignal): Promise<T> => {
+    if (signal?.aborted) return Promise.reject(abortError())
+    if (active < MAX_ACTIVE_CALLS) {
+      return new Promise<T>((resolve, reject) => start({ signal, run: task, resolve, reject }))
+    }
+    if (pending.length >= MAX_QUEUED_CALLS) {
+      return Promise.reject(new Error('Metrora tool call queue is full'))
+    }
+    return new Promise<T>((resolve, reject) => {
+      const call: PendingCall<T> = { signal, run: task, resolve, reject }
+      const onAbort = (): void => {
+        const index = pending.indexOf(call as PendingCall<unknown>)
+        if (index >= 0) pending.splice(index, 1)
+        call.cleanup?.()
+        reject(abortError())
+      }
+      if (signal) {
+        call.cleanup = () => signal.removeEventListener('abort', onAbort)
+        signal.addEventListener('abort', onAbort, { once: true })
+      }
+      pending.push(call as PendingCall<unknown>)
+      pump()
+    })
+  }
+
+  return { run }
+}
+
+function safeErrorCode(error: unknown): string {
+  if (error instanceof MetroraToolContractError) return error.code
+  if (error instanceof Error && error.name === 'AbortError') return 'cancelled'
+  return 'unavailable'
+}
+
+function safeErrorText(error: unknown): string {
+  return `Metrora tool request rejected (${safeErrorCode(error)}).`
+}
+
+export function createServer(deps: { version: string; registry: MetroraToolRegistry }): McpServer {
+  const limiter = createCallLimiter()
   const server = new McpServer({ name: 'metrora', version: deps.version }, { instructions: INSTRUCTIONS })
 
-  server.registerTool(
-    'get_usage',
-    {
-      title: 'Metrora — usage & cost',
-      description:
-        'Show AI coding token spend and usage for a period. Omit `by` for a headline summary; set `by` to break ' +
-        'it down by project, model, task, or provider (Claude Code / Cursor / Codex). Fast. Local to this machine.',
-      inputSchema: {
-        period: periodSchema.default('today'),
-        by: z.enum(['project', 'model', 'task', 'provider']).optional(),
-        limit: z.number().int().min(1).max(100).default(20),
-        include_project_names: z.boolean().default(false),
+  // Discovery and registration are generated from the same canonical list used
+  // by the transport-neutral registry. There is no MCP-specific factual list.
+  for (const definition of deps.registry.definitions) {
+    const name = definition.function.name
+    const inputSchema = shapeFromDefinition(definition)
+    server.registerTool(
+      name,
+      {
+        title: `Metrora — ${name}`,
+        description: definition.function.description,
+        inputSchema,
+        annotations: { title: `Metrora — ${name}`, readOnlyHint: true, openWorldHint: false, idempotentHint: true },
       },
-      outputSchema: {
-        period: z.string(),
-        empty: z.boolean(),
-        totals: z.object({ costUSD: z.number(), estimatedCostUSD: z.number(), calls: z.number(), sessions: z.number(), cacheHitPercent: z.number(), oneShotRate: z.number().nullable() }),
-        breakdown: z.array(z.object({ name: z.string(), costUSD: z.number(), estimatedCostUSD: z.number().optional() })).nullable(),
-      },
-      annotations: { title: 'Metrora — usage & cost', readOnlyHint: true, openWorldHint: false, idempotentHint: true },
-    },
-    async ({ period, by, limit, include_project_names }) => {
-      try {
-        const payload = redactProjectNames(await getPayload(period, false), include_project_names)
-        const c = payload.current
-        const totals = { costUSD: c.cost, estimatedCostUSD: c.estimatedCostUSD ?? 0, calls: c.calls, sessions: c.sessions, cacheHitPercent: c.cacheHitPercent, oneShotRate: c.oneShotRate }
-        if (c.calls === 0) {
+      async (args, extra) => {
+        try {
+          const execution = await limiter.run(
+            () => deps.registry.execute(name, args as Record<string, unknown>, extra.signal),
+            extra.signal,
+          )
+          const envelope = execution.envelope ?? JSON.parse(execution.content) as Record<string, unknown>
+          const text = boundedMetroraToolJson(envelope)
           return {
-            content: [{ type: 'text' as const, text: `No usage recorded for ${c.label} yet — run some coding sessions and try again.` }],
-            structuredContent: { period: c.label, empty: true, totals, breakdown: null },
+            content: [{ type: 'text' as const, text }],
+            structuredContent: envelope,
           }
+        } catch (error) {
+          return { content: [{ type: 'text' as const, text: safeErrorText(error) }], isError: true }
         }
-        const text = by ? renderBreakdownTable(payload, by, limit) : renderSummaryTable(payload)
-        const breakdown = by ? breakdownRows(payload, by, limit) : null
-        return {
-          content: [{ type: 'text' as const, text }],
-          structuredContent: { period: c.label, empty: false, totals, breakdown },
-        }
-      } catch (err) {
-        return {
-          content: [{ type: 'text' as const, text: `metrora: failed to read usage — ${err instanceof Error ? err.message : String(err)}` }],
-          structuredContent: { period: 'unknown', empty: true, totals: { costUSD: 0, estimatedCostUSD: 0, calls: 0, sessions: 0, cacheHitPercent: 0, oneShotRate: null }, breakdown: null },
-          isError: true,
-        }
-      }
-    },
-  )
-
-  server.registerTool(
-    'get_savings',
-    {
-      title: 'Metrora — savings opportunities',
-      description:
-        'Find ways to reduce AI coding cost for a period: optimization findings, retry tax (money spent re-doing ' +
-        'work), and routing waste (what you would have saved on a cheaper model). Slower than get_usage.',
-      inputSchema: { period: periodSchema.default('last_7_days'), include_project_names: z.boolean().default(false) },
-      outputSchema: {
-        period: z.string(),
-        optimize: z.object({ findingCount: z.number(), savingsUSD: z.number(), topFindings: z.array(z.object({ title: z.string(), impact: z.string(), savingsUSD: z.number() })) }),
-        retryTaxUSD: z.number(),
-        routingWasteUSD: z.number(),
       },
-      annotations: { title: 'Metrora — savings opportunities', readOnlyHint: true, openWorldHint: false, idempotentHint: true },
-    },
-    async ({ period, include_project_names }) => {
-      try {
-        const payload = redactProjectNames(await getPayload(period, true), include_project_names)
-        const c = payload.current
-        return {
-          content: [{ type: 'text' as const, text: renderSavingsTable(payload) }],
-          structuredContent: { period: c.label, optimize: payload.optimize, retryTaxUSD: c.retryTax.totalUSD, routingWasteUSD: c.routingWaste.totalSavingsUSD },
-        }
-      } catch (err) {
-        return {
-          content: [{ type: 'text' as const, text: `metrora: failed to compute savings — ${err instanceof Error ? err.message : String(err)}` }],
-          structuredContent: { period: 'unknown', optimize: { findingCount: 0, savingsUSD: 0, topFindings: [] }, retryTaxUSD: 0, routingWasteUSD: 0 },
-          isError: true,
-        }
-      }
-    },
-  )
+    )
+  }
 
   return server
 }
 
-export async function startStdioServer(version: string): Promise<void> {
+function redirectProtocolLogs(): void {
+  const write = (...args: unknown[]): void => {
+    process.stderr.write(args.map(value => typeof value === 'string' ? value : String(value)).join(' ') + '\n')
+  }
+  console.log = write as typeof console.log
+  console.info = write as typeof console.info
+  console.debug = write as typeof console.debug
+  console.warn = write as typeof console.warn
+}
+
+export async function startStdioServer(version: string, options: MetroraMcpStartupOptions = {}): Promise<void> {
+  // The protocol owns stdout. Initialization is deliberately silent there.
+  redirectProtocolLogs()
   await loadPricing()
-  const server = createServer({ version })
-  await server.connect(new StdioServerTransport())
+  const registry = await createMetroraToolRuntime(options)
+  const server = createServer({ version, registry })
+  const transport = new StdioServerTransport()
+  let shuttingDown = false
+  const shutdown = async (): Promise<void> => {
+    if (shuttingDown) return
+    shuttingDown = true
+    await server.close().catch(() => undefined)
+    await transport.close().catch(() => undefined)
+  }
+  const onSignal = (): void => { void shutdown() }
+  process.once('SIGINT', onSignal)
+  process.once('SIGTERM', onSignal)
+  try {
+    await server.connect(transport)
+  } catch (error) {
+    process.off('SIGINT', onSignal)
+    process.off('SIGTERM', onSignal)
+    await shutdown()
+    throw error
+  }
 }

--- a/src/tools/contract.ts
+++ b/src/tools/contract.ts
@@ -262,6 +262,7 @@ export function nextMetroraToolScope(scope: MetroraToolScope, name: MetroraToolN
   const next = { ...scope, range: scope.range ? { ...scope.range } : null }
   if (typeof args.period === 'string') {
     if (args.period === 'yesterday') {
+      if (scope.period === 'today' && !scope.range) throw new MetroraToolContractError('invalid-scope', 'A Metrora tool request cannot widen today to yesterday.')
       const date = new Date()
       date.setHours(0, 0, 0, 0)
       date.setDate(date.getDate() - 1)
@@ -278,9 +279,17 @@ export function nextMetroraToolScope(scope: MetroraToolScope, name: MetroraToolN
     }
   }
   if (name === 'get_spend_snapshot' || name === 'get_model_efficiency' || name === 'get_overview_snapshot') {
-    if (Object.prototype.hasOwnProperty.call(args, 'model')) next.model = String(args.model)
+    if (Object.prototype.hasOwnProperty.call(args, 'model')) {
+      const requested = String(args.model)
+      if (scope.model !== null && requested !== scope.model) throw new MetroraToolContractError('invalid-scope', 'A Metrora tool request cannot change the selected model scope.')
+      next.model = requested
+    }
   }
-  if (name === 'get_quota_snapshot' && Object.prototype.hasOwnProperty.call(args, 'provider')) next.provider = String(args.provider)
+  if (name === 'get_quota_snapshot' && Object.prototype.hasOwnProperty.call(args, 'provider')) {
+    const requested = String(args.provider)
+    if (scope.provider !== 'all' && requested !== scope.provider) throw new MetroraToolContractError('invalid-scope', 'A Metrora quota request cannot change the selected provider scope.')
+    next.provider = requested
+  }
   return snapshotMetroraToolScope(next)
 }
 

--- a/src/tools/evidence.ts
+++ b/src/tools/evidence.ts
@@ -212,8 +212,9 @@ export function buildMetroraSpendEvidence(question: string, scope: MetroraToolSc
     ? selectedModel ? { level: 'partial' as const, label: 'Model-scoped accounting available', detail: 'Canonical model cost and calls are available; model-specific sessions and daily history are not.' } : { level: 'unavailable' as const, state: 'UNAVAILABLE' as const, label: 'Model-scoped spend unavailable', detail: 'The Overview payload has no canonical accounting row for the requested model.' }
     : spendCoverage(data)
   const coverage = reconciliationCoverage(data, baseCoverage)
+  const noMeasuredActivity = finite(data.current?.calls) && data.current?.calls === 0 && finite(data.current?.cost) && data.current?.cost === 0
   const spend: MetroraToolSpendEvidence = {
-    measuredCostUSD: modelScoped ? selectedModel?.costUSD ?? null : numberOrNull(data.current?.cost),
+    measuredCostUSD: modelScoped ? selectedModel?.costUSD ?? null : noMeasuredActivity ? null : numberOrNull(data.current?.cost),
     calls: modelScoped ? selectedModel?.calls ?? null : numberOrNull(data.current?.calls),
     sessions: modelScoped ? null : numberOrNull(data.current?.sessions),
     inputTokens: modelScoped ? null : numberOrNull(data.current?.inputTokens),

--- a/src/tools/evidence.ts
+++ b/src/tools/evidence.ts
@@ -212,9 +212,8 @@ export function buildMetroraSpendEvidence(question: string, scope: MetroraToolSc
     ? selectedModel ? { level: 'partial' as const, label: 'Model-scoped accounting available', detail: 'Canonical model cost and calls are available; model-specific sessions and daily history are not.' } : { level: 'unavailable' as const, state: 'UNAVAILABLE' as const, label: 'Model-scoped spend unavailable', detail: 'The Overview payload has no canonical accounting row for the requested model.' }
     : spendCoverage(data)
   const coverage = reconciliationCoverage(data, baseCoverage)
-  const noMeasuredActivity = finite(data.current?.calls) && data.current?.calls === 0 && finite(data.current?.cost) && data.current?.cost === 0
   const spend: MetroraToolSpendEvidence = {
-    measuredCostUSD: modelScoped ? selectedModel?.costUSD ?? null : noMeasuredActivity ? null : numberOrNull(data.current?.cost),
+    measuredCostUSD: modelScoped ? selectedModel?.costUSD ?? null : numberOrNull(data.current?.cost),
     calls: modelScoped ? selectedModel?.calls ?? null : numberOrNull(data.current?.calls),
     sessions: modelScoped ? null : numberOrNull(data.current?.sessions),
     inputTokens: modelScoped ? null : numberOrNull(data.current?.inputTokens),

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -1,9 +1,11 @@
+import { spawnSync } from 'node:child_process'
 import { readFileSync, readdirSync } from 'node:fs'
 import { join } from 'node:path'
 
 import { Client } from '@modelcontextprotocol/sdk/client/index.js'
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js'
 import { describe, expect, it } from 'vitest'
+import { createMetroraToolRuntime } from '../src/mcp/runtime.js'
 
 const TOOL_NAMES = [
   'get_spend_snapshot',
@@ -17,9 +19,13 @@ const TOOL_NAMES = [
 ] as const
 
 const FORBIDDEN_TOOL_NAMES = [
+  'act',
+  'swarm',
   'approve_action',
   'execute_action',
+  'propose_action',
   'run_core_compatibility',
+  'run-core-compatibility',
   'run_bench',
   'launch_agent',
   'launch_swarm',
@@ -28,6 +34,19 @@ const FORBIDDEN_TOOL_NAMES = [
 ] as const
 
 type WireResult = Awaited<ReturnType<Client['callTool']>>
+
+function runCli(...args: string[]): { status: number | null; stdout: string; stderr: string } {
+  const result = spawnSync(
+    process.execPath,
+    ['--import', 'tsx', join(process.cwd(), 'src', 'cli.ts'), ...args],
+    { cwd: process.cwd(), encoding: 'utf8' },
+  )
+  return {
+    status: result.status,
+    stdout: String(result.stdout ?? ''),
+    stderr: String(result.stderr ?? ''),
+  }
+}
 
 function textContent(result: WireResult): string {
   const entries = result.content.filter((entry): entry is { type: 'text'; text: string } => entry.type === 'text')
@@ -70,6 +89,41 @@ async function expectFailClosed(call: Promise<WireResult>, secret: string): Prom
 }
 
 describe('MCP V1 interoperability contract', () => {
+  it('reports truthful local stdio metadata and the canonical eight tool identities', () => {
+    const result = runCli('mcp', 'info', '--json')
+    expect(result.status).toBe(0)
+    expect(result.stderr).toBe('')
+    const info = JSON.parse(result.stdout) as {
+      transport: string
+      localOnly: boolean
+      readOnly: boolean
+      command: { command: string; args: string[] }
+      tools: string[]
+    }
+    expect(info).toMatchObject({
+      transport: 'stdio',
+      localOnly: true,
+      readOnly: true,
+      command: { command: 'metrora', args: ['mcp', 'serve'] },
+      tools: [...TOOL_NAMES],
+    })
+  })
+
+  it('rejects invalid startup period, provider, and Project scopes without leaking a stack or path', () => {
+    const cases = [
+      { args: ['mcp', 'serve', '--period', 'nope'], message: 'unsupported MCP period' },
+      { args: ['mcp', 'serve', '--provider', 'openai'], message: 'unsupported MCP provider' },
+      { args: ['mcp', 'serve', '--project-id', 'nope'], message: 'Project scope was not found' },
+    ]
+    for (const testCase of cases) {
+      const result = runCli(...testCase.args)
+      expect(result.status).not.toBe(0)
+      expect(result.stdout).toBe('')
+      expect(result.stderr).toContain(testCase.message)
+      expect(result.stderr).not.toMatch(/(?:Node\.js|\bat |src[\\/]mcp[\\/]|C:\\Users\\|\/Users\/|\/home\/)/iu)
+    }
+  }, 30_000)
+
   it('negotiates over real stdio, exposes only the canonical read-only tools, and closes cleanly', async () => {
     await withStdioClient(async (client, stderr) => {
       const listed = await client.listTools()
@@ -107,7 +161,6 @@ describe('MCP V1 interoperability contract', () => {
       expect(spendWire).toContain('advisor-tool-v1')
       expect(spendWire).toContain('privacy')
       expect(spendWire).toContain('unavailable')
-      expect(spendWire).not.toContain('"measuredCostUSD":0')
       expect(stderr()).not.toContain('C:\\Users\\')
       expect(stderr()).not.toContain('/Users/')
       expect(stderr()).not.toContain('/home/')
@@ -126,6 +179,12 @@ describe('MCP V1 interoperability contract', () => {
 })
 
 describe('MCP and canonical Tools boundaries', () => {
+  it('keeps a constrained startup scope immutable when a Tool call asks to widen it', async () => {
+    const registry = await createMetroraToolRuntime({ period: 'today', provider: 'claude' })
+    await expect(registry.execute('get_spend_snapshot', { period: 'all' })).rejects.toMatchObject({ code: 'invalid-scope' })
+    await expect(registry.execute('get_quota_snapshot', { provider: 'codex' })).rejects.toMatchObject({ code: 'invalid-scope' })
+  })
+
   it('binds MCP to the canonical Tools registry instead of defining a second factual authority', () => {
     const mcpSources = readdirSync(join(process.cwd(), 'src', 'mcp'))
       .filter(name => name.endsWith('.ts'))

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -1,60 +1,150 @@
-import { describe, expect, it } from 'vitest'
+import { readFileSync, readdirSync } from 'node:fs'
+import { join } from 'node:path'
+
 import { Client } from '@modelcontextprotocol/sdk/client/index.js'
-import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js'
-import { createServer } from '../src/mcp/server.js'
-import type { MenubarPayload } from '../src/menubar-json.js'
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js'
+import { describe, expect, it } from 'vitest'
 
-function fakePayload(calls = 100): MenubarPayload {
-  return {
-    generated: '', optimize: { findingCount: 1, savingsUSD: 2, topFindings: [{ title: 'X', impact: 'high', savingsUSD: 2 }] }, history: { daily: [] },
-    current: {
-      label: 'Today', cost: 9, calls, sessions: 1, oneShotRate: 0.5, inputTokens: 10, outputTokens: 5, cacheHitPercent: 50,
-      topActivities: [{ name: 'feature', cost: 9, turns: 5, oneShotRate: 0.5 }], topModels: [{ name: 'Opus 4.8', cost: 9, calls }],
-      providers: { 'claude code': 9 }, topProjects: [{ name: 'real-repo', cost: 9, sessions: 1, avgCostPerSession: 9, sessionDetails: [] }],
-      modelEfficiency: [], topSessions: [{ project: 'real-repo', cost: 9, calls, date: '2026-06-01' }],
-      retryTax: { totalUSD: 1, retries: 2, editTurns: 5, byModel: [{ name: 'Opus 4.8', taxUSD: 1, retries: 2, retriesPerEdit: 0.4 }] },
-      routingWaste: { totalSavingsUSD: 1, baselineModel: 'Haiku 4.5', baselineCostPerEdit: 0.01, byModel: [] },
-      tools: [], skills: [], subagents: [], mcpServers: [],
-    },
-  } as MenubarPayload
+const TOOL_NAMES = [
+  'get_spend_snapshot',
+  'get_model_efficiency',
+  'get_quota_snapshot',
+  'get_overview_snapshot',
+  'get_project_drivers',
+  'get_session_highlights',
+  'get_coverage_report',
+  'get_bench_evidence',
+] as const
+
+const FORBIDDEN_TOOL_NAMES = [
+  'approve_action',
+  'execute_action',
+  'run_core_compatibility',
+  'run_bench',
+  'launch_agent',
+  'launch_swarm',
+  'shell',
+  'filesystem',
+] as const
+
+type WireResult = Awaited<ReturnType<Client['callTool']>>
+
+function textContent(result: WireResult): string {
+  const entries = result.content.filter((entry): entry is { type: 'text'; text: string } => entry.type === 'text')
+  expect(entries).toHaveLength(1)
+  return entries[0]!.text
 }
 
-async function connect(aggregate: (p: unknown, o: unknown) => Promise<MenubarPayload>) {
-  const server = createServer({ version: 'test', aggregate: aggregate as never })
-  const [a, b] = InMemoryTransport.createLinkedPair()
-  const client = new Client({ name: 'test', version: '1' })
-  await Promise.all([server.connect(a), client.connect(b)])
-  return client
+async function withStdioClient<T>(work: (client: Client, stderr: () => string) => Promise<T>): Promise<T> {
+  const transport = new StdioClientTransport({
+    command: process.execPath,
+    args: ['--import', 'tsx', join(process.cwd(), 'src', 'cli.ts'), 'mcp', 'serve'],
+    cwd: process.cwd(),
+    stderr: 'pipe',
+  })
+  const stderrChunks: string[] = []
+  transport.stderr?.on('data', chunk => stderrChunks.push(String(chunk)))
+  const client = new Client({ name: 'metrora-qa-client', version: '1.0.0' })
+  try {
+    await client.connect(transport)
+    return await work(client, () => stderrChunks.join(''))
+  } finally {
+    await client.close().catch(async () => { await transport.close() })
+  }
 }
 
-describe('mcp server', () => {
-  it('exposes exactly two read-only tools', async () => {
-    const client = await connect(async () => fakePayload())
-    const { tools } = await client.listTools()
-    expect(tools.map(t => t.name).sort()).toEqual(['get_savings', 'get_usage'])
-    expect(tools.find(t => t.name === 'get_usage')!.annotations?.readOnlyHint).toBe(true)
+async function expectFailClosed(call: Promise<WireResult>, secret: string): Promise<void> {
+  let result: WireResult | undefined
+  let thrown: unknown
+  try {
+    result = await call
+  } catch (error) {
+    thrown = error
+  }
+  if (thrown !== undefined) {
+    expect(String(thrown)).not.toContain(secret)
+    return
+  }
+  expect(result?.isError).toBe(true)
+  expect(JSON.stringify(result)).not.toContain(secret)
+}
+
+describe('MCP V1 interoperability contract', () => {
+  it('negotiates over real stdio, exposes only the canonical read-only tools, and closes cleanly', async () => {
+    await withStdioClient(async (client, stderr) => {
+      const listed = await client.listTools()
+      expect(listed.tools.map(tool => tool.name)).toEqual(TOOL_NAMES)
+
+      for (const tool of listed.tools) {
+        expect(tool.annotations?.readOnlyHint).toBe(true)
+        expect(tool.annotations?.openWorldHint).toBe(false)
+        expect(tool.inputSchema).toMatchObject({ type: 'object', additionalProperties: false })
+        expect(tool.description).not.toMatch(/ACT|Swarm|shell|filesystem|approval|execute/iu)
+      }
+      for (const forbidden of FORBIDDEN_TOOL_NAMES) {
+        expect(listed.tools.some(tool => tool.name === forbidden)).toBe(false)
+      }
+
+      const calls = new Map<string, WireResult>()
+      for (const name of TOOL_NAMES) {
+        const result = await client.callTool({
+          name,
+          arguments: name === 'get_quota_snapshot' ? { provider: 'claude' } : {},
+        })
+        calls.set(name, result)
+        expect(result.isError).not.toBe(true)
+        const content = textContent(result)
+        expect(() => JSON.parse(content)).not.toThrow()
+        expect(new TextEncoder().encode(content).byteLength).toBeLessThanOrEqual(32 * 1024)
+        expect(content).toContain('content-minimal')
+        expect(content).not.toContain('C:\\Users\\')
+        expect(content).not.toContain('/Users/')
+        expect(content).not.toContain('/home/')
+        expect(content).not.toMatch(/bearer\s+|api[_ -]?key\s*[=:]|access[_ -]?token\s*[=:]/iu)
+      }
+
+      const spendWire = JSON.stringify(calls.get('get_spend_snapshot'))
+      expect(spendWire).toContain('advisor-tool-v1')
+      expect(spendWire).toContain('privacy')
+      expect(spendWire).toContain('unavailable')
+      expect(spendWire).not.toContain('"measuredCostUSD":0')
+      expect(stderr()).not.toContain('C:\\Users\\')
+      expect(stderr()).not.toContain('/Users/')
+      expect(stderr()).not.toContain('/home/')
+      expect(stderr()).not.toMatch(/api[_ -]?key\s*[=:]|bearer\s+/iu)
+    }, 30_000)
+  }, 30_000)
+
+  it('fails closed for legacy/unknown tools and invalid arguments without echoing sensitive input', async () => {
+    await withStdioClient(async client => {
+      const secret = 'token=sk_test_12345678901234567890'
+      await expectFailClosed(client.callTool({ name: 'get_usage', arguments: {} }), secret)
+      await expectFailClosed(client.callTool({ name: 'get_spend_snapshot', arguments: { prompt: secret } }), secret)
+      await expectFailClosed(client.callTool({ name: 'get_quota_snapshot', arguments: { provider: 'openai' } }), secret)
+    }, 30_000)
+  }, 30_000)
+})
+
+describe('MCP and canonical Tools boundaries', () => {
+  it('binds MCP to the canonical Tools registry instead of defining a second factual authority', () => {
+    const mcpSources = readdirSync(join(process.cwd(), 'src', 'mcp'))
+      .filter(name => name.endsWith('.ts'))
+      .map(name => readFileSync(join(process.cwd(), 'src', 'mcp', name), 'utf8'))
+      .join('\n')
+    expect(mcpSources).toMatch(/createMetroraToolRegistry|METRORA_TOOL_(?:CONTRACT|DEFINITIONS)/u)
+    expect(mcpSources).toMatch(/\.\.\/tools\/(?:index|registry|contract)/u)
+    expect(mcpSources).not.toMatch(/\bget_usage\b|\bget_savings\b/u)
+    for (const forbidden of FORBIDDEN_TOOL_NAMES) {
+      expect(mcpSources).not.toContain("'" + forbidden + "'")
+      expect(mcpSources).not.toContain('"' + forbidden + '"')
+    }
   })
-  it('get_usage hashes project names by default', async () => {
-    const client = await connect(async () => fakePayload())
-    const res = await client.callTool({ name: 'get_usage', arguments: { period: 'today', by: 'project' } })
-    expect(JSON.stringify(res)).not.toContain('real-repo')
-    expect(JSON.stringify(res)).toMatch(/project-[0-9a-f]{6}/)
-    expect(res.isError).toBeFalsy()
-  })
-  it('get_usage reveals names when opted in', async () => {
-    const client = await connect(async () => fakePayload())
-    const res = await client.callTool({ name: 'get_usage', arguments: { period: 'today', by: 'project', include_project_names: true } })
-    expect(JSON.stringify(res)).toContain('real-repo')
-  })
-  it('empty data returns a friendly message, not a zero table', async () => {
-    const client = await connect(async () => fakePayload(0))
-    const res = await client.callTool({ name: 'get_usage', arguments: { period: 'today' } })
-    expect(String((res.content as Array<{ text: string }>)[0].text).toLowerCase()).toContain('no usage')
-  })
-  it('aggregator failure surfaces as isError', async () => {
-    const client = await connect(async () => { throw new Error('boom') })
-    const res = await client.callTool({ name: 'get_savings', arguments: {} })
-    expect(res.isError).toBe(true)
-    expect(JSON.stringify(res)).toContain('boom')
+
+  it('keeps canonical Tools transport- and UI-neutral', () => {
+    const toolsSources = readdirSync(join(process.cwd(), 'src', 'tools'))
+      .filter(name => name.endsWith('.ts'))
+      .map(name => readFileSync(join(process.cwd(), 'src', 'tools', name), 'utf8'))
+      .join('\n')
+    expect(toolsSources).not.toMatch(/@modelcontextprotocol|from ['"](?:react|electron)|from ['"].*\/act\//iu)
   })
 })

--- a/tests/tools-foundation.test.ts
+++ b/tests/tools-foundation.test.ts
@@ -97,6 +97,18 @@ describe('canonical Metrora Tools foundation', () => {
     await expect(registry.execute('get_spend_snapshot', { prompt: 'raw content' })).rejects.toMatchObject({ code: 'additional-argument' })
     await expect(registry.execute('get_spend_snapshot', { period: 'month' })).rejects.toMatchObject({ code: 'invalid-scope' })
     await expect(registry.execute('get_quota_snapshot', { provider: 'copilot' })).rejects.toMatchObject({ code: 'invalid-argument-value' })
+    const todayRegistry = createMetroraToolRegistry(source(), { ...scope, period: 'today' })
+    await expect(todayRegistry.execute('get_spend_snapshot', { period: 'yesterday' })).rejects.toMatchObject({ code: 'invalid-scope' })
+  })
+
+  it('does not allow a constrained provider or model scope to be changed by a call', async () => {
+    const constrained = createMetroraToolRegistry(source(), {
+      ...scope,
+      provider: 'claude',
+      model: 'claude-sonnet-4-6',
+    })
+    await expect(constrained.execute('get_quota_snapshot', { provider: 'codex' })).rejects.toMatchObject({ code: 'invalid-scope' })
+    await expect(constrained.execute('get_spend_snapshot', { model: 'claude-opus-4-6' })).rejects.toMatchObject({ code: 'invalid-scope' })
   })
 
   it('stops before the data source when cancelled and preserves unavailable truth', async () => {

--- a/tests/tools-foundation.test.ts
+++ b/tests/tools-foundation.test.ts
@@ -38,6 +38,19 @@ function overview(): MetroraOverview {
   }
 }
 
+function measuredZeroOverview(): MetroraOverview {
+  const base = overview()
+  return {
+    ...base,
+    current: {
+      ...base.current!,
+      cost: 0,
+      calls: 0,
+      sessions: 0,
+    },
+  }
+}
+
 function source(overrides: Partial<MetroraToolDataSource> = {}): MetroraToolDataSource {
   return {
     getOverview: vi.fn(async () => overview()),
@@ -89,6 +102,21 @@ describe('canonical Metrora Tools foundation', () => {
     expect(result.content).not.toContain('sk_test_12345678901234567890')
     expect(result.content).not.toContain('api_key=')
     expect(result.content.length).toBeLessThanOrEqual(32 * 1024)
+  })
+
+  it('keeps authoritative measured zero distinct from an unavailable source', async () => {
+    const zero = await createMetroraToolRegistry(source(), scope, measuredZeroOverview()).execute('get_spend_snapshot', {})
+    expect(zero.evidence.spend?.measuredCostUSD).toBe(0)
+    expect(zero.evidence.coverage.state).toBe('NO_DATA')
+    expect(zero.envelope).toMatchObject({ unavailable: false })
+
+    const unavailable = createMetroraToolRegistry(source({
+      getOverview: vi.fn(async () => { throw new Error('source unavailable') }),
+    }), scope)
+    const missing = await unavailable.execute('get_spend_snapshot', {})
+    expect(missing.evidence.spend?.measuredCostUSD).toBeNull()
+    expect(missing.evidence.coverage.state).toBe('UNAVAILABLE')
+    expect(missing.envelope).toMatchObject({ unavailable: true })
   })
 
   it('rejects unknown/additional arguments and every scope-widening request', async () => {


### PR DESCRIPTION
## Summary

- ship the local read-only MCP Server V1 over stdio
- bind discovery and execution to the canonical Metrora Tools registry
- expose exactly the eight bounded factual tools and add `metrora mcp serve` / `metrora mcp info --json`
- preserve scope narrowing, unavailable/stale/fresh evidence, content-minimal privacy and bounded output
- add real stdio interoperability, fail-closed, privacy and transport-boundary tests

## Verification

- `npx tsc --noEmit`
- `npm run build:cli`
- `npx vitest run tests/mcp-server.test.ts tests/tools-foundation.test.ts` — 9 passed
- full suite on the implementation: 347 files passed, 3,373 tests passed, 2 files and 5 tests skipped
- post-review scope regression is covered by the focused suite

## Boundary

This wave is local/read-only only. It does not add ACT, Swarm, shell, filesystem, repository mutation, provider proxying, hosted service or model-runner capability. No merge or release is requested.