### PR TITLE
docs: converge public surfaces after OpenCode acceptance

### DIFF
--- a/docs/ACT_CONTRACT_PREP_001.md
+++ b/docs/ACT_CONTRACT_PREP_001.md
@@ -1,85 +1,88 @@
 # ACT Contract Preparation 001
 
-**Status:** current-main-native ACT foundation v2 contract and implementation note; the bounded first executor is implemented on this branch for review.
+**Status:** current-main ACT foundation v2 contract and implementation note; the first bounded executor is shipped for Core Compatibility.
 
 ## Purpose
 
-ACT is the explicit trusted boundary for operations that run a controlled workload or change state.
+ACT / ActionContract is the trusted Metrora-owned boundary for **specific product workflows that Metrora itself defines as bounded state-changing or controlled execution**.
 
-The former custom conversational and Desktop proposal bridge is no longer
-shipped after the accepted Code surface became the product boundary. ACT still
-defines the trusted contract for any bounded caller and does **not** authorize
-itself from an untrusted request.
+It is not a universal execution layer beneath every coding action in Metrora.
 
-Canonical relationship:
+After the accepted Code surface became the product boundary, ordinary coding execution inside **Code** is owned by the embedded upstream OpenCode runtime, including its normal filesystem, shell, Git and permission/question mechanics.
+
+Current ACT relationship:
 
 ```text
-bounded caller / product workflow
+Metrora-owned bounded workflow
 → read-only evidence + proposal
 → explicit trusted confirmation
 → ActionContractV1 validation
-→ bounded executor
+→ bounded Metrora executor
 → lifecycle + canonical result/evidence
 → caller-facing result
 ```
 
-ACT is an execution authority underneath product workflows, not a user-facing `Act` chat mode.
+ACT is not a user-facing `Act` chat mode and is not inserted in front of upstream Code merely to duplicate OpenCode's own execution/permission system.
 
 ## ActionContractV1 shape
 
-A public action contract should remain a strict JSON-safe envelope containing at least:
+A public Metrora action contract should remain a strict JSON-safe envelope containing, where applicable:
 
 - `contractVersion: "metrora.action.v1"` and schema version;
-- opaque action ID, kind, lifecycle status, creation time/originating surface;
+- opaque action ID, kind, lifecycle status and originating Metrora surface/workflow;
 - immutable target/scope;
-- selected runtime/model/Project/Workspace where applicable;
+- selected runtime/model/Project/Workspace where relevant to that Metrora-owned action;
 - declared network/filesystem/provider boundaries;
 - explicit preconditions/effects;
-- exact user confirmation summary/digest where implemented;
+- exact trusted confirmation summary/digest where implemented;
 - bounded timeout/work/resource/cost limits;
 - cancellation/expiry behavior;
 - deterministic result/evidence references;
 - explicit failure/cancel reason;
 - rollback semantics, including declared `none` before confirmation.
 
-The contract must reject undeclared fields, arbitrary shell/path input, unbounded prompts, provider-native credentials, arbitrary remote endpoints and hidden side effects.
+A proposal is not authorization. A successful process/HTTP call is not proof that a Metrora-owned action satisfied its contract.
 
-A proposal is not authorization. A successful process/HTTP call is not proof that the action satisfied the contract.
+The generic contract must not become an escape hatch for arbitrary shell/path input, provider credentials, arbitrary remote endpoints, unbounded prompts or hidden side effects.
 
-## First narrow ACT operation: Core Compatibility
+## Current narrow ACT operation: Core Compatibility
 
-The first safe operation is the existing public Core Compatibility workflow; the historical command name was `Run Core Conformance Bench`.
+The first and currently implemented operation is the public Core Compatibility workflow; the historical command name was `Run Core Conformance Bench`.
 
 Product classification:
 
 - Bench family: **Compatibility / Runtime Health**;
 - public pack: `metrora.bench.core@1.0.0`;
-- first runtime: local Ollama;
+- runtime: local Ollama;
 - model: explicitly selected;
 - effect: bounded local Compatibility evidence/history;
 - no user-content workload;
 - no arbitrary prompt;
 - no provider credential forwarding;
 - no remote endpoint;
-- cancellation/timeout/unavailable/malformed stay distinct.
+- cancellation/timeout/unavailable/malformed remain distinct.
 
-This remains a useful first ACT proof because its external effect is narrow and evidence-oriented.
+This remains a useful ACT proof because the Metrora-owned effect is narrow and evidence-oriented.
 
 It must **not** be treated as the definition of Metrora Bench. Mainstream Bench product direction is Performance-first; see [Bench evidence families](BENCH_EVIDENCE_FAMILIES.md).
 
-A future Performance run may receive its own action kind only after a normalized Performance contract/executor is implemented. Do not broaden the first Core Compatibility action into arbitrary benchmark execution merely for convenience.
+A future Metrora-owned Performance action may receive its own action kind only if that workflow actually needs an ActionContract. Do not broaden Core Compatibility into arbitrary benchmark or coding execution for architectural symmetry.
 
 ## Implemented foundation boundary
 
-The v2 foundation currently binds `metrora.action.v1` to the single `run-core-compatibility` kind. Its strict JSON-safe contract fixes the local Ollama loopback runtime, explicit model, `core-v1` selector, canonical pack identity/digest, fixed generation parameters, bounded timeouts, cancellation precedence, declared journal/history writes, and no rollback capability.
+The current foundation binds `metrora.action.v1` to the single `run-core-compatibility` kind.
 
-Approval is issued and verified by a trusted process using exact action, proposal, confirmation, execution, target, model, pack, and parameter digests. Stored `ready` authority is revalidated for freshness after restart; stale, malformed, forged, replayed, duplicate, or mismatched actions fail closed.
+Its strict contract fixes the local Ollama loopback runtime, explicit model, `core-v1` selector, canonical pack identity/digest, fixed generation parameters, bounded timeouts, cancellation precedence, declared journal/history writes and no rollback capability.
 
-Execution delegates to the existing canonical task-pack runner and history store. ACT persists lifecycle state, bounded progress/counts, digests and references only; task prompts, generated output, credentials, repository paths and shell operations are not persisted or accepted. Orphaned running state is recovered only from exact existing evidence, otherwise it reaches a terminal failure/cancellation without retry.
+Approval is issued and verified by a trusted Metrora process using exact action, proposal, confirmation, execution, target, model, pack and parameter digests. Stored `ready` authority is revalidated for freshness after restart; stale, malformed, forged, replayed, duplicate or mismatched actions fail closed.
+
+Execution delegates to the existing canonical task-pack runner and history store. ACT persists lifecycle state, bounded progress/counts, digests and references only; task prompts, generated output, credentials, repository paths and arbitrary shell operations are not persisted or accepted by this action kind.
+
+Orphaned running state is recovered only from exact existing evidence; otherwise it reaches a terminal failure/cancellation without retry.
 
 ## Contract-facing confirmation shape
 
-Before execution, a caller should show material effects in ordinary language, for example:
+Before Core Compatibility execution, an authorized caller may show material effects in ordinary language, for example:
 
 ```text
 Core Compatibility
@@ -92,16 +95,15 @@ Writes      Local Bench history
 [Run] [Cancel]
 ```
 
-The former custom conversational action card and Desktop ACT bridge are not part
-of the shipped surface. Any future caller must expose only the selected model,
-pack identity, bounded checks/progress, proposal digest and safe lifecycle state;
-the internal contract and approval token stay inside the trusted authority.
+The former custom conversational action card and Desktop ACT bridge are not part of the shipped product surface.
 
-The model does not supply the trusted approval token merely by emitting `yes` or a tool call.
+Any future caller of this action should expose only the selected model, pack identity, bounded checks/progress, proposal digest and safe lifecycle state; the internal contract and approval token remain inside trusted authority.
+
+A model does not supply a trusted approval token merely by emitting `yes` or a tool call.
 
 ## Lifecycle and observable progress
 
-ACT exposes authoritative lifecycle events without exposing hidden model reasoning:
+The current ACT operation exposes authoritative lifecycle events without exposing hidden model reasoning:
 
 ```text
 proposed
@@ -110,14 +112,42 @@ proposed
 → completed | unavailable | failed | cancelled
 ```
 
-Progress must be tied to actual executed work/result evidence.
+Progress is tied to actual executed work/result evidence.
 
-CLI or other explicitly authorized consumers may display the narrow Core
-Compatibility lifecycle. Tool/action activity remains compact and bounded.
+CLI or another explicitly authorized Metrora consumer may display the narrow Core Compatibility lifecycle.
 
-## Smartphone projection
+## Relationship to Code / OpenCode
 
-A first mobile projection may display content-minimal action state only after the capability is explicitly authorized.
+Canonical Code rule:
+
+> **Metrora adds. OpenCode executes.**
+
+OpenCode's ordinary local coding actions are **not** ActionContract operations merely because they change files or invoke shell/Git commands.
+
+Inside the accepted Code surface, OpenCode owns:
+
+- file read/write/edit mechanics;
+- shell/process execution;
+- Git/diff/review mechanics;
+- normal Tool execution;
+- normal permission/question flow;
+- Agent/Subagent execution mechanics.
+
+Metrora may add bounded factual Tools/context without interposing ACT around those commodity mechanics.
+
+If a future Metrora product feature introduces a **new Metrora-owned trust domain or stronger effect**, it may require a new bounded action/control contract. Examples could include:
+
+- remote/background Job authority;
+- enrolled-endpoint control;
+- managed Workspace/Organization actions;
+- release/merge/publication automation;
+- other high-impact Metrora-owned workflows.
+
+Those future contracts must be designed for their exact effect; they are not implied by the current Core Compatibility ACT implementation.
+
+## Smartphone / remote projection
+
+A mobile or remote projection may display content-minimal state for an explicitly authorized Metrora-owned action.
 
 Safe projected fields may include:
 
@@ -129,58 +159,55 @@ Safe projected fields may include:
 - bounded result counts;
 - evidence/result digest.
 
-Do not project:
+Do not project provider keys, task prompts, generated output, arbitrary local paths or unrestricted execution arguments.
 
-- provider keys;
-- task prompts;
-- generated output;
-- arbitrary paths;
-- unrestricted execution arguments.
-
-Remote smartphone **execution/approval** is a separate stronger authority, not implied by a read-only projection.
+Remote **execution/approval** is a separate stronger authority and is not implied by read-only projection.
 
 ## Provider/runtime endpoints
 
-Do not add an arbitrary `OpenAI-compatible endpoint` escape hatch to ACT.
+Do not add an arbitrary `OpenAI-compatible endpoint` escape hatch to the current ACT operation.
 
-Any future provider/runtime adapter needs its own reviewed origin/auth/model-discovery/protocol/privacy/conformance contract.
+Any future Metrora-owned provider/runtime action needs its own reviewed origin/auth/model-discovery/protocol/privacy/conformance contract.
 
 `OpenAI-compatible` is not a compatibility or authorization guarantee.
 
 ## OSS reuse rule
 
-ACT itself should stay Metrora-owned because it defines trust/authorization semantics.
+Metrora should own ActionContract semantics where Metrora owns the effect.
 
-Commodity external runtimes, benchmark engines, sandboxes or UI primitives may be used behind bounded adapters after licence/security/provenance review.
+Commodity runtimes, benchmark engines, sandboxes or other OSS may be used behind a bounded Metrora-owned action after licence/security/provenance review.
 
-An external agent/harness framework must never bypass ActionContract/ACT authority merely because it exposes its own tool/approval system.
+An upstream runtime cannot self-authorize a **Metrora-owned ActionContract effect** merely because it exposes its own Tool/approval mechanism.
 
-No dependency is added by this document.
+Equally, ACT must not claim authority over ordinary upstream Code actions that Metrora has deliberately delegated to OpenCode.
 
-## Explicitly outside this foundation
+## Explicitly outside the current ACT foundation
 
+- ordinary OpenCode filesystem/shell/Git execution;
+- general coding-agent permissions/questions;
 - automatic conversational execution;
-- arbitrary shell/repository writes;
+- arbitrary repository/shell execution through `metrora.action.v1`;
 - mobile write/execute routes;
-- managed Bench;
+- managed remote Jobs;
 - arbitrary provider URLs;
 - billing/entitlements;
-- Swarm/orchestration;
 - proprietary recommendation/routing policy.
 
-## Relationship to current Draft implementation work
+## Relationship to current main
 
-This branch contains the concrete `metrora.action.v1` implementation around Core Compatibility for review against current `main`. The core/CLI boundary keeps proposal validation, trusted approval, execution, cancellation, recovery and evidence under one ACT authority. The removed custom renderer bridge is not replaced by a second runner, mobile execution path or MCP action path.
+The concrete `metrora.action.v1` Core Compatibility implementation is already part of current public `main`.
 
-Any acceptance pass must ensure there is one ACT authority rather than a
-separate conversational proposal system that can diverge.
+The core/CLI boundary keeps proposal validation, trusted approval, execution, cancellation, recovery and evidence under one ACT authority **for this action kind**. The removed custom conversational/renderer proposal bridge is not replaced by a second runner, mobile execution path or MCP action path.
+
+Future ActionContract additions should be justified one bounded Metrora-owned effect at a time.
 
 ## Ratified public principles
 
-1. Callers may propose; ACT authorizes/executes.
-2. ACT is not a chat mode.
-3. The first safe action is Core Compatibility, not arbitrary Bench execution.
+1. A Metrora-owned ActionContract proposal is not authorization.
+2. ACT is not a chat mode or a universal Code execution layer.
+3. The current action is Core Compatibility, not arbitrary Bench or repository execution.
 4. Mainstream Bench remains Performance-first.
-5. The model cannot self-authorize.
-6. External OSS cannot bypass Metrora action authority.
-7. State-changing execution requires explicit bounded effects, limits, cancellation and evidence.
+5. A model cannot self-authorize a Metrora-owned ActionContract effect.
+6. Ordinary OpenCode file/shell/Git/permission mechanics remain upstream Code behavior.
+7. Stronger future Metrora-owned effects require their own explicit bounded authority contracts.
+8. ActionContract lifecycle/evidence must preserve explicit scope, effects, limits, cancellation and result authority.

--- a/docs/BENCH_EVIDENCE_FAMILIES.md
+++ b/docs/BENCH_EVIDENCE_FAMILIES.md
@@ -108,11 +108,21 @@ Any future implementation needs separate review for:
 
 Agent evaluation measures a complete agent workflow, not only a foundation model.
 
-It becomes relevant only after Metrora has real, separately authorized agent/Swarm execution to evaluate.
+Metrora now has real Agent/Subagent execution through the accepted upstream OpenCode Code surface. That makes future Agent Evaluation technically relevant, but it does **not** define a benchmark methodology or make ordinary product sessions comparable evaluation evidence.
 
 No Agent Evaluation implementation is shipped today.
 
-Any future implementation requires stronger container/sandbox, repository, network, secret, cost and action-authority controls.
+Any future implementation requires a separately versioned methodology and stronger review for:
+
+- task/dataset and repository rights;
+- disposable container/sandbox isolation;
+- repository, network and secret boundaries;
+- runtime/Agent configuration identity;
+- cost/resource limits;
+- reproducibility and contamination disclosure;
+- artifact/result retention;
+- scoring/comparability semantics;
+- clear separation from ordinary Code usage and Activity history.
 
 ## Comparison rules
 

--- a/docs/ECOSYSTEM_SURFACES.md
+++ b/docs/ECOSYSTEM_SURFACES.md
@@ -1,13 +1,12 @@
 # Metrora ecosystem surfaces
 
 **Status:** public product direction and implementation-status guide  
-**Decision revision:** 2026-09-04
-**Authority reviewed:** `maikolsiragusaa/metrora@6cfbaaeb713a4f8a82948ca706c0eee3c02cf561`
-**Scope:** post-acceptance cleanup of superseded conversational surfaces
+**Decision revision:** 2026-09-05  
+**Authority reviewed:** `maikolsiragusaa/metrora@c960183820467c73ce92c8ccc606a6dd3552c80c`
 
-Metrora is a local-first control and intelligence system for AI-assisted development. Its product surfaces should compose around shared facts and contracts rather than grow into separate products that each calculate their own version of the truth.
+Metrora is a local-first control and intelligence system for AI-assisted development. Product surfaces compose around shared facts/contracts instead of growing into parallel engines that each invent their own truth or execution mechanics.
 
-This page distinguishes what exists now from what is being built or remains planned.
+This page distinguishes what exists now from what remains future work.
 
 ## How the ecosystem fits together
 
@@ -19,45 +18,75 @@ Usage · Activity · Models · Capacity · Projects
          ↓         ↓           ↓
         MCP   integrations   Desktop
                                   │
-                                  └─ Code surface / host lifecycle
-
-        bounded state-changing request
-                   ↓
-              proposal only
-                  ↓
-                 ACT
-                  ↓
-          bounded execution
+                                  └─ Code
+                                     ↓
+                                  OpenCode
+                         Sessions · Agents · Tools
+                         files · shell · Git · MCP/ACP
 
 Bench   = methodology-bound test/evidence system
 Widgets = shareable presentation of canonical evidence
 Wrapped = recap/share experience built on canonical evidence + Widgets
-Code    = upstream coding surface hosted by Desktop; Metrora owns the host boundary
-Swarm   = future coordinated capability behind trusted authority
 ```
 
-Canonical rule:
+Canonical rule for the Code surface:
 
-> **Tools expose capability. MCP and bounded integrations consume capability. ACT grants execution authority.**
+> **Metrora adds. OpenCode executes.**
 
-ACT is not a chat mode and an MCP client is not trusted execution authority simply because it can discover a Metrora tool.
+Metrora owns the host boundary, canonical evidence/accounting and Metrora-specific Tools/context. OpenCode owns the commodity coding surface and its Sessions, Agents/Subagents, provider/model controls, standard Tools, filesystem/shell/Git mechanics and ordinary permissions/questions.
 
 ## Current status
 
 | Surface | Product job | Status |
 | --- | --- | --- |
 | **Usage / Activity / Models / Capacity** | Factual local evidence, history, economics and provider-reported capacity | **Available** |
-| **Projects** | User-controlled context and scope across relevant evidence | **Available** |
+| **Projects** | User-controlled Metrora context and scope across relevant evidence | **Available** |
 | **Tools** | Typed factual access to Metrora evidence | **Available** — canonical registry, contract, evidence and privacy layer |
-| **Code** | Upstream coding surface hosted by Desktop | **Available** — Metrora owns the host lifecycle, navigation boundary and usage/accounting projection |
+| **Code** | Coding/agent work through official upstream OpenCode hosted by Desktop | **Available** — accepted OpenCode `1.18.27` runtime/Web UI with Metrora host lifecycle, security, packaging and accounting integration |
 | **Bench** | Performance-first testing plus separate Compatibility / Runtime Health evidence | **Available** — native llama.cpp/`llama-bench` Performance and Core Compatibility are separate bounded paths |
-| **ACT** | Trusted authorization/lifecycle for bounded state-changing operations | **Available** — `metrora.action.v1` and `run-core-compatibility`; not a user-facing mode |
+| **ACT / ActionContract** | Trusted lifecycle for the bounded Metrora-owned Core Compatibility action | **Available for that narrow operation** — not a user-facing mode and not a universal wrapper around Code |
 | **MCP** | Standard external access to canonical Metrora Tools | **Available** — local read-only MCP Server V1 |
 | **Widgets** | Shareable visual/statistical presentation of canonical evidence | **Foundation exists through Share Card; broader Widgets family planned** |
 | **Wrapped** | Periodic recap/share experience using canonical evidence and Widgets | **Planned** |
-| **Swarm** | Coordinated multi-agent capability | **Planned** |
+| **Durable Jobs / remote control** | Future Metrora-owned work/status/result control above local sessions when needed | **Future / separately gated** |
 
-Status labels are intentionally conservative. A public direction is not presented as shipped until working product authority exists.
+Status labels are intentionally conservative. A direction is not presented as shipped until working product authority exists.
+
+## Code
+
+The Desktop **Code** destination hosts the real official upstream OpenCode Web UI/runtime rather than a Metrora reconstruction of it.
+
+Current accepted host boundary includes:
+
+- pinned OpenCode `1.18.27`;
+- deterministic staged binary/provenance checks;
+- loopback-only embedded server;
+- random per-launch authentication held by the Electron main process;
+- exact-origin navigation restrictions and popup denial;
+- persistent upstream browser/project UI state;
+- clean sidecar shutdown;
+- Windows packaging paths that include the pinned OpenCode runtime.
+
+OpenCode remains upstream authority for its own coding Sessions and agent mechanics. Metrora does not create a second conversation/session universe for the same work.
+
+Metrora accounting continues to identify this source as **OpenCode**. Being launched inside Metrora does not invent a new provider identity.
+
+## Metrora Tools inside Code
+
+Metrora-specific intelligence is added to the upstream Code surface through bounded Metrora Tools rather than through a parallel coding-agent engine.
+
+The first accepted end-to-end proof is `metrora_usage_snapshot`:
+
+```text
+user asks a Metrora-specific question in Code
+→ OpenCode selects metrora_usage_snapshot
+→ Metrora returns bounded canonical evidence
+→ OpenCode explains the result
+```
+
+Future factual Tool expansion should reuse the same canonical Metrora registries/contracts used elsewhere rather than implement Code-specific accounting or evidence paths.
+
+A Tool result remains evidence. A caller or model may explain it, but cannot silently replace Metrora's canonical measurement, scope or unavailable-state semantics.
 
 ## Tools
 
@@ -74,21 +103,15 @@ Metrora already has typed read-only capabilities for questions such as:
 
 The reusable implementation lives in `src/tools`; the factual registry is not owned by one UI.
 
-This matters because the same factual capability is reused by the Local MCP Server V1 and other bounded Metrora integrations without implementing parallel evidence paths.
-
-A tool result remains evidence. A caller or model may explain it, but cannot silently replace Metrora's canonical measurement, scope or unavailable-state semantics.
+The same factual capability can therefore be consumed by Local MCP, Code integrations and other bounded surfaces without implementing parallel evidence engines.
 
 ## MCP
 
 Metrora adopts the Model Context Protocol as an interoperability direction.
 
-The shipped first product is a **local, read-only Metrora MCP Server V1** that exposes the canonical factual Tools.
+The shipped first product is a **local, read-only Metrora MCP Server V1** that exposes canonical factual Tools.
 
-A compatible external AI client could then ask a question such as:
-
-> “How much did I spend today?”
-
-and use Metrora's factual evidence instead of guessing or requiring a new Metrora-specific model integration.
+A compatible external AI client can use Metrora facts without requiring AI traffic to pass through a Metrora proxy.
 
 Local MCP V1 principles:
 
@@ -100,23 +123,35 @@ Local MCP V1 principles:
 - no ability to bypass Metrora privacy/scope contracts;
 - failure of MCP cannot corrupt canonical Metrora history.
 
-A future hosted MCP surface may be offered separately for managed remote access or other hosted capabilities. Local MCP remains a local read authority and is not a hosted metering product.
+A future hosted or state-changing control surface is separate work. OpenCode's ability to consume MCP servers is also distinct from exposing Metrora for inbound external control.
 
-### Future actions through MCP
+### Future control through external clients
 
-External AI clients may later be able to **propose** bounded Metrora actions. They do not gain direct ACT or Swarm authority.
+Future external control should use an explicit bounded Metrora-owned control object rather than grant a client generic execution authority.
+
+Conceptually:
 
 ```text
-external AI
-→ MCP
-→ bounded proposal
-→ Metrora trusted authority
-→ explicit user approval
-→ ACT
-→ bounded execution
+external AI client
+→ Metrora MCP or bounded control API
+→ Metrora facts / Project / optional durable Job
+→ authorized execution through an accepted runtime where needed
+→ status / result / evidence
 ```
 
-Any future Swarm capability follows the same authority rule.
+The exact Job/control schema, authorization and remote lifecycle are future work. Local MCP V1 remains read-only until such a contract exists.
+
+Browser/UI automation is not part of the public architecture described here.
+
+## ACT / ActionContract
+
+The current public ActionContract foundation is intentionally narrow.
+
+Today it binds `metrora.action.v1` to the bounded `run-core-compatibility` workflow and its confirmation/lifecycle/evidence semantics.
+
+It remains useful for that Metrora-owned operation, but it should not be interpreted as a requirement that every ordinary OpenCode file edit, shell command or Git action pass through a second Metrora permission engine. Those everyday coding mechanics belong to the accepted upstream Code surface.
+
+If Metrora later introduces stronger Metrora-owned effects — for example remote/background Jobs or other explicitly authorized product workflows — they require their own bounded trust/control contracts.
 
 ## Bench
 
@@ -129,10 +164,12 @@ Primary direction:
 Separate evidence families:
 
 - **Compatibility / Runtime Health** — including the current deterministic `core-v1` checks;
-- **Coding Evaluation** — future, separately versioned and methodology/licence gated;
-- **Agent Evaluation** — later, once real coordinated execution exists.
+- **Coding Evaluation** — future, separately versioned and methodology/licence/sandbox gated;
+- **Agent Evaluation** — future, separately versioned and methodology/isolation gated.
 
-ACT may invoke a supported Bench operation, but Bench remains the canonical owner of Bench evidence/history.
+The existence of real OpenCode Agent/Subagent execution does not by itself define an Agent Evaluation methodology.
+
+A supported ActionContract may invoke a specific Bench workflow, but Bench remains the canonical owner of Bench evidence/history.
 
 ## Widgets and Wrapped
 
@@ -155,12 +192,12 @@ Local static sharing should remain useful without requiring an account. Any futu
 
 Ordinary pages stay concise:
 
-`Usage · Activity · Models · Capacity · Projects · Settings`
+`Usage · Activity · Models · Capacity · Projects · Code · Bench · Settings`
 
-Systems with an independent interaction model or authority can carry a branded name when useful:
+Systems with an independent interaction/protocol identity can carry a fuller name on first/external mention, for example:
 
 - **Metrora Bench**;
-- **Metrora MCP Server** on first/external mention.
+- **Metrora MCP Server**.
 
 Within an established Metrora context, prefer:
 
@@ -168,51 +205,48 @@ Within an established Metrora context, prefer:
 
 rather than repeating “Metrora” before every noun.
 
-`ACT` remains an execution authority, not a primary navigation item. `Swarm` remains future functionality until it actually ships.
+`ACT` remains an internal/bounded action authority, not a primary navigation item. There is no current separate `Swarm` product surface.
 
 ## Public README direction
 
-The repository README should become easier for both users and future contributors to understand at a glance.
-
-The ratified direction is:
+The repository README should remain easy for users and contributors to understand at a glance:
 
 - immediate download/install actions near the top;
-- a concise product thesis;
-- an original visual ecosystem map;
-- large visual feature sections instead of long walls of documentation;
-- clear `Available`, `Building` and `Planned` labels;
+- concise `Observe · Compare · Code · Control` thesis;
+- truthful current Code/OpenCode boundary;
+- clear current/future labels;
 - local-first/privacy positioning;
 - supported-tools credibility;
 - obvious routes into documentation and contribution.
 
-Modern visual OSS READMEs such as LobeHub are useful composition references, but Metrora should create original artwork and copy rather than clone another project's images or page pixel-for-pixel.
-
-Conceptual branded illustrations are preferable to screenshots that would immediately become stale while the target Desktop UX is still moving.
+Original Metrora visuals/copy are preferred over cloning another project's branded imagery.
 
 ## Visual-asset provenance
 
 Metrora contains historical visual material inherited from the incorporated upstream snapshot. A 2026-08-30 audit confirmed that multiple old top-level repository marketing/screenshots in `assets/` are byte-identical to material from that incorporated upstream source.
 
-Those files should be audited before the README visual redesign:
+Before using assets for current Metrora marketing:
 
 - remove obsolete inherited screenshots when proven unused;
-- do not use inherited marketing imagery as new Metrora brand artwork;
+- do not present inherited marketing imagery as new Metrora brand artwork;
 - do not delete runtime/package assets without proving they are unused;
 - review provider logos/icons separately because trademark/asset rights are independent from repository code licensing;
 - replace README/marketing visuals progressively with original Metrora artwork or current truthful screenshots.
 
-Required upstream provenance and licence notices remain governed by `THIRD_PARTY_NOTICES.md` and `LICENSES/`.
+Required upstream provenance/licence notices remain governed by `THIRD_PARTY_NOTICES.md` and `LICENSES/`.
 
 ## Near-term progression
 
-This is a dependency-oriented direction, not a rigid roadmap gate:
+This is dependency-oriented direction, not a rigid roadmap gate:
 
-1. **Code surface** — preserve the accepted upstream coding surface and keep its host/lifecycle/accounting boundary explicit.
-2. **Local MCP Server V1** — shipped in Interoperability Foundation Wave 001; expose the same factual Tools read-only through MCP.
-3. **README / asset refresh** — simplify the repository story and replace stale inherited marketing imagery with original Metrora visuals.
-4. **Widgets V1** — evolve Share Card into reusable static, privacy-aware Widgets.
-5. Maintain the independent **llama.cpp runtime / Performance Bench** path with focused compatibility, provenance and acceptance work.
-6. External action proposals and **Swarm** remain later, separately authorized capability work.
+1. **Code/OpenCode** — keep the accepted pinned upstream surface, host/security/persistence/accounting and packaging boundary healthy.
+2. **Code host UX** — reduce first-entry latency/blank loading at the host layer without reconstructing the upstream UI.
+3. **Metrora Tools in Code** — add the highest-value bounded factual capabilities through canonical Tool contracts.
+4. **Local MCP V1** — keep factual/read-only interoperability stable; stronger control remains separately gated.
+5. **README / asset truthfulness** — keep the public story aligned with the shipped product.
+6. **Widgets** — evolve Share Card into reusable static/privacy-aware presentations when useful.
+7. Maintain independent **llama.cpp / Performance Bench** reliability/provenance work.
+8. Durable Job/external-control work remains later and separately authorized.
 
 See also:
 


### PR DESCRIPTION
## Summary

Aligns the remaining public product/authority documentation with the accepted and merged upstream OpenCode Code foundation.

Canonical rule: **Metrora adds. OpenCode executes.**

## Scope

Docs only. No runtime, package, release, Store, MCP implementation or Bench implementation changes.

## Changes

- `ECOSYSTEM_SURFACES.md`
  - records OpenCode `1.18.27` as the accepted Code runtime/Web UI foundation;
  - documents the Metrora host/security/accounting boundary;
  - records `metrora_usage_snapshot` as the first accepted Metrora Tool-in-Code proof;
  - removes separate Swarm product/runtime direction;
  - frames future external control around bounded Metrora-owned Job/control semantics;
  - scopes ACT to Metrora-owned actions rather than ordinary OpenCode execution.
- `ACT_CONTRACT_PREP_001.md`
  - makes current Core Compatibility the explicit narrow ActionContract authority;
  - clarifies that ordinary OpenCode filesystem/shell/Git/permission mechanics remain upstream Code behavior;
  - reserves stronger future ActionContracts for explicit Metrora-owned trust domains/effects.
- `BENCH_EVIDENCE_FAMILIES.md`
  - recognizes that real Agent/Subagent execution now exists through OpenCode;
  - keeps Agent Evaluation future because a separately versioned methodology, isolation, rights and comparability contract are still required.

## Evidence basis

Public `main` remains `c960183820467c73ce92c8ccc606a6dd3552c80c`.

The accepted Code foundation has already passed physical session/project/provider/model/Tool/accounting/persistence/shutdown acceptance. Windows Store/AppX and Windows Candidate #1098 are also green through canonical payload, portable, NSIS, clean install, migration/rollback, controlled interruption/recovery and independent downloaded-format verification.

The ready-for-review docs CI fast path is green on HEAD `4c5820f040577315e282b0b51206026ec845ac11`.

No merge or release is implied by Ready-for-Review status.