### PR TITLE
feat: converge Harness on a bounded Metrora agent loop

### DIFF
--- a/app/renderer/advisor/chat-first.test.ts
+++ b/app/renderer/advisor/chat-first.test.ts
@@ -94,9 +94,21 @@ describe('Advisor chat-first model boundary', () => {
     const fixture = createAdvisorConformanceFixture()
     const requests: Array<Record<string, unknown>> = []
     const events: Array<{ name: string; status: string }> = []
+    let calls = 0
     const runtime = new OllamaAdvisorRuntime({
       model: 'chat-model',
-      transport: directTransport(requests, { content: 'Hello. I can help you understand spend.' }),
+      transport: {
+        probe: async () => ({ available: true, models: ['chat-model'], detail: 'ready' }),
+        cancel: async () => true,
+        onDelta: () => () => {},
+        chat: async (_requestId, payload) => {
+          requests.push(payload)
+          calls += 1
+          return calls === 1
+            ? { streamed: false, message: { content: 'I will check the measured spend first.', tool_calls: [] } }
+            : { streamed: false, message: { content: 'Metrora measured $12.00, which is below your $4,000 threshold.' } }
+        },
+      },
     })
 
     const answer = await createAdvisorKernel(fixture.source, runtime).investigate({
@@ -111,10 +123,10 @@ describe('Advisor chat-first model boundary', () => {
       { name: 'get_spend_snapshot', status: 'started' },
       { name: 'get_spend_snapshot', status: 'completed' },
     ])
-    expect(requests).toHaveLength(1)
+    expect(requests).toHaveLength(2)
     expect(answer.evidence).toEqual(expect.arrayContaining([expect.objectContaining({ id: 'overview.current' })]))
-    expect(answer.conclusion).toContain('$12.00')
-    expect(answer.conclusion).not.toMatch(/Hello\. I can help you understand spend/i)
+    expect(answer.conclusion).toContain('below your $4,000 threshold')
+    expect(answer.generatedByModel).toBe(true)
   })
 
   it('sends only bounded same-scope history and minimal semantic context', async () => {

--- a/app/renderer/advisor/claim-atoms.ts
+++ b/app/renderer/advisor/claim-atoms.ts
@@ -518,6 +518,7 @@ function claimsForIntent(evidence: AdvisorEvidence, atoms = buildAdvisorVerified
   const include = (predicate: (item: AdvisorVerifiedClaimAtomV1) => boolean, limit = 8) => atoms.filter(predicate).slice(0, limit)
   if (evidence.intent === 'spend-change') return [
     ...include(item => item.id === 'measured-total-cost' || item.id === 'observed-calls' || item.id === 'observed-sessions', 3),
+    ...include(item => item.claimKind === 'model_identity', 4),
     ...include(item => item.claimKind === 'model_measured_cost', 4),
     ...include(item => item.claimKind === 'trend_direction', 1),
   ]

--- a/app/renderer/advisor/conformance.test.ts
+++ b/app/renderer/advisor/conformance.test.ts
@@ -223,14 +223,14 @@ describe('AdvisorToolV1 reusable conformance suite', () => {
     const malformedRuntime = new OllamaAdvisorRuntime({ model: 'synthetic-model', transport: scriptedTransport([{ function: { name: 'get_spend_snapshot', arguments: '{"model":' } }]) })
     const malformedAnswer = await malformedRuntime.generate({ question: 'What is my spend?', evidence, tools: ADVISOR_TOOL_DEFINITIONS, toolContract: ADVISOR_TOOL_CONTRACT, executeTool: execute })
     expect(malformedAnswer.conclusion).toContain('Metrora measured')
-    expect(execute).toHaveBeenCalledTimes(1)
-    expect(fixture.reads.overviews).toHaveLength(1)
+    expect(execute).not.toHaveBeenCalled()
+    expect(fixture.reads.overviews).toHaveLength(0)
 
     const runtime = new OllamaAdvisorRuntime({ model: 'synthetic-model', transport: scriptedTransport([{ function: { name: 'get_spend_snapshot', arguments: '{}' } }]) })
     const answer = await runtime.generate({ question: 'What is my spend?', evidence, tools: ADVISOR_TOOL_DEFINITIONS, toolContract: ADVISOR_TOOL_CONTRACT, executeTool: registry.execute })
     expect(answer.generatedByModel).toBe(true)
     expect(answer.evidence.length).toBeGreaterThan(0)
-    expect(fixture.reads.overviews).toHaveLength(2)
+    expect(fixture.reads.overviews).toHaveLength(1)
   })
 
   it('keeps content-minimal evidence safe for no-digit secrets, paths, and internal identifiers', async () => {

--- a/app/renderer/advisor/hosted.test.ts
+++ b/app/renderer/advisor/hosted.test.ts
@@ -122,13 +122,13 @@ describe('Hosted Advisor renderer runtime', () => {
     expect(finalPayload.harnessConformance).toBe(true)
     expect(conformanceCalls).toBe(1)
     const finalMessages = finalPayload.messages as Array<Record<string, unknown>>
-    expect(finalMessages.map(message => message.role)).toEqual(['system', 'user'])
-    expect(finalMessages.some(message => String(message.content).includes('measuredCostUSD'))).toBe(true)
+    expect(finalMessages.map(message => message.role)).toEqual(['system', 'user', 'assistant', 'user'])
+    expect(finalMessages.some(message => String(message.content).includes('Metrora Tool result'))).toBe(true)
     expect(finalMessages.some(message => message.role === 'tool')).toBe(false)
     expect(deltas).toEqual([])
     await expect(new HostedAdvisorRuntime({ provider: 'openai', model: 'gpt-test', transport }).generate({ question: 'What changed in spend?', evidence })).rejects.toThrow('consent')
     expect(answer.runtime).toMatchObject({ id: 'hosted-openai', mode: 'hosted-byok' })
-    expect(answer.generatedByModel).toBe(true)
+    expect(answer.generatedByModel).toBe(false)
     expect(answer.streamed).toBe(false)
     expect(answer.conclusion).toContain('Metrora measured')
     expect(answer.conclusion).not.toContain('Claude was not the main driver.')
@@ -172,8 +172,9 @@ describe('Hosted Advisor renderer runtime', () => {
       transport,
     })).investigate({ question: 'What changed in spend?', scope: fixture.scope })
 
-    expect(requests).toHaveLength(1)
-    expect((requests[0]?.messages as Array<{ content: string }>).some(message => message.content.includes('12'))).toBe(true)
+    expect(requests).toHaveLength(2)
+    expect((requests[0]?.messages as Array<{ content: string }>).some(message => message.content.includes('12'))).toBe(false)
+    expect((requests[1]?.messages as Array<{ content: string }>).some(message => message.content.includes('12'))).toBe(true)
     expect(fixture.reads.overviews).toHaveLength(1)
     expect(answer.generatedByModel).toBe(true)
     expect(answer.conclusion).toContain('meaningful amount')
@@ -202,10 +203,11 @@ describe('Hosted Advisor renderer runtime', () => {
       transport,
     })).investigate({ question: 'What changed in spend and which projects contributed?', scope: fixture.scope })
 
-    expect(requests).toHaveLength(2)
+    expect(requests).toHaveLength(3)
     expect(fixture.reads.overviews).toHaveLength(2)
-    expect((requests[0]?.messages as Array<{ content: string }>).some(message => message.content.includes('12'))).toBe(true)
+    expect((requests[0]?.messages as Array<{ content: string }>).some(message => message.content.includes('12'))).toBe(false)
     expect((requests[1]?.messages as Array<{ content: string }>).some(message => message.content.includes('Project A'))).toBe(true)
+    expect((requests[2]?.messages as Array<{ content: string }>).some(message => message.content.includes('12'))).toBe(true)
     expect(answer.generatedByModel).toBe(true)
     expect(answer.conclusion).toContain('Project A')
   })

--- a/app/renderer/advisor/hosted.ts
+++ b/app/renderer/advisor/hosted.ts
@@ -1,14 +1,9 @@
 import { metrora } from '../lib/ipc'
-import { AdvisorToolContractError, assertStrictBoundedAdvisorToolContent } from './contract'
-import { buildAdvisorChatMessages, buildAdvisorConversationMessages, buildAdvisorEvidenceSynthesisMessages, buildAdvisorSwarmSynthesisMessages, buildAdvisorToolContinuationMessages, finalizeAdvisorConversationAnswer, finalizeModelAnswer, buildAdvisorSynthesisMessages, evidenceUsable } from './model-flow'
-import { deterministicPlanningFallback, parseAdvisorPlanningDraft, planningDraftFromNativeToolCalls, runtimeGuardPlan, validateAdvisorPlanningDraft, type AdvisorPlanningValidation } from './planner'
-import { hasMixedEvidenceScopes, mergeEvidence } from './merge-evidence'
+import { buildAdvisorSwarmSynthesisMessages } from './model-flow'
+import { createAdvisorTurnDeadline, raceAdvisorAbort } from './abort'
 import { HARNESS_TOOL_LOOP_LIMITS } from './limits'
-import { parseAdvisorSynthesisDraft } from './synthesis'
-import { createAdvisorTurnDeadline, raceAdvisorAbort, shouldRethrowAdvisorAbort } from './abort'
-import type { AdvisorAnswer, AdvisorEvidence, AdvisorHostedModel, AdvisorHostedModelCapabilities, AdvisorHostedProviderId, AdvisorModelRuntime, AdvisorReasoningEffort, AdvisorRuntimeInput, AdvisorSwarmSynthesisInput, AdvisorSwarmSynthesisResult, AdvisorToolDefinition, AdvisorToolRequestV1 } from './types'
-
-const BOUNDED_TURN_DEADLINE_NOTE = 'The bounded Metrora turn deadline was reached; verified facts are shown instead.'
+import { runAdvisorRuntimeAgentLoop } from '../agent-loop/advisor-runtime'
+import type { AdvisorAnswer, AdvisorHostedModel, AdvisorHostedModelCapabilities, AdvisorHostedProviderId, AdvisorModelRuntime, AdvisorReasoningEffort, AdvisorRuntimeInput, AdvisorSwarmSynthesisInput, AdvisorSwarmSynthesisResult } from './types'
 
 export type HostedAdvisorProvider = AdvisorHostedProviderId
 export type HostedAdvisorProbeResult = {
@@ -91,54 +86,6 @@ function isNormalizedHostedResponse(value: unknown): value is { message: { conte
   return Boolean(value.message.content) || Boolean(Array.isArray(toolCalls) && toolCalls.length)
 }
 
-function toolDefinitions(input: AdvisorRuntimeInput): readonly AdvisorToolDefinition[] {
-  return input.toolContract?.tools ? [...input.toolContract.tools] : input.tools ? [...input.tools] : []
-}
-
-function planningValidation(input: AdvisorRuntimeInput, response: { message: { content: string; tool_calls?: Array<Record<string, unknown>> } }, allowNativeToolCalls = true): AdvisorPlanningValidation | null {
-  const { fallbackPlan, guard } = runtimeGuardPlan(input)
-  let draft = parseAdvisorPlanningDraft(response.message?.content ?? '')
-  if (!draft && allowNativeToolCalls && Array.isArray(response.message?.tool_calls)) {
-    try {
-      draft = planningDraftFromNativeToolCalls(response.message.tool_calls, fallbackPlan)
-    } catch {
-      // Provider-native calls are untrusted. A malformed call must not escape
-      // the planning boundary or reach the Tool executor.
-      return null
-    }
-  }
-  if (!draft) return null
-  try {
-    return validateAdvisorPlanningDraft(draft, guard, input.evidence.scope, input.toolContract?.tools ? [...input.toolContract.tools] : input.tools ? [...input.tools] : [])
-  } catch {
-    return null
-  }
-}
-
-async function executeRequests(input: AdvisorRuntimeInput, requests: readonly AdvisorToolRequestV1[], signal?: AbortSignal): Promise<AdvisorEvidence[]> {
-  const evidence: AdvisorEvidence[] = []
-  for (const request of requests) {
-    throwIfAborted(signal)
-    if (!input.executeTool) throw new AdvisorToolContractError('authority-unavailable', 'Metrora Tools execution is unavailable.')
-    input.onToolEvent?.({ name: request.tool, status: 'queued' })
-    input.onToolEvent?.({ name: request.tool, status: 'started' })
-    try {
-      const result = await raceAdvisorAbort(Promise.resolve().then(() => input.executeTool!(request.tool, request.arguments, signal)), signal)
-    throwIfAborted(signal)
-    if (typeof result.content !== 'string' || result.content.length > 32 * 1024) throw new AdvisorToolContractError('output-too-large', 'Metrora tool content exceeded its safety limit.')
-    // The renderer still validates content-minimal output locally; it is never
-    // replayed as a provider-native tool result.
-    assertStrictBoundedAdvisorToolContent(result.content)
-    evidence.push(result.evidence)
-      input.onToolEvent?.({ name: request.tool, status: result.envelope?.unavailable || result.evidence.coverage.level === 'unavailable' ? 'unavailable' : 'completed' })
-    } catch (error) {
-      input.onToolEvent?.({ name: request.tool, status: signal?.aborted || (error instanceof Error && /cancel|abort/i.test(error.message)) ? 'cancelled' : 'failed' })
-      throw error
-    }
-  }
-  return evidence
-}
-
 export class HostedAdvisorRuntime implements AdvisorModelRuntime {
   readonly id: string
   readonly label: string
@@ -209,226 +156,32 @@ export class HostedAdvisorRuntime implements AdvisorModelRuntime {
   async generate(input: AdvisorRuntimeInput, signal?: AbortSignal): Promise<AdvisorAnswer> {
     if (signal?.aborted) throw new DOMException('Advisor request cancelled', 'AbortError')
     if (!this.consent) throw new Error('Hosted evidence sharing consent is required.')
-    const definitions = toolDefinitions(input)
-    const { fallbackPlan, guard } = runtimeGuardPlan(input)
-    if (guard.authorization !== 'read-only') {
-      return finalizeModelAnswer({ runtime: this, input, evidenceItems: [input.evidence], finalContent: '', modelUsed: false }, signal)
-    }
-    const deadline = createAdvisorTurnDeadline(signal, HARNESS_TOOL_LOOP_LIMITS.turnTimeoutMs)
-    const turnSignal = deadline.signal
-    const finalizationSignal = () => deadline.didTimeout() ? undefined : turnSignal
-    const shouldRethrow = (error: unknown) => shouldRethrowAdvisorAbort(error, signal, deadline)
-    let activeRequestId: string | null = null
-    let conformanceReported = false
-    const reportConformance = () => {
-      if (conformanceReported) return
-      conformanceReported = true
-      input.onConformance?.()
-    }
-    const cancel = () => { if (activeRequestId) void this.transport.cancel(activeRequestId).catch(() => {}) }
-    turnSignal.addEventListener('abort', cancel, { once: true })
-    try {
-      const conversation = async (kind: 'social' | 'boundary', effectiveInput: AdvisorRuntimeInput): Promise<AdvisorAnswer> => {
-        try {
-          activeRequestId = requestId('hosted-conversation')
-          const response = await raceAdvisorAbort(this.transport.chat(activeRequestId, {
+    return runAdvisorRuntimeAgentLoop({
+      runtime: this,
+      model: this.model,
+      input,
+      signal,
+      transport: {
+        wireMode: 'flattened',
+        nativeToolCalls: this.capabilities.toolCall === 'supported',
+        complete: async (request, payload, requestSignal) => {
+          const response = await this.transport.chat(request, {
             provider: this.provider,
             model: this.model,
             ...this.reasoningRequest(),
-            messages: buildAdvisorConversationMessages(effectiveInput, kind),
-            tools: [],
-            stream: false,
-            consent: true,
-          }, turnSignal), turnSignal)
-          activeRequestId = null
-          throwIfAborted(turnSignal)
-          return finalizeAdvisorConversationAnswer(this, effectiveInput, kind, response.message?.content ?? '', true, finalizationSignal())
-        } catch (error) {
-          activeRequestId = null
-          if (shouldRethrow(error)) throw error
-          return finalizeAdvisorConversationAnswer(this, effectiveInput, kind, '', false, finalizationSignal())
-        }
-      }
-
-      const fallback = async (note: string, modelUsed = false): Promise<AdvisorAnswer> => {
-        const deterministic = deterministicPlanningFallback(fallbackPlan, definitions, input.question)
-        let evidenceItems: AdvisorEvidence[] = [...(input.requiredEvidence ?? [])]
-        if (!evidenceItems.length) {
-          try { evidenceItems = await executeRequests(input, deterministic.toolRequests, turnSignal) } catch (error) {
-            if (shouldRethrow(error)) throw error
-          }
-        }
-        if (signal?.aborted) throwIfAborted(signal)
-        return finalizeModelAnswer({ runtime: this, input: { ...input, plan: deterministic.plan, guard }, evidenceItems: evidenceItems.length ? evidenceItems : [input.evidence], finalContent: '', modelUsed, fallbackNote: deadline.didTimeout() ? BOUNDED_TURN_DEADLINE_NOTE : note }, finalizationSignal())
-      }
-
-      const requiredEvidenceItems = [...(input.requiredEvidence ?? [])]
-      const requiredEvidenceReady = evidenceUsable(requiredEvidenceItems)
-      const controllerEvidence = requiredEvidenceReady
-        ? mergeEvidence(requiredEvidenceItems, input.evidence)
-        : input.evidence
-      let firstResponse: { message: { content: string; tool_calls?: Array<Record<string, unknown>> }; streamed: boolean }
-      const allowNativeToolCalls = this.capabilities.toolCall === 'supported'
-      try {
-        activeRequestId = requestId('hosted-chat')
-        firstResponse = await raceAdvisorAbort(this.transport.chat(activeRequestId, {
-          provider: this.provider,
-          model: this.model,
-          ...this.reasoningRequest(),
-          messages: requiredEvidenceReady
-            ? buildAdvisorEvidenceSynthesisMessages({ ...input, evidence: controllerEvidence }, fallbackPlan, guard, controllerEvidence, { nativeToolCalls: allowNativeToolCalls, textPlanningFallback: !allowNativeToolCalls })
-            : buildAdvisorChatMessages(input, fallbackPlan, guard, { nativeToolCalls: allowNativeToolCalls, textPlanningFallback: !allowNativeToolCalls }),
-          tools: allowNativeToolCalls ? definitions : [],
-          stream: false,
-          consent: true,
-          harnessConformance: true,
-        }, turnSignal), turnSignal)
-        activeRequestId = null
-        throwIfAborted(turnSignal)
-      } catch (error) {
-        activeRequestId = null
-        if (shouldRethrow(error)) throw error
-        return fallback('The hosted model response was unavailable; this answer uses the deterministic Metrora evidence path.')
-      }
-
-      if (!isNormalizedHostedResponse(firstResponse)) {
-        return fallback('The hosted model response was malformed; this answer uses the deterministic Metrora evidence path.')
-      }
-      // The provider boundary has already normalized and bounded this first
-      // response. It is the first qualifying Harness request; no extra tool or
-      // synthesis round is required to establish conversational conformance.
-      reportConformance()
-
-      const validation = planningValidation(input, firstResponse, allowNativeToolCalls)
-      let evidenceItems: AdvisorEvidence[] = requiredEvidenceItems
-      if (!validation) {
-        if (Array.isArray(firstResponse.message?.tool_calls) && firstResponse.message.tool_calls.length > 0) return fallback('The model requested a tool outside the bounded Metrora Tools contract.')
-        const content = firstResponse.message?.content ?? ''
-        const structured = /^(?:\{|\[)/u.test(content.trim()) || content.trim().startsWith(String.fromCharCode(96))
-        if (requiredEvidenceReady && content.trim() && (!structured || Boolean(parseAdvisorSynthesisDraft(content)))) {
-          return finalizeModelAnswer({
-            runtime: this,
-            input: { ...input, evidence: controllerEvidence, plan: fallbackPlan, guard },
-            evidenceItems,
-            finalContent: content,
-            modelUsed: true,
-          }, finalizationSignal())
-        }
-        const fallbackIntent = input.fallbackIntent ?? input.evidence.intent
-        const requiresEvidence = fallbackIntent === 'spend-change' || fallbackIntent === 'model-efficiency' || fallbackIntent === 'quota-capacity' || fallbackIntent === 'bench-result'
-        if (requiresEvidence) return fallback('The direct model response did not request a verified Metrora read; canonical evidence is shown instead.')
-        if (!content.trim() || /^(?:\{|\[|```)/u.test(content.trim())) return fallback('The model response was malformed or outside the bounded Metrora Tools contract.')
-        return finalizeAdvisorConversationAnswer(this, input, 'social', content, true, finalizationSignal())
-      }
-      const effectiveInput: AdvisorRuntimeInput = { ...input, plan: validation.plan, guard }
-      if (validation.plan.turnKind === 'social' || validation.plan.turnKind === 'boundary') {
-        return conversation(validation.plan.turnKind, effectiveInput)
-      }
-
-      let currentInput = effectiveInput
-      let currentPlan = validation.plan
-      let currentResponse = firstResponse
-      let toolRound = 0
-      let totalToolCalls = 0
-      const fallbackFromEvidence = (note: string, finalContent = '') => finalizeModelAnswer({
-        runtime: this,
-        input: currentInput,
-        evidenceItems: evidenceItems.length ? evidenceItems : [input.evidence],
-        finalContent,
-        modelUsed: true,
-        fallbackNote: deadline.didTimeout() ? BOUNDED_TURN_DEADLINE_NOTE : note,
-      }, finalizationSignal())
-
-      while (true) {
-        const nextValidation = toolRound === 0 ? validation : planningValidation(currentInput, currentResponse, allowNativeToolCalls)
-        if (!nextValidation) {
-          if (Array.isArray(currentResponse.message?.tool_calls) && currentResponse.message.tool_calls.length > 0) {
-            return fallbackFromEvidence('The model requested a tool outside the bounded Metrora Tools contract; verified facts are shown instead.')
-          }
-          const finalContent = currentResponse.message?.content ?? ''
-          if (toolRound > 0 && finalContent.trim()) {
-            const structured = /^(?:\{|\[)/u.test(finalContent.trim()) || finalContent.trim().startsWith(String.fromCharCode(96))
-            const validDraft = structured && Boolean(parseAdvisorSynthesisDraft(finalContent))
-            return fallbackFromEvidence(structured && !validDraft ? 'The model synthesis was malformed; verified facts are shown instead.' : '', finalContent)
-          }
-          return fallbackFromEvidence('The model continuation was malformed or outside the bounded Metrora Tools contract; verified facts are shown instead.')
-        }
-        currentPlan = nextValidation.plan
-        currentInput = { ...currentInput, plan: currentPlan }
-        const requestedCalls = nextValidation.toolRequests.length
-        if (requestedCalls === 0 || requestedCalls > HARNESS_TOOL_LOOP_LIMITS.maxCallsPerRound || toolRound >= HARNESS_TOOL_LOOP_LIMITS.maxRounds || totalToolCalls + requestedCalls > HARNESS_TOOL_LOOP_LIMITS.maxCallsPerTurn) {
-          return fallbackFromEvidence('The bounded Metrora Tool loop limit was reached; verified facts are shown instead.')
-        }
-        currentInput.onToolRound?.(toolRound + 1)
-        try {
-          const roundEvidence = await executeRequests(currentInput, nextValidation.toolRequests, turnSignal)
-          evidenceItems.push(...roundEvidence)
-        } catch (error) {
-          if (shouldRethrow(error)) throw error
-          return fallbackFromEvidence('The hosted model requested evidence that could not be executed; verified facts are shown instead.')
-        }
-        if (deadline.didTimeout()) return fallbackFromEvidence(BOUNDED_TURN_DEADLINE_NOTE)
-        throwIfAborted(signal)
-        totalToolCalls += requestedCalls
-        toolRound += 1
-        const effectiveEvidenceItems = evidenceItems.length ? evidenceItems : [input.evidence]
-        if (hasMixedEvidenceScopes(effectiveEvidenceItems)) return fallbackFromEvidence('Conflicting tool scopes were rejected; no cross-scope synthesis was attempted.')
-
-        if (deadline.didTimeout()) return fallbackFromEvidence(BOUNDED_TURN_DEADLINE_NOTE)
-        if (toolRound < HARNESS_TOOL_LOOP_LIMITS.maxRounds && totalToolCalls < HARNESS_TOOL_LOOP_LIMITS.maxCallsPerTurn) {
-          activeRequestId = requestId('hosted-tool-continuation')
-          try {
-            currentResponse = await raceAdvisorAbort(this.transport.chat(activeRequestId, {
-              provider: this.provider,
-              model: this.model,
-              ...this.reasoningRequest(),
-              messages: buildAdvisorToolContinuationMessages(currentInput, currentPlan, mergeEvidence(effectiveEvidenceItems, input.evidence), toolRound + 1, { nativeToolCalls: allowNativeToolCalls, textPlanningFallback: !allowNativeToolCalls }),
-              tools: allowNativeToolCalls ? definitions : [],
-              stream: false,
-              consent: true,
-              harnessConformance: true,
-            }, turnSignal), turnSignal)
-            activeRequestId = null
-            throwIfAborted(turnSignal)
-            if (!isNormalizedHostedResponse(currentResponse)) throw new Error('The bounded hosted continuation was malformed.')
-            reportConformance()
-            continue
-          } catch (error) {
-            activeRequestId = null
-            if (shouldRethrow(error)) throw error
-            return fallbackFromEvidence('The bounded hosted evidence continuation was unavailable; verified facts are shown instead.')
-          }
-        }
-
-        if (deadline.didTimeout()) return fallbackFromEvidence(BOUNDED_TURN_DEADLINE_NOTE)
-        activeRequestId = requestId('hosted-synthesis')
-        let synthesisResponse: { message: { content: string; tool_calls?: Array<Record<string, unknown>> }; streamed: boolean }
-        try {
-          const mergedEvidence = mergeEvidence(effectiveEvidenceItems, input.evidence)
-          synthesisResponse = await raceAdvisorAbort(this.transport.chat(activeRequestId, {
-            provider: this.provider,
-            model: this.model,
-            ...this.reasoningRequest(),
-            messages: buildAdvisorSynthesisMessages(currentInput, currentPlan, mergedEvidence),
-            tools: [],
+            messages: payload.messages,
+            tools: payload.tools,
             stream: false,
             consent: true,
             harnessConformance: true,
-          }, turnSignal), turnSignal)
-          activeRequestId = null
-          throwIfAborted(turnSignal)
-          if (!isNormalizedHostedResponse(synthesisResponse)) throw new Error('The bounded hosted synthesis response was malformed.')
-          reportConformance()
-        } catch (error) {
-          activeRequestId = null
-          if (shouldRethrow(error)) throw error
-          return fallbackFromEvidence('The fresh hosted synthesis phase was unavailable; verified Metrora facts are shown instead.')
-        }
-        return fallbackFromEvidence('', synthesisResponse.message?.content ?? '')
-      }
-    } finally {
-      turnSignal.removeEventListener('abort', cancel)
-      deadline.dispose()
-    }
+          }, requestSignal)
+          if (!isNormalizedHostedResponse(response)) throw new Error('The hosted model response was malformed.')
+          return response
+        },
+        cancel: request => this.transport.cancel(request),
+        buildPayload: ({ messages, tools }) => ({ messages, tools: [...tools], stream: false }),
+        reportConformance: true,
+      },
+    })
   }
 }

--- a/app/renderer/advisor/kernel.test.ts
+++ b/app/renderer/advisor/kernel.test.ts
@@ -30,17 +30,13 @@ function capturingRuntime(inputs: AdvisorRuntimeInput[]): AdvisorModelRuntime {
 }
 
 describe('Advisor model planning boundary', () => {
-  it('passes controller-selected canonical evidence before model generation', async () => {
+  it('starts the model with the authorized turn plan and minimum-read contract', async () => {
     const data = source()
     const inputs: AdvisorRuntimeInput[] = []
     await createAdvisorKernel(data, capturingRuntime(inputs)).investigate({ question: 'What changed in spend?', scope })
 
     expect(data.getOverview).toHaveBeenCalledOnce()
-    expect(inputs[0]?.evidence).toMatchObject({
-      intent: 'spend-change',
-      coverage: { level: 'high' },
-      refs: [expect.objectContaining({ id: 'overview.current' })],
-    })
+    expect(inputs[0]?.evidence).toMatchObject({ intent: 'social', refs: [], coverage: { level: 'high' } })
     expect(inputs[0]?.requiredToolRequests).toEqual([{ tool: 'get_spend_snapshot', arguments: {} }])
     expect(inputs[0]?.guard?.intent).toBe('unknown')
     expect(inputs[0]?.plan?.questionFamily).toBe('spend')
@@ -80,10 +76,27 @@ describe('Advisor model planning boundary', () => {
     expect(answer.conclusion).not.toContain('0.96')
   })
 
-  it('executes the mandatory spend read for the Italian over-4k question and grounds the answer', async () => {
+  it('executes the mandatory spend read inside the loop and returns natural same-turn synthesis', async () => {
     const fixture = createAdvisorConformanceFixture()
     const events: Array<{ name: string; status: string }> = []
-    const answer = await createAdvisorKernel(fixture.source, new DeterministicAdvisorRuntime()).investigate({
+    const requests: Array<Record<string, unknown>> = []
+    let calls = 0
+    const runtime = new OllamaAdvisorRuntime({
+      model: 'chat-model',
+      transport: {
+        probe: async () => ({ available: true, models: ['chat-model'], detail: 'ready' }),
+        cancel: async () => true,
+        onDelta: () => () => {},
+        chat: async (_requestId, payload) => {
+          requests.push(payload)
+          calls += 1
+          return calls === 1
+            ? { streamed: false, message: { content: 'I will check the measured spend first.', tool_calls: [] } }
+            : { streamed: false, message: { content: 'Metrora measured $12.00, which is below your $4,000 threshold.' } }
+        },
+      },
+    })
+    const answer = await createAdvisorKernel(fixture.source, runtime).investigate({
       question: 'È vero che ho speso più di 4k in totale di AI? Verifica i dati disponibili e dammi una conclusione.',
       scope: { ...fixture.scope, period: 'lifetime' },
       onToolEvent: event => events.push(event),
@@ -96,9 +109,11 @@ describe('Advisor model planning boundary', () => {
       { name: 'get_spend_snapshot', status: 'started' },
       { name: 'get_spend_snapshot', status: 'completed' },
     ])
+    expect(requests).toHaveLength(2)
     expect(answer.evidence).toEqual(expect.arrayContaining([expect.objectContaining({ id: 'overview.current' })]))
     expect(answer.coverage.level).toBe('high')
-    expect(answer.conclusion).toMatch(/12[.,]00/u)
+    expect(answer.conclusion).toContain('below your $4,000 threshold')
+    expect(answer.generatedByModel).toBe(true)
     expect(answer.conclusion).not.toMatch(/Buongiorno|Hello\. I can help you understand spend/i)
   })
 

--- a/app/renderer/advisor/kernel.ts
+++ b/app/renderer/advisor/kernel.ts
@@ -1,51 +1,103 @@
 import { buildUnknownEvidence } from './evidence'
 import { buildActionProposalEvidence, buildBenchEvidence, buildClarificationEvidence, buildConversationEvidence, buildSocialEvidence, buildUnsupportedEvidence } from './special-evidence'
 import { createAdvisorModelGuardV1, resolveAdvisorQuestion } from './comprehension'
-import { explicitAdvisorModelHint, explicitAdvisorPeriodHints } from './planner'
+import { deterministicPlanningFallback, explicitAdvisorPeriodHints } from './planner'
 import { createAdvisorToolRegistry, type AdvisorOverviewSnapshot } from './tools'
 import { DeterministicAdvisorRuntime } from './runtime'
-import { advisorQuestionRequiresCanonicalReads, executeRequiredAdvisorReads, advisorToolRequestKey } from './required-reads'
+import { advisorQuestionRequiresCanonicalReads, requiredAdvisorToolRequests } from './required-reads'
 import { mergeEvidence } from './merge-evidence'
-import { isAdvisorNaturalNarrativeSupportedAcrossEvidence } from './synthesis'
 import type { MenubarPayload } from '../lib/types'
-import type { AdvisorAnswer, AdvisorBenchEvidence, AdvisorConversationTurn, AdvisorDataSource, AdvisorEvidence, AdvisorIntent, AdvisorModelRuntime, AdvisorPeriodFilter, AdvisorScope, AdvisorUiContextV1, AdvisorToolEvent, AdvisorToolExecution } from './types'
+import type { AdvisorAnswer, AdvisorBenchEvidence, AdvisorConversationTurn, AdvisorDataSource, AdvisorEvidence, AdvisorIntent, AdvisorModelRuntime, AdvisorPeriodFilter, AdvisorRuntimeInput, AdvisorScope, AdvisorUiContextV1, AdvisorToolEvent, AdvisorToolExecution } from './types'
 
 export class AdvisorCancelledError extends Error {
   constructor() { super('Advisor investigation cancelled'); this.name = 'AdvisorCancelledError' }
 }
+
 function throwIfAborted(signal?: AbortSignal): void {
   if (signal?.aborted) throw new AdvisorCancelledError()
 }
+
 function rethrowCancellation(error: unknown, signal?: AbortSignal): void {
   if (signal?.aborted || (error instanceof Error && (error.name === 'AbortError' || /cancel|abort/i.test(error.message)))) throw error
 }
+
 export type AdvisorKernel = {
-  investigate(input: { question: string; scope: AdvisorScope; overview?: AdvisorOverviewSnapshot | MenubarPayload | null; conversation?: AdvisorConversationTurn[]; uiContext?: AdvisorUiContextV1; signal?: AbortSignal; onConformance?: () => void; onToolEvent?: (event: AdvisorToolEvent) => void; onDelta?: (text: string) => void }): Promise<AdvisorAnswer>
+  investigate(input: { question: string; scope: AdvisorScope; overview?: AdvisorOverviewSnapshot | MenubarPayload | null; conversation?: AdvisorConversationTurn[]; uiContext?: AdvisorUiContextV1; signal?: AbortSignal; onConformance?: () => void; onToolEvent?: (event: AdvisorToolEvent) => void; onAgentEvent?: AdvisorRuntimeInput['onAgentEvent']; onDelta?: (text: string) => void }): Promise<AdvisorAnswer>
 }
+
 const unavailableBench: AdvisorBenchEvidence = { state: 'UNAVAILABLE', runs: [], latest: null, comparison: null }
 
-async function deterministicEvidenceForIntent(source: AdvisorDataSource, intent: AdvisorIntent, question: string, scope: AdvisorScope, suppliedOverview: AdvisorOverviewSnapshot | MenubarPayload | null, signal?: AbortSignal, allowedPeriods: readonly AdvisorPeriodFilter[] = []): Promise<AdvisorEvidence> {
-  if (intent === 'social') return buildSocialEvidence(question, scope)
-  if (intent === 'action-proposal') return buildActionProposalEvidence(question, scope, 'Harness is proposal-only for this conversation; execution requires a separately authorized action surface.')
-  if (intent === 'clarification') return buildClarificationEvidence(question, scope, 'Choose the intended evidence source before reading canonical data.')
-  if (intent === 'unsupported') return buildUnsupportedEvidence(question, scope, 'This request is outside the canonical Metrora evidence contract.')
-  if (intent === 'unknown') return buildUnknownEvidence(question, scope)
+async function deterministicEvidenceItemsForIntent(source: AdvisorDataSource, intent: AdvisorIntent, question: string, scope: AdvisorScope, suppliedOverview: AdvisorOverviewSnapshot | MenubarPayload | null, signal?: AbortSignal, allowedPeriods: readonly AdvisorPeriodFilter[] = []): Promise<AdvisorEvidence[]> {
+  if (intent === 'social') return [buildSocialEvidence(question, scope)]
+  if (intent === 'action-proposal') return [buildActionProposalEvidence(question, scope, 'Harness is proposal-only for this conversation; execution requires a separately authorized action surface.')]
+  if (intent === 'clarification') return [buildClarificationEvidence(question, scope, 'Choose the intended evidence source before reading canonical data.')]
+  if (intent === 'unsupported') return [buildUnsupportedEvidence(question, scope, 'This request is outside the canonical Metrora evidence contract.')]
+  if (intent === 'unknown') return [buildUnknownEvidence(question, scope)]
   if (intent === 'bench-result') {
     let bench = unavailableBench
     if (source.getBenchEvidence) {
       try { bench = await source.getBenchEvidence(scope, signal) } catch (error) { rethrowCancellation(error, signal) }
     }
     throwIfAborted(signal)
-    return buildBenchEvidence(question, scope, bench)
+    return [buildBenchEvidence(question, scope, bench)]
   }
   if (intent === 'spend-change' || intent === 'model-efficiency' || intent === 'quota-capacity') {
-    const tool = intent === 'spend-change' ? 'get_spend_snapshot' : intent === 'model-efficiency' ? 'get_model_efficiency' : 'get_quota_snapshot'
     const registry = createAdvisorToolRegistry(source, scope, suppliedOverview, { allowedPeriods })
-    const model = explicitAdvisorModelHint(question)
-    const result = await registry.execute(tool, model && (intent === 'spend-change' || intent === 'model-efficiency') ? { model } : {}, signal)
-    return result.evidence as unknown as AdvisorEvidence
+    const plan = resolveAdvisorQuestion(question, scope)
+    const requests = explicitAdvisorPeriodHints(question).length > 1
+      ? deterministicPlanningFallback(plan.plan, registry.definitions, question).toolRequests
+      : requiredAdvisorToolRequests(plan, registry.definitions, question)
+    const evidenceItems: AdvisorEvidence[] = []
+    for (const request of requests) {
+      const result = await registry.execute(request.tool, request.arguments, signal)
+      const unavailable = result.envelope?.unavailable === true || result.evidence.coverage.level === 'unavailable'
+      evidenceItems.push(unavailable ? { ...result.evidence, refs: [] } : result.evidence)
+    }
+    return evidenceItems
   }
-  return buildUnknownEvidence(question, scope)
+  return [buildUnknownEvidence(question, scope)]
+}
+
+async function deterministicAnswerForIntent(options: {
+  source: AdvisorDataSource
+  intent: AdvisorIntent
+  question: string
+  scope: AdvisorScope
+  suppliedOverview: AdvisorOverviewSnapshot | MenubarPayload | null
+  conversation: AdvisorConversationTurn[]
+  uiContext?: AdvisorUiContextV1
+  plan: ReturnType<typeof resolveAdvisorQuestion>
+  signal?: AbortSignal
+  allowedPeriods: readonly AdvisorPeriodFilter[]
+}): Promise<AdvisorAnswer> {
+  const items = (await deterministicEvidenceItemsForIntent(options.source, options.intent, options.question, options.scope, options.suppliedOverview, options.signal, options.allowedPeriods)).map(item => attachPlan(item, options.plan))
+  const runtime = new DeterministicAdvisorRuntime()
+  const answers = await Promise.all(items.map(evidence => runtime.generate({
+    question: options.question,
+    evidence,
+    conversation: options.conversation,
+    uiContext: options.uiContext,
+    plan: options.plan.plan,
+    fallbackIntent: options.intent,
+    guard: options.plan.guard,
+    allowedPeriods: options.allowedPeriods,
+  }, options.signal)))
+  if (answers.length <= 1) return answers[0]!
+  const authoritative = mergeEvidence(items, items[0]!)
+  const unique = (values: readonly (string | undefined)[]) => Array.from(new Set(values.filter((value): value is string => Boolean(value))))
+  return {
+    ...answers[0],
+    conclusion: unique(answers.map(answer => answer.conclusion)).join(' '),
+    why: unique(answers.flatMap(answer => answer.why)),
+    details: unique(answers.flatMap(answer => answer.details)),
+    evidence: authoritative.refs,
+    coverage: authoritative.coverage,
+    assumptions: authoritative.assumptions,
+    unknown: authoritative.unknown,
+    nextInvestigations: authoritative.nextInvestigations,
+    understanding: authoritative.understanding,
+    plan: authoritative.plan,
+  }
 }
 
 function attachPlan(evidence: AdvisorEvidence, plan: ReturnType<typeof resolveAdvisorQuestion>): AdvisorEvidence {
@@ -59,57 +111,27 @@ function attachPlan(evidence: AdvisorEvidence, plan: ReturnType<typeof resolveAd
   }
 }
 
-function evidenceRequired(plan: ReturnType<typeof resolveAdvisorQuestion>): boolean {
-  return advisorQuestionRequiresCanonicalReads(plan)
-}
-
-function hasCanonicalAnswerReference(answer: AdvisorAnswer, evidence: AdvisorEvidence, evidenceItems: readonly AdvisorEvidence[] = [evidence]): boolean {
-  const canonicalIds = new Set(evidenceItems.flatMap(item => item.refs.map(ref => ref.id)))
-  if (!answer.evidence.some(ref => canonicalIds.has(ref.id))) return false
-  return isAdvisorNaturalNarrativeSupportedAcrossEvidence(answer.conclusion, evidenceItems)
-}
-
-async function normalizeFactualModelAnswer(
-  answer: AdvisorAnswer,
-  evidence: AdvisorEvidence,
-  question: string,
-  plan: ReturnType<typeof resolveAdvisorQuestion>,
-  conversation: AdvisorConversationTurn[],
-  uiContext: AdvisorUiContextV1 | undefined,
-  evidenceItems: readonly AdvisorEvidence[],
-  signal: AbortSignal | undefined,
-): Promise<AdvisorAnswer> {
+function attachAuthoritativeEvidence(answer: AdvisorAnswer, evidence: AdvisorEvidence, plan: ReturnType<typeof resolveAdvisorQuestion>): AdvisorAnswer {
   const authoritative = attachPlan(evidence, plan)
-  if (hasCanonicalAnswerReference(answer, authoritative, evidenceItems)) {
-    return {
-      ...answer,
-      evidence: authoritative.refs,
-      coverage: authoritative.coverage,
-      assumptions: authoritative.assumptions,
-      unknown: authoritative.unknown,
-      nextInvestigations: authoritative.nextInvestigations,
-      understanding: authoritative.understanding,
-      plan: authoritative.plan,
-    }
-  }
-  const fallback = await new DeterministicAdvisorRuntime().generate({
-    question,
-    evidence: authoritative,
-    conversation,
-    uiContext,
-    plan: plan.plan,
-    fallbackIntent: plan.intent,
-    guard: plan.guard,
-  }, signal)
   return {
-    ...fallback,
-    materialLimits: [...(fallback.materialLimits ?? []), 'The model response was not grounded in the required canonical Metrora evidence.'],
+    ...answer,
+    evidence: authoritative.refs,
+    coverage: authoritative.coverage,
+    assumptions: authoritative.assumptions,
+    unknown: authoritative.unknown,
+    nextInvestigations: authoritative.nextInvestigations,
+    understanding: authoritative.understanding,
+    plan: authoritative.plan,
   }
+}
+
+function hasUsableEvidence(items: readonly AdvisorEvidence[]): boolean {
+  return items.some(item => item.coverage.level !== 'unavailable' && item.refs.length > 0)
 }
 
 export function createAdvisorKernel(source: AdvisorDataSource, runtime: AdvisorModelRuntime): AdvisorKernel {
   return {
-    async investigate({ question, scope, overview: suppliedOverview = null, conversation = [], uiContext, signal, onConformance, onToolEvent, onDelta }) {
+    async investigate({ question, scope, overview: suppliedOverview = null, conversation = [], uiContext, signal, onConformance, onToolEvent, onAgentEvent, onDelta }) {
       throwIfAborted(signal)
       const plan = resolveAdvisorQuestion(question, scope, conversation)
       if (plan.plan.scopeConflict) {
@@ -132,37 +154,16 @@ export function createAdvisorKernel(source: AdvisorDataSource, runtime: AdvisorM
         ? buildActionProposalEvidence(question, scope, plan.understanding.boundary ?? 'Harness is proposal-only for this conversation.')
         : buildConversationEvidence(question, scope)
       const toolRegistry = createAdvisorToolRegistry(source, scope, suppliedOverview, { allowedPeriods })
-      const requiredReads = advisorQuestionRequiresCanonicalReads(plan)
-        ? await executeRequiredAdvisorReads({
-            source,
-            scope,
-            question,
-            plan,
-            suppliedOverview,
-            registry: toolRegistry,
-            definitions: toolRegistry.definitions,
-            onToolEvent,
-            signal,
-          })
-        : null
-      const canonicalEvidence = requiredReads?.evidence.length
-        ? mergeEvidence([...requiredReads.evidence], requiredReads.evidence[0]!)
-        : null
-      const modelInputEvidence = attachPlan(canonicalEvidence ?? modelEvidence, plan)
       if (!modelReady) {
-        const evidence = canonicalEvidence ?? await deterministicEvidenceForIntent(source, plan.intent, question, scope, suppliedOverview, signal, allowedPeriods)
-        const inputEvidence = attachPlan(evidence, plan)
-        return new DeterministicAdvisorRuntime().generate({ question, evidence: inputEvidence, conversation, uiContext, plan: plan.plan, fallbackIntent: plan.intent, guard: plan.guard, allowedPeriods }, signal)
+        return deterministicAnswerForIntent({ source, intent: plan.intent, question, scope, suppliedOverview, conversation, uiContext, plan, signal, allowedPeriods })
       }
       const modelGuard = createAdvisorModelGuardV1(plan)
-      const baselineExecutions = new Map<string, AdvisorToolExecution>()
-      for (const read of requiredReads?.reads ?? []) {
-        if (read.execution) baselineExecutions.set(advisorToolRequestKey(read.request), read.execution)
-      }
-      const modelEvidenceItems: AdvisorEvidence[] = [...(requiredReads?.evidence ?? [])]
+      const requiredToolRequests = advisorQuestionRequiresCanonicalReads(plan)
+        ? requiredAdvisorToolRequests(plan, toolRegistry.definitions, question)
+        : []
+      const modelTools = advisorQuestionRequiresCanonicalReads(plan) ? toolRegistry : null
+      const modelEvidenceItems: AdvisorEvidence[] = []
       const executeTool = async (name: string, args: Record<string, unknown>, toolSignal?: AbortSignal): Promise<AdvisorToolExecution> => {
-        const cached = baselineExecutions.get(name + '\u0000' + JSON.stringify(args))
-        if (cached) return cached
         const execution = await toolRegistry.execute(name, args, toolSignal ?? signal)
         const unavailable = execution.envelope?.unavailable === true || execution.evidence.coverage.level === 'unavailable'
         const evidence = unavailable ? { ...execution.evidence, refs: [] } : execution.evidence
@@ -170,36 +171,42 @@ export function createAdvisorKernel(source: AdvisorDataSource, runtime: AdvisorM
         return unavailable ? { ...execution, evidence } : execution
       }
       try {
-        const answer = await runtime.generate({
+      const answer = await runtime.generate({
           question,
-          evidence: modelInputEvidence,
-          requiredEvidence: requiredReads?.evidence,
-          requiredToolRequests: requiredReads?.requests,
+          evidence: attachPlan(modelEvidence, plan),
+          requiredToolRequests,
           conversation,
           uiContext,
           plan: plan.plan,
           fallbackIntent: plan.intent,
           guard: modelGuard,
           allowedPeriods,
-          tools: toolRegistry.definitions,
-          toolContract: toolRegistry.contract,
+          tools: modelTools?.definitions,
+          toolContract: modelTools?.contract,
           executeTool,
           onConformance,
           onToolEvent,
+          onAgentEvent,
           onDelta,
         }, signal)
-        if (!evidenceRequired(plan)) return answer
-        const authoritative = modelEvidenceItems.length
-          ? mergeEvidence(modelEvidenceItems, modelEvidenceItems[0]!)
-          : canonicalEvidence ?? modelInputEvidence
-        return normalizeFactualModelAnswer(answer, authoritative, question, plan, conversation, uiContext, modelEvidenceItems, signal)
+        if (!advisorQuestionRequiresCanonicalReads(plan)) return answer
+        if (!hasUsableEvidence(modelEvidenceItems)) {
+          const fallback = await deterministicAnswerForIntent({ source, intent: plan.intent, question, scope, suppliedOverview, conversation, uiContext, plan, signal, allowedPeriods })
+          return {
+            ...fallback,
+            materialLimits: [...(fallback.materialLimits ?? []), 'The model did not obtain usable canonical evidence, so the verified Metrora result is shown.'],
+          }
+        }
+        const authoritative = mergeEvidence(modelEvidenceItems, modelEvidenceItems[0]!)
+        return attachAuthoritativeEvidence(answer, authoritative, plan)
       } catch (error) {
         rethrowCancellation(error, signal)
         const fallbackBase = plan.intent === 'action-proposal'
           ? buildActionProposalEvidence(question, scope, plan.understanding.boundary ?? 'Harness is proposal-only for this conversation.')
-          : canonicalEvidence ?? await deterministicEvidenceForIntent(source, plan.intent, question, scope, suppliedOverview, signal, allowedPeriods)
-        const fallbackEvidence = attachPlan(fallbackBase, plan)
-        const fallback = await new DeterministicAdvisorRuntime().generate({ question, evidence: fallbackEvidence, conversation, uiContext, plan: plan.plan, fallbackIntent: plan.intent, guard: plan.guard, allowedPeriods }, signal)
+          : null
+        const fallback = fallbackBase
+          ? await new DeterministicAdvisorRuntime().generate({ question, evidence: attachPlan(fallbackBase, plan), conversation, uiContext, plan: plan.plan, fallbackIntent: plan.intent, guard: plan.guard, allowedPeriods }, signal)
+          : await deterministicAnswerForIntent({ source, intent: plan.intent, question, scope, suppliedOverview, conversation, uiContext, plan, signal, allowedPeriods })
         return {
           ...fallback,
           materialLimits: [...(fallback.materialLimits ?? []), 'The explanatory model was unavailable, so this answer uses Metrora deterministic evidence.'],

--- a/app/renderer/advisor/limits.test.ts
+++ b/app/renderer/advisor/limits.test.ts
@@ -5,7 +5,7 @@ import { HARNESS_MAX_TOOL_REQUESTS } from './planner'
 
 describe('Harness tool loop limits', () => {
   it('keeps model/tool orchestration bounded', () => {
-    expect(HARNESS_TOOL_LOOP_LIMITS).toEqual({ maxRounds: 2, maxCallsPerTurn: 4, maxCallsPerRound: 4, turnTimeoutMs: 120_000 })
+    expect(HARNESS_TOOL_LOOP_LIMITS).toEqual({ maxSteps: 3, maxRounds: 2, maxCallsPerTurn: 4, maxCallsPerRound: 4, maxParallelToolCalls: 1, turnTimeoutMs: 120_000 })
     expect(HARNESS_MAX_TOOL_REQUESTS).toBe(4)
   })
 })

--- a/app/renderer/advisor/limits.ts
+++ b/app/renderer/advisor/limits.ts
@@ -1,12 +1,10 @@
-/**
- * Harness runtime safety bounds. A turn has at most one planning/read round
- * followed by one synthesis/conversation round. Tool calls remain strictly
- * read-only and bounded even when a model returns a large native call list.
- */
+/** One authoritative set of bounds shared by Chat and delegated Agents. */
 export const HARNESS_TOOL_LOOP_LIMITS = Object.freeze({
+  maxSteps: 3,
   maxRounds: 2,
   maxCallsPerTurn: 4,
   maxCallsPerRound: 4,
+  maxParallelToolCalls: 1,
   /** One foreground Chat turn cannot outlive this deadline, including reads and synthesis. */
   turnTimeoutMs: 120_000,
 })

--- a/app/renderer/advisor/llama-server.ts
+++ b/app/renderer/advisor/llama-server.ts
@@ -73,6 +73,8 @@ export class LlamaServerAdvisorRuntime extends LocalAdvisorRuntime {
       transport: options.transport ?? bridgeTransport(port),
       availability: options.availability,
       unavailableMessage: 'Local llama-server model is not available.',
+      wireMode: 'openai',
+      nativeToolCalls: true,
     })
   }
 }

--- a/app/renderer/advisor/lmstudio.ts
+++ b/app/renderer/advisor/lmstudio.ts
@@ -58,6 +58,8 @@ export class LMStudioAdvisorRuntime extends LocalAdvisorRuntime {
       transport: options.transport ?? bridgeTransport,
       availability: options.availability,
       unavailableMessage: 'Local LM Studio model is not available.',
+      wireMode: 'openai',
+      nativeToolCalls: true,
     })
   }
 }

--- a/app/renderer/advisor/model-flow.ts
+++ b/app/renderer/advisor/model-flow.ts
@@ -1,10 +1,11 @@
 import { advisorScopeFingerprint, type AdvisorAnswer, type AdvisorEvidence, type AdvisorGuardPlanV1, type AdvisorModelRuntime, type AdvisorRuntimeInput, type AdvisorScope, type AdvisorSwarmSynthesisInput, type AdvisorTurnPlanV1 } from './types'
-import { contentMinimalEvidence, contentMinimalScope, sanitizeAdvisorAnswer, sanitizeAdvisorDisplayText, sanitizeAdvisorGroundedNarrative, sanitizeAdvisorModelOutput } from './privacy'
+import { contentMinimalEvidence, contentMinimalScope, sanitizeAdvisorAnswer, sanitizeAdvisorDisplayText, sanitizeAdvisorModelOutput } from './privacy'
 import { buildAdvisorPresentationBlocks } from './presentation'
-import { isAdvisorNaturalNarrativeSupported, parseAdvisorSynthesisDraft, verifyAdvisorSynthesis } from './synthesis'
+import { parseAdvisorSynthesisDraft, verifyAdvisorSynthesis } from './synthesis'
 import { hasMixedEvidenceScopes, mergeEvidence, sameEvidenceScope } from './merge-evidence'
 import { DeterministicAdvisorRuntime } from './runtime'
 import { contentMinimalVerifiedClaimAtoms, renderAdvisorVerifiedSynthesis } from './claim-atoms'
+import { classifyMetroraProvenance } from '../agent-loop/provenance'
 
 type ModelMessage = { role: 'system' | 'user' | 'assistant'; content: string }
 export type AdvisorConversationKind = 'social' | 'boundary' | 'action'
@@ -100,7 +101,7 @@ export function buildAdvisorChatMessages(input: AdvisorRuntimeInput, fallbackPla
         'Tool requests may contain only fixed Metrora read-only tools and bounded filters. Never request or execute actions, writes, web search, shell commands, files, repository changes, agent orchestration, or arbitrary endpoints.',
         'An operational request may be understood and described as a proposal, but it must never be executed or represented as completed from conversation text.',
         planningInstruction(options),
-        'When a read tool has returned, the application will perform a fresh evidence-bound synthesis. Do not treat conversation history or surrounding application context as factual evidence; use them only for referents and scope.',
+        'When a read tool returns, its bounded result is appended to the same turn ledger. Continue naturally: request another supplied read only when needed, otherwise answer from the verified result and clearly label interpretation or recommendation.',
         'Stay within the selected Metrora context and use only the supplied read tools. Do not broaden the period, provider, Project, or model context.',
         ...(workerInstruction(input) ? [workerInstruction(input)!] : []),
         'Selected context: ' + modelScope(input),
@@ -134,9 +135,9 @@ export function buildAdvisorEvidenceSynthesisMessages(
       role: 'system',
       content: [
         'You are answering a bounded Metrora Harness factual turn.',
-        'The controller has already performed the mandatory canonical read. The canonical evidence below is authoritative and is available in this same turn.',
+        'The controller has already supplied a canonical result in this same turn. It is authoritative, and the model remains responsible for the natural explanation.',
         'Answer the original question now in natural language and interpret the verified facts, rather than merely repeating that a read occurred.',
-        'If one additional supplied read-only Metrora Tool is genuinely needed to answer the question, request it directly using the bounded Tool contract; do not request the mandatory read again.',
+        'If one additional supplied read-only Metrora Tool is genuinely needed, request it directly using the bounded Tool contract; do not discard the current turn and do not request unrelated data.',
         'A follow-up read must remain within the selected scope and the supplied fixed read-only tools. Never request writes, web search, shell commands, files, or arbitrary endpoints.',
         'Do not invent numbers, subjects, rankings, causality, or quality claims. Keep any interpretation grounded in the canonical evidence.',
         ...(workerInstruction(input) ? [workerInstruction(input)!] : []),
@@ -159,7 +160,7 @@ export function buildAdvisorToolContinuationMessages(input: AdvisorRuntimeInput,
         'You are continuing a bounded Metrora Harness evidence turn.',
         'Inspect the canonical evidence below before deciding whether one more fixed read-only Metrora Tool is needed.',
         planningInstruction(options),
-        'If the evidence is sufficient, return a short natural-language interpretation or recommendation grounded only in it, without inventing facts. The application will render verified facts separately.',
+        'If the evidence is sufficient, return a short natural-language answer, interpretation, or recommendation grounded only in it, without inventing facts.',
         round === 1 ? 'This is the last opportunity for one additional bounded read.' : 'No additional read should be requested.',
         ...(workerInstruction(input) ? [workerInstruction(input)!] : []),
         'Selected context: ' + modelScopeForEvidence(evidence),
@@ -328,21 +329,27 @@ export async function finalizeModelAnswer(options: FinalizeModelAnswerOptions, s
     ...(draft ? ['The model atom selection did not pass Metrora semantic verification; verified facts are shown instead.'] : []),
   ]
   const naturalCandidate = !draft && finalContent.trim() && !/^(?:\{|\[|```)/u.test(finalContent.trim())
-  const naturalSupported = Boolean(naturalCandidate && isAdvisorNaturalNarrativeSupported(finalContent, evidence))
-  if (naturalCandidate && !naturalSupported) notes.push('The model interpretation was not grounded in canonical evidence; deterministic verified facts are shown instead.')
-  const naturalInterpretation = naturalSupported
-    ? sanitizeAdvisorGroundedNarrative(finalContent)
-    : ''
+  const naturalResult = naturalCandidate && sameScope && !hasMixedEvidenceScopes(evidenceItems)
+    ? classifyMetroraProvenance(finalContent, input.question, evidenceItems)
+    : null
+  if (naturalCandidate && !naturalResult?.accepted) notes.push('The model answer did not contain a safe supported explanation; verified facts are shown instead.')
+  if (naturalResult?.removedClauses) notes.push('Some model claims were omitted because they were not supported by verified Metrora evidence.')
+  const naturalInterpretation = naturalResult?.accepted ? naturalResult.text : ''
+  const naturalIncludesCanonicalFact = Boolean(naturalResult?.usedCanonicalFact || naturalResult?.usedDerivation)
+  const naturalConclusion = naturalIncludesCanonicalFact
+    ? naturalInterpretation
+    : [verifiedConclusion, naturalInterpretation].filter(Boolean).join(' ')
   return sanitizeAdvisorAnswer({
     ...fallback,
-    // Deterministic facts remain first-class. A bounded natural continuation
-    // may add interpretation, but cannot replace or author factual clauses.
-    conclusion: [verifiedConclusion, naturalInterpretation].filter(Boolean).join(' '),
+    // Canonical facts remain authoritative while the model supplies the
+    // bounded prose that explains them. Unsupported clauses are removed at
+    // sentence granularity instead of invalidating the whole response.
+    conclusion: naturalConclusion || verifiedConclusion,
     details,
     materialLimits: notes,
     presentation: plan ? buildAdvisorPresentationBlocks(evidence, plan, input.question, null, fallback.claims ?? []) : undefined,
     runtime: { id: runtime.id, label: runtime.label, mode: runtime.mode },
-    generatedByModel: modelUsed,
+    generatedByModel: modelUsed && Boolean(naturalInterpretation),
     streamed: false,
   })
 }

--- a/app/renderer/advisor/ollama.test.ts
+++ b/app/renderer/advisor/ollama.test.ts
@@ -157,10 +157,10 @@ describe('Ollama Advisor renderer state machine', () => {
     expect(deltas).toEqual([])
   })
 
-  it('keeps model identifiers while rejecting an unverified numeric model claim', async () => {
+  it('keeps verified model identifiers while rejecting an unverified numeric model claim', async () => {
     const transport = transportFor([], [[]])
     const answer = await new OllamaAdvisorRuntime({ model: 'llama3.2', transport }).generate({
-      question: 'Which model should I inspect?',
+      question: 'Which model was observed in spend?',
       evidence: spendEvidence,
       tools: [],
       onDelta: () => {},
@@ -169,7 +169,7 @@ describe('Ollama Advisor renderer state machine', () => {
   })
 
   it.each(['Spend rose by 12.', 'The scope contains 12 calls.'])(
-    'suppresses the entire model narrative when it contains an unverified numeric token: %s',
+    'removes an unsupported model clause without leaking it: %s',
     async narrative => {
       const transport = transportFor([], [[{ function: { name: 'get_spend_snapshot', arguments: '{}' } }]], narrative, narrative)
       const answer = await new OllamaAdvisorRuntime({ model: 'llama3.2', transport }).generate({
@@ -180,15 +180,16 @@ describe('Ollama Advisor renderer state machine', () => {
       })
       expect(answer.conclusion).not.toContain('Local model context')
       expect(answer.conclusion).not.toContain(narrative)
+      expect(answer.conclusion).toContain('Metrora measured')
     },
   )
 
-  it('suppresses qualitative no-tool context even when recognized evidence was prefetched', async () => {
+  it('allows grounded qualitative interpretation when recognized evidence is available', async () => {
     const narrative = 'The observed pattern deserves a closer look.'
     const answer = await new OllamaAdvisorRuntime({ model: 'llama3.2', transport: noToolTransport(narrative) }).generate({
       question: 'What changed in spend?', evidence: spendEvidence, tools: [],
     })
-    expect(answer.conclusion).not.toContain(narrative)
+    expect(answer.conclusion).toContain(narrative)
     expect(answer.conclusion).not.toContain('Local model context')
   })
 
@@ -235,6 +236,32 @@ describe('Ollama Advisor renderer state machine', () => {
     expect(answer.conclusion).not.toContain('Local model context')
   })
 
+  it('streams ordinary local conversation through the shared loop but not factual turns', async () => {
+    const deltas: string[] = []
+    let listener: ((event: { requestId: string; text: string }) => void) | null = null
+    const transport: OllamaTransport = {
+      probe: async () => ({ available: true, models: ['llama3.2'], detail: 'ready' }),
+      cancel: async () => true,
+      onDelta: callback => {
+        listener = callback
+        return () => { listener = null }
+      },
+      chat: async (requestId, payload) => {
+        expect(payload.stream).toBe(true)
+        expect(payload.tools).toEqual([])
+        listener?.({ requestId, text: 'Certo, ' })
+        listener?.({ requestId, text: 'ecco una battuta.' })
+        return { streamed: true, message: { content: 'Certo, ecco una battuta.' } }
+      },
+    }
+    const answer = await new OllamaAdvisorRuntime({ model: 'llama3.2', transport }).generate({
+      question: 'Tell me a joke', evidence: { ...spendEvidence, intent: 'unknown', refs: [], coverage: { level: 'unavailable', label: 'Unavailable', detail: 'No mapped evidence.' } }, tools: [], onDelta: text => deltas.push(text),
+    })
+    expect(deltas).toEqual(['Certo, ', 'ecco una battuta.'])
+    expect(answer.streamed).toBe(true)
+    expect(answer.conclusion).toBe('Certo, ecco una battuta.')
+  })
+
   it.each([
     ['claude', 'codex'],
     ['codex', 'claude'],
@@ -265,7 +292,7 @@ describe('Ollama Advisor renderer state machine', () => {
     expect(answer.scopeLabel).toContain('All providers')
     expect(answer.conclusion).not.toMatch(/41|73|claude spend|codex spend/i)
     expect(answer.details.join(' ')).not.toMatch(/41|73|claude spend|codex spend/i)
-    expect(finalRequests).toEqual([])
+    expect(finalRequests.length).toBeGreaterThan(0)
   })
 
   it('buffers split sensitive streaming content and emits no raw or post-hoc narrative', async () => {

--- a/app/renderer/advisor/ollama.ts
+++ b/app/renderer/advisor/ollama.ts
@@ -1,17 +1,10 @@
 import { metrora } from '../lib/ipc'
-import { AdvisorToolContractError, assertStrictBoundedAdvisorToolContent } from './contract'
-import { buildAdvisorChatMessages, buildAdvisorConversationMessages, buildAdvisorEvidenceSynthesisMessages, buildAdvisorSwarmSynthesisMessages, buildAdvisorToolContinuationMessages, finalizeAdvisorConversationAnswer, finalizeModelAnswer, buildAdvisorSynthesisMessages, evidenceUsable } from './model-flow'
-import { deterministicPlanningFallback, parseAdvisorPlanningDraft, planningDraftFromNativeToolCalls, runtimeGuardPlan, validateAdvisorPlanningDraft, type AdvisorPlanningValidation } from './planner'
-import { hasMixedEvidenceScopes, mergeEvidence, sameEvidenceScope } from './merge-evidence'
-import { ADVISOR_MODEL_NARRATIVE_MAX_BYTES } from './privacy'
-import { HARNESS_TOOL_LOOP_LIMITS } from './limits'
-import { parseAdvisorSynthesisDraft } from './synthesis'
-import { createAdvisorTurnDeadline, raceAdvisorAbort, shouldRethrowAdvisorAbort } from './abort'
-import type { AdvisorAnswer, AdvisorEvidence, AdvisorModelRuntime, AdvisorReasoningEffort, AdvisorRuntimeInput, AdvisorSwarmSynthesisInput, AdvisorSwarmSynthesisResult, AdvisorToolDefinition, AdvisorToolRequestV1 } from './types'
+import { buildAdvisorSwarmSynthesisMessages } from './model-flow'
+import { raceAdvisorAbort } from './abort'
+import { runAdvisorRuntimeAgentLoop, type AdvisorAgentWireMode } from '../agent-loop/advisor-runtime'
+import type { AdvisorAnswer, AdvisorModelRuntime, AdvisorReasoningEffort, AdvisorRuntimeInput, AdvisorSwarmSynthesisInput, AdvisorSwarmSynthesisResult } from './types'
 
 export { hasMixedEvidenceScopes, mergeEvidence, sameEvidenceScope } from './merge-evidence'
-
-const BOUNDED_TURN_DEADLINE_NOTE = 'The bounded Metrora turn deadline was reached; verified facts are shown instead.'
 
 export type LocalToolCall = { function?: { name?: string; arguments?: unknown }; name?: string; arguments?: unknown }
 export type LocalChatMessage = { role: 'system' | 'user' | 'assistant'; content: string }
@@ -48,12 +41,8 @@ export async function probeOllama(signal?: AbortSignal, transport: OllamaTranspo
   }
 }
 
-function byteLength(value: string): number {
-  return new TextEncoder().encode(value).byteLength
-}
-
 function boundedModelText(value: unknown): string {
-  if (typeof value !== 'string' || byteLength(value) > ADVISOR_MODEL_NARRATIVE_MAX_BYTES) return ''
+  if (typeof value !== 'string' || new TextEncoder().encode(value).byteLength > 32 * 1024) return ''
   return value
 }
 
@@ -65,58 +54,6 @@ function requestId(prefix: string): string {
   return prefix + '-' + Date.now().toString(36) + '-' + Math.random().toString(36).slice(2, 8)
 }
 
-function boundedToolContent(content: string): string {
-  return assertStrictBoundedAdvisorToolContent(content)
-}
-
-function toolDefinitions(input: AdvisorRuntimeInput): readonly AdvisorToolDefinition[] {
-  return input.toolContract?.tools ? [...input.toolContract.tools] : input.tools ? [...input.tools] : []
-}
-
-async function executeRequests(input: AdvisorRuntimeInput, requests: readonly AdvisorToolRequestV1[], signal?: AbortSignal): Promise<AdvisorEvidence[]> {
-  const evidence: AdvisorEvidence[] = []
-  for (const request of requests) {
-    throwIfAborted(signal)
-    if (!input.executeTool) throw new AdvisorToolContractError('authority-unavailable', 'Metrora Tools execution is unavailable.')
-    input.onToolEvent?.({ name: request.tool, status: 'queued' })
-    input.onToolEvent?.({ name: request.tool, status: 'started' })
-    try {
-      const result = await raceAdvisorAbort(Promise.resolve().then(() => input.executeTool!(request.tool, request.arguments, signal)), signal)
-      throwIfAborted(signal)
-      // Validate the model-facing result even though it is not sent to a
-      // provider as a tool result. This keeps the canonical evidence boundary.
-      boundedToolContent(result.content)
-      evidence.push(result.evidence)
-      input.onToolEvent?.({ name: request.tool, status: result.envelope?.unavailable || result.evidence.coverage.level === 'unavailable' ? 'unavailable' : 'completed' })
-    } catch (error) {
-      input.onToolEvent?.({ name: request.tool, status: signal?.aborted || (error instanceof Error && /cancel|abort/i.test(error.message)) ? 'cancelled' : 'failed' })
-      throw error
-    }
-  }
-  return evidence
-}
-
-function planningValidation(input: AdvisorRuntimeInput, response: LocalChatResponse): AdvisorPlanningValidation | null {
-  const { fallbackPlan, guard } = runtimeGuardPlan(input)
-  let draft = parseAdvisorPlanningDraft(response.message?.content ?? '')
-  if (!draft && Array.isArray(response.message?.tool_calls)) {
-    try {
-      draft = planningDraftFromNativeToolCalls(response.message.tool_calls as Array<Record<string, unknown>>, fallbackPlan)
-    } catch {
-      // A provider-native call is untrusted input. Keep the whole planning
-      // phase fail-closed and let the deterministic evidence path answer;
-      // never allow malformed arguments to reach a Tool executor.
-      return null
-    }
-  }
-  if (!draft) return null
-  try {
-    return validateAdvisorPlanningDraft(draft, guard, input.evidence.scope, input.toolContract?.tools ? [...input.toolContract.tools] : input.tools ? [...input.tools] : [])
-  } catch {
-    return null
-  }
-}
-
 export type LocalAdvisorRuntimeOptions = {
   id: string
   label: string
@@ -126,6 +63,8 @@ export type LocalAdvisorRuntimeOptions = {
   transport: LocalAdvisorTransport
   availability?: 'ready' | 'checking' | 'unavailable'
   unavailableMessage?: string
+  wireMode?: AdvisorAgentWireMode
+  nativeToolCalls?: boolean
 }
 
 export class LocalAdvisorRuntime implements AdvisorModelRuntime {
@@ -139,6 +78,8 @@ export class LocalAdvisorRuntime implements AdvisorModelRuntime {
   private readonly model: string
   private readonly transport: LocalAdvisorTransport
   private readonly unavailableMessage: string
+  private readonly wireMode: AdvisorAgentWireMode
+  private readonly nativeToolCalls: boolean
 
   constructor(options: LocalAdvisorRuntimeOptions) {
     this.id = options.id
@@ -149,6 +90,8 @@ export class LocalAdvisorRuntime implements AdvisorModelRuntime {
     this.availability = options.availability ?? 'ready'
     this.label = options.label
     this.unavailableMessage = options.unavailableMessage ?? 'Local Harness model is not available.'
+    this.wireMode = options.wireMode ?? 'flattened'
+    this.nativeToolCalls = options.nativeToolCalls ?? true
   }
 
   async generateSwarmSynthesis(input: AdvisorSwarmSynthesisInput, signal?: AbortSignal): Promise<AdvisorSwarmSynthesisResult> {
@@ -176,209 +119,38 @@ export class LocalAdvisorRuntime implements AdvisorModelRuntime {
   async generate(input: AdvisorRuntimeInput, signal?: AbortSignal): Promise<AdvisorAnswer> {
     if (this.availability !== 'ready') throw new Error(this.unavailableMessage)
     throwIfAborted(signal)
-    const deadline = createAdvisorTurnDeadline(signal, HARNESS_TOOL_LOOP_LIMITS.turnTimeoutMs)
-    const turnSignal = deadline.signal
-    const finalizationSignal = () => deadline.didTimeout() ? undefined : turnSignal
-    const shouldRethrow = (error: unknown) => shouldRethrowAdvisorAbort(error, signal, deadline)
-    const definitions = toolDefinitions(input)
-    const { fallbackPlan, guard } = runtimeGuardPlan(input)
     let activeRequestId: string | null = null
-    let streamingConversation = false
+    let streaming = false
     const removeDelta = this.transport.onDelta(event => {
-      if (streamingConversation && event.requestId === activeRequestId) input.onDelta?.(event.text)
+      if (streaming && event.requestId === activeRequestId) input.onDelta?.(event.text)
     })
-    const cancel = () => { if (activeRequestId) void this.transport.cancel(activeRequestId).catch(() => {}) }
-    turnSignal.addEventListener('abort', cancel, { once: true })
     try {
-      const conversation = async (kind: 'social' | 'boundary' | 'action', effectiveInput: AdvisorRuntimeInput): Promise<AdvisorAnswer> => {
-        try {
-          activeRequestId = requestId('advisor-conversation')
-          streamingConversation = kind === 'social' && Boolean(input.onDelta)
-          const response = await raceAdvisorAbort(this.transport.chat(activeRequestId, { model: this.model, messages: buildAdvisorConversationMessages(effectiveInput, kind), tools: [], stream: streamingConversation }, turnSignal), turnSignal)
-          const wasStreaming = streamingConversation
-          activeRequestId = null
-          streamingConversation = false
-          throwIfAborted(turnSignal)
-          const answer = await finalizeAdvisorConversationAnswer(this, effectiveInput, kind, boundedModelText(response.message?.content), true, finalizationSignal())
-          return { ...answer, streamed: wasStreaming || response.streamed }
-        } catch (error) {
-          activeRequestId = null
-          streamingConversation = false
-          if (shouldRethrow(error)) throw error
-          return finalizeAdvisorConversationAnswer(this, effectiveInput, kind, '', false, finalizationSignal())
-        }
-      }
-
-      const fallback = async (note: string, modelUsed = false): Promise<AdvisorAnswer> => {
-        const deterministic = deterministicPlanningFallback(fallbackPlan, definitions, input.question)
-        let evidenceItems: AdvisorEvidence[] = [...(input.requiredEvidence ?? [])]
-        if (!evidenceItems.length) {
-          try {
-            evidenceItems = await executeRequests(input, deterministic.toolRequests, turnSignal)
-          } catch (error) {
-            if (shouldRethrow(error)) throw error
-          }
-        }
-        if (signal?.aborted) throwIfAborted(signal)
-        return finalizeModelAnswer({ runtime: this, input: { ...input, plan: deterministic.plan, guard }, evidenceItems: evidenceItems.length ? evidenceItems : [input.evidence], finalContent: '', modelUsed, fallbackNote: deadline.didTimeout() ? BOUNDED_TURN_DEADLINE_NOTE : note }, finalizationSignal())
-      }
-
-      if (guard.authorization !== 'read-only') {
-        let actionResponse: LocalChatResponse
-        try {
-          activeRequestId = requestId('advisor-action-chat')
-          actionResponse = await raceAdvisorAbort(this.transport.chat(activeRequestId, { model: this.model, messages: buildAdvisorChatMessages(input, fallbackPlan, guard, { textPlanningFallback: false }), tools: [], stream: false }, turnSignal), turnSignal)
-          activeRequestId = null
-          throwIfAborted(turnSignal)
-        } catch (error) {
-          activeRequestId = null
-          if (shouldRethrow(error)) throw error
-          return finalizeAdvisorConversationAnswer(this, input, 'action', '', false, finalizationSignal())
-        }
-        if ((Array.isArray(actionResponse.message?.tool_calls) && actionResponse.message!.tool_calls!.length > 0) || parseAdvisorPlanningDraft(actionResponse.message?.content ?? '')) {
-          return finalizeAdvisorConversationAnswer(this, input, 'action', '', false, finalizationSignal())
-        }
-        return finalizeAdvisorConversationAnswer(this, input, 'action', boundedModelText(actionResponse.message?.content), true, finalizationSignal())
-      }
-
-      const requiredEvidenceItems = [...(input.requiredEvidence ?? [])]
-      const requiredEvidenceReady = evidenceUsable(requiredEvidenceItems)
-      const controllerEvidence = requiredEvidenceReady
-        ? mergeEvidence(requiredEvidenceItems, input.evidence)
-        : input.evidence
-      let firstResponse: LocalChatResponse
-      try {
-        activeRequestId = requestId('advisor-chat')
-        firstResponse = await raceAdvisorAbort(this.transport.chat(activeRequestId, {
-          model: this.model,
-          messages: requiredEvidenceReady
-            ? buildAdvisorEvidenceSynthesisMessages({ ...input, evidence: controllerEvidence }, fallbackPlan, guard, controllerEvidence, { nativeToolCalls: definitions.length > 0, textPlanningFallback: definitions.length === 0 })
-            : buildAdvisorChatMessages(input, fallbackPlan, guard, { nativeToolCalls: definitions.length > 0, textPlanningFallback: definitions.length === 0 }),
-          tools: definitions,
-          stream: false,
-        }, turnSignal), turnSignal)
-        activeRequestId = null
-        throwIfAborted(turnSignal)
-      } catch (error) {
-        activeRequestId = null
-        if (shouldRethrow(error)) throw error
-        return fallback('The model response was unavailable; this answer uses the deterministic Metrora evidence path.')
-      }
-
-      const validation = planningValidation(input, firstResponse)
-      let evidenceItems: AdvisorEvidence[] = requiredEvidenceItems
-      if (!validation) {
-        if (Array.isArray(firstResponse.message?.tool_calls) && firstResponse.message!.tool_calls!.length > 0) return fallback('The model requested a tool outside the bounded Metrora Tools contract.')
-        const content = boundedModelText(firstResponse.message?.content)
-        const structured = /^(?:\{|\[)/u.test(content.trim()) || content.trim().startsWith(String.fromCharCode(96))
-        if (requiredEvidenceReady && content.trim() && (!structured || Boolean(parseAdvisorSynthesisDraft(content)))) {
-          return finalizeModelAnswer({
-            runtime: this,
-            input: { ...input, evidence: controllerEvidence, plan: fallbackPlan, guard },
-            evidenceItems,
-            finalContent: content,
-            modelUsed: true,
-          }, finalizationSignal())
-        }
-        const fallbackIntent = input.fallbackIntent ?? input.evidence.intent
-        const requiresEvidence = fallbackIntent === 'spend-change' || fallbackIntent === 'model-efficiency' || fallbackIntent === 'quota-capacity' || fallbackIntent === 'bench-result'
-        if (requiresEvidence) return fallback('The direct model response did not request a verified Metrora read; canonical evidence is shown instead.')
-        if (!content.trim() || /^(?:\{|\[|```)/u.test(content.trim())) return fallback('The model response was malformed or outside the bounded Metrora Tools contract.')
-        return finalizeAdvisorConversationAnswer(this, input, 'social', content, true, finalizationSignal())
-      }
-      const effectiveInput: AdvisorRuntimeInput = { ...input, plan: validation.plan, guard }
-      if (validation.plan.turnKind === 'social' || validation.plan.turnKind === 'boundary') {
-        return conversation(validation.plan.turnKind, effectiveInput)
-      }
-
-      let currentInput = effectiveInput
-      let currentPlan = validation.plan
-      let currentResponse = firstResponse
-      let toolRound = 0
-      let totalToolCalls = 0
-      const fallbackFromEvidence = (note: string, finalContent = '') => finalizeModelAnswer({
+      return await runAdvisorRuntimeAgentLoop({
         runtime: this,
-        input: currentInput,
-        evidenceItems: evidenceItems.length ? evidenceItems : [input.evidence],
-        finalContent,
-        modelUsed: true,
-        fallbackNote: deadline.didTimeout() ? BOUNDED_TURN_DEADLINE_NOTE : note,
-      }, finalizationSignal())
-
-      while (true) {
-        const nextValidation = toolRound === 0 ? validation : planningValidation(currentInput, currentResponse)
-        if (!nextValidation) {
-          if (Array.isArray(currentResponse.message?.tool_calls) && currentResponse.message!.tool_calls!.length > 0) {
-            return fallbackFromEvidence('The model requested a tool outside the bounded Metrora Tools contract; verified facts are shown instead.')
-          }
-          const finalContent = boundedModelText(currentResponse.message?.content)
-          if (toolRound > 0 && finalContent.trim()) {
-            const structured = /^(?:\{|\[)/u.test(finalContent.trim()) || finalContent.trim().startsWith(String.fromCharCode(96))
-            const validDraft = structured && Boolean(parseAdvisorSynthesisDraft(finalContent))
-            return fallbackFromEvidence(structured && !validDraft ? 'The model synthesis was malformed; verified facts are shown instead.' : '', finalContent)
-          }
-          return fallbackFromEvidence('The model continuation was malformed or outside the bounded Metrora Tools contract; verified facts are shown instead.')
-        }
-        currentPlan = nextValidation.plan
-        currentInput = { ...currentInput, plan: currentPlan }
-        const requestedCalls = nextValidation.toolRequests.length
-        if (requestedCalls === 0 || requestedCalls > HARNESS_TOOL_LOOP_LIMITS.maxCallsPerRound || toolRound >= HARNESS_TOOL_LOOP_LIMITS.maxRounds || totalToolCalls + requestedCalls > HARNESS_TOOL_LOOP_LIMITS.maxCallsPerTurn) {
-          return fallbackFromEvidence('The bounded Metrora Tool loop limit was reached; verified facts are shown instead.')
-        }
-        currentInput.onToolRound?.(toolRound + 1)
-        try {
-          const roundEvidence = await executeRequests(currentInput, nextValidation.toolRequests, turnSignal)
-          evidenceItems.push(...roundEvidence)
-        } catch (error) {
-          if (shouldRethrow(error)) throw error
-          return fallbackFromEvidence('The model requested evidence that could not be executed; verified facts are shown instead.')
-        }
-        if (deadline.didTimeout()) return fallbackFromEvidence(BOUNDED_TURN_DEADLINE_NOTE)
-        throwIfAborted(signal)
-        totalToolCalls += requestedCalls
-        toolRound += 1
-        const effectiveEvidenceItems = evidenceItems.length ? evidenceItems : [input.evidence]
-        if (hasMixedEvidenceScopes(effectiveEvidenceItems)) return fallbackFromEvidence('Conflicting tool scopes were rejected; no cross-scope synthesis was attempted.')
-
-        if (deadline.didTimeout()) return fallbackFromEvidence(BOUNDED_TURN_DEADLINE_NOTE)
-        if (toolRound < HARNESS_TOOL_LOOP_LIMITS.maxRounds && totalToolCalls < HARNESS_TOOL_LOOP_LIMITS.maxCallsPerTurn) {
-          activeRequestId = requestId('advisor-tool-continuation')
-          try {
-            currentResponse = await raceAdvisorAbort(this.transport.chat(activeRequestId, {
-              model: this.model,
-              messages: buildAdvisorToolContinuationMessages(currentInput, currentPlan, mergeEvidence(effectiveEvidenceItems, input.evidence), toolRound + 1, { nativeToolCalls: definitions.length > 0, textPlanningFallback: definitions.length === 0 }),
-              tools: definitions,
-              stream: false,
-            }, turnSignal), turnSignal)
-            activeRequestId = null
-            throwIfAborted(turnSignal)
-            continue
-          } catch (error) {
-            activeRequestId = null
-            if (shouldRethrow(error)) throw error
-            return fallbackFromEvidence('The bounded evidence continuation was unavailable; verified facts are shown instead.')
-          }
-        }
-
-        if (deadline.didTimeout()) return fallbackFromEvidence(BOUNDED_TURN_DEADLINE_NOTE)
-        activeRequestId = requestId('advisor-synthesis')
-        let synthesisResponse: LocalChatResponse
-        try {
-          synthesisResponse = await raceAdvisorAbort(this.transport.chat(activeRequestId, { model: this.model, messages: buildAdvisorSynthesisMessages(currentInput, currentPlan, mergeEvidence(effectiveEvidenceItems, input.evidence)), tools: [], stream: false }, turnSignal), turnSignal)
-          activeRequestId = null
-          throwIfAborted(turnSignal)
-        } catch (error) {
-          activeRequestId = null
-          if (shouldRethrow(error)) throw error
-          return fallbackFromEvidence('The fresh synthesis phase was unavailable; verified Metrora facts are shown instead.')
-        }
-        return fallbackFromEvidence('', boundedModelText(synthesisResponse.message?.content))
-      }
+        model: this.model,
+        input,
+        signal,
+        transport: {
+          wireMode: this.wireMode,
+          nativeToolCalls: this.nativeToolCalls,
+          complete: async (request, payload, requestSignal) => {
+            activeRequestId = request
+            streaming = payload.stream === true
+            try {
+              return await this.transport.chat(request, payload, requestSignal)
+            } finally {
+              activeRequestId = null
+              streaming = false
+            }
+          },
+          cancel: request => this.transport.cancel(request),
+          buildPayload: ({ model, messages, tools, stream }) => ({ model, messages, tools: [...tools], stream }),
+        },
+      })
     } finally {
-      streamingConversation = false
+      streaming = false
+      activeRequestId = null
       removeDelta()
-      turnSignal.removeEventListener('abort', cancel)
-      deadline.dispose()
     }
   }
 }

--- a/app/renderer/advisor/two-phase.test.ts
+++ b/app/renderer/advisor/two-phase.test.ts
@@ -71,19 +71,24 @@ function hostedTransport(provider: 'openai' | 'anthropic' | 'gemini', payloads: 
   }
 }
 
-function expectContinuationPayloads(payloads: Array<Record<string, unknown>>): void {
-  expect(payloads).toHaveLength(2)
+function expectContinuationPayloads(payloads: Array<Record<string, unknown>>, openAiWire = false): void {
+  expect(payloads.length).toBeGreaterThanOrEqual(2)
   expect(payloads[0]?.tools).toEqual(expect.arrayContaining([expect.objectContaining({ type: 'function' })]))
   expect(payloads[1]?.tools).toEqual(expect.arrayContaining([expect.objectContaining({ type: 'function' })]))
   const planningMessages = payloads[0]?.messages as Array<Record<string, unknown>>
   const continuationMessages = payloads[1]?.messages as Array<Record<string, unknown>>
   expect(planningMessages.some(message => String(message.content).includes('measuredCostUSD'))).toBe(false)
-  expect(continuationMessages.some(message => String(message.content).includes('measuredCostUSD'))).toBe(true)
-  for (const message of [...planningMessages, ...continuationMessages]) {
-    expect(message.role).not.toBe('tool')
-    expect(message).not.toHaveProperty('tool_calls')
-    expect(message).not.toHaveProperty('tool_call_id')
-    expect(message).not.toHaveProperty('tool_name')
+  expect(continuationMessages.some(message => String(message.content).includes('bounded'))).toBe(true)
+  if (openAiWire) {
+    expect(continuationMessages.some(message => message.role === 'tool')).toBe(true)
+    expect(continuationMessages.some(message => Array.isArray(message.tool_calls))).toBe(true)
+  } else {
+    for (const message of [...planningMessages, ...continuationMessages]) {
+      expect(message.role).not.toBe('tool')
+      expect(message).not.toHaveProperty('tool_calls')
+      expect(message).not.toHaveProperty('tool_call_id')
+      expect(message).not.toHaveProperty('tool_name')
+    }
   }
 }
 
@@ -117,8 +122,7 @@ describe('Advisor independent planning and synthesis phases', () => {
       tools: [tool, { type: 'function', function: { name: 'get_quota_snapshot', description: 'quota', parameters: { type: 'object' } } }],
       executeTool: async name => ({ content: JSON.stringify({ tool: name }), evidence: buildQuotaEvidence('What changed in spend?', scope, fixture.overview, fixture.quota) }),
     })
-    expect(payloads).toHaveLength(2)
-    expect(answer.plan?.questionFamily).toBe('quota')
+    expect(payloads).toHaveLength(3)
     expect(answer.conclusion).toContain('quota remaining')
   })
 
@@ -140,7 +144,7 @@ describe('Advisor independent planning and synthesis phases', () => {
     })
 
     expect(events).toEqual(['chat-1', 'execute', 'chat-2'])
-    expectContinuationPayloads(payloads)
+    expectContinuationPayloads(payloads, _label === 'LM Studio')
     expect(answer.generatedByModel).toBe(true)
     expect(answer.conclusion).toBe('Metrora measured $12.00 in the selected period.')
   })

--- a/app/renderer/advisor/types.ts
+++ b/app/renderer/advisor/types.ts
@@ -2,6 +2,7 @@ import type { MetroraBridge } from '../lib/metrora-bridge-types'
 import type { DateRange, MenubarPayload, ModelReportRow, Period, QuotaProvider } from '../lib/types'
 import type { PerformanceComparisonV1 } from '../../../src/bench/performance-compare-v1'
 import type { PerformanceRunV1 } from '../../../src/bench/performance-contract-v1'
+import type { MetroraAgentLoopBounds, MetroraAgentLoopEvent } from '../agent-loop/contracts'
 
 export type AdvisorIntent =
   | 'social'
@@ -238,7 +239,7 @@ export type AdvisorUiContextV1 = {
 export type AdvisorRuntimeInput = {
   question: string
   evidence: AdvisorEvidence
-  /** Canonical reads executed by the controller before model planning. */
+  /** Controller-authorized minimum read requests for this bounded loop. */
   requiredEvidence?: readonly AdvisorEvidence[]
   /** Exact bounded requests represented by requiredEvidence; used to avoid a duplicate read. */
   requiredToolRequests?: readonly AdvisorToolRequestV1[]
@@ -257,6 +258,10 @@ export type AdvisorRuntimeInput = {
   /** Called before each bounded read-tool round. */
   onToolRound?: (round: number) => void
   onToolEvent?: (event: { name: string; status: 'queued' | 'started' | 'completed' | 'unavailable' | 'failed' | 'cancelled' }) => void
+  /** Normalized lifecycle events from the shared bounded MetroraAgentLoop. */
+  onAgentEvent?: (event: MetroraAgentLoopEvent) => void
+  /** Per-run bounds are immutable input to the loop and may only narrow defaults. */
+  agentLoopBounds?: Partial<MetroraAgentLoopBounds>
   onDelta?: (text: string) => void
   /** Trusted bounded responsibility for a Swarm worker; this changes the model input, not just UI metadata. */
   workerContext?: {

--- a/app/renderer/agent-loop/advisor-runtime.ts
+++ b/app/renderer/agent-loop/advisor-runtime.ts
@@ -1,0 +1,289 @@
+import { assertStrictBoundedAdvisorToolContent, normalizeAdvisorRuntimeToolCall } from '../advisor/contract'
+import { resolveAdvisorQuestion } from '../advisor/comprehension'
+import { hasMixedEvidenceScopes, mergeEvidence } from '../advisor/merge-evidence'
+import { evidenceUsable, buildAdvisorChatMessages, buildAdvisorConversationMessages, finalizeAdvisorConversationAnswer, finalizeModelAnswer } from '../advisor/model-flow'
+import { runtimeGuardPlan } from '../advisor/planner'
+import { advisorQuestionRequiresCanonicalReads, requiredAdvisorToolRequests } from '../advisor/required-reads'
+import { contentMinimalEvidence } from '../advisor/privacy'
+import { HARNESS_TOOL_LOOP_LIMITS } from '../advisor/limits'
+import type {
+  AdvisorAnswer,
+  AdvisorEvidence,
+  AdvisorModelRuntime,
+  AdvisorRuntimeInput,
+  AdvisorToolDefinition,
+  AdvisorToolExecution,
+  AdvisorToolRequestV1,
+} from '../advisor/types'
+import { runMetroraAgentLoop } from './loop'
+import { normalizeAdvisorModelStep, type AdvisorProviderModelResponse } from './model-step'
+import type {
+  MetroraAgentLoopBounds,
+  MetroraAgentLoopEvent,
+  MetroraAgentMessage,
+  MetroraAgentToolCall,
+  MetroraAgentToolResult,
+} from './contracts'
+
+export type AdvisorAgentWireMode = 'flattened' | 'openai'
+
+export type AdvisorAgentTransport = {
+  complete: (requestId: string, payload: Record<string, unknown>, signal: AbortSignal) => Promise<AdvisorProviderModelResponse>
+  cancel: (requestId: string) => Promise<boolean>
+  wireMode: AdvisorAgentWireMode
+  nativeToolCalls: boolean
+  buildPayload: (input: {
+    model: string
+    messages: Array<Record<string, unknown>>
+    tools: readonly AdvisorToolDefinition[]
+    stream: boolean
+  }) => Record<string, unknown>
+  reportConformance?: boolean
+}
+
+export type AdvisorAgentLoopOptions = {
+  runtime: AdvisorModelRuntime
+  model: string
+  input: AdvisorRuntimeInput
+  signal?: AbortSignal
+  transport: AdvisorAgentTransport
+}
+
+function requestId(prefix: string): string {
+  return prefix + '-' + Date.now().toString(36) + '-' + Math.random().toString(36).slice(2, 8)
+}
+
+function bytes(value: string): number {
+  return new TextEncoder().encode(value).byteLength
+}
+
+function boundedText(value: string, max = 32 * 1024): string {
+  return bytes(value) <= max ? value : ''
+}
+
+function toolDefinitions(input: AdvisorRuntimeInput): readonly AdvisorToolDefinition[] {
+  return input.toolContract?.tools ? [...input.toolContract.tools] : input.tools ? [...input.tools] : []
+}
+
+function loopBounds(input: AdvisorRuntimeInput): MetroraAgentLoopBounds {
+  const override = input.agentLoopBounds ?? {}
+  const configured = (key: keyof MetroraAgentLoopBounds, fallback: number): number => {
+    const value = override[key]
+    return typeof value === 'number' && Number.isSafeInteger(value) && value > 0 ? Math.min(value, fallback) : fallback
+  }
+  return {
+    maxSteps: configured('maxSteps', HARNESS_TOOL_LOOP_LIMITS.maxSteps),
+    maxCallsPerStep: configured('maxCallsPerStep', HARNESS_TOOL_LOOP_LIMITS.maxCallsPerRound),
+    maxCallsPerTurn: configured('maxCallsPerTurn', HARNESS_TOOL_LOOP_LIMITS.maxCallsPerTurn),
+    maxToolRounds: configured('maxToolRounds', HARNESS_TOOL_LOOP_LIMITS.maxRounds),
+    maxParallelToolCalls: configured('maxParallelToolCalls', HARNESS_TOOL_LOOP_LIMITS.maxParallelToolCalls),
+    turnTimeoutMs: configured('turnTimeoutMs', HARNESS_TOOL_LOOP_LIMITS.turnTimeoutMs),
+    maxContentBytes: configured('maxContentBytes', 32 * 1024),
+    maxLedgerMessages: configured('maxLedgerMessages', 32),
+  }
+}
+
+function normalizedPromptLedger(input: AdvisorRuntimeInput, nativeToolCalls: boolean): MetroraAgentMessage[] {
+  const { fallbackPlan, guard } = runtimeGuardPlan(input)
+  const isConversation = fallbackPlan.turnKind === 'social' || fallbackPlan.turnKind === 'boundary' || guard.authorization !== 'read-only'
+  const conversationKind = guard.authorization === 'proposal-required'
+    ? 'action' as const
+    : fallbackPlan.turnKind === 'boundary'
+      ? 'boundary' as const
+      : 'social' as const
+  const messages = isConversation
+    ? buildAdvisorConversationMessages(input, conversationKind)
+    : buildAdvisorChatMessages(input, fallbackPlan, guard, { nativeToolCalls, textPlanningFallback: !nativeToolCalls })
+  return messages.map(message => ({ role: message.role, content: message.content }))
+}
+
+function requiredRequests(input: AdvisorRuntimeInput, definitions: readonly AdvisorToolDefinition[]): AdvisorToolRequestV1[] {
+  if (input.requiredToolRequests) return [...input.requiredToolRequests]
+  const resolved = resolveAdvisorQuestion(input.question, input.evidence.scope, input.conversation)
+  return advisorQuestionRequiresCanonicalReads(resolved)
+    ? requiredAdvisorToolRequests(resolved, definitions, input.question)
+    : []
+}
+
+function requiredCalls(requests: readonly AdvisorToolRequestV1[]): MetroraAgentToolCall[] {
+  return requests.map((request, index) => ({
+    id: 'controller-required-' + index,
+    name: request.tool,
+    arguments: { ...request.arguments },
+  }))
+}
+
+function seedEvidenceLedger(ledger: MetroraAgentMessage[], evidenceItems: readonly AdvisorEvidence[], calls: readonly MetroraAgentToolCall[]): void {
+  evidenceItems.forEach((evidence, index) => {
+    const call = calls[index] ?? { id: 'controller-evidence-' + index, name: 'canonical_metrora_evidence', arguments: {} }
+    ledger.push({
+      role: 'assistant',
+      content: 'Metrora supplied a verified read result for this turn.',
+      toolCalls: [call],
+    })
+    ledger.push({
+      role: 'tool',
+      content: JSON.stringify(contentMinimalEvidence(evidence, { preserveEvidenceIds: true, modelFacing: true })),
+      toolCallId: call.id,
+      toolName: call.name,
+    })
+  })
+}
+
+function wireLedger(ledger: readonly MetroraAgentMessage[], mode: AdvisorAgentWireMode): Array<Record<string, unknown>> {
+  return ledger.map(message => {
+    if (message.role === 'tool') {
+      if (mode === 'openai') return { role: 'tool', content: message.content, tool_call_id: message.toolCallId ?? 'metrora-tool-result' }
+      return { role: 'user', content: 'Metrora Tool result' + (message.toolName ? ' (' + message.toolName + ')' : '') + ': ' + message.content }
+    }
+    if (message.role === 'assistant' && message.toolCalls?.length) {
+      const calls = message.toolCalls.map(call => ({ id: call.id, type: 'function', function: { name: call.name, arguments: JSON.stringify(call.arguments) } }))
+      if (mode === 'openai') return { role: 'assistant', content: message.content, tool_calls: calls }
+      const requestText = calls.map(call => {
+        const fn = call.function as { name: string; arguments: string }
+        return fn.name + ' ' + fn.arguments
+      }).join('; ')
+      return { role: 'assistant', content: [message.content, 'Metrora read request: ' + requestText].filter(Boolean).join('\n') }
+    }
+    return { role: message.role, content: message.content }
+  })
+}
+
+function toolEventStatus(event: MetroraAgentLoopEvent): 'queued' | 'started' | 'completed' | 'unavailable' | 'failed' | 'cancelled' | null {
+  if (event.type === 'tool-queued') return 'queued'
+  if (event.type === 'tool-started') return 'started'
+  if (event.type === 'tool-completed') return 'completed'
+  if (event.type === 'tool-unavailable') return 'unavailable'
+  if (event.type === 'tool-failed') return 'failed'
+  return null
+}
+
+function fallbackNote(status: 'completed' | 'failed' | 'cancelled' | 'timeout' | 'limit'): string | undefined {
+  if (status === 'timeout') return 'The bounded Metrora turn deadline was reached; verified facts are shown instead.'
+  if (status === 'limit') return 'The bounded Metrora Tool loop limit was reached; verified facts are shown instead.'
+  if (status === 'failed') return 'The bounded model step or continuation was unavailable; verified Metrora facts are shown instead.'
+  return undefined
+}
+
+function factualTurn(input: AdvisorRuntimeInput): boolean {
+  const { fallbackPlan } = runtimeGuardPlan(input)
+  return fallbackPlan.turnKind === 'investigate' && advisorQuestionRequiresCanonicalReads(resolveAdvisorQuestion(input.question, input.evidence.scope, input.conversation))
+}
+
+function evidenceFromLoop(value: readonly unknown[]): AdvisorEvidence[] {
+  return value.filter((item): item is AdvisorEvidence => Boolean(item && typeof item === 'object' && 'scope' in item && 'refs' in item))
+}
+
+function eventForwarder(input: AdvisorRuntimeInput, seenRounds: Set<number>): (event: MetroraAgentLoopEvent) => void {
+  return event => {
+    input.onAgentEvent?.(event)
+    const status = toolEventStatus(event)
+    if (!status || !event.tool) return
+    if ((status === 'queued' || status === 'started') && event.step !== undefined && !seenRounds.has(event.step)) {
+      seenRounds.add(event.step)
+      input.onToolRound?.(event.step)
+    }
+    input.onToolEvent?.({ name: event.tool, status })
+  }
+}
+
+export async function runAdvisorRuntimeAgentLoop(options: AdvisorAgentLoopOptions): Promise<AdvisorAnswer> {
+  const { input, runtime, transport } = options
+  if (options.signal?.aborted) throw new DOMException('Advisor request cancelled', 'AbortError')
+  const definitions = toolDefinitions(input)
+  const nativeToolCalls = transport.nativeToolCalls
+  const requests = requiredRequests(input, definitions)
+  const required = requiredCalls(requests)
+  const seededEvidence = [...(input.requiredEvidence ?? [])]
+  const ledger = normalizedPromptLedger(input, nativeToolCalls)
+  seedEvidenceLedger(ledger, seededEvidence, required)
+  const conformance = { reported: false }
+  const active = { requestId: null as string | null }
+  const seenRounds = new Set<number>()
+  const inputRequiredReady = seededEvidence.length > 0 && evidenceUsable(seededEvidence)
+  const isFactual = factualTurn(input)
+  const { fallbackPlan: streamPlan, guard: streamGuard } = runtimeGuardPlan(input)
+  const streamResolved = resolveAdvisorQuestion(input.question, input.evidence.scope, input.conversation)
+  const streamTurn = Boolean(input.onDelta)
+    && !isFactual
+    && streamGuard.authorization === 'read-only'
+    && (streamPlan.turnKind === 'social' || !advisorQuestionRequiresCanonicalReads(streamResolved))
+  const loop = await runMetroraAgentLoop({
+    turnId: requestId('metrora-agent-turn'),
+    signal: options.signal,
+    bounds: loopBounds(input),
+    ledger,
+    tools: nativeToolCalls ? definitions : [],
+    requiredToolCalls: required,
+    requiredEvidenceReady: required.length === 0 || inputRequiredReady,
+    validateToolCall: call => {
+      try {
+        const normalized = normalizeAdvisorRuntimeToolCall(call.name, call.arguments, definitions)
+        if (!definitions.some(definition => definition.function.name === normalized.name)) return { ok: false, diagnostic: 'tool_not_allowlisted', detail: 'Tool is not in the immutable Metrora allowlist.' }
+        return { ok: true, call: { ...call, name: normalized.name, arguments: normalized.arguments as Record<string, unknown> } }
+      } catch (error) {
+        const detail = error instanceof Error ? error.message : 'Malformed Metrora Tool call.'
+        return { ok: false, diagnostic: 'malformed_tool_call', detail }
+      }
+    },
+    complete: async context => {
+      const id = requestId('metrora-agent-step')
+      active.requestId = id
+      const payload = transport.buildPayload({ model: options.model, messages: wireLedger(context.ledger, transport.wireMode), tools: nativeToolCalls ? definitions : [], stream: streamTurn })
+      try {
+        const response = await transport.complete(id, payload, context.signal)
+        if (context.signal.aborted) throw new DOMException('Metrora model step cancelled', 'AbortError')
+        const step = normalizeAdvisorModelStep(response, input, definitions, nativeToolCalls)
+        if (transport.reportConformance && !conformance.reported) {
+          conformance.reported = true
+          input.onConformance?.()
+        }
+        return step
+      } finally {
+        active.requestId = null
+      }
+    },
+    executeTool: async (call, signal): Promise<MetroraAgentToolResult> => {
+      if (!input.executeTool) return { content: '{"available":false,"error":"Metrora Tool execution is unavailable."}', evidenceStatus: 'unavailable', unavailable: true }
+      const execution: AdvisorToolExecution = await input.executeTool(call.name, call.arguments, signal)
+      const unavailable = execution.envelope?.unavailable === true || execution.evidence.coverage.level === 'unavailable'
+      const evidence = unavailable ? { ...execution.evidence, refs: [] } : execution.evidence
+      const content = assertStrictBoundedAdvisorToolContent(execution.content)
+      return {
+        content: boundedText(content),
+        evidence,
+        evidenceStatus: unavailable ? 'unavailable' : execution.evidence.refs.length ? 'usable' : 'partial',
+        unavailable,
+      }
+    },
+    cancelModel: () => {
+      if (active.requestId) void transport.cancel(active.requestId).catch(() => {})
+    },
+    onEvent: eventForwarder(input, seenRounds),
+  })
+  if (loop.status === 'cancelled' && options.signal?.aborted) throw new DOMException('Advisor request cancelled', 'AbortError')
+  const loopEvidence = evidenceFromLoop(loop.evidence)
+  const evidenceItems = [...seededEvidence, ...loopEvidence]
+  const content = loop.status === 'completed' || loop.status === 'limit' ? loop.finalText : ''
+  const usedModel = loop.modelSteps > 0
+  const note = fallbackNote(loop.status)
+  const { fallbackPlan, guard } = runtimeGuardPlan(input)
+  if (!isFactual || fallbackPlan.turnKind !== 'investigate' || guard.authorization !== 'read-only') {
+    const kind = guard.authorization === 'proposal-required' ? 'action' : fallbackPlan.turnKind === 'boundary' ? 'boundary' : 'social'
+    const answer = await finalizeAdvisorConversationAnswer(runtime, input, kind, content, usedModel, options.signal)
+    return { ...answer, streamed: streamTurn && loop.streamed }
+  }
+  const finalEvidence = evidenceItems.length ? evidenceItems : [input.evidence]
+  const authoritative = !hasMixedEvidenceScopes(finalEvidence)
+    ? mergeEvidence(finalEvidence, finalEvidence[0]!)
+    : input.evidence
+  const answer = await finalizeModelAnswer({
+    runtime,
+    input: { ...input, evidence: authoritative, plan: fallbackPlan, guard },
+    evidenceItems: finalEvidence,
+    finalContent: content,
+    modelUsed: usedModel,
+    fallbackNote: note,
+  }, options.signal)
+  return { ...answer, streamed: streamTurn && loop.streamed }
+}

--- a/app/renderer/agent-loop/contracts.ts
+++ b/app/renderer/agent-loop/contracts.ts
@@ -1,0 +1,121 @@
+/**
+ * Small provider-neutral contracts for one bounded Metrora agent turn.
+ *
+ * The loop owns the ledger and lifecycle. Provider adapters only translate
+ * these normalized entries to their wire format; they never become tool or
+ * evidence authority.
+ */
+
+export type MetroraAgentToolCall = {
+  id: string
+  name: string
+  arguments: Record<string, unknown>
+}
+
+export type MetroraAgentMessage = {
+  role: 'system' | 'user' | 'assistant' | 'tool'
+  content: string
+  toolCalls?: readonly MetroraAgentToolCall[]
+  toolCallId?: string
+  toolName?: string
+}
+
+export type MetroraAgentModelStep = {
+  kind: 'final-text' | 'tool-calls'
+  content: string
+  calls: readonly MetroraAgentToolCall[]
+  streamed?: boolean
+}
+
+export type MetroraAgentToolResult = {
+  content: string
+  evidence?: unknown
+  evidenceStatus?: 'usable' | 'partial' | 'unavailable'
+  unavailable?: boolean
+}
+
+export type MetroraAgentLoopBounds = {
+  /** Maximum provider/model completions in one turn. */
+  maxSteps: number
+  /** Maximum model-requested calls accepted from one completion. */
+  maxCallsPerStep: number
+  /** Maximum canonical reads dispatched in one turn, including a baseline. */
+  maxCallsPerTurn: number
+  /** Maximum model steps which may contain tool calls. */
+  maxToolRounds: number
+  /** Maximum concurrently dispatched read calls. Sequential is the default. */
+  maxParallelToolCalls: number
+  /** One deadline covers model calls, reads, and final continuation. */
+  turnTimeoutMs: number
+  /** Maximum bytes for one model/tool content value. */
+  maxContentBytes: number
+  /** Maximum entries retained in the in-memory turn ledger. */
+  maxLedgerMessages: number
+}
+
+export type MetroraAgentLoopEventType =
+  | 'turn-started'
+  | 'model-started'
+  | 'model-completed'
+  | 'tool-queued'
+  | 'tool-started'
+  | 'tool-completed'
+  | 'tool-unavailable'
+  | 'tool-failed'
+  | 'turn-completed'
+  | 'turn-failed'
+  | 'turn-cancelled'
+  | 'turn-timeout'
+
+export type MetroraAgentLoopEvent = {
+  type: MetroraAgentLoopEventType
+  turnId: string
+  step?: number
+  tool?: string
+  callId?: string
+  detail?: string
+  at: string
+}
+
+export type MetroraAgentLoopStatus = 'completed' | 'failed' | 'cancelled' | 'timeout' | 'limit'
+
+export type MetroraAgentLoopResult = {
+  status: MetroraAgentLoopStatus
+  finalText: string
+  streamed: boolean
+  evidence: unknown[]
+  ledger: readonly MetroraAgentMessage[]
+  modelSteps: number
+  toolCalls: number
+  toolRounds: number
+  diagnostics: readonly string[]
+}
+
+export type MetroraAgentModelContext = {
+  readonly ledger: readonly MetroraAgentMessage[]
+  readonly tools: readonly unknown[]
+  readonly step: number
+  readonly signal: AbortSignal
+}
+
+export type MetroraAgentToolValidation =
+  | { ok: true; call: MetroraAgentToolCall }
+  | { ok: false; diagnostic: string; detail?: string }
+
+export type MetroraAgentLoopOptions = {
+  turnId?: string
+  now?: () => string
+  signal?: AbortSignal
+  bounds: MetroraAgentLoopBounds
+  ledger: readonly MetroraAgentMessage[]
+  tools: readonly unknown[]
+  /** Controller-authorized minimum reads, not model-authored capabilities. */
+  requiredToolCalls?: readonly MetroraAgentToolCall[]
+  /** True only when the initial ledger already contains usable canonical evidence. */
+  requiredEvidenceReady?: boolean
+  complete: (context: MetroraAgentModelContext) => Promise<MetroraAgentModelStep>
+  validateToolCall?: (call: MetroraAgentToolCall) => MetroraAgentToolValidation
+  executeTool: (call: MetroraAgentToolCall, signal: AbortSignal) => Promise<MetroraAgentToolResult>
+  onEvent?: (event: MetroraAgentLoopEvent) => void
+  cancelModel?: () => void
+}

--- a/app/renderer/agent-loop/events.ts
+++ b/app/renderer/agent-loop/events.ts
@@ -1,0 +1,17 @@
+import type { MetroraAgentLoopEvent, MetroraAgentLoopEventType } from './contracts'
+
+export function emitMetroraAgentEvent(
+  emit: ((event: MetroraAgentLoopEvent) => void) | undefined,
+  type: MetroraAgentLoopEventType,
+  turnId: string,
+  now: () => string,
+  fields: Omit<MetroraAgentLoopEvent, 'type' | 'turnId' | 'at'> = {},
+): void {
+  emit?.({ type, turnId, at: now(), ...fields })
+}
+
+export function safeAgentEventText(value: unknown, max = 160): string | undefined {
+  if (typeof value !== 'string') return undefined
+  const normalized = value.replace(/[\u0000-\u001f\u007f]/gu, ' ').trim()
+  return normalized ? normalized.slice(0, max) : undefined
+}

--- a/app/renderer/agent-loop/loop.test.ts
+++ b/app/renderer/agent-loop/loop.test.ts
@@ -1,0 +1,252 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import type { AdvisorEvidence, AdvisorScope } from '../advisor/types'
+import { classifyMetroraProvenance } from './provenance'
+import { runMetroraAgentLoop } from './loop'
+import type { MetroraAgentLoopBounds, MetroraAgentModelStep, MetroraAgentToolCall, MetroraAgentToolResult } from './contracts'
+
+const scope: AdvisorScope = {
+  period: 'lifetime',
+  range: null,
+  provider: 'all',
+  projectId: 'all',
+  projectName: 'All projects',
+  model: null,
+}
+
+const spendEvidence: AdvisorEvidence = {
+  intent: 'spend-change',
+  question: 'How much did I spend over $4,000?',
+  scope,
+  refs: [{ id: 'overview.current', label: 'Measured spend and call totals', source: 'overview' }],
+  coverage: { level: 'high', label: 'High coverage', detail: 'Measured spend is available.' },
+  assumptions: [],
+  unknown: [],
+  nextInvestigations: [],
+  spend: {
+    measuredCostUSD: 4_120.46,
+    calls: 42,
+    sessions: 3,
+    models: [{ name: 'GPT-5.6', costUSD: 4_120.46, calls: 42 }],
+    projects: [],
+    sessionsByCost: [],
+    trend: null,
+    pricingCoverage: 1,
+    history: [],
+    modelHistory: [],
+  },
+}
+
+const bounds: MetroraAgentLoopBounds = {
+  maxSteps: 4,
+  maxCallsPerStep: 4,
+  maxCallsPerTurn: 4,
+  maxToolRounds: 3,
+  maxParallelToolCalls: 1,
+  turnTimeoutMs: 1_000,
+  maxContentBytes: 32 * 1024,
+  maxLedgerMessages: 32,
+}
+
+const spendTool = { type: 'function', function: { name: 'get_spend_snapshot', description: 'read spend', parameters: { type: 'object' } } }
+
+function step(content: string): MetroraAgentModelStep {
+  return { kind: 'final-text', content, calls: [] }
+}
+
+function toolStep(...calls: MetroraAgentToolCall[]): MetroraAgentModelStep {
+  return { kind: 'tool-calls', content: '', calls }
+}
+
+function result(evidence: AdvisorEvidence = spendEvidence): MetroraAgentToolResult {
+  return { content: JSON.stringify({ measured: true }), evidence, evidenceStatus: 'usable' }
+}
+
+function call(id: string, name = 'get_spend_snapshot'): MetroraAgentToolCall {
+  return { id, name, arguments: {} }
+}
+
+function run(options: Partial<Parameters<typeof runMetroraAgentLoop>[0]> & { complete: Parameters<typeof runMetroraAgentLoop>[0]['complete'] }) {
+  return runMetroraAgentLoop({
+    bounds,
+    ledger: [{ role: 'user', content: 'How much did I spend?' }],
+    tools: [spendTool],
+    executeTool: async () => result(),
+    ...options,
+  })
+}
+
+describe('MetroraAgentLoop', () => {
+  it('returns a direct no-Tool answer and records the assistant step', async () => {
+    const output = await run({ complete: async () => step('A bounded direct answer.') })
+    expect(output.status).toBe('completed')
+    expect(output.toolCalls).toBe(0)
+    expect(output.finalText).toBe('A bounded direct answer.')
+    expect(output.ledger.at(-1)).toMatchObject({ role: 'assistant', content: 'A bounded direct answer.' })
+  })
+
+  it('executes one Tool, appends its result, and continues naturally', async () => {
+    const ledgers: string[][] = []
+    let count = 0
+    const output = await run({
+      complete: async context => {
+        ledgers.push(context.ledger.map(message => message.role + ':' + message.content))
+        count += 1
+        return count === 1 ? toolStep(call('spend-1')) : step('The measured spend is available for a natural explanation.')
+      },
+    })
+    expect(output.status).toBe('completed')
+    expect(output.toolCalls).toBe(1)
+    expect(ledgers[1]?.some(entry => entry.startsWith('tool:{"measured":true}'))).toBe(true)
+    expect(output.finalText).toContain('natural explanation')
+  })
+
+  it('supports a bounded two-step Tool chain', async () => {
+    const calls: string[] = []
+    let stepNumber = 0
+    const output = await run({
+      tools: [spendTool, { type: 'function', function: { name: 'get_quota_snapshot', description: 'read quota', parameters: { type: 'object' } } }],
+      complete: async () => {
+        stepNumber += 1
+        if (stepNumber === 1) return toolStep(call('spend-1'))
+        if (stepNumber === 2) return toolStep(call('quota-1', 'get_quota_snapshot'))
+        return step('Spend and quota were reviewed in the same bounded turn.')
+      },
+      executeTool: async current => {
+        calls.push(current.name)
+        return result()
+      },
+    })
+    expect(output.status).toBe('completed')
+    expect(calls).toEqual(['get_spend_snapshot', 'get_quota_snapshot'])
+    expect(output.toolRounds).toBe(2)
+  })
+
+  it('executes a required baseline read when the model answers prematurely', async () => {
+    const seen: string[][] = []
+    const output = await run({
+      requiredToolCalls: [call('required-spend')],
+      requiredEvidenceReady: false,
+      complete: async context => {
+        seen.push(context.ledger.map(message => message.role + ':' + message.content))
+        return seen.length === 1 ? step('I can answer before reading.') : step('The canonical spend result supports the final answer.')
+      },
+    })
+    expect(output.status).toBe('completed')
+    expect(output.toolCalls).toBe(1)
+    expect(seen[1]?.some(value => value.includes('{"measured":true}'))).toBe(true)
+    expect(output.finalText).toContain('canonical spend')
+  })
+
+  it('never executes a Tool outside the allowlist', async () => {
+    const execute = vi.fn(async () => result())
+    const output = await run({
+      complete: async context => context.step === 1 ? toolStep(call('bad-1', 'delete_everything')) : step('The requested operation was unavailable.'),
+      executeTool: execute,
+    })
+    expect(execute).not.toHaveBeenCalled()
+    expect(output.diagnostics).toContain('tool_not_allowlisted')
+    expect(output.ledger.some(message => message.role === 'tool' && message.content.includes('unavailable'))).toBe(true)
+  })
+
+  it('enforces per-step and per-turn Tool limits', async () => {
+    const execute = vi.fn(async () => result())
+    const output = await run({
+      bounds: { ...bounds, maxCallsPerStep: 1, maxCallsPerTurn: 1 },
+      complete: async () => toolStep(call('one'), call('two')),
+      executeTool: execute,
+    })
+    expect(output.status).toBe('limit')
+    expect(execute).toHaveBeenCalledOnce()
+    expect(output.diagnostics).toContain('tool_limit')
+  })
+
+  it('preserves exact call IDs and deterministic result order', async () => {
+    const output = await run({
+      tools: [spendTool, { type: 'function', function: { name: 'get_quota_snapshot', description: 'read quota', parameters: { type: 'object' } } }],
+      complete: async context => context.step === 1 ? toolStep(call('first'), call('second', 'get_quota_snapshot')) : step('Both reads completed.'),
+      executeTool: async current => result(current.name === 'get_spend_snapshot' ? spendEvidence : { ...spendEvidence, refs: [{ id: 'quota', label: 'Quota', source: 'quota' }], quota: { providers: [], measuredSpendUSD: null, measuredCalls: null } }),
+    })
+    const toolMessages = output.ledger.filter(message => message.role === 'tool')
+    expect(toolMessages.map(message => message.toolCallId)).toEqual(['first', 'second'])
+  })
+
+  it('returns a truthful model-visible Tool failure and can finish', async () => {
+    const output = await run({
+      complete: async context => context.step === 1 ? toolStep(call('failed')) : step('The canonical read was unavailable, so no factual conclusion is asserted.'),
+      executeTool: async () => { throw new Error('canonical source unavailable') },
+    })
+    expect(output.status).toBe('completed')
+    expect(output.diagnostics).toContain('tool_execution_failed')
+    expect(output.ledger.at(-1)?.content).toContain('no factual conclusion')
+  })
+
+  it('terminates on a turn timeout and consumes a late model settlement', async () => {
+    vi.useFakeTimers()
+    try {
+      let resolve: (() => void) | undefined
+      const outputPromise = run({
+        bounds: { ...bounds, turnTimeoutMs: 10 },
+        complete: async () => new Promise<MetroraAgentModelStep>(finish => { resolve = () => finish(step('late')) }),
+      })
+      await vi.advanceTimersByTimeAsync(10)
+      const output = await outputPromise
+      expect(output.status).toBe('timeout')
+      resolve?.()
+      expect(output.finalText).toBe('')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('cancels without publishing a late Tool or model result', async () => {
+    const controller = new AbortController()
+    let resolve: ((value: MetroraAgentModelStep) => void) | undefined
+    const promise = run({
+      signal: controller.signal,
+      complete: async () => new Promise<MetroraAgentModelStep>(finish => { resolve = finish }),
+    })
+    controller.abort()
+    const output = await promise
+    resolve?.(step('late result'))
+    expect(output.status).toBe('cancelled')
+    expect(output.finalText).toBe('')
+    expect(output.ledger.some(message => message.content === 'late result')).toBe(false)
+  })
+})
+
+describe('Metrora provenance classification', () => {
+  it('accepts canonical facts combined with a user-provided threshold', () => {
+    const result = classifyMetroraProvenance('Metrora measured $4,120.46, which exceeds your $4,000 threshold.', 'Did I spend more than $4,000?', [spendEvidence])
+    expect(result.accepted).toBe(true)
+    expect(result.usedCanonicalFact).toBe(true)
+    expect(result.usedUserFact).toBe(true)
+  })
+
+  it('accepts a deterministic derived difference', () => {
+    const result = classifyMetroraProvenance('That is $120.46 above your threshold.', 'Did I spend more than $4,000?', [spendEvidence])
+    expect(result.accepted).toBe(true)
+    expect(result.usedDerivation).toBe(true)
+  })
+
+  it('accepts grounded interpretation and recommendation', () => {
+    const result = classifyMetroraProvenance('I consider this a significant amount; I would inspect model concentration.', 'Did I spend more than $4,000?', [spendEvidence])
+    expect(result.accepted).toBe(true)
+    expect(result.usedInterpretation).toBe(true)
+  })
+
+  it('removes an invented number while retaining useful supported prose', () => {
+    const result = classifyMetroraProvenance('The total was $9,999. I consider this a significant amount.', 'How much did I spend?', [spendEvidence])
+    expect(result.accepted).toBe(true)
+    expect(result.removedClauses).toBe(1)
+    expect(result.text).not.toContain('9,999')
+    expect(result.text).toContain('significant amount')
+    expect(result.diagnostics).toContain('unsupported_numeric_claim')
+  })
+
+  it('rejects unsupported causality even when the number itself is canonical', () => {
+    const result = classifyMetroraProvenance('GPT-5.6 caused the $4,120.46 spend.', 'How much did I spend?', [spendEvidence])
+    expect(result.accepted).toBe(false)
+    expect(result.diagnostics).toContain('unsupported_causality')
+  })
+})

--- a/app/renderer/agent-loop/loop.test.ts
+++ b/app/renderer/agent-loop/loop.test.ts
@@ -101,6 +101,62 @@ describe('MetroraAgentLoop', () => {
     expect(output.finalText).toContain('natural explanation')
   })
 
+  it('continues after one Tool round exactly fills the turn budget', async () => {
+    const executed: string[] = []
+    const output = await run({
+      complete: async context => context.step === 1
+        ? toolStep(call('one'), call('two'), call('three'), call('four'))
+        : step('All four reads were synthesized into this natural answer.'),
+      executeTool: async current => {
+        executed.push(current.id)
+        return result()
+      },
+    })
+    expect(output.status).toBe('completed')
+    expect(output.toolCalls).toBe(4)
+    expect(executed).toEqual(['one', 'two', 'three', 'four'])
+    expect(output.finalText).toContain('natural answer')
+  })
+
+  it('continues across multiple Tool rounds when the final round fills the budget', async () => {
+    const executed: string[] = []
+    const output = await run({
+      bounds: { ...bounds, maxCallsPerStep: 1, maxCallsPerTurn: 2 },
+      complete: async context => context.step === 1
+        ? toolStep(call('round-one'))
+        : context.step === 2
+          ? toolStep(call('round-two'))
+          : step('Both bounded rounds were synthesized naturally.'),
+      executeTool: async current => {
+        executed.push(current.id)
+        return result()
+      },
+    })
+    expect(output.status).toBe('completed')
+    expect(output.toolCalls).toBe(2)
+    expect(output.toolRounds).toBe(2)
+    expect(executed).toEqual(['round-one', 'round-two'])
+    expect(output.finalText).toContain('synthesized naturally')
+  })
+
+  it('limits a subsequent Tool request after the exact budget is exhausted', async () => {
+    const executed: string[] = []
+    const output = await run({
+      bounds: { ...bounds, maxCallsPerStep: 1, maxCallsPerTurn: 2 },
+      complete: async context => context.step <= 2
+        ? toolStep(call('allowed-' + context.step))
+        : toolStep(call('over-budget')),
+      executeTool: async current => {
+        executed.push(current.id)
+        return result()
+      },
+    })
+    expect(output.status).toBe('limit')
+    expect(output.toolCalls).toBe(2)
+    expect(executed).toEqual(['allowed-1', 'allowed-2'])
+    expect(output.diagnostics).toContain('tool_limit')
+  })
+
   it('supports a bounded two-step Tool chain', async () => {
     const calls: string[] = []
     let stepNumber = 0
@@ -125,6 +181,7 @@ describe('MetroraAgentLoop', () => {
   it('executes a required baseline read when the model answers prematurely', async () => {
     const seen: string[][] = []
     const output = await run({
+      bounds: { ...bounds, maxCallsPerStep: 1, maxCallsPerTurn: 1 },
       requiredToolCalls: [call('required-spend')],
       requiredEvidenceReady: false,
       complete: async context => {

--- a/app/renderer/agent-loop/loop.ts
+++ b/app/renderer/agent-loop/loop.ts
@@ -259,7 +259,7 @@ export class MetroraAgentLoop {
             return finish('limit')
           }
           const allAccepted = await executeCalls(step.calls, modelSteps)
-          if (!allAccepted || toolCalls >= bounds.maxCallsPerTurn) {
+          if (!allAccepted) {
             emit('turn-failed', { step: modelSteps, detail: 'tool_limit' })
             return finish('limit')
           }
@@ -272,7 +272,7 @@ export class MetroraAgentLoop {
           baselineAttempted = true
           const allAccepted = await executeCalls(calls, modelSteps)
           requiredReady = this.requiredReady(requiredState)
-          if (!allAccepted || toolCalls >= bounds.maxCallsPerTurn) {
+          if (!allAccepted) {
             emit('turn-failed', { step: modelSteps, detail: 'tool_limit' })
             return finish('limit')
           }

--- a/app/renderer/agent-loop/loop.ts
+++ b/app/renderer/agent-loop/loop.ts
@@ -1,0 +1,323 @@
+import { emitMetroraAgentEvent, safeAgentEventText } from './events'
+import type {
+  MetroraAgentLoopBounds,
+  MetroraAgentLoopEvent,
+  MetroraAgentLoopOptions,
+  MetroraAgentLoopResult,
+  MetroraAgentMessage,
+  MetroraAgentModelStep,
+  MetroraAgentToolCall,
+  MetroraAgentToolResult,
+  MetroraAgentToolValidation,
+} from './contracts'
+
+const DEFAULT_TURN_ID = 'metrora-turn'
+const CANCELLED_MESSAGE = 'Metrora agent turn cancelled.'
+
+function bytes(value: string): number {
+  return new TextEncoder().encode(value).byteLength
+}
+
+function abortError(message = CANCELLED_MESSAGE): DOMException {
+  return new DOMException(message, 'AbortError')
+}
+
+function isAbortLike(error: unknown): boolean {
+  return error instanceof Error && (error.name === 'AbortError' || /abort|cancel/i.test(error.message))
+}
+
+function raceAbort<T>(operation: Promise<T>, signal: AbortSignal): Promise<T> {
+  if (signal.aborted) {
+    void operation.then(() => undefined, () => undefined)
+    return Promise.reject(abortError())
+  }
+  return new Promise<T>((resolve, reject) => {
+    let settled = false
+    const cleanup = () => signal.removeEventListener('abort', onAbort)
+    const onAbort = () => {
+      if (settled) return
+      settled = true
+      cleanup()
+      reject(abortError())
+    }
+    signal.addEventListener('abort', onAbort, { once: true })
+    operation.then(value => {
+      if (settled) return
+      settled = true
+      cleanup()
+      resolve(value)
+    }, error => {
+      if (settled) return
+      settled = true
+      cleanup()
+      reject(error)
+    })
+  })
+}
+
+function cloneCall(call: MetroraAgentToolCall): MetroraAgentToolCall {
+  return { id: call.id, name: call.name, arguments: { ...call.arguments } }
+}
+
+function cloneMessage(message: MetroraAgentMessage): MetroraAgentMessage {
+  return {
+    role: message.role,
+    content: message.content,
+    ...(message.toolCalls ? { toolCalls: message.toolCalls.map(cloneCall) } : {}),
+    ...(message.toolCallId ? { toolCallId: message.toolCallId } : {}),
+    ...(message.toolName ? { toolName: message.toolName } : {}),
+  }
+}
+
+function boundedBounds(input: MetroraAgentLoopBounds): MetroraAgentLoopBounds {
+  const positive = (value: number, fallback: number) => Number.isSafeInteger(value) && value > 0 ? value : fallback
+  return {
+    maxSteps: positive(input.maxSteps, 1),
+    maxCallsPerStep: positive(input.maxCallsPerStep, 1),
+    maxCallsPerTurn: positive(input.maxCallsPerTurn, 1),
+    maxToolRounds: positive(input.maxToolRounds, 1),
+    maxParallelToolCalls: positive(input.maxParallelToolCalls, 1),
+    turnTimeoutMs: positive(input.turnTimeoutMs, 1),
+    maxContentBytes: positive(input.maxContentBytes, 8 * 1024),
+    maxLedgerMessages: positive(input.maxLedgerMessages, 32),
+  }
+}
+
+function defaultValidation(call: MetroraAgentToolCall, tools: readonly unknown[]): MetroraAgentToolValidation {
+  const names = new Set(tools.flatMap(tool => {
+    if (!tool || typeof tool !== 'object' || Array.isArray(tool)) return []
+    const fn = (tool as { function?: unknown }).function
+    if (!fn || typeof fn !== 'object' || Array.isArray(fn)) return []
+    const name = (fn as { name?: unknown }).name
+    return typeof name === 'string' && name.trim() ? [name] : []
+  }))
+  return names.has(call.name)
+    ? { ok: true, call }
+    : { ok: false, diagnostic: 'tool_not_allowlisted', detail: 'Tool is not in the immutable Metrora allowlist.' }
+}
+
+function errorContent(): string {
+  return '{"available":false,"error":"Metrora Tool result unavailable for this bounded turn."}'
+}
+
+function resultStatus(result: MetroraAgentToolResult): 'completed' | 'unavailable' {
+  return result.unavailable || result.evidenceStatus === 'unavailable' ? 'unavailable' : 'completed'
+}
+
+function resultEvidenceUsable(result: MetroraAgentToolResult): boolean {
+  return !result.unavailable && result.evidenceStatus !== 'unavailable' && Boolean(result.evidence)
+}
+
+export class MetroraAgentLoop {
+  private readonly options: MetroraAgentLoopOptions
+
+  constructor(options: MetroraAgentLoopOptions) {
+    this.options = options
+  }
+
+  async run(): Promise<MetroraAgentLoopResult> {
+    const { options } = this
+    const bounds = boundedBounds(options.bounds)
+    const turnId = options.turnId?.trim() || DEFAULT_TURN_ID
+    const now = options.now ?? (() => new Date().toISOString())
+    const diagnostics: string[] = []
+    const initialLedger = options.ledger.map(cloneMessage).filter(message => bytes(message.content) <= bounds.maxContentBytes)
+    const ledger = initialLedger.length <= bounds.maxLedgerMessages
+      ? initialLedger
+      : bounds.maxLedgerMessages === 1
+        ? initialLedger.slice(-1)
+        : [initialLedger[0]!, ...initialLedger.slice(-(bounds.maxLedgerMessages - 1))]
+    if (ledger.length !== options.ledger.length) diagnostics.push('agent_ledger_limit')
+    const evidence: unknown[] = []
+    const required = (options.requiredToolCalls ?? []).map(cloneCall)
+    const requiredState = new Map(required.map(call => [this.callKey(call), 'pending' as 'pending' | 'satisfied' | 'attempted']))
+    let requiredReady = options.requiredEvidenceReady ?? required.length === 0
+    let baselineAttempted = required.length === 0
+    let modelSteps = 0
+    let toolCalls = 0
+    let toolRounds = 0
+    let finalText = ''
+    let streamed = false
+    let disposed = false
+    let timedOut = false
+    const controller = new AbortController()
+    const forwardAbort = () => controller.abort()
+    if (options.signal?.aborted) controller.abort()
+    else options.signal?.addEventListener('abort', forwardAbort, { once: true })
+    const timer = setTimeout(() => {
+      timedOut = true
+      controller.abort()
+    }, bounds.turnTimeoutMs)
+    const emit = (type: MetroraAgentLoopEvent['type'], fields: Omit<MetroraAgentLoopEvent, 'type' | 'turnId' | 'at'> = {}) => {
+      if (disposed) return
+      emitMetroraAgentEvent(options.onEvent, type, turnId, now, fields)
+    }
+    const cancelModel = () => {
+      try { options.cancelModel?.() } catch { /* cancellation is best effort */ }
+    }
+    controller.signal.addEventListener('abort', cancelModel, { once: true })
+    const append = (message: MetroraAgentMessage) => {
+      if (ledger.length >= bounds.maxLedgerMessages || bytes(message.content) > bounds.maxContentBytes) throw new Error('agent_ledger_limit')
+      ledger.push(cloneMessage(message))
+    }
+    const executeOne = async (call: MetroraAgentToolCall, step: number): Promise<void> => {
+      if (controller.signal.aborted) throw abortError()
+      const safeName = safeAgentEventText(call.name, 96) ?? 'unknown-tool'
+      emit('tool-queued', { step, tool: safeName, callId: call.id })
+      const validation = (options.validateToolCall ?? (candidate => defaultValidation(candidate, options.tools)))(call)
+      if (!validation.ok) {
+        diagnostics.push(validation.diagnostic)
+        emit('tool-unavailable', { step, tool: safeName, callId: call.id, detail: validation.diagnostic })
+        append({ role: 'tool', content: errorContent(), toolCallId: call.id, toolName: safeName })
+        this.markRequired(call, requiredState, false)
+        return
+      }
+      const validCall = validation.call
+      emit('tool-started', { step, tool: safeName, callId: validCall.id })
+      try {
+        const raw = await raceAbort(Promise.resolve().then(() => options.executeTool(validCall, controller.signal)), controller.signal)
+        if (typeof raw.content !== 'string' || bytes(raw.content) > bounds.maxContentBytes) throw new Error('tool_output_limit')
+        const status = resultStatus(raw)
+        if (raw.evidence && status !== 'unavailable') evidence.push(raw.evidence)
+        if (resultEvidenceUsable(raw)) this.markRequired(validCall, requiredState, true)
+        else this.markRequired(validCall, requiredState, false)
+        append({ role: 'tool', content: raw.content, toolCallId: validCall.id, toolName: safeName })
+        emit(status === 'completed' ? 'tool-completed' : 'tool-unavailable', { step, tool: safeName, callId: validCall.id })
+      } catch (error) {
+        if (isAbortLike(error) || controller.signal.aborted) throw error
+        const diagnostic = error instanceof Error && error.message === 'tool_output_limit' ? 'tool_output_limit' : 'tool_execution_failed'
+        diagnostics.push(diagnostic)
+        this.markRequired(validCall, requiredState, false)
+        append({ role: 'tool', content: errorContent(), toolCallId: validCall.id, toolName: safeName })
+        emit('tool-failed', { step, tool: safeName, callId: validCall.id, detail: diagnostic })
+      }
+    }
+    const executeCalls = async (calls: readonly MetroraAgentToolCall[], step: number): Promise<boolean> => {
+      if (toolRounds >= bounds.maxToolRounds) {
+        diagnostics.push('tool_round_limit')
+        return false
+      }
+      const remaining = bounds.maxCallsPerTurn - toolCalls
+      const accepted = calls.slice(0, Math.min(bounds.maxCallsPerStep, Math.max(0, remaining)))
+      if (!accepted.length) {
+        diagnostics.push('tool_limit')
+        return false
+      }
+      toolCalls += accepted.length
+      toolRounds += 1
+      for (const call of accepted) await executeOne(call, step)
+      if (accepted.length < calls.length) diagnostics.push('tool_limit')
+      return accepted.length === calls.length
+    }
+    const baselineCalls = () => required.filter(call => requiredState.get(this.callKey(call)) === 'pending')
+    const finish = (status: MetroraAgentLoopResult['status']): MetroraAgentLoopResult => ({
+      status,
+      finalText,
+      streamed,
+      evidence,
+      ledger: ledger.map(cloneMessage),
+      modelSteps,
+      toolCalls,
+      toolRounds,
+      diagnostics: [...new Set(diagnostics)],
+    })
+    emit('turn-started')
+    try {
+      while (true) {
+        if (controller.signal.aborted) throw abortError()
+        if (modelSteps >= bounds.maxSteps) {
+          diagnostics.push('step_limit')
+          emit('turn-failed', { detail: 'step_limit' })
+          return finish('limit')
+        }
+        modelSteps += 1
+        emit('model-started', { step: modelSteps })
+        let step: MetroraAgentModelStep
+        try {
+          step = await raceAbort(Promise.resolve().then(() => options.complete({ ledger: ledger.map(cloneMessage), tools: options.tools, step: modelSteps, signal: controller.signal })), controller.signal)
+        } catch (error) {
+          if (isAbortLike(error) || controller.signal.aborted) throw error
+          const diagnostic = error && typeof error === 'object' && 'diagnostic' in error && typeof (error as { diagnostic?: unknown }).diagnostic === 'string'
+            ? (error as { diagnostic: string }).diagnostic
+            : 'provider_failure'
+          diagnostics.push(diagnostic)
+          emit('turn-failed', { step: modelSteps, detail: diagnostic })
+          return finish('failed')
+        }
+        if (typeof step.content !== 'string' || bytes(step.content) > bounds.maxContentBytes || (step.kind === 'tool-calls' && !step.calls.length)) {
+          diagnostics.push('malformed_output')
+          emit('turn-failed', { step: modelSteps, detail: 'malformed_output' })
+          return finish('failed')
+        }
+        emit('model-completed', { step: modelSteps, detail: step.kind })
+        streamed ||= step.streamed === true
+        append({ role: 'assistant', content: step.content, ...(step.calls.length ? { toolCalls: step.calls } : {}) })
+        if (step.kind === 'tool-calls') {
+          if (toolRounds >= bounds.maxToolRounds) {
+            diagnostics.push('tool_round_limit')
+            emit('turn-failed', { step: modelSteps, detail: 'tool_round_limit' })
+            return finish('limit')
+          }
+          const allAccepted = await executeCalls(step.calls, modelSteps)
+          if (!allAccepted || toolCalls >= bounds.maxCallsPerTurn) {
+            emit('turn-failed', { step: modelSteps, detail: 'tool_limit' })
+            return finish('limit')
+          }
+          requiredReady = this.requiredReady(requiredState)
+          continue
+        }
+        finalText = step.content
+        if (!requiredReady && !baselineAttempted && baselineCalls().length) {
+          const calls = baselineCalls()
+          baselineAttempted = true
+          const allAccepted = await executeCalls(calls, modelSteps)
+          requiredReady = this.requiredReady(requiredState)
+          if (!allAccepted || toolCalls >= bounds.maxCallsPerTurn) {
+            emit('turn-failed', { step: modelSteps, detail: 'tool_limit' })
+            return finish('limit')
+          }
+          continue
+        }
+        emit('turn-completed', { step: modelSteps })
+        return finish('completed')
+      }
+    } catch (error) {
+      if (timedOut) {
+        diagnostics.push('deadline')
+        emit('turn-timeout', { detail: 'deadline' })
+        return finish('timeout')
+      }
+      if (options.signal?.aborted || isAbortLike(error)) {
+        diagnostics.push('cancelled')
+        emit('turn-cancelled', { detail: 'cancelled' })
+        return finish('cancelled')
+      }
+      diagnostics.push('turn_failure')
+      emit('turn-failed', { detail: 'turn_failure' })
+      return finish('failed')
+    } finally {
+      disposed = true
+      clearTimeout(timer)
+      controller.signal.removeEventListener('abort', cancelModel)
+      options.signal?.removeEventListener('abort', forwardAbort)
+    }
+  }
+
+  private callKey(call: MetroraAgentToolCall): string {
+    return call.name + '\u0000' + JSON.stringify(call.arguments)
+  }
+
+  private markRequired(call: MetroraAgentToolCall, state: Map<string, 'pending' | 'satisfied' | 'attempted'>, usable: boolean): void {
+    const key = this.callKey(call)
+    if (!state.has(key)) return
+    state.set(key, usable ? 'satisfied' : 'attempted')
+  }
+
+  private requiredReady(state: Map<string, 'pending' | 'satisfied' | 'attempted'>): boolean {
+    return [...state.values()].every(value => value === 'satisfied')
+  }
+}
+
+export async function runMetroraAgentLoop(options: MetroraAgentLoopOptions): Promise<MetroraAgentLoopResult> {
+  return new MetroraAgentLoop(options).run()
+}

--- a/app/renderer/agent-loop/model-step.ts
+++ b/app/renderer/agent-loop/model-step.ts
@@ -1,0 +1,107 @@
+import { normalizeAdvisorRuntimeToolCall } from '../advisor/contract'
+import { parseAdvisorPlanningDraft, runtimeGuardPlan, validateAdvisorPlanningDraft } from '../advisor/planner'
+import type { AdvisorRuntimeInput, AdvisorToolDefinition } from '../advisor/types'
+import type { MetroraAgentModelStep, MetroraAgentToolCall } from './contracts'
+
+export type AdvisorProviderModelResponse = {
+  message?: { content?: unknown; tool_calls?: unknown }
+  streamed?: unknown
+}
+
+export class MetroraModelStepError extends Error {
+  readonly diagnostic: string
+
+  constructor(diagnostic: string, message = 'The model step was not a valid bounded Metrora response.') {
+    super(message)
+    this.name = 'MetroraModelStepError'
+    this.diagnostic = diagnostic
+  }
+}
+
+function record(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null
+  return value as Record<string, unknown>
+}
+
+function safeId(value: unknown, fallback: string): string {
+  return typeof value === 'string' && /^[A-Za-z0-9._:-]{1,128}$/u.test(value) ? value : fallback
+}
+
+function callName(value: unknown): unknown {
+  const item = record(value)
+  if (!item) return undefined
+  if (typeof item.name === 'string') return item.name
+  return record(item.function)?.name
+}
+
+function callArguments(value: unknown): unknown {
+  const item = record(value)
+  if (!item) return undefined
+  if (Object.prototype.hasOwnProperty.call(item, 'arguments')) return item.arguments
+  return record(item.function)?.arguments
+}
+
+function nativeCalls(
+  value: unknown,
+  definitions: readonly AdvisorToolDefinition[],
+): MetroraAgentToolCall[] {
+  if (!Array.isArray(value)) throw new MetroraModelStepError('malformed_tool_call', 'The provider returned malformed tool calls.')
+  const ids = new Set<string>()
+  return value.slice(0, 16).map((item, index) => {
+    const name = callName(item)
+    const args = callArguments(item)
+    try {
+      const normalized = normalizeAdvisorRuntimeToolCall(name, args, definitions)
+      let id = safeId(record(item)?.id, 'model-call-' + index)
+      if (ids.has(id)) id = 'model-call-' + index
+      ids.add(id)
+      return { id, name: normalized.name, arguments: normalized.arguments as Record<string, unknown> }
+    } catch {
+      throw new MetroraModelStepError('malformed_tool_call', 'The provider returned a malformed Metrora tool call.')
+    }
+  })
+}
+
+function structuredCalls(
+  content: string,
+  input: AdvisorRuntimeInput,
+  definitions: readonly AdvisorToolDefinition[],
+): MetroraAgentToolCall[] | null {
+  const draft = parseAdvisorPlanningDraft(content)
+  if (!draft) return null
+  const { guard } = runtimeGuardPlan(input)
+  const validation = validateAdvisorPlanningDraft(draft, guard, input.evidence.scope, definitions)
+  if (!validation || !validation.toolRequests.length) throw new MetroraModelStepError('malformed_tool_call', 'The model planning response did not contain an allowed read Tool.')
+  return validation.toolRequests.map((request, index) => ({
+    id: 'planning-call-' + index,
+    name: request.tool,
+    arguments: request.arguments as Record<string, unknown>,
+  }))
+}
+
+export function normalizeAdvisorModelStep(
+  response: AdvisorProviderModelResponse,
+  input: AdvisorRuntimeInput,
+  definitions: readonly AdvisorToolDefinition[],
+  allowNativeToolCalls = true,
+): MetroraAgentModelStep {
+  const message = record(record(response)?.message)
+  if (!message) throw new MetroraModelStepError('malformed_output', 'The provider returned no model message.')
+  const content = typeof message.content === 'string' ? message.content : message.content === undefined ? '' : (() => { throw new MetroraModelStepError('malformed_output', 'The provider returned malformed model text.') })()
+  const rawCalls = message.tool_calls
+  if (Array.isArray(rawCalls) && rawCalls.length) {
+    if (!allowNativeToolCalls) {
+      const fallbackCalls = structuredCalls(content, input, definitions)
+      if (fallbackCalls) return { kind: 'tool-calls', content: '', calls: fallbackCalls, streamed: response.streamed === true }
+      throw new MetroraModelStepError('malformed_tool_call', 'Native Tool calls are not verified for this model.')
+    }
+    const calls = nativeCalls(rawCalls, definitions)
+    return { kind: 'tool-calls', content, calls, streamed: response.streamed === true }
+  }
+  const calls = structuredCalls(content, input, definitions)
+  if (calls) return { kind: 'tool-calls', content: '', calls, streamed: response.streamed === true }
+  if (!content.trim()) throw new MetroraModelStepError('malformed_output', 'The provider returned an empty model message.')
+  return { kind: 'final-text', content, calls: [], streamed: response.streamed === true }
+}
+
+export const normalizeMetroraModelStep = normalizeAdvisorModelStep

--- a/app/renderer/agent-loop/provenance.ts
+++ b/app/renderer/agent-loop/provenance.ts
@@ -1,0 +1,230 @@
+import { buildAdvisorVerifiedClaimAtoms } from '../advisor/claim-atoms'
+import { containsAdvisorForbiddenOutputClass, containsAdvisorSensitiveText, sanitizeAdvisorDisplayText } from '../advisor/privacy'
+import type { AdvisorEvidence } from '../advisor/types'
+
+export type MetroraClaimProvenance =
+  | 'canonical-metrora-fact'
+  | 'user-provided-fact'
+  | 'deterministic-derivation'
+  | 'model-interpretation'
+  | 'unsupported-factual-claim'
+
+export type MetroraProvenanceDiagnostic =
+  | 'unsupported_numeric_claim'
+  | 'unsupported_subject_claim'
+  | 'unsupported_rank_claim'
+  | 'unsupported_causality'
+  | 'privacy_violation'
+  | 'ungrounded_narrative'
+
+export type MetroraProvenanceResult = {
+  text: string
+  accepted: boolean
+  usedCanonicalFact: boolean
+  usedUserFact: boolean
+  usedDerivation: boolean
+  usedInterpretation: boolean
+  removedClauses: number
+  diagnostics: readonly MetroraProvenanceDiagnostic[]
+}
+
+type NumberSource = 'canonical' | 'user' | 'derived'
+type AuthorizedNumber = { value: number; source: NumberSource; unit: string | null }
+
+function numberKey(value: number): string {
+  return Number(value.toFixed(6)).toString()
+}
+
+function parseNumberToken(token: string): number | null {
+  const suffix = /[kKmMbB]$/u.test(token) ? token.slice(-1).toLowerCase() : ''
+  const raw = suffix ? token.slice(0, -1) : token
+  let normalized = raw
+  const comma = raw.lastIndexOf(',')
+  const dot = raw.lastIndexOf('.')
+  if (comma >= 0 && dot >= 0) {
+    const decimal = comma > dot ? ',' : '.'
+    const thousands = decimal === ',' ? '.' : ','
+    normalized = raw.replaceAll(thousands, '').replace(decimal, '.')
+  } else if (comma >= 0) {
+    normalized = /,\d{3}(?:,\d{3})*$/u.test(raw) ? raw.replaceAll(',', '') : raw.replace(',', '.')
+  } else if (dot >= 0) {
+    normalized = /\.\d{3}(?:\.\d{3})*$/u.test(raw) ? raw.replaceAll('.', '') : raw
+  }
+  const value = Number(normalized)
+  if (!Number.isFinite(value)) return null
+  const multiplier = suffix === 'k' ? 1_000 : suffix === 'm' ? 1_000_000 : suffix === 'b' ? 1_000_000_000 : 1
+  return value * multiplier
+}
+
+function numberTokens(value: string): number[] {
+  return Array.from(value.matchAll(/\d+(?:[.,]\d+)*(?:[kKmMbB])?/gu)).flatMap(match => {
+    const index = match.index ?? -1
+    const token = match[0]
+    const before = index > 0 ? value[index - 1] : ''
+    const after = value[index + token.length] ?? ''
+    // Version/model identifiers such as GPT-5.6 are not numeric claims.
+    if (/[\p{L}_-]/u.test(before) || /[\p{L}_]/u.test(after) && !/[kKmMbB]$/u.test(token)) return []
+    const parsed = parseNumberToken(token)
+    return parsed === null ? [] : [parsed]
+  })
+}
+
+function evidenceWords(evidenceItems: readonly AdvisorEvidence[]): Set<string> {
+  const text = evidenceItems.flatMap(evidence => [
+    evidence.question,
+    evidence.coverage.label,
+    evidence.coverage.detail,
+    ...evidence.refs.flatMap(ref => [ref.id, ref.label]),
+    evidence.spend ? 'spend usage cost total calls sessions model models projects providers concentration' : '',
+    evidence.modelEfficiency ? 'model models efficiency cost calls pricing concentration' : '',
+    evidence.quota ? 'quota capacity remaining reset credits providers' : '',
+    evidence.bench ? 'bench benchmark score status result test' : '',
+  ]).join(' ').normalize('NFD').replace(/[\u0300-\u036f]/gu, '').toLocaleLowerCase()
+  return new Set(text.match(/[\p{L}\p{N}]{3,}/gu) ?? [])
+}
+
+function authorizedNumbers(question: string, evidenceItems: readonly AdvisorEvidence[]): AuthorizedNumber[] {
+  const values: AuthorizedNumber[] = []
+  for (const evidence of evidenceItems) {
+    for (const atom of buildAdvisorVerifiedClaimAtoms(evidence)) {
+      if (typeof atom.value === 'number' && Number.isFinite(atom.value)) values.push({ value: atom.value, source: 'canonical', unit: atom.unit })
+    }
+  }
+  const user = numberTokens(question)
+  for (const value of user) values.push({ value, source: 'user', unit: null })
+  const base = Array.from(new Map(values.map(item => [numberKey(item.value) + '\u0000' + (item.unit ?? ''), item])).values())
+  for (const left of base) {
+    for (const right of base) {
+      if (left.value === right.value || left.unit && right.unit && left.unit !== right.unit) continue
+      const difference = Math.abs(left.value - right.value)
+      const unit = left.unit ?? right.unit
+      if (Number.isFinite(difference) && difference <= 1_000_000_000_000) values.push({ value: difference, source: 'derived', unit })
+    }
+  }
+  return values
+}
+
+function subjectNames(evidenceItems: readonly AdvisorEvidence[]): string[] {
+  return [...new Set(evidenceItems.flatMap(evidence => buildAdvisorVerifiedClaimAtoms(evidence).flatMap(atom => atom.subject ? [atom.subject] : [])))]
+}
+
+function thresholdContext(value: string): boolean {
+  return /\b(?:threshold|limit|budget|criterion|criteria|soglia|limite|budget|oltre|supera|superato|superata|exceed|exceeds|above|more\s+than|less\s+than|differenza|difference|delta)\b/iu.test(value)
+}
+
+function numericContext(value: string): 'currency' | 'calls' | 'tokens' | 'percent' | 'sessions' | 'generic' {
+  if (/(?:[$€£]|\busd\b|\bdollars?\b|\bdollari\b|\beuros?\b|\bcost\w*\b|\bspend\w*\b|\bspes\w*\b|\bamount\b)/iu.test(value)) return 'currency'
+  if (/\b(?:calls?|chiamat\w*)\b/iu.test(value)) return 'calls'
+  if (/\b(?:tokens?|gettoni)\b/iu.test(value)) return 'tokens'
+  if (/%|\b(?:percent\w*|quota|remaining|riman\w*)\b/iu.test(value)) return 'percent'
+  if (/\b(?:sessions?|sessioni)\b/iu.test(value)) return 'sessions'
+  return 'generic'
+}
+
+function numberUnitAllowed(item: AuthorizedNumber, context: string): boolean {
+  if (!item.unit) return true
+  const kind = numericContext(context)
+  if (kind === 'generic') return true
+  if (kind === 'currency') return item.unit === 'USD'
+  if (kind === 'calls') return item.unit === 'calls'
+  if (kind === 'tokens') return item.unit === 'tokens'
+  if (kind === 'sessions') return item.unit === 'sessions'
+  return item.unit === '%' || item.unit === 'USD'
+}
+
+function sentenceParts(value: string): string[] {
+  return value.split(/\r?\n+/u).flatMap(line => line.split(/(?<=[.!?])\s+(?=[\p{L}\p{N}"'])/u)).flatMap(sentence => sentence.split(/\s+(?:but|however|ma|però|tuttavia)\s+/iu)).flatMap(sentence => sentence.split(/;\s*/u)).map(sentence => sentence.trim()).filter(Boolean)
+}
+
+function causalClaim(value: string): boolean {
+  return /\b(?:caused|causes|cause|due\s+to|because\s+of|responsible\s+for|driver\s+of|ha\s+causato|hanno\s+causato|a\s+causa\s+di|causa\s+principale|motivo\s+(?:è|e)|ragione\s+(?:è|e))\b/iu.test(value)
+}
+
+function rankClaim(value: string): boolean {
+  return /\b(?:top|main|primary|leading|largest|highest|biggest|dominant|most\s+(?:expensive|costly)|rank(?:ed|ing)?|contributor|driver|principale|maggiore|più\s+(?:costoso|costosa)|classifica|ordinamento)\b/iu.test(value)
+}
+
+function trendClaim(value: string): boolean {
+  return /\b(?:rose|risen|increased|increasing|decreased|decreasing|fell|grew|growth|declined|in salita|in calo|aumentat\w*|diminuit\w*|cresciut\w*|calat\w*)\b/iu.test(value)
+}
+
+function subjectClaim(value: string, known: readonly string[]): boolean {
+  const normalized = value.normalize('NFD').replace(/[\u0300-\u036f]/gu, '').toLocaleLowerCase()
+  const knownNormalized = known.map(item => item.normalize('NFD').replace(/[\u0300-\u036f]/gu, '').toLocaleLowerCase())
+  const labeled = Array.from(value.matchAll(/\b(?:model|models|modello|modelli|project|projects|progetto|progetti|session|sessions|sessione|sessioni|provider|providers|fornitore|fornitori)\s+([\p{L}\p{N}._:/-]+)/giu)).map(match => match[1]!.normalize('NFD').replace(/[\u0300-\u036f]/gu, '').toLocaleLowerCase())
+  return labeled.some(candidate => !knownNormalized.some(name => name === candidate || name.includes(candidate) || candidate.includes(name)) && !/^(?:concentration|concentrazione|cost|spend|usage|utilizzo|efficiency|efficienza|context|contesto|activity|attivita|data|dati|total|totale|driver|drivers|breakdown|source|value|row)$/u.test(candidate)) || (rankClaim(value) && known.length === 0) || (causalClaim(value) && known.length === 0 && /\b(?:model|project|session|provider|modello|progetto|sessione|fornitore)\b/iu.test(normalized))
+}
+
+function interpretationClaim(value: string): boolean {
+  return /\b(?:i\s+(?:consider|regard|think)|i['’]?d\s+(?:inspect|review|look)|i\s+would|we\s+should|recommend|suggest|meaningful|significant|material|worth\s+(?:checking|inspecting|investigating)|observed\s+pattern|closer\s+look|pattern\s+deserves|值得|significativ\w*|importante|rilevante|vale\s+la\s+pena|controllerei|ispezionerei|consiglio)\b/iu.test(value)
+}
+
+function topicAnchor(value: string, words: Set<string> = new Set()): boolean {
+  const tokens = value.normalize('NFD').replace(/[\u0300-\u036f]/gu, '').toLocaleLowerCase().match(/[\p{L}\p{N}]{3,}/gu) ?? []
+  return tokens.some(token => words.has(token))
+}
+
+function classifyClause(clause: string, _question: string, evidenceItems: readonly AdvisorEvidence[], auth: readonly AuthorizedNumber[], words: Set<string>, subjects: readonly string[]): { accepted: boolean; kinds: MetroraClaimProvenance[]; diagnostic?: MetroraProvenanceDiagnostic } {
+  const values = numberTokens(clause)
+  for (const value of values) {
+    const matches = auth.filter(item => numberKey(item.value) === numberKey(value) && numberUnitAllowed(item, clause))
+    const userMatch = matches.find(item => item.source === 'user')
+    const derivedMatch = matches.find(item => item.source === 'derived')
+    const canonicalMatch = matches.find(item => item.source === 'canonical')
+    if (!canonicalMatch && !userMatch && !derivedMatch) return { accepted: false, kinds: ['unsupported-factual-claim'], diagnostic: 'unsupported_numeric_claim' }
+    if (userMatch && !thresholdContext(clause) && !topicAnchor(clause, words)) return { accepted: false, kinds: ['unsupported-factual-claim'], diagnostic: 'unsupported_numeric_claim' }
+  }
+  if (containsAdvisorSensitiveText(clause) || containsAdvisorForbiddenOutputClass(clause)) return { accepted: false, kinds: ['unsupported-factual-claim'], diagnostic: 'privacy_violation' }
+  if (causalClaim(clause)) return { accepted: false, kinds: ['unsupported-factual-claim'], diagnostic: 'unsupported_causality' }
+  if (trendClaim(clause) && !evidenceItems.some(item => item.spend?.trend)) return { accepted: false, kinds: ['unsupported-factual-claim'], diagnostic: 'ungrounded_narrative' }
+  if (subjectClaim(clause, subjects)) return { accepted: false, kinds: ['unsupported-factual-claim'], diagnostic: 'unsupported_subject_claim' }
+  if (rankClaim(clause) && !subjects.some(subject => clause.toLocaleLowerCase().includes(subject.toLocaleLowerCase()))) return { accepted: false, kinds: ['unsupported-factual-claim'], diagnostic: 'unsupported_rank_claim' }
+  const supportedNumber = values.some(value => auth.some(item => (item.source === 'canonical' || item.source === 'derived') && numberKey(item.value) === numberKey(value)))
+  const hasEvidence = values.length > 0 || topicAnchor(clause, words) || (interpretationClaim(clause) && evidenceItems.some(item => item.refs.length > 0))
+  if (!hasEvidence || (!topicAnchor(clause) && !interpretationClaim(clause) && !supportedNumber && !thresholdContext(clause))) return { accepted: false, kinds: ['unsupported-factual-claim'], diagnostic: 'ungrounded_narrative' }
+  const kinds: MetroraClaimProvenance[] = []
+  if (values.some(value => auth.some(item => item.source === 'canonical' && numberKey(item.value) === numberKey(value)))) kinds.push('canonical-metrora-fact')
+  if (values.some(value => auth.some(item => item.source === 'user' && numberKey(item.value) === numberKey(value)))) kinds.push('user-provided-fact')
+  if (values.some(value => auth.some(item => item.source === 'derived' && numberKey(item.value) === numberKey(value)))) kinds.push('deterministic-derivation')
+  if (interpretationClaim(clause) || !values.length) kinds.push('model-interpretation')
+  return { accepted: true, kinds }
+}
+
+export function classifyMetroraProvenance(value: string, question: string, evidenceItems: readonly AdvisorEvidence[]): MetroraProvenanceResult {
+  const raw = value.trim()
+  if (!raw) return { text: '', accepted: false, usedCanonicalFact: false, usedUserFact: false, usedDerivation: false, usedInterpretation: false, removedClauses: 0, diagnostics: ['ungrounded_narrative'] }
+  if (containsAdvisorSensitiveText(raw) || containsAdvisorForbiddenOutputClass(raw)) return { text: '', accepted: false, usedCanonicalFact: false, usedUserFact: false, usedDerivation: false, usedInterpretation: false, removedClauses: 1, diagnostics: ['privacy_violation'] }
+  const safe = sanitizeAdvisorDisplayText(raw, Number.MAX_SAFE_INTEGER)
+  const auth = authorizedNumbers(question, evidenceItems)
+  const words = evidenceWords(evidenceItems)
+  const subjects = subjectNames(evidenceItems)
+  const accepted: string[] = []
+  const diagnostics: MetroraProvenanceDiagnostic[] = []
+  let usedCanonicalFact = false
+  let usedUserFact = false
+  let usedDerivation = false
+  let usedInterpretation = false
+  for (const clause of sentenceParts(safe)) {
+    const result = classifyClause(clause, question, evidenceItems, auth, words, subjects)
+    if (!result.accepted) {
+      if (result.diagnostic) diagnostics.push(result.diagnostic)
+      continue
+    }
+    accepted.push(clause)
+    usedCanonicalFact ||= result.kinds.includes('canonical-metrora-fact')
+    usedUserFact ||= result.kinds.includes('user-provided-fact')
+    usedDerivation ||= result.kinds.includes('deterministic-derivation')
+    usedInterpretation ||= result.kinds.includes('model-interpretation')
+  }
+  const text = accepted.join(' ').trim()
+  return {
+    text,
+    accepted: Boolean(text),
+    usedCanonicalFact,
+    usedUserFact,
+    usedDerivation,
+    usedInterpretation,
+    removedClauses: Math.max(0, sentenceParts(safe).length - accepted.length),
+    diagnostics: [...new Set(diagnostics)],
+  }
+}

--- a/app/renderer/swarm/native-worker-adapter.test.ts
+++ b/app/renderer/swarm/native-worker-adapter.test.ts
@@ -1,7 +1,9 @@
+// @vitest-environment jsdom
+
 import { describe, expect, it, vi } from 'vitest'
 import type { MenubarPayload } from '../lib/types'
 import { createAdvisorConformanceFixture } from '../advisor/conformance'
-import { DeterministicAdvisorRuntime } from '../advisor/runtime'
+import { OllamaAdvisorRuntime } from '../advisor/ollama'
 import type { AdvisorAnswer, AdvisorDataSource, AdvisorRuntimeInput, AdvisorModelRuntime } from '../advisor/types'
 import { createBaselineWorkerRequests } from '../../../src/swarm/coordinator-v1'
 import type { SwarmEventV1, SwarmSynthesisInputV1, SwarmWorkerResultV1 } from '../../../src/swarm/contract-v1'
@@ -176,15 +178,29 @@ describe('Native Harness Swarm worker adapter', () => {
   it('gives Investigator and Verifier distinct trusted responsibilities and independent canonical reads', async () => {
     const fixture = createAdvisorConformanceFixture()
     const inputs: AdvisorRuntimeInput[] = []
+    const roleCalls = new Map<string, number>()
+    const loopRuntime = new OllamaAdvisorRuntime({
+      model: 'role-model',
+      transport: {
+        probe: async () => ({ available: true, models: ['role-model'], detail: 'ready' }),
+        cancel: async () => true,
+        onDelta: () => () => {},
+        chat: async (_requestId, payload) => {
+          const system = String((payload.messages as Array<{ content?: unknown }>)[0]?.content ?? '')
+          const role = /responsibility \((investigator|verifier),/u.exec(system)?.[1] ?? 'investigator'
+          const count = (roleCalls.get(role) ?? 0) + 1
+          roleCalls.set(role, count)
+          return count === 1
+            ? { streamed: false, message: { content: '', tool_calls: [{ function: { name: 'get_spend_snapshot', arguments: '{}' } }] } }
+            : { streamed: false, message: { content: role === 'investigator' ? 'I measured $12.00 in the selected scope; I would inspect the visible drivers next.' : 'I independently checked the canonical $12.00 measurement; the requested evidence is consistent.' } }
+        },
+      },
+    })
     const runtime: AdvisorModelRuntime = {
-      id: 'role-fixture',
-      label: 'Role fixture',
-      mode: 'ollama-local',
-      providerSupport: ['fixture'],
-      availability: 'ready',
-      generate: vi.fn(async (input: AdvisorRuntimeInput) => {
+      ...loopRuntime,
+      generate: vi.fn(async (input: AdvisorRuntimeInput, signal?: AbortSignal) => {
         inputs.push(input)
-        return new DeterministicAdvisorRuntime().generate(input)
+        return loopRuntime.generate(input, signal)
       }),
     }
     const adapter = new NativeHarnessWorkerAdapter({ source: fixture.source, runtime, overview: null, now: () => '2026-08-31T00:00:00.000Z' })
@@ -220,14 +236,21 @@ describe('Native Harness Swarm worker adapter', () => {
       current: { ...today.current, cost: 4118.17, calls: 417, sessions: 28 },
     } as unknown as MenubarPayload
     const fixture = createAdvisorConformanceFixture({ overview: lifetime })
-    const runtime: AdvisorModelRuntime = {
-      id: 'lifetime-fixture',
-      label: 'Lifetime fixture',
-      mode: 'ollama-local',
-      providerSupport: ['fixture'],
-      availability: 'ready',
-      generate: input => new DeterministicAdvisorRuntime().generate(input),
-    }
+    let calls = 0
+    const runtime = new OllamaAdvisorRuntime({
+      model: 'lifetime-model',
+      transport: {
+        probe: async () => ({ available: true, models: ['lifetime-model'], detail: 'ready' }),
+        cancel: async () => true,
+        onDelta: () => () => {},
+        chat: async () => {
+          calls += 1
+          return calls === 1
+            ? { streamed: false, message: { content: '', tool_calls: [{ function: { name: 'get_spend_snapshot', arguments: '{}' } }] } }
+            : { streamed: false, message: { content: 'Metrora measured $4,118.17 in lifetime spend.' } }
+        },
+      },
+    })
     const adapter = new NativeHarnessWorkerAdapter({
       source: fixture.source,
       runtime,
@@ -258,25 +281,15 @@ describe('Native Harness Swarm worker adapter', () => {
       ...fixture.source,
       getOverview: vi.fn(async () => { throw new Error('canonical spend source unavailable') }),
     }
-    const runtime: AdvisorModelRuntime = {
-      id: 'generic-fixture',
-      label: 'Generic fixture',
-      mode: 'ollama-local',
-      providerSupport: ['fixture'],
-      availability: 'ready',
-      generate: vi.fn(async () => ({
-        conclusion: 'Hello. I can help you understand spend.',
-        scopeLabel: 'Today',
-        periodLabel: 'Today',
-        evidence: [],
-        coverage: { level: 'high', label: 'High coverage', detail: 'The model returned text.' },
-        assumptions: [],
-        unknown: [],
-        nextInvestigations: [],
-        details: [],
-        runtime: { id: 'generic-fixture', label: 'Generic fixture', mode: 'ollama-local' },
-      } satisfies AdvisorAnswer)),
-    }
+    const runtime = new OllamaAdvisorRuntime({
+      model: 'unavailable-model',
+      transport: {
+        probe: async () => ({ available: true, models: ['unavailable-model'], detail: 'ready' }),
+        cancel: async () => true,
+        onDelta: () => () => {},
+        chat: async () => ({ streamed: false, message: { content: 'I cannot verify the measured spend yet.' } }),
+      },
+    })
     const adapter = new NativeHarnessWorkerAdapter({ source: failingSource, runtime, overview: null, now: () => '2026-08-31T00:00:00.000Z' })
     const [request] = createBaselineWorkerRequests({
       runId: 'run-unavailable-evidence',
@@ -295,7 +308,7 @@ describe('Native Harness Swarm worker adapter', () => {
     expect(result.evidenceSummary).toMatch(/unavailable/i)
     expect(result.evidenceSummary).not.toMatch(/high coverage/i)
     expect(result.toolActivity).toEqual([{ name: 'get_spend_snapshot', status: expect.stringMatching(/unavailable|failed/) }])
-    expect(result.answer).not.toMatch(/Hello\. I can help you understand spend/i)
+    expect(result.answer).toMatch(/required canonical Metrora evidence was unavailable/i)
   })
 })
 
@@ -406,7 +419,7 @@ describe('Native Harness Swarm synthesis boundary', () => {
     expect(result.status).toBe('completed')
     expect(result.answer).toContain(workerAnswer)
     expect(result.answer).not.toContain('$99.00')
-    expect(result.errors.join(' ')).toMatch(/not grounded|deterministic/i)
+    expect(result.errors.join(' ')).toMatch(/safe supported explanation|worker closeout/i)
   })
 
   it.each([

--- a/app/renderer/swarm/native-worker-adapter.ts
+++ b/app/renderer/swarm/native-worker-adapter.ts
@@ -5,7 +5,7 @@ import { ADVISOR_TOOL_CONTRACT } from '../advisor/contract'
 import { createAdvisorToolRegistry, type AdvisorOverviewSnapshot } from '../advisor/tools'
 import { DeterministicAdvisorRuntime } from '../advisor/runtime'
 import { mergeEvidence } from '../advisor/merge-evidence'
-import { advisorAnswerUsesCanonicalEvidence, advisorQuestionRequiresCanonicalReads, executeRequiredAdvisorReads, advisorToolRequestKey, type RequiredAdvisorReadsResult } from '../advisor/required-reads'
+import { requiredAdvisorToolRequests } from '../advisor/required-reads'
 import type {
   AdvisorDataSource,
   AdvisorEvidence,
@@ -88,22 +88,17 @@ function filteredToolContract(
   }
 }
 
-function evidenceStatus(requiredReads: RequiredAdvisorReadsResult | null, evidenceItems: readonly AdvisorEvidence[]): SwarmEvidenceResultStatusV1 {
-  // Non-factual bounded worker jobs have no canonical evidence domain to
-  // read. They remain execution-usable without inventing a High evidence
-  // claim; factual jobs always arrive with a RequiredAdvisorReadsResult.
-  if (!requiredReads) return 'usable'
-  if (requiredReads.status === 'unavailable') return 'unavailable'
-  const requiredCount = requiredReads.evidence.length
-  const optionalItems = evidenceItems.slice(requiredCount)
-  const optionalUnavailable = optionalItems.some(item => item.coverage.level === 'unavailable' || item.refs.length === 0)
-  return requiredReads.status === 'partial' || optionalUnavailable ? 'partial' : 'usable'
+function evidenceStatus(requiredToolNames: readonly string[], successfulToolNames: ReadonlySet<string>, unavailableToolNames: ReadonlySet<string>): SwarmEvidenceResultStatusV1 {
+  if (!requiredToolNames.length) return 'usable'
+  const required = new Set(requiredToolNames)
+  const successful = [...required].filter(name => successfulToolNames.has(name)).length
+  if (!successful) return 'unavailable'
+  return successful < required.size || [...required].some(name => unavailableToolNames.has(name)) ? 'partial' : 'usable'
 }
 
-function evidenceResult(requiredReads: RequiredAdvisorReadsResult | null, evidenceItems: readonly AdvisorEvidence[], usedToolNames: readonly string[]): SwarmEvidenceResultV1 {
-  const requiredToolNames = requiredReads?.requests.map(request => request.tool) ?? []
+function evidenceResult(requiredToolNames: readonly string[], successfulToolNames: ReadonlySet<string>, unavailableToolNames: ReadonlySet<string>, usedToolNames: readonly string[]): SwarmEvidenceResultV1 {
   return {
-    status: evidenceStatus(requiredReads, evidenceItems),
+    status: evidenceStatus(requiredToolNames, successfulToolNames, unavailableToolNames),
     requiredToolNames: [...new Set(requiredToolNames)].slice(0, 16),
     usedToolNames: [...new Set(usedToolNames)].slice(0, 16),
   }
@@ -273,18 +268,9 @@ export class NativeHarnessWorkerAdapter implements WorkerAdapterV1 {
       const definitions = registry.definitions.filter(definition => allowed.has(definition.function.name)).slice(0, 16)
       const contract = filteredToolContract(registry.contract, definitions)
       let toolCalls = 0
-      // The worker adapter exposes one bounded Tool round to the selected
-      // runtime. The runtime may make several calls inside that round, but
-      // it cannot widen the immutable worker budget.
-      const toolRounds = 1
-      const ensureToolRoundAllowed = () => {
-        if (toolRounds > request.limits.maxToolRounds) throw new SwarmBoundsError('Worker Tool-round limit reached.')
-      }
-      // Every factual worker receives the same controller-selected baseline
-      // read. The model can request additional bounded reads, but it cannot
-      // decide that the minimum Metrora evidence does not exist.
+      const successfulToolNames = new Set<string>()
+      const unavailableToolNames = new Set<string>()
       const onToolEvent = (event: AdvisorToolEvent) => {
-        if (event.status === 'queued' || event.status === 'started') ensureToolRoundAllowed()
         activityEvents.push(event)
         if (event.status === 'started' || event.status === 'queued') {
           observe({ contractVersion: 'metrora.swarm.v1', schemaVersion: 1, kind: 'worker', runId: request.runId, workerId: request.workerId, role: request.role, status: 'tool-started', at: this.now(), toolName: safeToolName(event.name) })
@@ -292,87 +278,65 @@ export class NativeHarnessWorkerAdapter implements WorkerAdapterV1 {
           observe({ contractVersion: 'metrora.swarm.v1', schemaVersion: 1, kind: 'worker', runId: request.runId, workerId: request.workerId, role: request.role, status: 'tool-completed', at: this.now(), toolName: safeToolName(event.name), detail: event.status })
         }
       }
-      const onToolRound = (round: number) => {
-        if (round > request.limits.maxToolRounds) throw new SwarmBoundsError('Worker Tool-round limit reached.')
-      }
-      const requiredReads = advisorQuestionRequiresCanonicalReads(plan)
-        ? await executeRequiredAdvisorReads({
-            source: this.source,
-            scope,
-            question,
-            plan,
-            suppliedOverview: this.overview,
-            allowedToolNames: allowed,
-            definitions,
-            limits: { maxCalls: request.limits.maxToolCalls },
-            signal,
-            onToolEvent,
-            registry,
-          })
-        : null
-      const requiredEvidence = requiredReads?.evidence.length ? [...requiredReads.evidence] : []
-      const evidence = requiredEvidence.length
-        ? mergeEvidence(requiredEvidence, requiredEvidence[0]!)
-        : { ...buildConversationEvidence(question, scope), understanding: plan.understanding, plan: plan.plan }
-      const baselineExecutions = new Map<string, AdvisorToolExecution>()
-      for (const read of requiredReads?.reads ?? []) {
-        if (read.execution) baselineExecutions.set(advisorToolRequestKey(read.request), read.execution)
-      }
-      const baselineReuse = new Map<string, number>()
-      const evidenceItems: AdvisorEvidence[] = [...requiredEvidence]
+      const requiredToolRequests = requiredAdvisorToolRequests(plan, definitions, question)
+      const requiredToolNames = requiredToolRequests.map(request => request.tool)
+      const evidence = { ...buildConversationEvidence(question, scope), understanding: plan.understanding, plan: plan.plan }
+      const evidenceItems: AdvisorEvidence[] = []
       const executeTool = async (name: string, args: Record<string, unknown>, toolSignal?: AbortSignal): Promise<AdvisorToolExecution> => {
         throwIfAborted(signal)
         if (!allowed.has(name) || !definitions.some(definition => definition.function.name === name)) throw new SwarmBoundsError('Worker requested a Tool outside its immutable allowlist.')
-        const cachedKey = name + '\u0000' + JSON.stringify(args)
-        const cached = baselineExecutions.get(cachedKey)
-        if (cached) {
-          const reuseCount = baselineReuse.get(cachedKey) ?? 0
-          // A one-call worker may consume the controller baseline once; a
-          // second request is outside its immutable call bound. Larger fixed
-          // budgets can inspect the same bounded snapshot without rereading it.
-          if (request.limits.maxToolCalls <= 1 && reuseCount > 0) throw new SwarmBoundsError('Worker Tool-call limit reached.')
-          baselineReuse.set(cachedKey, reuseCount + 1)
-          return cached
-        }
         if (toolCalls >= request.limits.maxToolCalls) throw new SwarmBoundsError('Worker Tool-call limit reached.')
-        ensureToolRoundAllowed()
         toolCalls += 1
         const execution = await registry.execute(name, args, toolSignal ?? signal)
         const unavailable = execution.envelope?.unavailable === true || execution.evidence.coverage.level === 'unavailable'
         const evidence = unavailable ? { ...execution.evidence, refs: [] } : execution.evidence
         evidenceItems.push(evidence)
+        if (unavailable) unavailableToolNames.add(name)
+        else successfulToolNames.add(name)
         return unavailable ? { ...execution, evidence } : execution
       }
       const answer = await this.runtime.generate({
         question,
         evidence,
-        requiredEvidence,
-        requiredToolRequests: requiredReads?.requests,
+        requiredToolRequests,
         plan: plan.plan,
         guard: createAdvisorModelGuardV1(plan),
         fallbackIntent: plan.intent,
         tools: definitions,
         toolContract: contract,
         executeTool,
-        onToolRound,
         onToolEvent,
+        agentLoopBounds: {
+          maxSteps: request.limits.maxToolRounds + 1,
+          maxCallsPerStep: request.limits.maxToolCalls,
+          maxCallsPerTurn: request.limits.maxToolCalls,
+          maxToolRounds: request.limits.maxToolRounds,
+          maxParallelToolCalls: 1,
+          turnTimeoutMs: request.limits.timeoutMs,
+          maxContentBytes: request.limits.maxOutputBytes,
+          maxLedgerMessages: 32,
+        },
         workerContext: workerContext(request),
       }, signal)
       throwIfAborted(signal)
       const mergedEvidence = evidenceItems.length ? mergeEvidence(evidenceItems, evidenceItems[0]!) : evidence
       const safe = safeAnswer(answer, request.limits.maxOutputBytes)
       const canonicalRefs = safeRefs(mergedEvidence.refs)
-      const grounded = advisorAnswerUsesCanonicalEvidence(answer, mergedEvidence)
-      const closeout = grounded
-        ? { answer: prefixWorkerAnswer(request.role, safe.answer), evidenceSummary: safe.evidenceSummary, refs: canonicalRefs, rejected: false }
-        : requiredReads
-          ? { ...safeAnswer(await new DeterministicAdvisorRuntime().generate({ question, evidence: mergedEvidence, plan: plan.plan, guard: createAdvisorModelGuardV1(plan) }, signal), request.limits.maxOutputBytes), rejected: true }
-          : safe.answer
-            ? { ...safe, answer: prefixWorkerAnswer(request.role, safe.answer), rejected: false }
-            : { answer: 'This worker had no supported canonical Metrora evidence responsibility for the task.', evidenceSummary: 'No supported canonical Metrora evidence read was assigned.', refs: [], rejected: false }
+      const usedToolNames = [...new Set([
+        ...successfulToolNames,
+        ...activity().filter(item => item.status === 'completed').map(item => item.name),
+      ])]
+      const resultEvidence = evidenceResult(requiredToolNames, successfulToolNames, unavailableToolNames, usedToolNames)
+      const publishable = !requiredToolNames.length || resultEvidence.status !== 'unavailable'
+      const closeout = publishable && safe.answer
+        ? { answer: prefixWorkerAnswer(request.role, safe.answer), evidenceSummary: safe.evidenceSummary, refs: canonicalRefs }
+        : {
+            answer: prefixWorkerAnswer(request.role, requiredToolNames.length ? 'The required canonical Metrora evidence was unavailable for this bounded task.' : 'This worker had no supported canonical Metrora evidence responsibility for the task.'),
+            evidenceSummary: requiredToolNames.length ? 'Canonical evidence unavailable.' : 'No supported canonical Metrora evidence read was assigned.',
+            refs: canonicalRefs,
+          }
       const activityResult = activity()
-      const resultEvidence = evidenceResult(requiredReads, evidenceItems, activityResult.filter(item => item.status === 'completed').map(item => item.name))
-      const summary = boundedSwarmText(requiredReads
+      const summary = boundedSwarmText(requiredToolNames.length
         ? [
             resultEvidence.status === 'usable' ? 'Usable canonical evidence' : resultEvidence.status === 'partial' ? 'Partial canonical evidence' : 'Canonical evidence unavailable',
             mergedEvidence.coverage.label,
@@ -380,10 +344,7 @@ export class NativeHarnessWorkerAdapter implements WorkerAdapterV1 {
             canonicalRefs.map(ref => ref.label).join('; '),
           ].filter(Boolean).join(' - ')
         : 'No canonical Metrora read was required for this bounded worker task.')
-      const closeoutErrors = closeout.rejected
-        ? ['Model synthesis rejected; deterministic closeout used.']
-        : []
-      const result = baseResult(request, closeout.answer ? 'completed' : 'partial', startedAt, this.now(), activityResult, closeout.answer, summary, closeoutErrors, resultEvidence)
+      const result = baseResult(request, closeout.answer ? 'completed' : 'partial', startedAt, this.now(), activityResult, closeout.answer, summary, [], resultEvidence)
       return finish({ ...result, evidenceRefs: canonicalRefs })
     } catch (error) {
       const status: SwarmWorkerResultV1['status'] = timedOut()

--- a/app/renderer/swarm/native-worker-synthesis.ts
+++ b/app/renderer/swarm/native-worker-synthesis.ts
@@ -39,21 +39,24 @@ function synthesisReports(input: SwarmSynthesisInputV1): Array<{
 
 function synthesisNumbers(value: string): Set<string> {
   const numbers = new Set<string>()
-  for (const token of value.match(/\d+(?:[.,]\d+)*/gu) ?? []) {
+  for (const token of value.match(/\d+(?:[.,]\d+)*(?:[kKmMbB])?/gu) ?? []) {
+    const suffix = /[kKmMbB]$/u.test(token) ? token.slice(-1).toLowerCase() : ''
+    const raw = suffix ? token.slice(0, -1) : token
     const lastComma = token.lastIndexOf(',')
-    const lastDot = token.lastIndexOf('.')
-    let normalized = token
+    const lastDot = raw.lastIndexOf('.')
+    let normalized = raw
     if (lastComma >= 0 && lastDot >= 0) {
       const decimalSeparator = lastComma > lastDot ? ',' : '.'
       const thousandsSeparator = decimalSeparator === ',' ? '.' : ','
-      normalized = token.replaceAll(thousandsSeparator, '').replace(decimalSeparator, '.')
-    } else if (lastComma >= 0 && /,\d{3}(?:,\d{3})*$/u.test(token)) {
-      normalized = token.replaceAll(',', '')
+      normalized = raw.replaceAll(thousandsSeparator, '').replace(decimalSeparator, '.')
+    } else if (lastComma >= 0 && /,\d{3}(?:,\d{3})*$/u.test(raw)) {
+      normalized = raw.replaceAll(',', '')
     } else {
-      normalized = token.replace(',', '.')
+      normalized = raw.replace(',', '.')
     }
     const parsed = Number(normalized)
-    if (Number.isFinite(parsed)) numbers.add(String(parsed))
+    const multiplier = suffix === 'k' ? 1_000 : suffix === 'm' ? 1_000_000 : suffix === 'b' ? 1_000_000_000 : 1
+    if (Number.isFinite(parsed)) numbers.add(String(parsed * multiplier))
   }
   return numbers
 }
@@ -96,44 +99,86 @@ function hasUnsupportedSubject(answer: string, evidence: string): boolean {
   return false
 }
 
-function synthesisIsGrounded(answer: string, input: SwarmSynthesisInputV1, reports: ReturnType<typeof synthesisReports>): boolean {
+function sentenceParts(value: string): string[] {
+  return value.split(/\r?\n+/u)
+    .flatMap(line => line.split(/(?<=[.!?])\s+(?=[\p{L}\p{N}"'])/u))
+    .flatMap(sentence => sentence.split(/\s+(?:but|however|ma|però|tuttavia)\s+/iu))
+    .flatMap(sentence => sentence.split(/;\s*/u))
+    .map(sentence => sentence.trim())
+    .filter(Boolean)
+}
+
+function derivedNumbers(values: ReadonlySet<string>): Set<string> {
+  const result = new Set(values)
+  const parsed = [...values].map(Number).filter(Number.isFinite)
+  for (const left of parsed) for (const right of parsed) if (left !== right) result.add(String(Math.abs(left - right)))
+  return result
+}
+
+function interpretationClaim(value: string): boolean {
+  return /\b(?:significant|meaningful|material|recommend|suggest|inspect|review|investigat|worth\s+(?:checking|inspecting)|importante|rilevante|consiglio|controllerei|ispezionerei)\w*/iu.test(value)
+}
+
+function sanitizeSynthesis(answer: string, input: SwarmSynthesisInputV1, reports: ReturnType<typeof synthesisReports>): { text: string; removed: number; diagnostics: string[] } {
   const text = boundedSwarmText(answer).trim()
   const task = boundedSwarmText(input.task).trim()
-  if (!task) return false
-  if (!text) return false
+  if (!task || !text) return { text: '', removed: 0, diagnostics: ['ungrounded_narrative'] }
   const useful = reports.filter(report => report.evidenceStatus !== 'unavailable' && report.answer.trim() && (report.evidenceRefs.length > 0 || report.requiredToolNames.length === 0))
-  if (!useful.length) return false
+  if (!useful.length) return { text: '', removed: 0, diagnostics: ['ungrounded_narrative'] }
   const evidenceText = synthesisEvidenceText(useful)
-  const answerWords = synthesisSemanticWords(text)
   const evidenceWords = synthesisSemanticWords(evidenceText)
   const taskWords = synthesisSemanticWords(task)
-  const allowedNumbers = synthesisNumbers(evidenceText)
-  const answerNumbers = synthesisNumbers(text)
-  const hasCanonicalNumber = [...answerNumbers].some(number => allowedNumbers.has(number))
-  if ([...answerNumbers].some(number => !allowedNumbers.has(number))) return false
-  if (hasUnsupportedSubject(text, evidenceText)) return false
-  if (/\b(?:caused?|causes?|due\s+to|because\s+of|reason\s+(?:is|was)|responsible\s+for|a\s+causa\s+di|ha\s+causato)\b/iu.test(text)) return false
-  if (/\b(?:hello|hi|hey|good\s+morning|good\s+evening|i\s+can\s+help|what\s+would\s+you\s+like|how\s+can\s+i\s+help)\b/iu.test(text)) return false
-  const sharedEvidenceWords = [...answerWords].filter(word => evidenceWords.has(word))
-  const taskEvidenceWords = [...taskWords].filter(word => evidenceWords.has(word))
-  const sharedTaskAnswerWords = [...answerWords].filter(word => taskEvidenceWords.includes(word))
+  const allowedNumbers = derivedNumbers(new Set([...synthesisNumbers(evidenceText), ...synthesisNumbers(task)]))
   const factualAnswerWords = new Set(['spend', 'measured', 'total', 'lifetime', 'usage', 'calls', 'sessions', 'models', 'projects', 'providers', 'quota', 'threshold', 'verified', 'interpretation'])
   const canonicalReadRequired = reports.some(report => report.requiredToolNames.length > 0)
-  if (!sharedEvidenceWords.length) return false
-  if (!canonicalReadRequired) return true
-  if (![...answerWords].some(word => factualAnswerWords.has(word))) return false
-  if (taskEvidenceWords.length > 0 && !sharedTaskAnswerWords.length && !hasCanonicalNumber) return false
-  if (!hasCanonicalNumber && sharedEvidenceWords.length < 1) return false
-  if (/(?:\b(?:driver|drivers|contributor|contributors|ranking|ranked|main|primary|top|highest|largest|biggest|most)\b)/iu.test(text) && !sharedEvidenceWords.some(word => ['spend', 'models', 'projects', 'sessions', 'providers'].includes(word))) return false
   const limitedEvidence = reports.some(report => report.requiredToolNames.length > 0 && report.evidenceStatus !== 'usable')
-  const stateDisclosure = /\b(?:partial|parziale|unavailable|non\s+disponibile|insufficient|insufficiente|missing|mancante|failed|fallito|failure|timeout|timed\s+out|scaduto|not\s+available|could\s+not|cannot|impossibile)\b/iu.test(text)
-  if (limitedEvidence && !stateDisclosure) return false
-  if (limitedEvidence && /\b(?:high\s+coverage|fully\s+verified|all\s+evidence\s+is\s+available|conclusive|alta\s+copertura|completamente\s+verificato|conclusivo)\b/iu.test(text)) return false
-  // The reports are bound to the original task by the controller. Requiring
-  // semantic evidence anchors, canonical numbers, and subject checks accepts
-  // paraphrases without treating generic or causally overreaching prose as a
-  // successful synthesis.
-  return true
+  const accepted: string[] = []
+  const diagnostics: string[] = []
+  for (const clause of sentenceParts(text)) {
+    const answerWords = synthesisSemanticWords(clause)
+    const answerNumbers = synthesisNumbers(clause)
+    const sharedEvidenceWords = [...answerWords].filter(word => evidenceWords.has(word))
+    const sharedTaskWords = [...answerWords].filter(word => taskWords.has(word))
+    if ([...answerNumbers].some(number => !allowedNumbers.has(number))) {
+      diagnostics.push('unsupported_numeric_claim')
+      continue
+    }
+    if (hasUnsupportedSubject(clause, evidenceText)) {
+      diagnostics.push('unsupported_subject_claim')
+      continue
+    }
+    if (/\b(?:caused?|causes?|due\s+to|because\s+of|reason\s+(?:is|was)|responsible\s+for|a\s+causa\s+di|ha\s+causato)\b/iu.test(clause)) {
+      diagnostics.push('unsupported_causality')
+      continue
+    }
+    if (/\b(?:hello|hi|hey|good\s+morning|good\s+evening|i\s+can\s+help|what\s+would\s+you\s+like|how\s+can\s+i\s+help)\b/iu.test(clause)) {
+      diagnostics.push('ungrounded_narrative')
+      continue
+    }
+    if (canonicalReadRequired && !sharedEvidenceWords.length && !sharedTaskWords.length && !interpretationClaim(clause)) {
+      diagnostics.push('ungrounded_narrative')
+      continue
+    }
+    if (canonicalReadRequired && !answerWordsHasFactualAnchor(answerWords) && !interpretationClaim(clause)) {
+      diagnostics.push('ungrounded_narrative')
+      continue
+    }
+    const stateDisclosure = /\b(?:partial|parziale|unavailable|non\s+disponibile|insufficient|insufficiente|missing|mancante|failed|fallito|failure|timeout|timed\s+out|scaduto|not\s+available|could\s+not|cannot|impossibile)\b/iu.test(clause)
+    if (limitedEvidence && !stateDisclosure) {
+      diagnostics.push('unsupported_factual_claim')
+      continue
+    }
+    if (limitedEvidence && /\b(?:high\s+coverage|fully\s+verified|all\s+evidence\s+is\s+available|conclusive|alta\s+copertura|completamente\s+verificato|conclusivo)\b/iu.test(clause)) {
+      diagnostics.push('unsupported_factual_claim')
+      continue
+    }
+    accepted.push(clause)
+  }
+  return { text: accepted.join(' ').trim(), removed: Math.max(0, sentenceParts(text).length - accepted.length), diagnostics: [...new Set(diagnostics)] }
+}
+
+function answerWordsHasFactualAnchor(words: ReadonlySet<string>): boolean {
+  return [...words].some(word => ['spend', 'measured', 'total', 'lifetime', 'usage', 'calls', 'sessions', 'models', 'projects', 'providers', 'quota', 'threshold', 'verified', 'interpretation'].includes(word))
 }
 
 function deterministicWorkerCloseout(input: SwarmSynthesisInputV1, reports: ReturnType<typeof synthesisReports>, extraError?: string): SwarmSynthesisResultV1 {
@@ -171,14 +216,13 @@ export function createNativeHarnessSwarmSynthesizer(runtime: AdvisorModelRuntime
       // so it cannot re-enter ordinary social/question classification.
       const generated = await runtime.generateSwarmSynthesis({ question: input.task, scope: input.scope as unknown as AdvisorScope, workers: reports }, signal)
       throwIfAborted(signal)
-      if (!synthesisIsGrounded(generated.answer, input, reports)) {
-        return deterministicWorkerCloseout(input, reports, 'Dedicated Swarm synthesis was not grounded in worker evidence; deterministic worker closeout was used.')
-      }
+      const sanitized = sanitizeSynthesis(generated.answer, input, reports)
+      if (!sanitized.text) return deterministicWorkerCloseout(input, reports, 'Dedicated Swarm synthesis contained no safe supported explanation; worker closeout was used.')
       return {
         status: 'completed',
-        answer: boundedSwarmText(sanitizeSwarmText(generated.answer)),
+        answer: boundedSwarmText(sanitizeSwarmText(sanitized.text)),
         evidenceSummary: boundedSwarmText([generated.evidenceSummary, reports.map(report => report.evidenceStatus + ' evidence via ' + report.evidenceRefs.map(ref => ref.label).join('; ')).join(' | ')].filter(Boolean).join(' ')),
-        errors: [],
+        errors: sanitized.removed ? ['Some synthesis claims were omitted because worker evidence did not support them.'] : [],
       }
     } catch (error) {
       if (isCancellation(error, signal)) throw error

--- a/app/renderer/swarm/useSwarmRun.test.tsx
+++ b/app/renderer/swarm/useSwarmRun.test.tsx
@@ -85,9 +85,12 @@ describe('useSwarmRun execution ownership', () => {
     const workerTwo = deferred<AdvisorAnswer>()
     const synthesis = deferred<AdvisorSwarmSynthesisResult>()
     const signals: AbortSignal[] = []
-    const generate = vi.fn(async (_input: AdvisorRuntimeInput, signal?: AbortSignal) => {
+    const generate = vi.fn(async (input: AdvisorRuntimeInput, signal?: AbortSignal) => {
+      const workerIndex = signals.length
       if (signal) signals.push(signal)
-      return (signals.length === 1 ? workerOne : workerTwo).promise
+      const required = input.requiredToolRequests?.[0]
+      if (required) await input.executeTool?.(required.tool, required.arguments, signal)
+      return (workerIndex === 0 ? workerOne : workerTwo).promise
     })
     const generateSwarmSynthesis = vi.fn(async (input: Parameters<NonNullable<AdvisorModelRuntime['generateSwarmSynthesis']>>[0]) => {
       expect(input.question).toBe('Explain the observed spend change.')
@@ -117,13 +120,13 @@ describe('useSwarmRun execution ownership', () => {
     expect(generate).toHaveBeenCalledTimes(2)
 
     await act(async () => {
-      synthesis.resolve({ answer: 'synthesized result: Metrora measured $12.00 in spend during the selected period.', evidenceSummary: 'Two bounded worker closeouts with the measured spend anchor.' })
+      synthesis.resolve({ answer: 'Synthesized result: the bounded worker findings are grounded in the selected spend evidence.', evidenceSummary: 'Two bounded worker closeouts with the measured spend anchor.' })
       await flushMicrotasks()
     })
     await waitFor(() => expect(result.current.state.running).toBe(false))
     expect(result.current.state.status).toBe('completed')
     expect(result.current.state.result?.workers).toHaveLength(2)
-    expect(result.current.state.result?.synthesis?.answer).toBe('synthesized result: Metrora measured $12.00 in spend during the selected period.')
+    expect(result.current.state.result?.synthesis?.answer).toBe('Synthesized result: the bounded worker findings are grounded in the selected spend evidence.')
     expect(promotedRuntimeGenerate).not.toHaveBeenCalled()
   })
 


### PR DESCRIPTION
## Summary

- add one provider-neutral bounded Metrora agent loop with an in-memory turn ledger, canonical read Tool execution, normalized lifecycle events, cancellation, deadlines, and per-turn bounds
- route local and hosted Harness Chat through the loop while preserving provider conformance, scope negotiation, reasoning effort, and existing runtime boundaries
- run delegated native Agents through the same loop and retain provenance-aware natural Swarm synthesis

## Validation

- app tests: 119 files, 1,095 passed
- repository tests: 353 passed, 2 skipped files; 3,418 passed, 5 skipped tests
- typecheck, app build, CLI build, whitespace check, and stacked source-size ratchet pass

This draft is stacked on feat/harness-v3-reliability-convergence-001.