### PR TITLE
feat: expose canonical Metrora tools in Code

### DIFF
--- a/app/electron/cli.test.ts
+++ b/app/electron/cli.test.ts
@@ -4,7 +4,7 @@ import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync, chmodSync 
 import { tmpdir } from 'node:os'
 import { delimiter, dirname, join, isAbsolute, relative, win32, posix } from 'node:path'
 
-import { spawnCli, spawnCliAction, spawnEnvFor, spawnSpecFor, killAll, shutdownCli, resetCliShutdownForTests, CliError, nodeManagerDirs, notFoundStage, resolveMetroraPath, resolveTarget } from './cli'
+import { resolveMetroraToolBridgeSpec, spawnCli, spawnCliAction, spawnEnvFor, spawnSpecFor, killAll, shutdownCli, resetCliShutdownForTests, CliError, nodeManagerDirs, notFoundStage, resolveMetroraPath, resolveTarget } from './cli'
 
 let dir: string
 const originalBin = process.env.METRORA_BIN
@@ -302,6 +302,41 @@ describe('spawnSpecFor (bundled CLI runs via Electron-as-node)', () => {
 
     const result = (await spawnCli(['status'])) as { ranAsNode: boolean; firstArg: string }
     expect(result).toEqual({ ranAsNode: true, firstArg: 'status' })
+  })
+})
+
+describe('resolveMetroraToolBridgeSpec', () => {
+  it('serializes an argv-only bundled bridge and keeps the environment narrow', () => {
+    delete process.env.METRORA_BIN
+    delete process.env.VITE_DEV_SERVER_URL
+    process.env.METRORA_PATH_DIRS = ''
+    process.env.METRORA_CLI_PATH_FILE = join(dir, 'no-persisted-path')
+    const entry = join(dir, 'launch.js')
+    writeFileSync(entry, '// bundled CLI\n')
+    process.env.METRORA_BUNDLED_CLI = entry
+
+    const serialized = resolveMetroraToolBridgeSpec()
+    expect(serialized).toBeTruthy()
+    const bridge = JSON.parse(serialized!) as { command: string[]; environment: Record<string, string> }
+    expect(bridge.command).toEqual([process.execPath, entry, 'tools', 'call'])
+    expect(bridge.environment).toEqual({ ELECTRON_RUN_AS_NODE: '1' })
+    expect(serialized).not.toContain('PATH')
+    expect(serialized).not.toContain('METRORA_SERVER_PASSWORD')
+  })
+
+  it('keeps a native external bridge direct and does not invent a shell', () => {
+    const native = fakeBin('metrora-native.exe', 'process.stdout.write("{}")', 'external')
+    const serialized = resolveMetroraToolBridgeSpec()
+    expect(JSON.parse(serialized!)).toEqual({ command: [native, 'tools', 'call'], environment: {} })
+  })
+
+  it('returns no bridge when the canonical CLI cannot be resolved', () => {
+    delete process.env.METRORA_BIN
+    delete process.env.VITE_DEV_SERVER_URL
+    delete process.env.METRORA_BUNDLED_CLI
+    process.env.METRORA_PATH_DIRS = ''
+    process.env.METRORA_CLI_PATH_FILE = join(dir, 'no-persisted-path')
+    expect(resolveMetroraToolBridgeSpec()).toBeNull()
   })
 })
 

--- a/app/electron/cli.ts
+++ b/app/electron/cli.ts
@@ -23,6 +23,12 @@ export type SpawnPriority = 'interactive' | 'background'
 export type CliTarget = { kind: 'external'; bin: string } | { kind: 'bundled'; entry: string }
 type SpawnSpec = { bin: string; args: string[]; env: NodeJS.ProcessEnv }
 
+/** The only data the OpenCode custom-tool transport is allowed to inherit. */
+export type MetroraToolBridgeSpec = {
+  command: string[]
+  environment: Record<string, string>
+}
+
 export type NotFoundStage =
   | 'bin-not-absolute'
   | 'bin-not-executable'
@@ -192,6 +198,30 @@ export function spawnSpecFor(target: CliTarget, args: string[]): SpawnSpec {
     }
   }
   return { bin: target.bin, args, env: spawnEnvFor(target.bin) }
+}
+
+/**
+ * Resolve the read-only Tools bridge once in Electron's main process. The
+ * custom tool receives an argv vector, never a shell command, plus the one
+ * runtime flag needed when the packaged CLI is launched by Electron.
+ */
+export function resolveMetroraToolBridgeSpec(): string | null {
+  const target = resolveTarget()
+  if (!target) return null
+  const spec = spawnSpecFor(target, ['tools', 'call'])
+  const command = [spec.bin, ...spec.args]
+  if (command.length === 3) {
+    if (!isAbsolute(command[0]!) || command[1] !== 'tools' || command[2] !== 'call') return null
+  } else if (command.length === 4) {
+    if (!isAbsolute(command[0]!) || !isAbsolute(command[1]!) || command[2] !== 'tools' || command[3] !== 'call') return null
+  } else {
+    return null
+  }
+  const environment: Record<string, string> = {}
+  if (spec.env.ELECTRON_RUN_AS_NODE === '1') environment.ELECTRON_RUN_AS_NODE = '1'
+  const bridge: MetroraToolBridgeSpec = { command, environment }
+  const serialized = JSON.stringify(bridge)
+  return Buffer.byteLength(serialized, 'utf8') <= 8 * 1024 ? serialized : null
 }
 
 function readPersistedPath(): string | null {

--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -2,7 +2,7 @@ import { app, BrowserWindow, dialog, ipcMain, Menu, nativeTheme, shell, WebConte
 import { writeFile } from 'node:fs/promises'
 import path from 'node:path'
 
-import { resolveMetroraPath, shutdownCli, spawnCli, spawnCliAction } from './cli'
+import { resolveMetroraPath, resolveMetroraToolBridgeSpec, shutdownCli, spawnCli, spawnCliAction } from './cli'
 import { createApplicationMenuTemplate } from './menu'
 import { getQuota } from './quota'
 import { saveShareCardPng } from './share-card-export'
@@ -141,6 +141,7 @@ function registerHandlers(): void {
     userDataPath: app.getPath('userData'),
     isPackaged: app.isPackaged,
     workingDirectory: process.cwd(),
+    toolBridgeSpec: resolveMetroraToolBridgeSpec(),
     readUsageSnapshot: () => spawnCli(
       ['status', '--format', 'menubar-json', '--period', 'today', '--no-timeline', '--no-optimize'],
       { extraEnv: { METRORA_READ_MODE: 'snapshot' }, priority: 'background' },

--- a/app/electron/opencode/config.ts
+++ b/app/electron/opencode/config.ts
@@ -1,8 +1,8 @@
 import { chmod, mkdir, readFile, stat, writeFile } from 'node:fs/promises'
 import path from 'node:path'
 
-import { OPENCODE_CUSTOM_TOOL_ID, OPENCODE_VERSION } from './types'
-import { OPENCODE_USAGE_TOOL_SOURCE } from './tool'
+import { OPENCODE_CUSTOM_TOOL_ID, OPENCODE_METRORA_TOOL_IDS, OPENCODE_VERSION } from './types'
+import { OPENCODE_METRORA_TOOL_SOURCES, OPENCODE_USAGE_TOOL_SOURCE } from './tool'
 import type { MetroraUsageSnapshot } from './snapshot'
 
 export const LOOPBACK_HOST = '127.0.0.1' as const
@@ -89,7 +89,7 @@ export async function writeRuntimeFiles(paths: OpenCodeRuntimePaths): Promise<vo
 
   // Keep a private package manifest because OpenCode's extension loader checks
   // the config directory as a package boundary. No network dependency is
-  // required by the one dependency-free Metrora tool.
+  // required by the dependency-free Metrora custom tools.
   const runtimePackage = {
     name: 'metrora-opencode-runtime',
     version: '1.0.0',
@@ -125,8 +125,14 @@ export async function writeRuntimeFiles(paths: OpenCodeRuntimePaths): Promise<vo
   await writeFile(paths.configPath, JSON.stringify(config, null, 2), { encoding: 'utf8', mode: 0o600 })
   await restrictPermissions(paths.configPath, 0o600)
 
-  await writeFile(path.join(paths.toolsDir, `${OPENCODE_CUSTOM_TOOL_ID}.js`), OPENCODE_USAGE_TOOL_SOURCE, { encoding: 'utf8', mode: 0o600 })
-  await restrictPermissions(path.join(paths.toolsDir, `${OPENCODE_CUSTOM_TOOL_ID}.js`), 0o600)
+  const legacyToolPath = path.join(paths.toolsDir, `${OPENCODE_CUSTOM_TOOL_ID}.js`)
+  await writeFile(legacyToolPath, OPENCODE_USAGE_TOOL_SOURCE, { encoding: 'utf8', mode: 0o600 })
+  await restrictPermissions(legacyToolPath, 0o600)
+  for (const toolId of OPENCODE_METRORA_TOOL_IDS) {
+    const toolPath = path.join(paths.toolsDir, `${toolId}.js`)
+    await writeFile(toolPath, OPENCODE_METRORA_TOOL_SOURCES[toolId], { encoding: 'utf8', mode: 0o600 })
+    await restrictPermissions(toolPath, 0o600)
+  }
 }
 
 export async function writeUsageSnapshot(paths: OpenCodeRuntimePaths, value: MetroraUsageSnapshot): Promise<void> {

--- a/app/electron/opencode/runtime.test.ts
+++ b/app/electron/opencode/runtime.test.ts
@@ -6,7 +6,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { readPreferredOpenCodePort, runtimePaths } from './config'
 import { buildOpenCodeServerArgs, createLaunchEnvironment, OpenCodeRuntime, resolveOpenCodeExecutable, type OpenCodeFetch, type SpawnedOpenCodeProcess } from './runtime'
-import { OPENCODE_COMMIT, OPENCODE_CUSTOM_TOOL_ID, OPENCODE_VERSION } from './types'
+import { OPENCODE_COMMIT, OPENCODE_CUSTOM_TOOL_ID, OPENCODE_CUSTOM_TOOL_IDS, OPENCODE_METRORA_TOOL_IDS, OPENCODE_VERSION } from './types'
 
 const temporaryDirectories: string[] = []
 
@@ -75,7 +75,7 @@ describe('OpenCode upstream sidecar runtime', () => {
       requests.push({ url, authorization: init?.headers?.Authorization ?? '' })
       return url.endsWith('/global/health')
         ? jsonResponse({ healthy: true, version: OPENCODE_VERSION })
-        : jsonResponse([OPENCODE_CUSTOM_TOOL_ID])
+        : jsonResponse([...OPENCODE_CUSTOM_TOOL_IDS])
     }
     const runtime = new OpenCodeRuntime({
       appPath: root,
@@ -85,6 +85,7 @@ describe('OpenCode upstream sidecar runtime', () => {
       executableOverride: executable,
       acquirePort: async () => 43127,
       randomPassword: () => 'p'.repeat(64),
+      toolBridgeSpec: '{"command":["C:/metrora/cli.exe","tools","call"],"environment":{}}',
       spawnProcess,
       fetchImpl,
       readUsageSnapshot: async () => ({
@@ -117,6 +118,7 @@ describe('OpenCode upstream sidecar runtime', () => {
           OPENCODE_CONFIG_DIR: join(userData, 'opencode', OPENCODE_VERSION),
           OPENCODE_CONFIG: join(userData, 'opencode', OPENCODE_VERSION, 'opencode.json'),
           OPENCODE_DISABLE_AUTOUPDATE: '1',
+          METRORA_TOOL_BRIDGE_SPEC: expect.any(String),
         }),
       }),
     )
@@ -136,6 +138,9 @@ describe('OpenCode upstream sidecar runtime', () => {
     expect(runtimePackage.dependencies?.['@opencode-ai/plugin']).toBe(OPENCODE_VERSION)
     expect(runtimeLock.packages?.['']?.dependencies?.['@opencode-ai/plugin']).toBe(OPENCODE_VERSION)
     expect(readFileSync(join(paths.toolsDir, `${OPENCODE_CUSTOM_TOOL_ID}.js`), 'utf8')).toContain('METRORA_USAGE_SNAPSHOT_FILE')
+    for (const toolId of OPENCODE_METRORA_TOOL_IDS) {
+      expect(readFileSync(join(paths.toolsDir, `${toolId}.js`), 'utf8')).toContain('METRORA_TOOL_BRIDGE_SPEC')
+    }
     const snapshot = readFileSync(paths.snapshotPath, 'utf8')
     expect(snapshot).toContain('metrora.usage-snapshot.v1')
     expect(snapshot).not.toContain('must not cross the boundary')
@@ -144,6 +149,33 @@ describe('OpenCode upstream sidecar runtime', () => {
     await runtime.stop()
     expect(child.killed).toBe(true)
     expect(runtime.status()).toMatchObject({ state: 'idle', customToolRegistered: null })
+  })
+
+  it('fails closed when one expected custom tool is missing', async () => {
+    const root = tempDirectory()
+    const userData = join(root, 'user-data')
+    const executable = join(root, 'opencode.exe')
+    writeFileSync(executable, 'official binary placeholder')
+    const child = fakeChild()
+    const missingTool = OPENCODE_METRORA_TOOL_IDS[0]
+    const runtime = new OpenCodeRuntime({
+      appPath: root,
+      resourcesPath: root,
+      userDataPath: userData,
+      isPackaged: false,
+      executableOverride: executable,
+      acquirePort: async () => 43132,
+      spawnProcess: () => child,
+      fetchImpl: async url => url.endsWith('/global/health')
+        ? jsonResponse({ healthy: true, version: OPENCODE_VERSION })
+        : jsonResponse(OPENCODE_CUSTOM_TOOL_IDS.filter(toolId => toolId !== missingTool)),
+      healthTimeoutMs: 500,
+      pollIntervalMs: 1,
+    })
+
+    await expect(runtime.start()).resolves.toMatchObject({ state: 'unavailable', customToolRegistered: false })
+    expect(runtime.status().detail).toContain('expected Metrora custom tools')
+    expect(child.killed).toBe(true)
   })
 
   it('does not block OpenCode startup on a slow usage snapshot refresh', async () => {
@@ -166,7 +198,7 @@ describe('OpenCode upstream sidecar runtime', () => {
       spawnProcess,
       fetchImpl: async url => url.endsWith('/global/health')
         ? jsonResponse({ healthy: true, version: OPENCODE_VERSION })
-        : jsonResponse([OPENCODE_CUSTOM_TOOL_ID]),
+        : jsonResponse([...OPENCODE_CUSTOM_TOOL_IDS]),
       readUsageSnapshot: async () => snapshotRefresh,
       healthTimeoutMs: 500,
       pollIntervalMs: 1,
@@ -213,7 +245,7 @@ describe('OpenCode upstream sidecar runtime', () => {
         authorizations.push(init?.headers?.Authorization ?? '')
         return url.endsWith('/global/health')
           ? jsonResponse({ healthy: true, version: OPENCODE_VERSION })
-          : jsonResponse([OPENCODE_CUSTOM_TOOL_ID])
+          : jsonResponse([...OPENCODE_CUSTOM_TOOL_IDS])
       },
       healthTimeoutMs: 500,
       pollIntervalMs: 1,
@@ -262,7 +294,7 @@ describe('OpenCode upstream sidecar runtime', () => {
       spawnProcess: () => fakeChild(),
       fetchImpl: async url => url.endsWith('/global/health')
         ? jsonResponse({ healthy: true, version: OPENCODE_VERSION })
-        : jsonResponse([OPENCODE_CUSTOM_TOOL_ID]),
+        : jsonResponse([...OPENCODE_CUSTOM_TOOL_IDS]),
       healthTimeoutMs: 500,
       pollIntervalMs: 1,
     })
@@ -301,7 +333,7 @@ describe('OpenCode upstream sidecar runtime', () => {
         authorizations.push(init?.headers?.Authorization ?? '')
         return url.endsWith('/global/health')
           ? jsonResponse({ healthy: true, version: OPENCODE_VERSION })
-          : jsonResponse([OPENCODE_CUSTOM_TOOL_ID])
+        : jsonResponse([...OPENCODE_CUSTOM_TOOL_IDS])
       },
       healthTimeoutMs: 500,
       pollIntervalMs: 1,
@@ -344,8 +376,11 @@ describe('OpenCode upstream sidecar runtime', () => {
     expect(buildOpenCodeServerArgs(43129)).toEqual(['serve', '--hostname', '127.0.0.1', '--port', '43129'])
     expect(() => buildOpenCodeServerArgs(0)).toThrow()
     const paths = runtimePaths('C:/user-data')
-    const environment = createLaunchEnvironment({ paths, username: 'metrora', password: 'x'.repeat(64), baseEnv: {} })
+    const environment = createLaunchEnvironment({ paths, username: 'metrora', password: 'x'.repeat(64), baseEnv: {}, toolBridgeSpec: '{"command":["C:/cli.exe","tools","call"],"environment":{}}' })
     expect(environment.OPENCODE_SERVER_PASSWORD).toBe('x'.repeat(64))
     expect(environment.OPENCODE_CONFIG).toBe(paths.configPath)
+    expect(environment.METRORA_TOOL_BRIDGE_SPEC).toContain('C:/cli.exe')
+    const withoutBridge = createLaunchEnvironment({ paths, username: 'metrora', password: 'x'.repeat(64), baseEnv: {} })
+    expect(withoutBridge.METRORA_TOOL_BRIDGE_SPEC).toBeUndefined()
   })
 })

--- a/app/electron/opencode/runtime.ts
+++ b/app/electron/opencode/runtime.ts
@@ -9,7 +9,7 @@ import { readPreferredOpenCodePort, runtimePaths, writePreferredOpenCodePort, wr
 import { sanitizeUsageSnapshot } from './snapshot'
 import {
   OPENCODE_COMMIT,
-  OPENCODE_CUSTOM_TOOL_ID,
+  OPENCODE_CUSTOM_TOOL_IDS,
   OPENCODE_LOOPBACK_HOST,
   OPENCODE_VERSION,
   OpenCodeError,
@@ -55,6 +55,8 @@ export type OpenCodeRuntimeOptions = {
   acquirePort?: () => Promise<number>
   isLoopbackPortAvailable?: (port: number) => Promise<boolean>
   readUsageSnapshot?: () => Promise<unknown>
+  /** Serialized argv-only bridge for the private Metrora custom tools. */
+  toolBridgeSpec?: string | null
   now?: () => number
   randomPassword?: () => string
   healthTimeoutMs?: number
@@ -95,8 +97,9 @@ export function createLaunchEnvironment(options: {
   paths: OpenCodeRuntimePaths
   username: string
   password: string
+  toolBridgeSpec?: string | null
 }): NodeJS.ProcessEnv {
-  return {
+  const environment: NodeJS.ProcessEnv = {
     ...(options.baseEnv ?? process.env),
     OPENCODE_SERVER_USERNAME: options.username,
     OPENCODE_SERVER_PASSWORD: options.password,
@@ -105,6 +108,8 @@ export function createLaunchEnvironment(options: {
     OPENCODE_DISABLE_AUTOUPDATE: '1',
     METRORA_USAGE_SNAPSHOT_FILE: options.paths.snapshotPath,
   }
+  if (options.toolBridgeSpec) environment.METRORA_TOOL_BRIDGE_SPEC = options.toolBridgeSpec
+  return environment
 }
 
 export async function freeLoopbackPort(): Promise<number> {
@@ -269,7 +274,7 @@ export class OpenCodeRuntime {
         args,
         {
           cwd: this.options.workingDirectory ?? this.options.appPath,
-          env: createLaunchEnvironment({ paths, username: SERVER_USERNAME, password }),
+          env: createLaunchEnvironment({ paths, username: SERVER_USERNAME, password, toolBridgeSpec: this.options.toolBridgeSpec }),
           stdio: ['ignore', 'ignore', 'ignore'],
           windowsHide: true,
         },
@@ -291,9 +296,9 @@ export class OpenCodeRuntime {
       if (reportedVersion !== OPENCODE_VERSION) {
         throw new OpenCodeError('version-mismatch', `OpenCode version verification failed; expected ${OPENCODE_VERSION}.`)
       }
-      const registered = await this.verifyCustomTool(origin, auth, abort.signal)
+      const registered = await this.verifyCustomTools(origin, auth, abort.signal)
       this.customToolRegistered = registered
-      if (!registered) throw new OpenCodeError('custom-tool', `OpenCode did not register ${OPENCODE_CUSTOM_TOOL_ID}.`)
+      if (!registered) throw new OpenCodeError('custom-tool', 'OpenCode did not register the expected Metrora custom tools.')
       if (abort.signal.aborted) throw new OpenCodeError('cancelled', 'OpenCode startup cancelled.')
 
       this.connection = { origin, username: SERVER_USERNAME, password }
@@ -344,13 +349,15 @@ export class OpenCodeRuntime {
     throw new OpenCodeError('timeout', 'OpenCode server did not become healthy.')
   }
 
-  private async verifyCustomTool(origin: string, authorization: string, signal: AbortSignal): Promise<boolean> {
+  private async verifyCustomTools(origin: string, authorization: string, signal: AbortSignal): Promise<boolean> {
     const fetchImpl = this.options.fetchImpl ?? ((url, init) => fetch(url, init))
     const response = await fetchImpl(`${origin}/experimental/tool/ids`, { headers: { Authorization: authorization }, signal: abortAfter(signal, REQUEST_TIMEOUT_MS) })
     if (!response.ok) throw new OpenCodeError('custom-tool', 'OpenCode tool discovery was unavailable.')
     const value = await responseJson(response)
     if (!Array.isArray(value)) throw new OpenCodeError('custom-tool', 'OpenCode tool discovery returned an invalid response.')
-    return value.slice(0, 1_000).every(item => typeof item === 'string') && value.includes(OPENCODE_CUSTOM_TOOL_ID)
+    const registered = value.slice(0, 1_000)
+    return registered.every(item => typeof item === 'string')
+      && OPENCODE_CUSTOM_TOOL_IDS.every(toolId => registered.includes(toolId))
   }
 
   private async acquireServerPort(paths: OpenCodeRuntimePaths): Promise<number> {

--- a/app/electron/opencode/tool.test.ts
+++ b/app/electron/opencode/tool.test.ts
@@ -5,7 +5,7 @@ import { join } from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
 
 import { createOpenCodeMetroraToolSource, OPENCODE_METRORA_TOOL_SOURCES, OPENCODE_USAGE_TOOL_SOURCE } from './tool'
-import { OPENCODE_METRORA_TOOL_IDS } from './types'
+import { OPENCODE_METRORA_TOOL_IDS, OPENCODE_METRORA_TOOL_MAP } from './types'
 
 const temporaryDirectories: string[] = []
 const originalSnapshotPath = process.env.METRORA_USAGE_SNAPSHOT_FILE
@@ -76,8 +76,20 @@ describe('Metrora OpenCode tool runtime file', () => {
   })
 
   it('writes all seven canonical tools with plain bounded schemas and no local data access', async () => {
+    const canonicalToolNames = [
+      'get_spend_snapshot',
+      'get_model_efficiency',
+      'get_overview_snapshot',
+      'get_project_drivers',
+      'get_session_highlights',
+      'get_coverage_report',
+      'get_bench_evidence',
+    ] as const
     expect(Object.keys(OPENCODE_METRORA_TOOL_SOURCES)).toEqual([...OPENCODE_METRORA_TOOL_IDS])
-    for (const toolId of OPENCODE_METRORA_TOOL_IDS) {
+    expect(Object.keys(OPENCODE_METRORA_TOOL_MAP)).toEqual([...OPENCODE_METRORA_TOOL_IDS])
+    expect(Object.values(OPENCODE_METRORA_TOOL_MAP)).toEqual([...canonicalToolNames])
+    for (const [index, toolId] of OPENCODE_METRORA_TOOL_IDS.entries()) {
+      expect(OPENCODE_METRORA_TOOL_MAP[toolId]).toBe(canonicalToolNames[index])
       const module = await importToolSource(OPENCODE_METRORA_TOOL_SOURCES[toolId])
       expect(module.default.args).toHaveProperty('filters')
       expect(module.default.args.filters).toMatchObject({ type: 'object', required: [], additionalProperties: false })
@@ -107,7 +119,7 @@ describe('Metrora OpenCode tool runtime file', () => {
     const module = await importToolSource(OPENCODE_METRORA_TOOL_SOURCES.metrora_get_spend_snapshot)
 
     await expect(module.default.execute({ filters: { period: 'today', model: 'model;still-one-argv' } })).resolves.toBe(JSON.stringify({
-      tool: 'metrora_get_spend_snapshot',
+      tool: 'get_spend_snapshot',
       args: { period: 'today', model: 'model;still-one-argv' },
     }))
   })

--- a/app/electron/opencode/tool.test.ts
+++ b/app/electron/opencode/tool.test.ts
@@ -4,16 +4,34 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
 
-import { OPENCODE_USAGE_TOOL_SOURCE } from './tool'
+import { createOpenCodeMetroraToolSource, OPENCODE_METRORA_TOOL_SOURCES, OPENCODE_USAGE_TOOL_SOURCE } from './tool'
+import { OPENCODE_METRORA_TOOL_IDS } from './types'
 
 const temporaryDirectories: string[] = []
 const originalSnapshotPath = process.env.METRORA_USAGE_SNAPSHOT_FILE
+const originalBridgeSpec = process.env.METRORA_TOOL_BRIDGE_SPEC
 
 afterEach(() => {
   for (const directory of temporaryDirectories.splice(0)) rmSync(directory, { recursive: true, force: true })
   if (originalSnapshotPath === undefined) delete process.env.METRORA_USAGE_SNAPSHOT_FILE
   else process.env.METRORA_USAGE_SNAPSHOT_FILE = originalSnapshotPath
+  if (originalBridgeSpec === undefined) delete process.env.METRORA_TOOL_BRIDGE_SPEC
+  else process.env.METRORA_TOOL_BRIDGE_SPEC = originalBridgeSpec
 })
+
+function importToolSource(source: string): Promise<{ default: { args: Record<string, unknown>; execute: (args?: unknown, context?: unknown) => Promise<string> } }> {
+  return import(`data:text/javascript;base64,${Buffer.from(source).toString('base64')}`) as Promise<{ default: { args: Record<string, unknown>; execute: (args?: unknown, context?: unknown) => Promise<string> } }>
+}
+
+function bridgeEntry(directory: string, body: string): string {
+  const entry = join(directory, 'bridge.mjs')
+  writeFileSync(entry, body)
+  process.env.METRORA_TOOL_BRIDGE_SPEC = JSON.stringify({
+    command: [process.execPath, entry, 'tools', 'call'],
+    environment: {},
+  })
+  return entry
+}
 
 describe('Metrora OpenCode tool runtime file', () => {
   it('is discovered as a dependency-free module and returns only a bounded snapshot', async () => {
@@ -33,7 +51,7 @@ describe('Metrora OpenCode tool runtime file', () => {
     writeFileSync(toolPath, OPENCODE_USAGE_TOOL_SOURCE)
     process.env.METRORA_USAGE_SNAPSHOT_FILE = snapshotPath
 
-    const module = await import(`data:text/javascript;base64,${Buffer.from(OPENCODE_USAGE_TOOL_SOURCE).toString('base64')}`) as { default: { execute: () => Promise<string> } }
+    const module = await importToolSource(OPENCODE_USAGE_TOOL_SOURCE)
     const output = await module.default.execute()
 
     expect(output.length).toBeLessThanOrEqual(8_000)
@@ -52,8 +70,77 @@ describe('Metrora OpenCode tool runtime file', () => {
     writeFileSync(toolPath, OPENCODE_USAGE_TOOL_SOURCE)
     delete process.env.METRORA_USAGE_SNAPSHOT_FILE
 
-    const module = await import(`data:text/javascript;base64,${Buffer.from(OPENCODE_USAGE_TOOL_SOURCE).toString('base64')}`) as { default: { execute: () => Promise<string> } }
+    const module = await importToolSource(OPENCODE_USAGE_TOOL_SOURCE)
 
     await expect(module.default.execute()).resolves.toBe('Metrora usage snapshot is unavailable.')
+  })
+
+  it('writes all seven canonical tools with plain bounded schemas and no local data access', async () => {
+    expect(Object.keys(OPENCODE_METRORA_TOOL_SOURCES)).toEqual([...OPENCODE_METRORA_TOOL_IDS])
+    for (const toolId of OPENCODE_METRORA_TOOL_IDS) {
+      const module = await importToolSource(OPENCODE_METRORA_TOOL_SOURCES[toolId])
+      expect(module.default.args).toHaveProperty('filters')
+      expect(module.default.args.filters).toMatchObject({ type: 'object', required: [], additionalProperties: false })
+      const properties = module.default.args.filters as { properties?: Record<string, unknown> }
+      if (toolId === 'metrora_get_spend_snapshot' || toolId === 'metrora_get_model_efficiency' || toolId === 'metrora_get_overview_snapshot') {
+        expect(properties.properties).toHaveProperty('model')
+      } else {
+        expect(properties.properties).not.toHaveProperty('model')
+      }
+      expect(OPENCODE_METRORA_TOOL_SOURCES[toolId]).toContain('METRORA_TOOL_BRIDGE_SPEC')
+      expect(OPENCODE_METRORA_TOOL_SOURCES[toolId]).toContain('shell: false')
+      expect(OPENCODE_METRORA_TOOL_SOURCES[toolId]).not.toContain('fetch(')
+      expect(OPENCODE_METRORA_TOOL_SOURCES[toolId]).not.toContain('node:fs')
+      expect(OPENCODE_METRORA_TOOL_SOURCES[toolId]).not.toContain('METRORA_USAGE_SNAPSHOT_FILE')
+    }
+    const spend = await importToolSource(OPENCODE_METRORA_TOOL_SOURCES.metrora_get_spend_snapshot)
+    expect(spend.default.args.filters).toMatchObject({ properties: { model: expect.any(Object), period: expect.any(Object) } })
+  })
+
+  it('passes one JSON argument through the argv-only bridge and returns canonical JSON', async () => {
+    const directory = mkdtempSync(join(tmpdir(), 'metrora-opencode-tool-bridge-'))
+    temporaryDirectories.push(directory)
+    bridgeEntry(directory, [
+      'const args = process.argv.slice(2);',
+      'process.stdout.write(JSON.stringify({ tool: args[2], args: JSON.parse(args[4]) }));',
+    ].join('\n'))
+    const module = await importToolSource(OPENCODE_METRORA_TOOL_SOURCES.metrora_get_spend_snapshot)
+
+    await expect(module.default.execute({ filters: { period: 'today', model: 'model;still-one-argv' } })).resolves.toBe(JSON.stringify({
+      tool: 'metrora_get_spend_snapshot',
+      args: { period: 'today', model: 'model;still-one-argv' },
+    }))
+  })
+
+  it('returns clean unavailable output for missing, malformed, oversized, nonzero and cancelled bridges', async () => {
+    const directory = mkdtempSync(join(tmpdir(), 'metrora-opencode-tool-bridge-'))
+    temporaryDirectories.push(directory)
+    const module = await importToolSource(createOpenCodeMetroraToolSource('metrora_get_coverage_report', { timeoutMs: 50 }))
+
+    delete process.env.METRORA_TOOL_BRIDGE_SPEC
+    await expect(module.default.execute({ filters: { period: 'today' } })).resolves.toBe('Metrora tool unavailable.')
+
+   bridgeEntry(directory, 'process.stdout.write("not-json")')
+   await expect(module.default.execute({ filters: { period: 'today' } })).resolves.toBe('Metrora tool unavailable.')
+
+   bridgeEntry(directory, 'process.stdout.write("x".repeat(40000)); setInterval(() => {}, 1000)')
+   await expect(module.default.execute({ filters: { period: 'today' } })).resolves.toBe('Metrora tool unavailable.')
+    process.env.METRORA_TOOL_BRIDGE_SPEC = '{malformed'
+    await expect(module.default.execute({ filters: { period: 'today' } })).resolves.toBe('Metrora tool unavailable.')
+
+   bridgeEntry(directory, 'process.exit(7)')
+   await expect(module.default.execute({ filters: { period: 'today' } })).resolves.toBe('Metrora tool unavailable.')
+
+    bridgeEntry(directory, 'process.stderr.write("secret-stderr".repeat(1000)); setInterval(() => {}, 1000)')
+    await expect(module.default.execute({ filters: { period: 'today' } })).resolves.toBe('Metrora tool unavailable.')
+
+   bridgeEntry(directory, 'setInterval(() => {}, 1000)')
+   await expect(module.default.execute({ filters: { period: 'today' } })).resolves.toBe('Metrora tool unavailable.')
+
+    const controller = new AbortController()
+    bridgeEntry(directory, 'setInterval(() => {}, 1000)')
+    const pending = module.default.execute({ filters: { period: 'today' } }, { abort: controller.signal })
+    controller.abort()
+    await expect(pending).resolves.toBe('Metrora tool unavailable.')
   })
 })

--- a/app/electron/opencode/tool.ts
+++ b/app/electron/opencode/tool.ts
@@ -1,3 +1,5 @@
+import { OPENCODE_METRORA_TOOL_IDS, type OpenCodeMetroraToolId } from './types'
+
 /**
  * This source is written into Metrora's private OpenCode config directory at
  * runtime. OpenCode discovers it through its normal config-directory tool
@@ -50,7 +52,7 @@ function projectSnapshot(value) {
 }
 
 export default {
-  description: "Read the current, read-only Metrora usage snapshot. Use this only when the user asks about Metrora usage, cost, quota, or activity.",
+  description: "Read the current, read-only Metrora usage snapshot for compatibility. It covers measured usage and activity only; use canonical Metrora Tools for bounded evidence.",
   args: {},
   async execute() {
     const snapshotPath = process.env.METRORA_USAGE_SNAPSHOT_FILE
@@ -64,3 +66,268 @@ export default {
   },
 }
 `
+
+const PERIOD_VALUES = ['today', 'yesterday', 'week', '30days', 'month', 'all', 'lifetime'] as const
+const MAX_ARGUMENT_BYTES = 8 * 1024
+const MAX_OUTPUT_BYTES = 32 * 1024
+const MAX_STDERR_BYTES = 8 * 1024
+const DEFAULT_TIMEOUT_MS = 45_000
+const UNAVAILABLE = 'Metrora tool unavailable.'
+
+type OpenCodeToolArgumentSchema = {
+  filters: {
+    type: 'object'
+    properties: Record<string, Record<string, unknown>>
+    required: string[]
+    additionalProperties: false
+  }
+}
+
+const PERIOD_ARGUMENT = {
+  type: 'string',
+  enum: [...PERIOD_VALUES],
+  description: 'Optional bounded period refinement; it cannot widen the startup scope.',
+}
+const MODEL_ARGUMENT = {
+  type: 'string',
+  maxLength: 256,
+  description: 'Optional exact model filter.',
+}
+
+function filterArguments(properties: Record<string, Record<string, unknown>>): OpenCodeToolArgumentSchema {
+  return {
+    filters: {
+      type: 'object',
+      properties,
+      required: [],
+      additionalProperties: false,
+    },
+  }
+}
+
+const TOOL_CONFIG: Record<OpenCodeMetroraToolId, { description: string; args: OpenCodeToolArgumentSchema }> = {
+  metrora_get_spend_snapshot: {
+    description: 'Read canonical Metrora measured spend, daily trend, model and Project drivers, and coverage.',
+    args: filterArguments({ period: PERIOD_ARGUMENT, model: MODEL_ARGUMENT }),
+  },
+  metrora_get_model_efficiency: {
+    description: 'Read canonical Metrora model rows and observed cost per call. Do not infer quality or comparable work.',
+    args: filterArguments({ period: PERIOD_ARGUMENT, model: MODEL_ARGUMENT }),
+  },
+  metrora_get_overview_snapshot: {
+    description: 'Read the canonical Metrora overview for the selected bounded scope.',
+    args: filterArguments({ period: PERIOD_ARGUMENT, model: MODEL_ARGUMENT }),
+  },
+  metrora_get_project_drivers: {
+    description: 'Read descriptive Project spend drivers from canonical Metrora evidence. Do not infer causality.',
+    args: filterArguments({ period: PERIOD_ARGUMENT }),
+  },
+  metrora_get_session_highlights: {
+    description: 'Read content-minimal highest-cost session highlights from canonical Metrora evidence.',
+    args: filterArguments({ period: PERIOD_ARGUMENT }),
+  },
+  metrora_get_coverage_report: {
+    description: 'Read canonical Metrora evidence coverage, assumptions, and unknowns for the selected scope.',
+    args: filterArguments({ period: PERIOD_ARGUMENT }),
+  },
+  metrora_get_bench_evidence: {
+    description: 'Read bounded canonical Metrora Bench history and compatible comparisons. Never start a Bench run.',
+    args: filterArguments({ period: PERIOD_ARGUMENT }),
+  },
+}
+
+function sourceJson(value: unknown): string {
+  return JSON.stringify(value)
+}
+
+/**
+ * Generate a dependency-light OpenCode module. The default timeout is part of
+ * the production boundary; the optional argument keeps the safety behavior
+ * directly testable without waiting 45 seconds in unit tests.
+ */
+export function createOpenCodeMetroraToolSource(
+  toolId: OpenCodeMetroraToolId,
+  options: { timeoutMs?: number } = {},
+): string {
+  const config = TOOL_CONFIG[toolId]
+  const timeoutMs = Number.isFinite(options.timeoutMs) && (options.timeoutMs ?? 0) > 0
+    ? Math.max(1, Math.floor(options.timeoutMs!))
+    : DEFAULT_TIMEOUT_MS
+  return String.raw`import { spawn } from "node:child_process"
+import { isAbsolute } from "node:path"
+
+const TOOL_NAME = ${sourceJson(toolId)}
+const MAX_ARGUMENT_BYTES = ${MAX_ARGUMENT_BYTES}
+const MAX_OUTPUT_BYTES = ${MAX_OUTPUT_BYTES}
+const MAX_STDERR_BYTES = ${MAX_STDERR_BYTES}
+const TIMEOUT_MS = ${timeoutMs}
+const UNAVAILABLE = ${sourceJson(UNAVAILABLE)}
+
+function byteLength(value) {
+  return Buffer.byteLength(value, "utf8")
+}
+
+function isRecord(value) {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value))
+}
+
+function readBridgeSpec() {
+  const raw = process.env.METRORA_TOOL_BRIDGE_SPEC
+  if (typeof raw !== "string" || byteLength(raw) > MAX_ARGUMENT_BYTES) return null
+  let value
+  try { value = JSON.parse(raw) } catch { return null }
+  if (!isRecord(value) || !Array.isArray(value.command) || !isRecord(value.environment)) return null
+  if (Object.keys(value).some(key => key !== "command" && key !== "environment")) return null
+  const command = value.command
+  if ((command.length !== 3 && command.length !== 4) || !command.every(item => typeof item === "string" && item.length > 0)) return null
+  if (!isAbsolute(command[0])) return null
+  if (command.length === 3) {
+    if (command[1] !== "tools" || command[2] !== "call") return null
+  } else {
+    if (!isAbsolute(command[1]) || command[2] !== "tools" || command[3] !== "call") return null
+  }
+  const environment = value.environment
+  if (Object.keys(environment).some(key => key !== "ELECTRON_RUN_AS_NODE")) return null
+  if (environment.ELECTRON_RUN_AS_NODE !== undefined && environment.ELECTRON_RUN_AS_NODE !== "1") return null
+  return { command: [...command], environment: { ...(environment.ELECTRON_RUN_AS_NODE === "1" ? { ELECTRON_RUN_AS_NODE: "1" } : {}) } }
+}
+
+function terminationSignal(context) {
+  const signal = context && context.abort
+  return signal && typeof signal.addEventListener === "function" && typeof signal.removeEventListener === "function"
+    ? signal
+    : null
+}
+
+function canonicalArguments(value) {
+  if (value === undefined) return {}
+  if (!isRecord(value)) return null
+  const keys = Object.keys(value)
+  if (keys.length === 0) return {}
+  if (keys.length !== 1 || !Object.prototype.hasOwnProperty.call(value, "filters") || !isRecord(value.filters)) return null
+  return value.filters
+}
+
+function invokeBridge(bridge, args, signal) {
+  if (signal?.aborted) return Promise.resolve(null)
+  let serializedArgs
+  try {
+    if (!isRecord(args)) return Promise.resolve(null)
+    serializedArgs = JSON.stringify(args)
+  } catch {
+    return Promise.resolve(null)
+  }
+  if (typeof serializedArgs !== "string" || byteLength(serializedArgs) > MAX_ARGUMENT_BYTES) return Promise.resolve(null)
+
+  return new Promise(resolve => {
+    let child
+    let settled = false
+    let stdout = ""
+    let stdoutBytes = 0
+   let stderrBytes = 0
+   let timer
+    let hardTimer
+   const finish = value => {
+     if (settled) return
+     settled = true
+      if (timer !== undefined) clearTimeout(timer)
+     signal?.removeEventListener("abort", onAbort)
+     resolve(value)
+   }
+   const terminate = () => {
+     try { child?.kill() } catch { /* the result remains unavailable */ }
+      hardTimer ??= setTimeout(() => {
+        try { child?.kill("SIGKILL") } catch { /* the result remains unavailable */ }
+      }, 250)
+   }
+    const onAbort = () => {
+      terminate()
+      finish(null)
+    }
+
+    try {
+      child = spawn(bridge.command[0], [...bridge.command.slice(1), TOOL_NAME, "--args-json", serializedArgs], {
+        shell: false,
+        windowsHide: true,
+        env: bridge.environment,
+        stdio: ["ignore", "pipe", "pipe"],
+      })
+    } catch {
+      finish(null)
+      return
+    }
+
+    signal?.addEventListener("abort", onAbort, { once: true })
+    if (signal?.aborted) {
+      terminate()
+      finish(null)
+      return
+    }
+    timer = setTimeout(() => {
+      terminate()
+      finish(null)
+    }, TIMEOUT_MS)
+    child.stdout?.on("data", chunk => {
+      const text = typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8")
+      stdoutBytes += byteLength(text)
+      if (stdoutBytes > MAX_OUTPUT_BYTES) {
+        terminate()
+        finish(null)
+        return
+      }
+      stdout += text
+    })
+    child.stderr?.on("data", chunk => {
+      const text = typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8")
+      stderrBytes += byteLength(text)
+      if (stderrBytes > MAX_STDERR_BYTES) {
+        terminate()
+        finish(null)
+      }
+    })
+    child.once("error", () => finish(null))
+    child.once("close", code => {
+      if (settled || code !== 0) {
+        if (!settled) finish(null)
+        return
+      }
+      const output = stdout.trim()
+      if (!output || byteLength(output) > MAX_OUTPUT_BYTES) {
+        finish(null)
+        return
+      }
+      try {
+        const parsed = JSON.parse(output)
+        if (!isRecord(parsed)) {
+          finish(null)
+          return
+        }
+        const canonical = JSON.stringify(parsed)
+        finish(typeof canonical === "string" && byteLength(canonical) <= MAX_OUTPUT_BYTES ? canonical : null)
+      } catch {
+        finish(null)
+      }
+    })
+  })
+}
+
+export default {
+  description: ${sourceJson(config.description)},
+  args: ${sourceJson(config.args)},
+  async execute(args, context) {
+    try {
+      const bridge = readBridgeSpec()
+      if (!bridge) return UNAVAILABLE
+      const output = await invokeBridge(bridge, canonicalArguments(args), terminationSignal(context))
+      return typeof output === "string" ? output : UNAVAILABLE
+    } catch {
+      return UNAVAILABLE
+    }
+  },
+}
+`
+}
+
+export const OPENCODE_METRORA_TOOL_SOURCES: Readonly<Record<OpenCodeMetroraToolId, string>> = Object.freeze(
+  Object.fromEntries(OPENCODE_METRORA_TOOL_IDS.map(toolId => [toolId, createOpenCodeMetroraToolSource(toolId)])) as Record<OpenCodeMetroraToolId, string>,
+)

--- a/app/electron/opencode/tool.ts
+++ b/app/electron/opencode/tool.ts
@@ -1,4 +1,4 @@
-import { OPENCODE_METRORA_TOOL_IDS, type OpenCodeMetroraToolId } from './types'
+import { OPENCODE_METRORA_TOOL_IDS, OPENCODE_METRORA_TOOL_MAP, type OpenCodeMetroraToolId } from './types'
 
 /**
  * This source is written into Metrora's private OpenCode config directory at
@@ -150,13 +150,15 @@ export function createOpenCodeMetroraToolSource(
   options: { timeoutMs?: number } = {},
 ): string {
   const config = TOOL_CONFIG[toolId]
+  const canonicalToolName = OPENCODE_METRORA_TOOL_MAP[toolId]
   const timeoutMs = Number.isFinite(options.timeoutMs) && (options.timeoutMs ?? 0) > 0
     ? Math.max(1, Math.floor(options.timeoutMs!))
     : DEFAULT_TIMEOUT_MS
   return String.raw`import { spawn } from "node:child_process"
 import { isAbsolute } from "node:path"
 
-const TOOL_NAME = ${sourceJson(toolId)}
+const OPENCODE_TOOL_ID = ${sourceJson(toolId)}
+const CANONICAL_TOOL_NAME = ${sourceJson(canonicalToolName)}
 const MAX_ARGUMENT_BYTES = ${MAX_ARGUMENT_BYTES}
 const MAX_OUTPUT_BYTES = ${MAX_OUTPUT_BYTES}
 const MAX_STDERR_BYTES = ${MAX_STDERR_BYTES}
@@ -246,7 +248,7 @@ function invokeBridge(bridge, args, signal) {
     }
 
     try {
-      child = spawn(bridge.command[0], [...bridge.command.slice(1), TOOL_NAME, "--args-json", serializedArgs], {
+      child = spawn(bridge.command[0], [...bridge.command.slice(1), CANONICAL_TOOL_NAME, "--args-json", serializedArgs], {
         shell: false,
         windowsHide: true,
         env: bridge.environment,

--- a/app/electron/opencode/types.ts
+++ b/app/electron/opencode/types.ts
@@ -12,6 +12,25 @@ export const OPENCODE_METRORA_TOOL_IDS = [
   'metrora_get_bench_evidence',
 ] as const
 export type OpenCodeMetroraToolId = typeof OPENCODE_METRORA_TOOL_IDS[number]
+export type OpenCodeCanonicalMetroraToolName =
+  | 'get_spend_snapshot'
+  | 'get_model_efficiency'
+  | 'get_overview_snapshot'
+  | 'get_project_drivers'
+  | 'get_session_highlights'
+  | 'get_coverage_report'
+  | 'get_bench_evidence'
+
+/** Closed-world transport mapping; the canonical registry stays surface-agnostic. */
+export const OPENCODE_METRORA_TOOL_MAP = Object.freeze({
+  metrora_get_spend_snapshot: 'get_spend_snapshot',
+  metrora_get_model_efficiency: 'get_model_efficiency',
+  metrora_get_overview_snapshot: 'get_overview_snapshot',
+  metrora_get_project_drivers: 'get_project_drivers',
+  metrora_get_session_highlights: 'get_session_highlights',
+  metrora_get_coverage_report: 'get_coverage_report',
+  metrora_get_bench_evidence: 'get_bench_evidence',
+} as const satisfies Readonly<Record<OpenCodeMetroraToolId, OpenCodeCanonicalMetroraToolName>>)
 /** All Metrora-owned custom tools expected from the private runtime config. */
 export const OPENCODE_CUSTOM_TOOL_IDS = [OPENCODE_CUSTOM_TOOL_ID, ...OPENCODE_METRORA_TOOL_IDS] as const
 export const OPENCODE_EXPECTED_CUSTOM_TOOL_IDS = OPENCODE_CUSTOM_TOOL_IDS

--- a/app/electron/opencode/types.ts
+++ b/app/electron/opencode/types.ts
@@ -1,6 +1,20 @@
 export const OPENCODE_VERSION = '1.18.27' as const
 export const OPENCODE_COMMIT = 'b04697366f05419e9bd7a92f841813dd976161c9' as const
 export const OPENCODE_CUSTOM_TOOL_ID = 'metrora_usage_snapshot' as const
+export const OPENCODE_LEGACY_CUSTOM_TOOL_ID = OPENCODE_CUSTOM_TOOL_ID
+export const OPENCODE_METRORA_TOOL_IDS = [
+  'metrora_get_spend_snapshot',
+  'metrora_get_model_efficiency',
+  'metrora_get_overview_snapshot',
+  'metrora_get_project_drivers',
+  'metrora_get_session_highlights',
+  'metrora_get_coverage_report',
+  'metrora_get_bench_evidence',
+] as const
+export type OpenCodeMetroraToolId = typeof OPENCODE_METRORA_TOOL_IDS[number]
+/** All Metrora-owned custom tools expected from the private runtime config. */
+export const OPENCODE_CUSTOM_TOOL_IDS = [OPENCODE_CUSTOM_TOOL_ID, ...OPENCODE_METRORA_TOOL_IDS] as const
+export const OPENCODE_EXPECTED_CUSTOM_TOOL_IDS = OPENCODE_CUSTOM_TOOL_IDS
 export const OPENCODE_LOOPBACK_HOST = '127.0.0.1' as const
 
 export type OpenCodeRuntimeState = 'idle' | 'starting' | 'ready' | 'stopping' | 'unavailable'

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -136,6 +136,26 @@ Pairing is explicit and revocable. Combined-device reporting is separate from th
 | `metrora menubar` | Install the retained macOS menubar development surface. |
 | `metrora antigravity-hook` | Install or remove supported Antigravity CLI usage capture. |
 
+### Canonical Tools adapter
+
+The read-only Code bridge and other bounded integrations use the same
+canonical registry through the CLI adapter:
+
+```bash
+metrora tools call get_spend_snapshot --args-json '{"period":"today"}'
+metrora tools call get_model_efficiency --args-json '{}' --period week --provider claude --project-id all
+```
+
+`--args-json` must be one bounded JSON object. Startup scope defaults to
+`--period all --provider all --project-id all`; tool arguments may only use the
+filters declared by the canonical contract. Success writes result content JSON
+to stdout only. Malformed/unknown calls and unavailable startup failures write
+a safe bounded diagnostic to stderr and return a non-zero status. This adapter
+does not invoke configuration-changing commands or Bench runs, and does not expose raw prompts,
+responses, source, credentials or filesystem paths. `get_quota_snapshot` is
+available to the canonical CLI/MCP contract, while the new OpenCode Code
+subset intentionally does not register it.
+
 The macOS menubar and other retained platform surfaces are not official Metrora distributions until their platform-specific release boundary passes.
 
 ## Identity boundary

--- a/docs/ECOSYSTEM_SURFACES.md
+++ b/docs/ECOSYSTEM_SURFACES.md
@@ -2,7 +2,7 @@
 
 **Status:** public product direction and implementation-status guide  
 **Decision revision:** 2026-09-05  
-**Authority reviewed:** `maikolsiragusaa/metrora@c960183820467c73ce92c8ccc606a6dd3552c80c`
+**Authority reviewed:** `maikolsiragusaa/metrora@c2e21993016c9f63a3bc38b456e2548753228ebb`
 
 Metrora is a local-first control and intelligence system for AI-assisted development. Product surfaces compose around shared facts/contracts instead of growing into parallel engines that each invent their own truth or execution mechanics.
 
@@ -75,16 +75,36 @@ Metrora accounting continues to identify this source as **OpenCode**. Being laun
 
 Metrora-specific intelligence is added to the upstream Code surface through bounded Metrora Tools rather than through a parallel coding-agent engine.
 
-The first accepted end-to-end proof is `metrora_usage_snapshot`:
+The retained compatibility tool is `metrora_usage_snapshot`; the current
+canonical Code subset is:
+
+```text
+metrora_get_spend_snapshot
+metrora_get_model_efficiency
+metrora_get_overview_snapshot
+metrora_get_project_drivers
+metrora_get_session_highlights
+metrora_get_coverage_report
+metrora_get_bench_evidence
+```
+
+The end-to-end path is:
 
 ```text
 user asks a Metrora-specific question in Code
-→ OpenCode selects metrora_usage_snapshot
-→ Metrora returns bounded canonical evidence
+→ OpenCode selects a Metrora custom tool
+→ argv-only bridge invokes metrora tools call
+→ canonical Metrora registry returns bounded evidence
 → OpenCode explains the result
 ```
 
-Future factual Tool expansion should reuse the same canonical Metrora registries/contracts used elsewhere rather than implement Code-specific accounting or evidence paths.
+`get_quota_snapshot` remains a canonical registry/MCP capability, but is not
+advertised as a new OpenCode custom tool in this wave. Code tool modules do not
+read Metrora storage directly or implement Code-specific accounting/evidence.
+
+If the bridge is unavailable, the upstream Code runtime remains startable and
+the custom tool reports unavailable. OpenCode's official binary/source and
+its pinned staging/provenance remain unchanged.
 
 A Tool result remains evidence. A caller or model may explain it, but cannot silently replace Metrora's canonical measurement, scope or unavailable-state semantics.
 
@@ -103,7 +123,10 @@ Metrora already has typed read-only capabilities for questions such as:
 
 The reusable implementation lives in `src/tools`; the factual registry is not owned by one UI.
 
-The same factual capability can therefore be consumed by Local MCP, Code integrations and other bounded surfaces without implementing parallel evidence engines.
+The same factual capability can therefore be consumed by Local MCP, Code
+integrations and other bounded surfaces without implementing parallel evidence
+engines. Local MCP exposes all eight canonical definitions; Code exposes the
+seven listed above plus the retained legacy compatibility tool.
 
 ## MCP
 

--- a/docs/OPENCODE_UPSTREAM_SURFACE_001.md
+++ b/docs/OPENCODE_UPSTREAM_SURFACE_001.md
@@ -12,10 +12,35 @@ renderer contains only a layout host; Sessions, agents, providers, models,
 reasoning, permissions, questions, Git, MCP, and the remaining coding-agent
 mechanics stay owned by the upstream Web UI and server.
 
-Metrora contributes exactly one OpenCode custom tool,
-`metrora_usage_snapshot`. It reads a bounded, sanitized, read-only projection of
-today's Metrora usage. Prompt/response content, source code, credentials, and
-arbitrary CLI payload fields are not included in that projection.
+Metrora retains the legacy compatibility tool `metrora_usage_snapshot` and adds
+seven canonical read-only Code tools:
+
+```text
+metrora_get_spend_snapshot
+metrora_get_model_efficiency
+metrora_get_overview_snapshot
+metrora_get_project_drivers
+metrora_get_session_highlights
+metrora_get_coverage_report
+metrora_get_bench_evidence
+```
+
+Each new module is only an OpenCode description/schema plus an argv-only bridge
+to `metrora tools call`. The plain JSON-schema `filters` wrapper is compatible
+with OpenCode `1.18.27`'s legacy custom-tool fallback; the transport unwraps it
+without changing the canonical argument names. The command validates and
+executes the canonical `src/tools` registry already used by Local MCP, returning bounded
+content-minimal JSON. Prompt/response content, source code, credentials, raw
+paths and arbitrary CLI payload fields are not included. The canonical
+`get_quota_snapshot` remains available to the registry/MCP contract but is not
+exposed as a new Code tool in this wave; Metrora never estimates quota from
+measured spend.
+
+If the CLI bridge cannot be resolved, OpenCode still starts and the seven tools
+return a clean unavailable result. The bridge uses an argv array with
+`shell:false`, bounded arguments/output, a timeout and cancellation propagation.
+The official OpenCode binary, source, pinned version and staging/provenance
+files are not modified by this integration.
 
 The binary is staged from the official GitHub release asset, verified against a
 pinned archive SHA-256, and packaged with a generated binary identity record.

--- a/src/main.ts
+++ b/src/main.ts
@@ -46,8 +46,7 @@ import { clearPlan, readConfig, readPlan, readPlans, saveConfig, savePlan, getCo
 import { clampResetDay, getPlanUsageOrNull, getPlanUsages, type PlanUsage } from './plan-usage.js'
 import { getPresetPlan, isPlanId, isPlanProvider, PLAN_IDS, PLAN_PROVIDERS, planDisplayName } from './plans.js'
 import { createRequire } from 'node:module'
-import { registerMetroraMcpCommands } from './mcp/cli.js'
-import { registerMetroraToolCommands } from './tools/cli.js'
+import { registerMetroraMcpCommands } from './mcp/cli.js'; import { registerMetroraToolCommands } from './tools/cli.js'
 
 const require = createRequire(import.meta.url); const { version } = require('../package.json')
 import { loadCurrency, getCurrency, isValidCurrencyCode } from './currency.js'
@@ -2293,8 +2292,7 @@ program
     await runAgyStatusLineHook()
   })
 
-registerMetroraMcpCommands(program, version)
-registerMetroraToolCommands(program)
+registerMetroraMcpCommands(program, version); registerMetroraToolCommands(program)
 
 program
   .command('doctor')

--- a/src/main.ts
+++ b/src/main.ts
@@ -47,6 +47,7 @@ import { clampResetDay, getPlanUsageOrNull, getPlanUsages, type PlanUsage } from
 import { getPresetPlan, isPlanId, isPlanProvider, PLAN_IDS, PLAN_PROVIDERS, planDisplayName } from './plans.js'
 import { createRequire } from 'node:module'
 import { registerMetroraMcpCommands } from './mcp/cli.js'
+import { registerMetroraToolCommands } from './tools/cli.js'
 
 const require = createRequire(import.meta.url); const { version } = require('../package.json')
 import { loadCurrency, getCurrency, isValidCurrencyCode } from './currency.js'
@@ -2293,6 +2294,7 @@ program
   })
 
 registerMetroraMcpCommands(program, version)
+registerMetroraToolCommands(program)
 
 program
   .command('doctor')

--- a/src/tools/cli.ts
+++ b/src/tools/cli.ts
@@ -1,0 +1,119 @@
+import type { Command } from 'commander'
+
+import { loadPricing } from '../models.js'
+import {
+  assertStrictBoundedMetroraToolContent,
+  assertMetroraToolName,
+  MetroraToolContractError,
+  parseMetroraToolArguments,
+  validateMetroraToolArguments,
+} from './contract.js'
+import type { MetroraMcpProvider, MetroraMcpStartupOptions } from '../mcp/runtime.js'
+import { createMetroraToolRuntime } from '../mcp/runtime.js'
+import type { MetroraToolPeriod, MetroraToolRegistry } from './types.js'
+
+const TOOL_PERIODS: ReadonlySet<MetroraToolPeriod> = new Set([
+  'today',
+  'week',
+  '30days',
+  'month',
+  'all',
+  'lifetime',
+])
+const TOOL_PROVIDERS: ReadonlySet<MetroraMcpProvider> = new Set(['all', 'claude', 'codex'])
+
+export type MetroraToolsCallOptions = {
+  argsJson: string
+  period: string
+  provider: string
+  projectId: string
+}
+
+export type MetroraToolsCallDependencies = {
+  createRuntime?: (options: MetroraMcpStartupOptions) => Promise<MetroraToolRegistry>
+  loadPricing?: () => Promise<void>
+  writeStdout?: (value: string) => void
+  writeStderr?: (value: string) => void
+}
+
+function isToolPeriod(value: string): value is MetroraToolPeriod {
+  return TOOL_PERIODS.has(value as MetroraToolPeriod)
+}
+
+function isToolProvider(value: string): value is MetroraMcpProvider {
+  return TOOL_PROVIDERS.has(value as MetroraMcpProvider)
+}
+
+function safeErrorCode(error: unknown): string {
+  if (error instanceof MetroraToolContractError) return error.code
+  if (error instanceof Error && error.name === 'MetroraMcpStartupError') return 'startup-unavailable'
+  if (error instanceof Error && error.name === 'AbortError') return 'cancelled'
+  return 'unavailable'
+}
+
+function safeErrorMessage(error: unknown): string {
+  return `metrora tools call failed (${safeErrorCode(error)}).`
+}
+
+/** Execute one canonical registry tool without adding a second evidence path. */
+export async function callMetroraTool(
+  toolName: string,
+  options: MetroraToolsCallOptions,
+  dependencies: Pick<MetroraToolsCallDependencies, 'createRuntime' | 'loadPricing'> = {},
+): Promise<string> {
+  const name = assertMetroraToolName(toolName)
+  const parsed = parseMetroraToolArguments(options.argsJson)
+  const args = validateMetroraToolArguments(name, parsed)
+
+  if (!isToolPeriod(options.period)) throw new MetroraToolContractError('invalid-scope', 'Metrora tool period is unsupported.')
+  if (!isToolProvider(options.provider)) throw new MetroraToolContractError('invalid-scope', 'Metrora tool provider is unsupported.')
+  if (typeof options.projectId !== 'string' || !options.projectId.trim()) {
+    throw new MetroraToolContractError('invalid-scope', 'Metrora tool Project scope is invalid.')
+  }
+
+  await (dependencies.loadPricing ?? loadPricing)()
+  const runtime = await (dependencies.createRuntime ?? createMetroraToolRuntime)({
+    period: options.period,
+    provider: options.provider,
+    projectId: options.projectId,
+  })
+  const execution = await runtime.execute(name, args)
+  return assertStrictBoundedMetroraToolContent(execution.content)
+}
+
+/** CLI boundary: stdout is result content only; diagnostics are bounded and safe. */
+export async function runMetroraToolsCall(
+  toolName: string,
+  options: MetroraToolsCallOptions,
+  dependencies: MetroraToolsCallDependencies = {},
+): Promise<number> {
+  const stdout = dependencies.writeStdout ?? (value => process.stdout.write(value))
+  const stderr = dependencies.writeStderr ?? (value => process.stderr.write(value))
+  try {
+    const content = await callMetroraTool(toolName, options, dependencies)
+    stdout(content + '\n')
+    return 0
+  } catch (error) {
+    stderr(safeErrorMessage(error) + '\n')
+    return 2
+  }
+}
+
+type MetroraToolsCommandOptions = MetroraToolsCallOptions
+
+/** Register the read-only canonical Tools CLI adapter. */
+export function registerMetroraToolCommands(program: Command): void {
+  program
+    .command('tools')
+    .description('Call a canonical read-only Metrora Tool')
+    .command('call <tool-name>')
+    .description('Return bounded canonical Tool result content as JSON')
+    .requiredOption('--args-json <json>', 'Tool arguments as one JSON object')
+    .option('--period <period>', 'Initial scope: today, week, 30days, month, all, lifetime', 'all')
+    .option('--provider <provider>', 'Initial provider scope: all, claude, codex', 'all')
+    .option('--project-id <projectId>', 'Initial user-owned Metrora Project scope', 'all')
+    .action(async (toolName: string, options: MetroraToolsCommandOptions) => {
+      const exitCode = await runMetroraToolsCall(toolName, options)
+      if (exitCode !== 0) process.exitCode = exitCode
+    })
+}

--- a/src/tools/contract.ts
+++ b/src/tools/contract.ts
@@ -34,6 +34,7 @@ const PERIOD_VALUES = ['today', 'week', '30days', 'month', 'all', 'lifetime'] as
 const TOOL_PERIOD_VALUES = ['today', 'yesterday', 'week', '30days', 'month', 'all', 'lifetime'] as const
 const PROVIDER_FILTER_VALUES = ['all', 'claude', 'codex'] as const
 const CONTROL_CHARACTERS = /[\u0000-\u001f\u007f]/u
+const FACTUAL_PROVIDER_IDENTIFIER = /^(?:[A-Za-z0-9._:-]{1,80}|\[provider\])$/u
 
 export type MetroraToolValidationCode =
   | 'unknown-tool'
@@ -130,6 +131,10 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
   if (!value || typeof value !== 'object' || Array.isArray(value)) return false
   const prototype = Object.getPrototypeOf(value)
   return prototype === Object.prototype || prototype === null
+}
+
+function safeProviderIdentifier(value: unknown): value is string {
+  return typeof value === 'string' && FACTUAL_PROVIDER_IDENTIFIER.test(value)
 }
 
 function jsonSafe(value: unknown, seen: Set<object>): unknown {
@@ -346,7 +351,7 @@ function containsUnsafeMetroraToolContent(value: unknown, key = ''): boolean {
   for (const [childKey, child] of Object.entries(value)) {
     const normalizedChildKey = childKey.replace(/[^a-z0-9]/giu, '').toLowerCase()
     if (normalizedChildKey === 'source' && (typeof child !== 'string' || !new Set(['overview', 'history', 'models', 'quota', 'bench']).has(child))) return true
-    if (normalizedChildKey === 'provider' && (typeof child !== 'string' || !new Set(['all', 'claude', 'codex', '[provider]']).has(child))) return true
+    if (normalizedChildKey === 'provider' && !safeProviderIdentifier(child)) return true
     if (normalizedChildKey === 'id' && (typeof child !== 'string' || !/^(?:[A-Za-z0-9._:-]{1,160}|evidence-\d+)$/u.test(child))) return true
     if (normalizedChildKey === 'projectid' && (typeof child !== 'string' || (child !== 'all' && child !== '[scoped-project]'))) return true
     if (containsUnsafeMetroraToolContent(child, childKey)) return true

--- a/tests/tools-cli.test.ts
+++ b/tests/tools-cli.test.ts
@@ -1,9 +1,58 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
 import { Command } from 'commander'
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
+import { OPENCODE_METRORA_TOOL_SOURCES } from '../app/electron/opencode/tool'
+import { OPENCODE_METRORA_TOOL_IDS, OPENCODE_METRORA_TOOL_MAP } from '../app/electron/opencode/types'
+import { isMetroraToolName } from '../src/tools/contract.js'
 import { registerMetroraToolCommands, runMetroraToolsCall } from '../src/tools/cli.js'
 import { createMetroraToolRegistry } from '../src/tools/registry.js'
 import type { MetroraToolDataSource, MetroraToolRegistry } from '../src/tools/types.js'
+
+const temporaryDirectories: string[] = []
+const originalBridgeSpec = process.env.METRORA_TOOL_BRIDGE_SPEC
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) rmSync(directory, { recursive: true, force: true })
+  if (originalBridgeSpec === undefined) delete process.env.METRORA_TOOL_BRIDGE_SPEC
+  else process.env.METRORA_TOOL_BRIDGE_SPEC = originalBridgeSpec
+})
+
+function importOpenCodeToolSource(source: string): Promise<{ default: { execute: (args?: unknown, context?: unknown) => Promise<string> } }> {
+  return import(`data:text/javascript;base64,${Buffer.from(source).toString('base64')}`) as Promise<{ default: { execute: (args?: unknown, context?: unknown) => Promise<string> } }>
+}
+
+function canonicalBridgeEntry(directory: string): void {
+  const entry = join(directory, 'canonical-bridge.mjs')
+  const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+  const tsxApiUrl = pathToFileURL(join(repositoryRoot, 'node_modules', 'tsx', 'dist', 'esm', 'api', 'index.mjs')).href
+  const cliUrl = pathToFileURL(join(repositoryRoot, 'src', 'tools', 'cli.ts')).href
+  const registryUrl = pathToFileURL(join(repositoryRoot, 'src', 'tools', 'registry.ts')).href
+  writeFileSync(entry, [
+    `const { tsImport } = await import(${JSON.stringify(tsxApiUrl)})`,
+    `const { runMetroraToolsCall } = await tsImport(${JSON.stringify(cliUrl)}, { parentURL: import.meta.url })`,
+    `const { createMetroraToolRegistry } = await tsImport(${JSON.stringify(registryUrl)}, { parentURL: import.meta.url })`,
+    'const scope = { period: "all", range: null, provider: "all", projectId: "all", projectName: "All projects", model: null }',
+    'const source = {',
+    '  getOverview: async () => ({ current: { label: "All", cost: 12.5, calls: 3, sessions: 2, inputTokens: 100, outputTokens: 50, cacheReadTokens: 0, cacheWriteTokens: 0, pricingCoverage: 1, providers: { Codex: 12.5 }, providerDetails: [{ id: "codex", label: "Codex", cost: 12.5 }], topModels: [{ name: "fixture-model", cost: 12.5, calls: 3 }], topProjects: [{ name: "fixture-project", cost: 12.5, sessions: 2 }], topSessions: [{ project: "fixture-project", cost: 12.5, calls: 3, date: "2026-09-05" }] }, history: { daily: [] }}),',
+    '  getModels: async () => [{ provider: "codex", providerDisplayName: "Codex", model: "fixture-model", inputTokens: 100, outputTokens: 50, reasoningTokens: 0, additiveReasoningTokens: 0, cacheWriteTokens: 0, cacheReadTokens: 0, totalTokens: 150, costUSD: 12.5, calls: 3, pricing: { state: "priced" } }],',
+    '  getQuota: async () => [],',
+    '  getBenchEvidence: async () => ({ state: "UNAVAILABLE" }),',
+    '}',
+    'const runtime = createMetroraToolRegistry(source, scope)',
+    'const argv = process.argv.slice(2)',
+    'const exitCode = await runMetroraToolsCall(argv[2], { argsJson: argv[4] ?? "{}", period: "all", provider: "all", projectId: "all" }, { createRuntime: async () => runtime, loadPricing: async () => {} })',
+    'process.exitCode = exitCode',
+    '',
+  ].join('\n'))
+  process.env.METRORA_TOOL_BRIDGE_SPEC = JSON.stringify({
+    command: [process.execPath, entry, 'tools', 'call'],
+    environment: {},
+  })
+}
 
 const scope = {
   period: 'all' as const,
@@ -48,6 +97,46 @@ async function run(
 }
 
 describe('canonical Metrora Tools CLI adapter', () => {
+  it('keeps every OpenCode transport ID mapped to one valid canonical registry name', () => {
+    const ids = [...OPENCODE_METRORA_TOOL_IDS]
+    const canonicalNames = [
+      'get_spend_snapshot',
+      'get_model_efficiency',
+      'get_overview_snapshot',
+      'get_project_drivers',
+      'get_session_highlights',
+      'get_coverage_report',
+      'get_bench_evidence',
+    ] as const
+
+    expect(Object.keys(OPENCODE_METRORA_TOOL_MAP)).toEqual(ids)
+    expect(Object.values(OPENCODE_METRORA_TOOL_MAP)).toEqual([...canonicalNames])
+    for (const toolId of ids) expect(isMetroraToolName(OPENCODE_METRORA_TOOL_MAP[toolId])).toBe(true)
+  })
+
+  it('routes spend and model OpenCode tools through the bridge, canonical CLI, and registry', async () => {
+    const directory = mkdtempSync(join(tmpdir(), 'metrora-opencode-canonical-bridge-'))
+    temporaryDirectories.push(directory)
+    canonicalBridgeEntry(directory)
+
+    const spend = await importOpenCodeToolSource(OPENCODE_METRORA_TOOL_SOURCES.metrora_get_spend_snapshot)
+    const spendOutput = await spend.default.execute({ filters: { period: 'today' } })
+    expect(spendOutput).not.toBe('Metrora tool unavailable.')
+    expect(JSON.parse(spendOutput)).toMatchObject({
+      intent: 'spend-change',
+      scope: { period: 'today', provider: 'all', projectId: 'all' },
+      spend: { measuredCostUSD: 12.5 },
+    })
+
+    const models = await importOpenCodeToolSource(OPENCODE_METRORA_TOOL_SOURCES.metrora_get_model_efficiency)
+    const modelsOutput = await models.default.execute({ filters: { model: 'fixture-model' } })
+    expect(modelsOutput).not.toBe('Metrora tool unavailable.')
+    expect(JSON.parse(modelsOutput)).toMatchObject({
+      intent: 'model-efficiency',
+      modelEfficiency: { rows: expect.arrayContaining([expect.objectContaining({ model: 'fixture-model', costUSD: 12.5 })]) },
+    })
+  })
+
   it('returns only bounded canonical result content and forwards the startup scope', async () => {
     const runtime = canonicalRegistry()
     const createRuntime = vi.fn(async (startup) => {

--- a/tests/tools-cli.test.ts
+++ b/tests/tools-cli.test.ts
@@ -1,0 +1,119 @@
+import { Command } from 'commander'
+import { describe, expect, it, vi } from 'vitest'
+
+import { registerMetroraToolCommands, runMetroraToolsCall } from '../src/tools/cli.js'
+import { createMetroraToolRegistry } from '../src/tools/registry.js'
+import type { MetroraToolDataSource, MetroraToolRegistry } from '../src/tools/types.js'
+
+const scope = {
+  period: 'all' as const,
+  range: null,
+  provider: 'all',
+  projectId: 'all',
+  projectName: 'All projects',
+  model: null,
+}
+
+function canonicalRegistry(): MetroraToolRegistry {
+  const source: MetroraToolDataSource = {
+    getOverview: vi.fn(async () => ({ current: undefined, history: { daily: [] } })),
+    getModels: vi.fn(async () => []),
+    getQuota: vi.fn(async () => []),
+    getBenchEvidence: vi.fn(async () => ({ state: 'UNAVAILABLE' as const })),
+  }
+  return createMetroraToolRegistry(source, scope)
+}
+
+const options = {
+  argsJson: '{}',
+  period: 'all',
+  provider: 'all',
+  projectId: 'all',
+}
+
+async function run(
+  toolName: string,
+  overrides: Partial<typeof options> = {},
+  runtime = canonicalRegistry(),
+) {
+  const stdout: string[] = []
+  const stderr: string[] = []
+  const exitCode = await runMetroraToolsCall(toolName, { ...options, ...overrides }, {
+    createRuntime: async () => runtime,
+    loadPricing: async () => {},
+    writeStdout: value => stdout.push(value),
+    writeStderr: value => stderr.push(value),
+  })
+  return { exitCode, stdout: stdout.join(''), stderr: stderr.join('') }
+}
+
+describe('canonical Metrora Tools CLI adapter', () => {
+  it('returns only bounded canonical result content and forwards the startup scope', async () => {
+    const runtime = canonicalRegistry()
+    const createRuntime = vi.fn(async (startup) => {
+      expect(startup).toEqual({ period: 'week', provider: 'claude', projectId: 'all' })
+      return runtime
+    })
+    const stdout: string[] = []
+    const stderr: string[] = []
+
+    const exitCode = await runMetroraToolsCall('get_spend_snapshot', {
+      ...options,
+      argsJson: '{"period":"today","model":"gpt-4o"}',
+      period: 'week',
+      provider: 'claude',
+    }, {
+      createRuntime,
+      loadPricing: async () => {},
+      writeStdout: value => stdout.push(value),
+      writeStderr: value => stderr.push(value),
+    })
+
+    expect(exitCode).toBe(0)
+    expect(stderr).toEqual([])
+    expect(stdout).toHaveLength(1)
+    expect(JSON.parse(stdout[0]!)).toMatchObject({ coverage: expect.any(Object), scope: expect.any(Object) })
+    expect(createRuntime).toHaveBeenCalledOnce()
+  })
+
+  it.each([
+    ['unknown tool', 'not_a_tool', '{}', 'unknown-tool'],
+    ['malformed JSON', 'get_spend_snapshot', '{', 'invalid-arguments'],
+    ['unsupported argument', 'get_project_drivers', '{"model":"not-allowed"}', 'additional-argument'],
+    ['unsupported startup period', 'get_spend_snapshot', '{}', 'invalid-scope'],
+  ])('fails closed for %s without writing result content', async (_label, toolName, argsJson, expectedCode) => {
+    const result = await run(toolName, {
+      argsJson,
+      ...(expectedCode === 'invalid-scope' ? { period: 'yesterday' } : {}),
+    })
+    expect(result.exitCode).toBe(2)
+    expect(result.stdout).toBe('')
+    expect(result.stderr).toBe(`metrora tools call failed (${expectedCode}).\n`)
+  })
+
+  it('rejects non-canonical or privacy-unsafe output without leaking it to stderr', async () => {
+    const unsafeRuntime = {
+      ...canonicalRegistry(),
+      execute: vi.fn(async () => ({ content: '{"prompt":"do not leak"}' })),
+    } as unknown as MetroraToolRegistry
+    const result = await run('get_spend_snapshot', {}, unsafeRuntime)
+    expect(result.exitCode).toBe(2)
+    expect(result.stdout).toBe('')
+    expect(result.stderr).toBe('metrora tools call failed (invalid-output).\n')
+    expect(result.stderr).not.toContain('do not leak')
+  })
+
+  it('registers only the explicit tools call command under tools', () => {
+    const program = new Command()
+    registerMetroraToolCommands(program)
+    const tools = program.commands.find(command => command.name() === 'tools')
+    expect(tools).toBeDefined()
+    expect(tools?.commands.map(command => command.name())).toEqual(['call'])
+    expect(tools?.commands[0]?.options.map(option => option.long)).toEqual([
+      '--args-json',
+      '--period',
+      '--provider',
+      '--project-id',
+    ])
+  })
+})

--- a/tests/tools-contract.test.ts
+++ b/tests/tools-contract.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest'
+
+import { assertStrictBoundedMetroraToolContent } from '../src/tools/contract.js'
+import { createMetroraToolRegistry } from '../src/tools/registry.js'
+import type { MetroraModelReportRow, MetroraToolDataSource, MetroraToolModelEvidenceRow, MetroraToolScope } from '../src/tools/types.js'
+
+const scope: MetroraToolScope = {
+  period: 'all',
+  range: null,
+  provider: 'all',
+  projectId: 'all',
+  projectName: 'All projects',
+  model: null,
+}
+
+function modelEvidenceRow(provider: string): MetroraToolModelEvidenceRow {
+  return {
+    model: 'fixture-model',
+    provider,
+    calls: 3,
+    costUSD: 12.5,
+    inputTokens: 100,
+    outputTokens: 50,
+    totalTokens: 150,
+    cacheReadTokens: null,
+    cacheWriteTokens: null,
+    reasoningTokens: null,
+    additiveReasoningTokens: null,
+    costPerCallUSD: 12.5 / 3,
+    pricingState: 'priced',
+  }
+}
+
+function modelReportRow(provider: string): MetroraModelReportRow {
+  return {
+    model: 'fixture-model',
+    provider,
+    calls: 3,
+    costUSD: 12.5,
+    inputTokens: 100,
+    outputTokens: 50,
+    totalTokens: 150,
+    pricing: { state: 'priced' },
+  }
+}
+
+function source(row: MetroraModelReportRow): MetroraToolDataSource {
+  return {
+    getOverview: async () => ({ current: {}, history: { daily: [] } }),
+    getModels: async () => [row],
+    getQuota: async () => [],
+  }
+}
+
+function contentWithProvider(provider: string): string {
+  return JSON.stringify({ modelEfficiency: { rows: [modelEvidenceRow(provider)] } })
+}
+
+describe('strict canonical Metrora tool output privacy', () => {
+  it('accepts bounded factual provider identifiers through model efficiency output', async () => {
+    for (const provider of ['opencode', 'gemini', 'zed', 'claude', 'codex', '[provider]']) {
+      const result = await createMetroraToolRegistry(source(modelReportRow(provider)), scope).execute('get_model_efficiency', {})
+      const bounded = assertStrictBoundedMetroraToolContent(result.content)
+      const row = JSON.parse(bounded).modelEfficiency.rows[0] as MetroraToolModelEvidenceRow
+      expect(row.provider).toBe(provider)
+    }
+  })
+
+  it.each([
+    ['filesystem path', 'C:\\Users\\someone\\secret'],
+    ['relative path', '../../private'],
+    ['bearer text', 'Bearer abc123'],
+    ['secret assignment', 'token=abc123'],
+    ['control characters', 'provider\nidentifier'],
+    ['overlong identifier', 'p'.repeat(81)],
+  ])('rejects unsafe provider fixture: %s', (_label, provider) => {
+    expect(() => assertStrictBoundedMetroraToolContent(contentWithProvider(provider))).toThrowError(
+      expect.objectContaining({ code: 'invalid-output' }),
+    )
+  })
+})


### PR DESCRIPTION
## Summary
- expose seven canonical read-only Metrora tools in OpenCode Code, plus the legacy compatibility tool
- route calls through the bundled Metrora CLI and canonical registry with bounded JSON output
- keep quota out of the Code custom-tool surface and leave the pinned upstream OpenCode source unchanged

## Validation
- deterministic core and desktop suites pass locally
- Windows unsigned package and bundled CLI smoke pass
- GitHub CI, architecture, public identity, brand, Store package and Windows candidate checks pass on the final head

## Physical acceptance
- spend tool: PASS
- Bench evidence tool: PASS
- model-efficiency tool: PASS after the bounded provider-identifier repair

All three Founder physical checks now pass. Merge is authorized.