### PR TITLE
docs: refresh Metrora public control-center story

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ No mandatory account. No mandatory AI proxy. No second coding engine.
 > [!IMPORTANT]
 > Metrora for Windows is live on the **Microsoft Store**, published by Vensent. The Android companion is also live on **Google Play** under the same `eu.metrora.app` application identity used by the direct Android channel. Repository builds and historical pre-releases remain development, verification or alternate-distribution artifacts rather than Store authority.
 
+> [!NOTE]
+> Repository `main` can be ahead of the currently published Store binaries. The accepted OpenCode-based Code foundation described below is current source/product authority; rollout through a Store channel remains a separate release event and should not be inferred from source availability alone.
+
 ## Observe. Compare. Code. Control.
 
 AI-assisted development is fragmented across editors, CLIs, desktop apps, subscriptions, gateways, providers and models. Metrora brings the useful evidence and control surfaces back together without requiring your AI requests to flow through a Metrora cloud gateway.
@@ -42,7 +45,7 @@ The result is intentionally broader than a token tracker: Metrora is the place w
 - **No mandatory proxy.** Supported AI traffic can remain on the path chosen by the user; Metrora reads supported local evidence instead of demanding to become the gateway.
 - **Multi-tool, not single-provider.** Metrora currently registers **39 local collectors** across major AI coding clients, CLIs, editors and gateways.
 - **Evidence-aware.** Observed, metered, derived, estimated, stale, partial and unavailable states remain distinguishable. Unknown does not silently become zero.
-- **Real Code surface.** Metrora embeds upstream OpenCode for coding sessions, agents, tools, files, shell and Git rather than shipping a lookalike client or second agent runtime.
+- **Real Code surface.** The current source foundation embeds upstream OpenCode for coding sessions, agents, tools, files, shell and Git rather than shipping a lookalike client or second agent runtime.
 - **One factual layer, many surfaces.** Desktop, CLI, local web, Android, MCP, Bench and Code integrations build on shared Metrora facts instead of inventing separate accounting engines.
 - **User-owned data.** Export, local inspection and reproducible evidence remain first-class product boundaries.
 
@@ -82,7 +85,7 @@ Metrora owns its canonical facts, accounting, evidence, Projects, Capacity, Benc
 
 ## Code, powered by upstream OpenCode
 
-The Desktop **Code** destination hosts the real upstream [OpenCode](https://github.com/anomalyco/opencode) Web UI and runtime.
+The accepted Desktop **Code** foundation hosts the real upstream [OpenCode](https://github.com/anomalyco/opencode) Web UI and runtime.
 
 Metrora deliberately does **not** maintain a parallel general-purpose session, agent, provider, permissions, filesystem, shell or Git engine for Code. The host integration keeps the upstream coding experience intact while Metrora adds the surrounding product context it is uniquely positioned to own.
 
@@ -121,8 +124,8 @@ This matters because an AI control center is only useful if its numbers remain e
 
 | Surface | Role | Current status |
 | --- | --- | --- |
-| **Desktop** | Primary local control center for observation, comparison, Code, Capacity and configuration | **Live on Microsoft Store for Windows** |
-| **Code** | Upstream OpenCode runtime/Web UI hosted inside Metrora | **Available in the current Desktop line** |
+| **Desktop** | Primary local control center for observation, comparison, Capacity and configuration | **Live on Microsoft Store for Windows** |
+| **Code** | Upstream OpenCode runtime/Web UI hosted inside Metrora | **Accepted in current source/product foundation; Store rollout follows its own release cadence** |
 | **CLI** | Automation, inspection, export and keyboard-first analysis | Bundled with Windows; source development supported |
 | **Local web** | Browser view served from the local machine | Available locally |
 | **Android** | Read-focused companion for an explicitly paired Desktop | **Live on Google Play**; direct GitHub APK channel also exists |
@@ -159,7 +162,7 @@ Current evidence families remain separate:
 - **Coding Evaluation** — future, only under a versioned methodology and sandbox/licence boundary;
 - **Agent Evaluation** — future, only under a versioned methodology and isolation boundary.
 
-OpenCode already provides real Agent/Subagent execution inside Code; that does not by itself turn ordinary coding sessions into a reproducible Agent Evaluation benchmark.
+OpenCode already provides real Agent/Subagent execution inside the accepted Code foundation; that does not by itself turn ordinary coding sessions into a reproducible Agent Evaluation benchmark.
 
 See [Bench evidence families](docs/BENCH_EVIDENCE_FAMILIES.md).
 
@@ -199,7 +202,7 @@ See [Ecosystem surfaces](docs/ECOSYSTEM_SURFACES.md) for current-versus-future s
 
 ### Windows
 
-Install from the [Microsoft Store](https://apps.microsoft.com/detail/9NXSZFQSBBDX). The Store package contains the Desktop application and bundled Metrora CLI runtime; no separate Node.js installation is required for ordinary use.
+Install from the [Microsoft Store](https://apps.microsoft.com/detail/9NXSZFQSBBDX). The Store package contains the Desktop application and bundled Metrora CLI runtime; no separate Node.js installation is required for ordinary use. See the source-versus-Store note above for capabilities added after the published baseline.
 
 ### Android
 

--- a/README.md
+++ b/README.md
@@ -4,102 +4,210 @@
 
 ### The local-first control center for AI-assisted development
 
-Bring usage, cost, models, projects, provider capacity, Bench and Code into one coherent view — without putting a mandatory proxy between you and your AI tools.
+**Observe usage. Compare models. Code with upstream OpenCode. Control the context around your AI workflow.**
 
-[Get Metrora for Windows](https://apps.microsoft.com/detail/9NXSZFQSBBDX) · [Get the Android companion](https://github.com/maikolsiragusaa/metrora/releases/tag/android-v0.1.0-alpha.3) · [Build from source](docs/GETTING_STARTED.md)
+No mandatory account. No mandatory AI proxy. No second coding engine.
 
-[Website](https://metrora.eu) · [Documentation](docs/README.md) · [Supported tools](docs/SUPPORTED_TOOLS.md)
+[Get Metrora for Windows](https://apps.microsoft.com/detail/9NXSZFQSBBDX) · [Get Metrora on Google Play](https://play.google.com/store/apps/details?id=eu.metrora.app) · [Build from source](docs/GETTING_STARTED.md)
+
+[Website](https://metrora.eu) · [Documentation](docs/README.md) · [Supported tools](docs/SUPPORTED_TOOLS.md) · [Community](https://metrora.eu/community)
 
 [![Metrora CI](https://github.com/maikolsiragusaa/metrora/actions/workflows/ci.yml/badge.svg)](https://github.com/maikolsiragusaa/metrora/actions/workflows/ci.yml)
 [![Microsoft Store](https://img.shields.io/badge/Microsoft%20Store-Download-0078D4?logo=microsoft&logoColor=white)](https://apps.microsoft.com/detail/9NXSZFQSBBDX)
-[![Android](https://img.shields.io/badge/Android-0.1.0--alpha.3-3DDC84?logo=android&logoColor=white)](https://github.com/maikolsiragusaa/metrora/releases/tag/android-v0.1.0-alpha.3)
-[![Fluxer Community](https://img.shields.io/badge/Fluxer-Community-4641D9?logo=fluxer&logoColor=white)](https://metrora.eu/community)
+[![Google Play](https://img.shields.io/badge/Google%20Play-Android-3DDC84?logo=googleplay&logoColor=white)](https://play.google.com/store/apps/details?id=eu.metrora.app)
+[![Code: OpenCode](https://img.shields.io/badge/Code-OpenCode%20upstream-0F1115)](https://github.com/anomalyco/opencode)
 [![License: MIT](https://img.shields.io/badge/License-MIT-0F1115.svg)](LICENSE)
 
 </div>
 
 > [!IMPORTANT]
-> Metrora for Windows is available on the **Microsoft Store**, published by Vensent. The current Store update is the accepted **RC11** Windows line and includes the companion runtime used for local Android pairing. The **Android companion is publicly available now as the production-signed `0.1.0-alpha.3` GitHub pre-release**, with a Google Play release planned within 30 days. Repository builds and historical GitHub Windows pre-releases remain separate development or archival artifacts.
+> Metrora for Windows is live on the **Microsoft Store**, published by Vensent. The Android companion is also live on **Google Play** under the same `eu.metrora.app` application identity used by the direct Android channel. Repository builds and historical pre-releases remain development, verification or alternate-distribution artifacts rather than Store authority.
 
 ## Observe. Compare. Code. Control.
 
-Metrora brings fragmented AI-development evidence together without requiring a new traffic path or a mandatory cloud account. The current product is organized around four shipped jobs:
+AI-assisted development is fragmented across editors, CLIs, desktop apps, subscriptions, gateways, providers and models. Metrora brings the useful evidence and control surfaces back together without requiring your AI requests to flow through a Metrora cloud gateway.
 
-| Stage | What Metrora provides today |
+| Stage | What Metrora does |
 | --- | --- |
-| **Observe** | Usage, Cost, Models, Projects and Activity from supported local tool evidence, with measured, derived, estimated and unavailable states kept distinct. |
-| **Compare** | Side-by-side model and provider views using observed economics, plus controlled local Bench evidence without inventing a universal quality ranking. |
-| **Code** | The accepted upstream coding surface embedded in Desktop, with Metrora retaining the host lifecycle, usage boundary and local product context. |
-| **Control** | Provider-reported Capacity/quota, budgets, Project scope, local settings and explicit reversible controls where Metrora has deterministic authority. No autonomous routing or orchestration is implied. |
+| **Observe** | Unifies Usage, Cost, Activity, Sessions, Models, Projects and supported provider evidence from local sources. |
+| **Compare** | Compares observed model/provider economics and methodology-bound Bench evidence without pretending every source is equally complete. |
+| **Code** | Embeds the official upstream **OpenCode** runtime and Web UI inside Metrora Desktop instead of rebuilding a parallel coding-agent stack. |
+| **Control** | Brings Capacity, budgets, Project scope, local settings and explicit Metrora-owned controls into the same control center. |
 
-Metrora is multi-tool and multi-provider by design. A supported collector can contribute useful local evidence without forcing the underlying AI request through Metrora.
+The result is intentionally broader than a token tracker: Metrora is the place where **facts, context, Code and control meet**.
 
-## Local-first by design
+## Why Metrora
 
-- **No mandatory account for local use.** Install Metrora, read supported local evidence and use the core product without creating a Metrora account.
-- **No mandatory proxy or gateway.** Your AI traffic does not need to pass through Metrora for Metrora to observe supported usage evidence.
-- **Local evidence stays authoritative.** Canonical measurements, pricing provenance and evidence states are owned by Metrora's local factual surfaces; downstream surfaces do not silently rewrite them.
-- **Unknown is not zero.** Missing, stale, partial or unavailable provider evidence remains explicit instead of being converted into a reassuring number.
-- **Companions consume bounded projections.** Android pairs locally with Desktop and does not become a second collector, pricing engine or accounting authority.
+- **Local-first.** Ordinary local use does not require a Metrora account or hosted backend.
+- **No mandatory proxy.** Supported AI traffic can remain on the path chosen by the user; Metrora reads supported local evidence instead of demanding to become the gateway.
+- **Multi-tool, not single-provider.** Metrora currently registers **39 local collectors** across major AI coding clients, CLIs, editors and gateways.
+- **Evidence-aware.** Observed, metered, derived, estimated, stale, partial and unavailable states remain distinguishable. Unknown does not silently become zero.
+- **Real Code surface.** Metrora embeds upstream OpenCode for coding sessions, agents, tools, files, shell and Git rather than shipping a lookalike client or second agent runtime.
+- **One factual layer, many surfaces.** Desktop, CLI, local web, Android, MCP, Bench and Code integrations build on shared Metrora facts instead of inventing separate accounting engines.
+- **User-owned data.** Export, local inspection and reproducible evidence remain first-class product boundaries.
 
-## Code surface
+## How the system fits together
 
-The Desktop Code destination hosts the accepted upstream coding surface. Metrora
-owns the host lifecycle, navigation boundary, usage snapshot/accounting and
-local product integrations; the upstream UI, sessions and tools remain upstream
-responsibilities.
+```mermaid
+flowchart TD
+    A[AI coding tools / CLIs / editors / gateways] --> B[Local collectors + provider parsers]
+    B --> C[Canonical Metrora facts]
+    C --> U[Usage + Activity + Sessions]
+    C --> M[Models + economics]
+    C --> P[Projects + provenance]
+    C --> Q[Capacity + coverage]
+    C --> B1[Bench evidence]
 
-## Bench: Performance first, evidence families kept separate
+    U --> T[Metrora Tools]
+    M --> T
+    P --> T
+    Q --> T
+    B1 --> T
 
-Metrora Bench is converging around the practical local question:
+    C --> D[Metrora Desktop]
+    C --> L[CLI / local web]
+    C --> A1[Android companion]
+    T --> X[Local MCP / bounded integrations]
 
-> **How does this declared model/runtime/configuration run on this hardware?**
+    D --> CODE[Code inside Metrora]
+    CODE --> OC[OpenCode upstream]
+    OC --> OCF[Sessions · Agents · Tools · Files · Shell · Git · MCP/ACP]
+```
 
-Different Bench questions remain separate evidence families:
+Two responsibilities stay deliberately separate:
 
-- **Performance** — the primary product direction: throughput, latency, TTFT, memory and runtime/hardware configuration where reliably measurable;
-- **Compatibility / Runtime Health** — the current `core-v1` deterministic checks;
-- **Coding Evaluation** — future, under a separately versioned methodology and sandbox/licence review;
-- **Agent Evaluation** — future, only once real agent/Swarm execution exists.
+> **Metrora adds. OpenCode executes.**
 
-Current shipped Bench evidence includes a small Ollama runtime-timing slice, Core Compatibility and the first native llama.cpp `llama-bench` Performance adapter behind a Metrora-owned bounded runner. No current result is presented as a universal model-quality or coding ranking.
+Metrora owns its canonical facts, accounting, evidence, Projects, Capacity, Bench, host security and product context. OpenCode owns commodity coding-agent mechanics inside the Code surface.
 
-See [Bench evidence families](docs/BENCH_EVIDENCE_FAMILIES.md), [BenchRunV1 local Ollama](docs/BENCHRUN_V1_OLLAMA_LOCAL.md) and [Bench Core Compatibility v1](docs/BENCH_TASK_PACK_V1.md).
+## Code, powered by upstream OpenCode
+
+The Desktop **Code** destination hosts the real upstream [OpenCode](https://github.com/anomalyco/opencode) Web UI and runtime.
+
+Metrora deliberately does **not** maintain a parallel general-purpose session, agent, provider, permissions, filesystem, shell or Git engine for Code. The host integration keeps the upstream coding experience intact while Metrora adds the surrounding product context it is uniquely positioned to own.
+
+Current Metrora host responsibilities include:
+
+- deterministic pinned OpenCode runtime provenance;
+- loopback-only embedded serving and per-launch authentication;
+- persistent project/browser state and fast prewarmed entry;
+- navigation and popup restrictions at the Electron boundary;
+- clean process lifecycle and Windows packaging integration;
+- OpenCode usage/accounting observation under the canonical `OpenCode` collector;
+- bounded Metrora-specific factual context through the Metrora Tool boundary.
+
+OpenCode is third-party upstream software and remains independently maintained. Metrora's integration does not imply affiliation with or endorsement by the OpenCode project.
+
+See [OpenCode upstream surface](docs/OPENCODE_UPSTREAM_SURFACE_001.md) and [Ecosystem surfaces](docs/ECOSYSTEM_SURFACES.md).
+
+## Facts before guesses
+
+Metrora is built around a simple rule: **evidence strength is part of the answer**.
+
+A value may be:
+
+- **observed** directly from a source;
+- **metered** by a provider or client;
+- **derived** deterministically from stronger evidence;
+- **estimated** under documented assumptions;
+- **explicitly zero**;
+- **partial, stale or unavailable**.
+
+Those states are not interchangeable. Historical API-equivalent pricing is date-effective, settled cost assignments do not silently change when a catalog changes later, and subscription coverage stays separate from API-equivalent valuation.
+
+This matters because an AI control center is only useful if its numbers remain explainable.
+
+## Product surfaces
+
+| Surface | Role | Current status |
+| --- | --- | --- |
+| **Desktop** | Primary local control center for observation, comparison, Code, Capacity and configuration | **Live on Microsoft Store for Windows** |
+| **Code** | Upstream OpenCode runtime/Web UI hosted inside Metrora | **Available in the current Desktop line** |
+| **CLI** | Automation, inspection, export and keyboard-first analysis | Bundled with Windows; source development supported |
+| **Local web** | Browser view served from the local machine | Available locally |
+| **Android** | Read-focused companion for an explicitly paired Desktop | **Live on Google Play**; direct GitHub APK channel also exists |
+| **MCP** | Read-only external access to canonical factual Metrora Tools | Local MCP Server V1 available |
+| **Bench** | Performance and compatibility evidence under explicit methodology | Performance + Core Compatibility foundations available |
+
+Source trees also retain macOS and GNOME companion work, but a source surface is not presented as an official distribution until its own accepted public channel exists.
+
+## Supported ecosystem
+
+Metrora currently registers **39 local collectors**. The supported set includes sources such as Claude, Codex, Gemini, Cursor, GitHub Copilot, OpenCode, Antigravity, Zed, Kiro, Cline, Cline CLI, Roo Code, KiloCode, Qwen, Kimi, Warp and other compatible clients or gateways.
+
+“Supported” is intentionally not a binary marketing claim. Metrora separately reports:
+
+1. whether the source can be discovered and analyzed locally;
+2. what evidence the source actually exposes;
+3. what provenance/coverage limitations remain;
+4. whether a concrete source path is approved for stronger signed-measurement workflows.
+
+See [Supported tools](docs/SUPPORTED_TOOLS.md) and the generated [collector inventory](docs/COLLECTOR_INVENTORY_V1.md).
+
+## Metrora Bench
+
+Bench is not a generic leaderboard bolted onto usage analytics.
+
+Its practical question is:
+
+> **How does this declared model/runtime/configuration behave under this declared methodology and hardware?**
+
+Current evidence families remain separate:
+
+- **Performance** — including bounded native llama.cpp/`llama-bench` evidence;
+- **Compatibility / Runtime Health** — deterministic Core Compatibility checks;
+- **Coding Evaluation** — future, only under a versioned methodology and sandbox/licence boundary;
+- **Agent Evaluation** — future, only under a versioned methodology and isolation boundary.
+
+OpenCode already provides real Agent/Subagent execution inside Code; that does not by itself turn ordinary coding sessions into a reproducible Agent Evaluation benchmark.
+
+See [Bench evidence families](docs/BENCH_EVIDENCE_FAMILIES.md).
+
+## Android companion
+
+Metrora for Android is available on [Google Play](https://play.google.com/store/apps/details?id=eu.metrora.app).
+
+The companion pairs with an explicitly approved Metrora Desktop and consumes bounded Desktop-generated projections instead of becoming a second collector, pricing engine or accounting authority. Pairing uses encrypted transport and device trust; ordinary companion flows do not export prompt/response bodies, source files, patches, provider secrets or unrestricted filesystem paths.
+
+The production-signed direct APK channel remains available for users who intentionally choose direct installation or Obtainium. See [Android public distribution](docs/ANDROID_PUBLIC_DISTRIBUTION_V1.md).
+
+## Public direction
+
+Metrora ships conservatively, but the direction is intentionally larger than tracking. The following are **directional areas, not delivery promises or a private execution plan**:
+
+```text
+stronger Sessions + Activity
+        ↓
+richer Models + economics + provenance
+        ↓
+deeper Projects + Capacity + Bench context
+        ↓
+more canonical Metrora Tools across Code / MCP / integrations
+        ↓
+bounded external control + remote/background supervision where safe
+        ↓
+smarter evidence-aware assistance, routing and automation
+```
+
+In parallel, Metrora is exploring richer privacy-aware sharing/recap surfaces built from canonical evidence rather than a second analytics pipeline.
+
+The architectural constraint does not change as the product grows: Metrora should add differentiated facts, context, intelligence and control **without rebuilding commodity engines that a mature upstream already owns well**.
+
+See [Ecosystem surfaces](docs/ECOSYSTEM_SURFACES.md) for current-versus-future status.
 
 ## Install Metrora
 
 ### Windows
 
-Get Metrora from the [Microsoft Store](https://apps.microsoft.com/detail/9NXSZFQSBBDX).
+Install from the [Microsoft Store](https://apps.microsoft.com/detail/9NXSZFQSBBDX). The Store package contains the Desktop application and bundled Metrora CLI runtime; no separate Node.js installation is required for ordinary use.
 
-The Store package installs the bundled Metrora desktop and CLI runtime without requiring a separate Node.js installation. Source builds remain available for development, inspection and contribution; see [Getting started](docs/GETTING_STARTED.md).
+### Android
 
-### Android companion
+Install the companion from [Google Play](https://play.google.com/store/apps/details?id=eu.metrora.app). The direct GitHub Android release channel remains documented for users who intentionally choose direct APK installation.
 
-The current public Android alpha is [`0.1.0-alpha.3`](https://github.com/maikolsiragusaa/metrora/releases/tag/android-v0.1.0-alpha.3), distributed as a production-signed direct APK from GitHub Releases:
+### Build from source
 
-- [Download `Metrora-Android-0.1.0-alpha.3.apk`](https://github.com/maikolsiragusaa/metrora/releases/download/android-v0.1.0-alpha.3/Metrora-Android-0.1.0-alpha.3.apk)
-- verify the public manifest and `SHA256SUMS` attached to the release;
-- for Obtainium, add `https://github.com/maikolsiragusaa/metrora` and track the `android-v*` releases.
-
-`0.1.0-alpha.1` remains an immutable historical release and `0.1.0-alpha.2` was never published. The direct GitHub APK remains available now; Google Play publication is planned within 30 days and remains a separate release channel until it is actually live. The companion pairs locally with the current Microsoft Store Desktop and does not become a second collection or accounting authority. F-Droid remains separately gated.
-
-## What Metrora helps you answer
-
-AI-assisted development is usually split across editors, desktop applications, CLIs, subscriptions, gateways and models. Each tool exposes a different fragment of the picture. Metrora reads supported evidence already available on your machine and lets you investigate questions such as:
-
-- Which tools, models and projects are driving usage and cost?
-- What provider Capacity or quota remains, when the provider exposes trustworthy evidence?
-- How do models or providers compare on observed economics in the selected scope?
-- What does a controlled local Bench run actually measure, and what remains unknown?
-- Why did a scoped period, model, Project or provider change, according to the available Metrora evidence?
-- Which explicit local controls or reversible optimizations are supported by deterministic Metrora authority?
-
-Metrora does not require a wrapper around your AI requests, and it does not claim general model quality or autonomous control from incomplete evidence.
-
-## Try Metrora from source
-
-Use Node.js 22.15 or newer for repository development and validation.
+For repository development and inspection, use Node.js 22.15 or newer:
 
 ```bash
 git clone https://github.com/maikolsiragusaa/metrora.git
@@ -109,18 +217,10 @@ npm run build:cli
 npm run dev -- --help
 ```
 
-Open the terminal dashboard:
+Run the terminal dashboard:
 
 ```bash
 npm run dev
-```
-
-Generate a copy-pasteable overview:
-
-```bash
-npm run dev -- overview
-npm run dev -- overview --provider codex
-npm run dev -- overview --from 2026-08-01 --to 2026-08-05
 ```
 
 Open the local browser dashboard:
@@ -129,7 +229,7 @@ Open the local browser dashboard:
 npm run dev -- web
 ```
 
-Build and validate the desktop application:
+Build and validate Desktop:
 
 ```bash
 npm --prefix app ci
@@ -138,152 +238,89 @@ npm --prefix app run typecheck
 npm --prefix app run build
 ```
 
-The root npm package is intentionally private and is not an official distribution channel. See the complete [getting-started guide](docs/GETTING_STARTED.md).
+Repository builds are development/inspection artifacts, not Store-signed releases. See [Getting started](docs/GETTING_STARTED.md).
 
-## Main commands
+## CLI highlights
 
 | Command | Purpose |
 | --- | --- |
-| `metrora` | Interactive usage dashboard. |
-| `metrora overview` | Plain-text usage summary for a period or exact date range. |
-| `metrora web` | Local browser dashboard. |
-| `metrora status` | Compact today-and-month status output. |
-| `metrora sessions` | Per-session usage report. |
-| `metrora models` | Per-model cost, token and task breakdown. |
-| `metrora compare` | Side-by-side model comparison. |
-| `metrora optimize` | Waste analysis and optional reversible fixes. |
-| `metrora budget` | Configure and check spend limits. |
-| `metrora plan` | Track subscription-plan usage and projected overage. |
-| `metrora audit` | Compare provider evidence with displayed token and cost totals. |
-| `metrora doctor` | Diagnose provider discovery and parsing health. |
-| `metrora export` | Export usage as CSV or JSON. |
-| `metrora bench local --model <model>` | Run bounded synthetic local runtime-timing evidence against an Ollama model; no quality or ranking score. |
-| `metrora bench task-pack --model <model>` | Run deterministic Core Compatibility checks against a local Ollama model; private history and factual comparison only. |
-| `metrora bench performance --executable <path> --model <path>` | Run bounded native llama.cpp `llama-bench` Performance evidence against existing executable/model files; no quality or universal score. |
+| `metrora overview` | Usage/cost overview for a period or date range |
+| `metrora sessions` | Per-session evidence |
+| `metrora models` | Per-model usage, token and cost evidence |
+| `metrora compare` | Side-by-side model comparison |
+| `metrora status` | Compact status output |
+| `metrora doctor` | Provider discovery and parser diagnostics |
+| `metrora audit` | Compare available source evidence with displayed totals |
+| `metrora export` | Export user-owned data as CSV or JSON |
+| `metrora bench ...` | Run bounded Bench workflows under explicit methodology |
+| `metrora mcp serve` | Start the local read-only Metrora MCP server |
 
-Most analytical commands support provider, project and date filters. The [CLI reference](docs/CLI_REFERENCE.md) groups the public commands by task and explains compatibility boundaries.
+The complete command surface and compatibility boundaries live in the [CLI reference](docs/CLI_REFERENCE.md).
 
-## Supported tools
-
-Metrora currently registers **39 local collectors**, including Claude, Codex, Gemini, Cursor, GitHub Copilot, OpenCode, Antigravity, Zed, Kiro, Cline, Cline CLI, Roo Code, KiloCode, Qwen, Kimi, Warp and other supported clients and gateways.
-
-Support is reported with three separate facts:
-
-1. whether Metrora can discover and analyze the source locally;
-2. what kind of evidence the source exposes, including measured, derived or estimated values;
-3. whether a concrete source path is approved for signed Workspace measurements.
-
-This prevents “supported” from implying stronger evidence than a provider actually exposes. See the [user-facing support matrix](docs/SUPPORTED_TOOLS.md) and the generated [collector inventory](docs/COLLECTOR_INVENTORY_V1.md).
-
-## Evidence and pricing
-
-Metrora distinguishes values that are:
-
-- **observed** directly from a source;
-- **derived** deterministically from observed values;
-- **estimated** using documented assumptions;
-- **metered** by a provider or client;
-- **explicitly zero** rather than unavailable;
-- **unknown or unavailable** when trustworthy attribution does not exist.
-
-Missing evidence is not silently converted to zero.
-
-Historical API-equivalent pricing is date-effective and non-retroactive by default. A later catalog refresh cannot silently rewrite settled historical costs. Provider- or client-metered values remain authoritative, subscription coverage stays separate from API-equivalent valuation, and explicit zero remains different from unavailable pricing. See [Pricing history](docs/PRICING_HISTORY.md).
-
-## Product surfaces
-
-| Surface | Role | Current status |
-| --- | --- | --- |
-| Desktop | Primary local control center for observation, comparison, Code, Capacity and configuration | **Available on Microsoft Store for Windows; RC11 current Store line** |
-| CLI | Automation, inspection, export and keyboard-first analysis | Bundled with the Windows Store app; also available from source for development |
-| Local web dashboard | Browser view served from the local machine | Available locally |
-| Android companion | Read-focused local-network companion for a paired Desktop | **Public GitHub pre-release `0.1.0-alpha.3`; Google Play release planned within 30 days** |
-| macOS menubar | Compact local usage view | Development source retained; not an official Metrora distribution |
-| GNOME extension | Compact Linux panel view | Development source retained; not an official Metrora distribution |
-
-Windows is the first supported public desktop distribution. Source support for other desktop platforms does not imply that an accepted public package exists for those platforms.
-
-The Android companion is publicly distributed through the [`android-v0.1.0-alpha.3`](https://github.com/maikolsiragusaa/metrora/releases/tag/android-v0.1.0-alpha.3) GitHub pre-release. It pairs with Metrora Desktop on the same LAN, can show a fresh Desktop-generated usage overview or an encrypted offline snapshot, and consumes bounded Project-aware Home, Activity Sessions/Pull Requests, Analyze/Models, Analyze/Spend and capability-driven Workspace projections. Activity uses additive cursor-paged metadata contracts and does not expose prompt/response content. QR pairing, image import, SAS/Desktop approval and mutual-TLS device trust remain the local security boundary. The Android app does not duplicate collection, parsing, pricing, history or evidence authority. The current Microsoft Store RC11 line includes the companion runtime required by this pairing path. Google Play publication is planned within 30 days; until that channel is actually live, GitHub remains the current public Android distribution authority.
-
-## Privacy model
+## Privacy and security
 
 Metrora is local-first by default:
 
 - no account is required for ordinary local use;
-- AI traffic does not pass through Metrora;
+- AI traffic does not need to pass through Metrora;
 - prompts, responses, source code, patches, secrets and unrestricted local paths are outside the default sharing boundary;
-- analytical claims keep observed, derived, estimated and unavailable evidence distinguishable;
-- optional device or Workspace connections require explicit scope and revocable authorization;
-- user-owned data remains exportable through documented formats.
+- Android consumes bounded projections from an explicitly paired Desktop;
+- optional Workspace/device connections require explicit scope and revocable authorization;
+- user-owned evidence remains exportable through documented formats.
 
-Read the [product principles](docs/PRODUCT_PRINCIPLES.md), [public contracts v1](docs/PUBLIC_CONTRACTS_V1.md), [Workspace v1 boundary](docs/WORKSPACE_V1.md) and [security policy](SECURITY.md).
-
-## Origin and independent development
-
-Metrora is independently maintained under its own product identity. Required
-third-party notices and licence texts remain in
-[THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md) and [`LICENSES/`](LICENSES/).
+Read [Product principles](docs/PRODUCT_PRINCIPLES.md), [Public contracts](docs/PUBLIC_CONTRACTS_V1.md), [Workspace v1](docs/WORKSPACE_V1.md) and [Security](SECURITY.md).
 
 ## Documentation
 
-Start from the [documentation index](docs/README.md):
+Start with the [documentation home](docs/README.md).
+
+Recommended paths:
 
 - [Getting started](docs/GETTING_STARTED.md)
-- [CLI reference](docs/CLI_REFERENCE.md)
+- [Architecture](docs/architecture.md)
 - [Ecosystem surfaces](docs/ECOSYSTEM_SURFACES.md)
-- [ACT contract preparation 001](docs/ACT_CONTRACT_PREP_001.md)
-- [Bench evidence families](docs/BENCH_EVIDENCE_FAMILIES.md)
-- [Local runtime and Performance Wave 001](docs/LOCAL_RUNTIME_PERFORMANCE_WAVE_001.md)
-- [BenchRunV1 local Ollama](docs/BENCHRUN_V1_OLLAMA_LOCAL.md)
-- [Bench Core Compatibility v1](docs/BENCH_TASK_PACK_V1.md)
+- [OpenCode upstream surface](docs/OPENCODE_UPSTREAM_SURFACE_001.md)
 - [Supported tools](docs/SUPPORTED_TOOLS.md)
-- [Product principles](docs/PRODUCT_PRINCIPLES.md)
-- [Pricing history](docs/PRICING_HISTORY.md)
-- [Workspace v1](docs/WORKSPACE_V1.md)
-- [Public contracts v1](docs/PUBLIC_CONTRACTS_V1.md)
-- [Android companion foundation](docs/ANDROID_COMPANION_FOUNDATION.md)
-- [Android public distribution v1](docs/ANDROID_PUBLIC_DISTRIBUTION_V1.md)
-- [Local companion API v1](docs/LOCAL_COMPANION_API.md)
-- [Windows distribution boundary](docs/WINDOWS_DISTRIBUTION.md)
-- [Community and commercial boundary](docs/COMMERCIAL_BOUNDARY.md)
+- [CLI reference](docs/CLI_REFERENCE.md)
+- [Accounting and pricing](docs/ACCOUNTING_AND_PRICING.md)
+- [Bench evidence families](docs/BENCH_EVIDENCE_FAMILIES.md)
+- [Android companion](docs/ANDROID_COMPANION_FOUNDATION.md)
+- [Local companion API](docs/LOCAL_COMPANION_API.md)
+
+Deep compatibility, release and public-contract documents remain linked from the documentation home rather than competing with the product overview here.
 
 ## Repository map
 
 ```text
-src/       collection, parsing, canonical records, CLI, analytics and sharing
-app/       Electron desktop application
-dash/      local React web dashboard
-android/   production-signed Android companion and public direct-APK source
-mac/       macOS menubar application
-gnome/     GNOME extension
-tests/     core test suite
-docs/      product, user, contract and technical documentation
+src/       canonical collection, parsing, pricing, analytics, evidence, Tools and CLI
+app/       Electron Desktop host and Metrora product UI
+dash/      local browser dashboard
+android/   Google Play / direct-channel Android companion source
+mac/       macOS companion source
+gnome/     GNOME Shell companion source
+tests/     core and integration tests
+docs/      user guides, architecture, public contracts and release evidence
+scripts/   bounded build, verification and migration utilities
 ```
-
-The current package publishes only the `metrora` command. Historical signed
-evidence identifiers remain internal protocol details and are not product
-facing names for new releases.
 
 ## Contributing
 
-Read [CONTRIBUTING.md](CONTRIBUTING.md) before opening a pull request. Provider and parser changes require fixtures, focused tests, provenance, privacy review and real-session validation where possible.
+Read [CONTRIBUTING.md](CONTRIBUTING.md) before opening a pull request. Provider/parser changes require fixtures, focused tests, provenance/privacy review and representative-record validation where possible.
 
 Security issues must be reported privately according to [SECURITY.md](SECURITY.md).
 
 ## Community
 
-<img src="./assets/brand/third-party/fluxer-symbol-color.svg" alt="Fluxer" width="48" />
+The public Metrora community is available through [metrora.eu/community](https://metrora.eu/community). Technical issues and pull requests stay on GitHub; security reports stay private.
 
-The public Metrora community is open on **Fluxer** for product discussion, questions, feedback and contributor conversation. Join through [metrora.eu/community](https://metrora.eu/community), the stable Metrora community entry point.
+## Origin, third-party software and licence
 
-Technical issues and pull requests stay on GitHub. Security reports must continue to follow the private process in [SECURITY.md](SECURITY.md).
+Metrora is independently maintained under its own product identity and distributed under the MIT License. Third-party software — including the upstream OpenCode component used by Code — retains its own project identity, licence and notices.
 
-## Product identity and licence
+Required notices and licence texts remain in [THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md) and [`LICENSES/`](LICENSES/).
 
 Metrora™ is the product and user-facing brand. Signal Grid™ is its canonical visual identity. Vensent™ is the publisher identity used for official Metrora distribution.
 
-Metrora is independently maintained and distributed under the MIT License. Product and repository surfaces use the assets and Graphite + Signal Cyan palette documented in [`assets/brand`](assets/brand/README.md).
-
-See the [project notices](NOTICE.md), [brand policy](BRAND_POLICY.md) and [licence](LICENSE).
+See [NOTICE.md](NOTICE.md), [BRAND_POLICY.md](BRAND_POLICY.md) and [LICENSE](LICENSE).
 
 Metrora™ — published by Vensent™. Copyright © 2026 Metrora contributors.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ No mandatory account. No mandatory AI proxy. No second coding engine.
 </div>
 
 > [!IMPORTANT]
-> Metrora for Windows is live on the **Microsoft Store**, published by Vensent. The Android companion is also live on **Google Play** under the same `eu.metrora.app` application identity used by the direct Android channel. Repository builds and historical pre-releases remain development, verification or alternate-distribution artifacts rather than Store authority.
+> Metrora for Windows is available on the **Microsoft Store**, published by Vensent. The Android companion is also live on **Google Play** under the same `eu.metrora.app` application identity used by the direct Android channel. Repository builds and historical pre-releases remain development, verification or alternate-distribution artifacts rather than Store authority.
 
 > [!NOTE]
 > Repository `main` can be ahead of the currently published Store binaries. The accepted OpenCode-based Code foundation described below is current source/product authority; rollout through a Store channel remains a separate release event and should not be inferred from source availability alone.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,9 +1,8 @@
 # Releasing Metrora
 
-Metrora does not yet have an official stable desktop release. Windows is
-currently distributed publicly through the Microsoft Store, published by
-Vensent, with RC11 as the current Store authority. This document defines the
-current public release boundary.
+Metrora does not yet have an official stable desktop release. Windows is publicly distributed through Microsoft Store, published by Vensent, with RC11 as the current Store authority. Android is publicly distributed through Google Play under package identity `eu.metrora.app`, with a separately documented direct APK channel.
+
+This document defines the public release boundary. Protected credentials, private custody procedures and unpublished operational details do not belong here.
 
 ## Canonical identity
 
@@ -11,75 +10,73 @@ current public release boundary.
 - Domain: **metrora.eu**
 - Repository: `maikolsiragusaa/metrora`
 - Canonical command: `metrora`
-- Published Store source line: `1.0.0-rc.11`
-- Published desktop build version: `1.0.0.11`
-- Published Store package version: `1.0.1.0`
-- Previous published Store line: `1.0.0-rc.10` / Desktop `1.0.0.10` / Store `1.0.0.0`
-- Latest published GitHub technical preview: `1.0.0-rc.7`
+- Published Windows Store source line: `1.0.0-rc.11`
+- Published Windows desktop build version: `1.0.0.11`
+- Published Windows Store package version: `1.0.1.0`
+- Previous Windows Store line: `1.0.0-rc.10` / Desktop `1.0.0.10` / Store `1.0.0.0`
+- Latest published GitHub Windows technical preview: `1.0.0-rc.7`
+- Android application ID: `eu.metrora.app`
+- Android public channels: Google Play + separately source-bound direct APK releases
 
-The published command is `metrora`. Historical protocol and signed-data
-identifiers are governed by their versioned contracts and are not release
-brands or names for new artifacts.
+Historical protocol/signed-data identifiers are governed by their versioned contracts and are not release brands or names for new artifacts.
 
 The root npm package is private and must not be published from this repository.
 
-## Current engineering authority
+## Current public channels
 
-`1.0.0-rc.11` is the current **published Microsoft Store source line** for the
-Windows distribution published by Vensent. It was accepted by Microsoft as the
-Store update with Desktop build version `1.0.0.11` and Store package identity
-version `1.0.1.0`.
+### Windows
 
-RC10 remains immutable historical publication evidence. RC9 and earlier
-candidate lines remain bound to their own source and acceptance records.
-Post-RC11 development is separate from the Store artifact; any future Store
-update requires its own candidate, acceptance, submission and publication
-decision.
+`1.0.0-rc.11` is the current published Microsoft Store source line for Windows distribution under publisher Vensent. It was accepted as the Store update with Desktop build `1.0.0.11` and Store package identity `1.0.1.0`.
 
-`1.0.0-rc.7` remains the latest published GitHub Windows technical preview. That channel is unsigned, manually updated and not Microsoft Store certified. Its source, release assets, manifests and checksums remain immutable historical publication evidence.
+RC10 remains immutable historical publication evidence. RC9 and earlier candidates remain bound to their own source/acceptance records. Post-RC11 development does not retroactively change the Store artifact; another Store update requires its own candidate, acceptance, submission and publication decision.
 
-The Microsoft Store path is separate from source builds and GitHub technical
-pre-releases. The live Store listing is the supported public Windows install
-path; later source work does not retroactively change the frozen RC11 authority.
+`1.0.0-rc.7` remains the latest published GitHub Windows technical preview. That unsigned channel is separate from Microsoft Store signing/certification and remains immutable historical evidence for its accepted source.
 
-Exact source commits and artifact digests belong in the applicable workflow/release acceptance evidence rather than being copied into general release guidance.
+### Android
+
+Google Play is a live public Android channel for package `eu.metrora.app`.
+
+A production-signed direct GitHub APK channel is also retained for users who intentionally choose direct installation or Obtainium. The current historical direct release is `0.1.0-alpha.3` under tag `android-v0.1.0-alpha.3`; earlier direct-release history remains immutable evidence.
+
+A GitHub APK release and a Google Play release are separate channel events even when they share application identity and monotonic `versionCode` ordering.
+
+See [`docs/ANDROID_PUBLIC_DISTRIBUTION_V1.md`](docs/ANDROID_PUBLIC_DISTRIBUTION_V1.md) and [`docs/VERSIONING.md`](docs/VERSIONING.md).
 
 ## Version authorities
 
-Metrora deliberately separates three version forms:
+Metrora deliberately separates product/source versions from platform packaging versions.
 
-- product/source SemVer: `1.0.0-rc.11` for the current published Store line;
-- desktop build version: `1.0.0.11` for that published line;
-- Microsoft Store AppX package identity version: `1.0.1.0` for that published line;
-- previous Store baseline: RC10 / `1.0.0.0`.
+Windows currently uses:
 
-The Store's four-component package identity is a platform contract and must not
-be confused with the desktop build counter or the SemVer pre-release label.
-`release/windows-store-package-version.v1.json` records the RC10-to-RC11
-packaging transition used for the published update. It must be advanced under a
-separate release decision before another Store candidate is derived. See
-[`docs/VERSIONING.md`](docs/VERSIONING.md).
+- product/source SemVer `1.0.0-rc.11`;
+- Desktop build version `1.0.0.11`;
+- Microsoft Store AppX package identity `1.0.1.0`.
+
+Android uses `versionName` plus strictly increasing integer `versionCode` under `eu.metrora.app`.
+
+A source version is not automatically evidence that a Store channel has published that exact source. Store/listing authority and source/build authority remain separate until the publication gate completes.
+
+See [`docs/VERSIONING.md`](docs/VERSIONING.md).
 
 ## Release responsibilities
 
-An official desktop release proceeds through separate responsibilities:
+An official release/update proceeds through separate responsibilities:
 
-1. freeze the public source commit and version;
+1. freeze the reviewed public source/version;
 2. run applicable tests, architecture and security gates;
-3. assemble the canonical product payload;
-4. derive declared platform formats and manifests;
-5. verify artifact inventory and digests independently;
-6. run platform and lifecycle acceptance;
-7. apply the exact accepted distribution identity and protected signing authority where required;
-8. publish artifacts, checksums, provenance and release notes;
-9. update `metrora.eu` only after the relevant channel is accepted;
-10. retain rollback authority and prior accepted artifacts.
+3. assemble the declared product/channel artifact;
+4. verify package identity, payload, provenance and digests independently;
+5. run platform/lifecycle/physical acceptance where required;
+6. apply the protected distribution identity/signing authority;
+7. publish through the intended channel as a separate action;
+8. update public website/docs only after the channel is actually accepted/live;
+9. retain rollback authority and historical release evidence.
 
-Build, packaging, protected signing, publication and rollback must not be collapsed into one all-purpose workflow.
+Build, packaging, signing, publication and rollback must not collapse into one opaque “release” step.
 
 ## Required validation
 
-Run the checks owned by the affected surface, including where applicable:
+Run checks owned by the changed surface, including where applicable:
 
 ```bash
 npm ci
@@ -91,99 +88,83 @@ npm --prefix app run typecheck
 npm --prefix app run build
 ```
 
-Platform workflows add their own manifest, payload, runtime, installation, update, rollback and state-preservation checks. The Store package check must execute the bundled CLI from the packaged AppX layout using the bundled Electron runtime; file presence alone is not sufficient.
+Platform workflows add their own manifest, payload, runtime, installation, update, rollback and state-preservation checks.
 
-## GitHub Windows pre-release
+A file merely being present in a package is not equivalent to executing the bundled runtime successfully.
 
-An unsigned Windows GitHub pre-release is a technical-evaluation channel. It is separate from Microsoft Store signing and certification.
+## Windows GitHub technical preview
+
+An unsigned Windows GitHub pre-release is a technical-evaluation channel. It is separate from Microsoft Store signing/certification.
 
 The published `v1.0.0-rc.7` pre-release remains bound to its accepted source commit and release evidence. New source changes do not retroactively alter that release.
 
-Any later GitHub pre-release must again come from one exact reviewed source commit and must pass the applicable candidate, artifact-binding and physical-acceptance boundaries before publication.
+Any later GitHub pre-release must again come from one exact reviewed source commit and pass the applicable artifact-binding and physical-acceptance boundaries before publication.
 
-The public acceptance contract is [`docs/WINDOWS_GITHUB_PRE_RELEASE_ACCEPTANCE_V1.md`](docs/WINDOWS_GITHUB_PRE_RELEASE_ACCEPTANCE_V1.md). The immutable RC7 publication record is [`release/1.0.0-rc.7/GITHUB_PRE_RELEASE.md`](release/1.0.0-rc.7/GITHUB_PRE_RELEASE.md).
+See [`docs/WINDOWS_GITHUB_PRE_RELEASE_ACCEPTANCE_V1.md`](docs/WINDOWS_GITHUB_PRE_RELEASE_ACCEPTANCE_V1.md).
 
-An unsigned GitHub pre-release must state that its portable/installer assets are unsigned, may trigger SmartScreen, require manual updates and are not Microsoft Store certified. It must not be presented as stable merely because GitHub represents it as a release object.
+## Microsoft Store boundary
 
-## Microsoft Store candidate boundary
-
-The published RC11 Store package was built from its exact reviewed source commit
-using the non-publishing Store workflow. The accepted package carries the
-Desktop companion runtime in `resources/cli.asar` and passed the bundled-runtime
-checks used for the submission boundary.
+The live Windows Store package derives from reviewed source and its accepted Store artifact/identity.
 
 For any future Store candidate:
 
-1. the exact AppX artifact and workflow manifest must verify;
-2. Store identity, publisher, architecture, capabilities and package version must match reviewed configuration;
-3. the packaged CLI must execute successfully from the AppX payload without a separately installed Node.js or a loose scoped `node_modules` runtime tree;
-4. the packaged companion module must import from `app/resources/cli.asar/dist/desktop-share-runtime.js` and expose `createDesktopShareRuntime` without starting a listener;
-5. the unsigned submission candidate must remain byte-identical to the workflow output;
-6. a separately test-signed copy may be used only for bounded local physical acceptance;
-7. local-test package/certificate/private-key material must be removed afterward;
-8. the sanitized local acceptance report must pass;
-9. submission requires an explicit stop/go after those checks.
+- exact artifact/workflow provenance must verify;
+- Store identity, publisher, architecture, capabilities and package version must match reviewed configuration;
+- bundled Metrora runtime must execute from the package without relying on an undeclared external runtime;
+- the pinned OpenCode runtime required by the current Code surface must be present and pass its package/runtime validation;
+- local physical acceptance must not be confused with Microsoft certification;
+- submission/publication requires a separate explicit decision after candidate validation.
 
-A passing local test is not Microsoft certification and does not authorize publication or Store-availability claims. A future Store update requires a new reviewed candidate and its own acceptance/submission decision.
+## Android channel boundary
 
-## Versioning and notes
+Android release variants share application identity but keep validation/signing/publication responsibilities separate.
 
-Metrora uses semantic versioning. The first independent candidate line is `1.0.0-rc.N`; the first official stable release is `1.0.0`. A release change updates every version-bearing package and generated metadata deliberately. See [`docs/VERSIONING.md`](docs/VERSIONING.md).
+Public invariants:
 
-Every public release note states:
+- application ID remains `eu.metrora.app`;
+- public upgrades use strictly increasing `versionCode` values;
+- debug/QA identities are not production identities;
+- direct-production signing and Play-upload signing are separate responsibilities;
+- private signing material is not repository/issue/PR/log content;
+- candidate build success is not publication authority;
+- direct APK assets remain source-bound and independently verifiable where documented;
+- Google Play status is taken from the live Store channel rather than inferred from a CI artifact.
 
-- version and source commit;
-- distribution channel and format;
-- signature status;
-- supported operating-system scope;
-- checksums and provenance location;
-- migration or rollback constraints;
+The current direct-channel contract is documented in [`docs/ANDROID_PUBLIC_DISTRIBUTION_V1.md`](docs/ANDROID_PUBLIC_DISTRIBUTION_V1.md).
+
+## Release notes
+
+Every public release note should state what users need to verify the release without dumping private operational detail:
+
+- version/source identity;
+- distribution channel/format;
+- signature status where relevant;
+- supported platform scope;
+- checksums/provenance location where published;
+- migration/rollback constraints;
 - known limitations;
 - privacy-impacting changes, if any.
 
 ## Rollback
 
-Do not rewrite or replace a broadly distributed release under the same version. Publish a new version and retain the previous accepted artifact long enough to support rollback.
+Do not rewrite or replace a broadly distributed release under the same version.
 
-Rollback preserves endpoint identity, OS-vault material, analytics, Workspace state, evidence, exports and user-owned local files according to the accepted migration contract.
+Rollback/migration must preserve user-owned state according to the accepted platform contract, including relevant endpoint identity, analytics, Workspace state, evidence and exports.
 
 ## Platform boundary
 
 - Windows is the first official desktop distribution target.
-- macOS development artifacts remain ad-hoc signed and unnotarized until platform-specific trusted-distribution acceptance passes.
-- Linux formats require packaging and support acceptance before official publication.
-- Mobile distribution has its own signing and release boundary and does not replace desktop or Workspace authority.
-
-## Android direct distribution boundary
-
-Android's direct channel is a Founder-gated GitHub Release with one
-production-signed `Metrora-Android-<versionName>.apk`, a public release manifest
-and `SHA256SUMS`. The current public release is `0.1.0-alpha.3` under
-`android-v0.1.0-alpha.3`; `0.1.0-alpha.1` remains historical public-release
-evidence, and `0.1.0-alpha.2` is historical failed evidence that was never
-public. The source-bound workflow is manual-only, does not publish from pushes
-or tags, and can prepare only a draft release after an existing tag is
-independently bound to the reviewed source commit. See
-[`docs/ANDROID_PUBLIC_DISTRIBUTION_V1.md`](docs/ANDROID_PUBLIC_DISTRIBUTION_V1.md).
-
-The V1 production custody contract uses a JKS keystore. The keystore and
-passwords remain Founder-owned external material; the repository workflow
-materializes them only for the protected signing step and does not persist
-them in `GITHUB_ENV` or release metadata.
-
-The QA physical-acceptance identity is not a production release identity.
-Google Play publication is planned within 30 days but remains a separate channel
-until the Play listing is actually public. The alpha.3 GitHub APK remains the
-current public Android authority in the meantime. F-Droid remains separately
-gated.
+- Android is an official companion distribution target through Google Play, with a separate direct channel.
+- macOS development artifacts remain development source until platform-specific trusted-distribution acceptance exists.
+- Linux formats require packaging/support acceptance before official publication.
+- mobile distribution does not replace Desktop/core factual authority.
 
 ## Prohibitions
 
 - no `npm publish` from the private root package;
 - no inherited upstream publication instructions presented as Metrora;
-- no protected credentials in untrusted pull requests;
+- no protected credentials/private signing material in untrusted pull requests or public documentation;
 - no publication from an unverified local build;
 - no silent replacement of accepted artifacts;
-- no claim of Microsoft Store certification/publication before Microsoft actually accepts that channel;
-- no claim of Google Play publication before the listing is actually public;
-- no claim of an official stable release before the relevant channel passes acceptance.
+- no Store/certification claim before the channel is actually live;
+- no claim of an official stable desktop release before the relevant stable channel passes acceptance.

--- a/docs/ANDROID_PUBLIC_DISTRIBUTION_V1.md
+++ b/docs/ANDROID_PUBLIC_DISTRIBUTION_V1.md
@@ -1,511 +1,210 @@
 # Android public distribution v1
 
-**Status:** direct-APK distribution contract; the current public Android
-release is `0.1.0-alpha.3` / `versionCode = 3`. Its GitHub prerelease tag is
-`android-v0.1.0-alpha.3`, with accepted artifact
-`Metrora-Android-0.1.0-alpha.3.apk` and SHA-256
-`e9868958d26b58ffefa3aaa51a687cd64abc5e73219cd2e9cc8f8d0c8561f305`.
-`0.1.0-alpha.1` remains historical public-release evidence. The
-`0.1.0-alpha.2` / `versionCode = 2` candidate failed production release
-acceptance and was never public.
+**Status:** Google Play is a live public Android channel for Metrora under application ID `eu.metrora.app`. A production-signed direct GitHub APK channel is also retained for intentional direct installation and Obtainium use.
 
-**Historical base audit:** `maikolsiragusaa/metrora@69f0688fea5bb48f37b770e8de590ad20e490d74`
+This document records the public distribution, identity, integrity and signing boundaries that matter to users and contributors. Historical direct-release evidence is preserved without treating old release-gate state as current Store authority.
 
-This document records the Founder-gated, direct GitHub APK contract for the
-implemented Android companion. The table below preserves historical evidence
-for the named audit base; its alpha.1 and no-public-release statements are not
-current alpha.3 authority. Google Play and F-Droid remain separate channels
-with their own gates.
+## Current distribution
 
-## Historical audit at the named base
+| Channel | Status | Authority |
+| --- | --- | --- |
+| **Google Play** | **Live** | Google Play listing for package `eu.metrora.app` |
+| **Direct GitHub APK** | **Available** | source-bound production-signed release assets under `android-v<versionName>` |
+| **F-Droid** | Not claimed as published | separate reproducibility/compliance gate |
 
-The audit covered the Android Gradle project and source tree, the existing
-Android companion workflow, repository release/version authorities, public
-brand authority, the read-only commercial strategy at
-`metrora-commercial@238ee31b21cd746172d19c9fcfc1e60db6e5720f`, and the
-read-only infra release/custody conventions.
+Recommended ordinary Android install path:
 
-| Capability | Actual state at the audit base | Release blocker | Implementable now | Founder/secret gate |
-| --- | --- | --- | --- | --- |
-| Android product | Mobile Product Foundation V1, bounded Activity, Analyze and Settings surfaces are in the source tree; UX V2 has a final QA APK acceptance authority | Final production-signed physical acceptance is still required | Yes | Production key and final physical stop/go |
-| GitHub flavor | `github`, `fdroid` and `play` flavors exist; `eu.metrora.app` is the release application ID and debug uses `.debug` isolation | No canonical public APK asset/metadata contract | Yes | None for validation; production key for release |
-| Current CI | `android-companion.yml` runs unit tests, lint, GitHub/F-Droid APK builds and Play AAB build; QA signing is limited to `githubDebug` on trusted runs | Existing release packages are validation artifacts, not public release artifacts | Yes | QA secret only for physical-acceptance validation |
-| Production signing | No production key is present in the repository or current CI | A public APK must not be unsigned, debug-signed or QA-signed | Workflow and verifier support | Founder-owned key, passwords and certificate fingerprint |
-| Source binding | Existing Windows release conventions are source-bound; Android had no equivalent public-release verifier | An arbitrary checkout must not become a release | Yes | Founder reviews the exact source commit |
-| Version authority | `android/app/build.gradle.kts` declares `versionName = 0.1.0-alpha.1` and `versionCode = 1` | Future public upgrades must advance `versionCode` strictly | Yes; retain the never-public initial value | Founder approves each release |
-| Release discovery | No changing asset semantics or updater service exists | Obtainium needs a predictable GitHub release and APK asset | Yes | Founder publishes the final release |
-| Brand tokens | Android primary cyan was `#0BD5F4`; the public authority is Graphite + Signal Cyan | Primary token drift from the canonical brand authority | Yes | None |
-| F-Droid | The flavor builds, but dependency/license/compliance status is not a release claim | CameraX/ZXing and reproducible metadata need a separate review | Characterize only | Separate F-Droid gate |
-| Google Play | The Play AAB builds | Listing, Play signing and publication gates are not complete | Preserve buildability only | Separate Play gate |
+[Get Metrora on Google Play](https://play.google.com/store/apps/details?id=eu.metrora.app)
 
-## Current accepted authority
+The direct APK path remains useful for users who deliberately prefer direct installation, release-manifest verification or Obtainium.
 
-The direct Android release gate has completed for alpha.3. The public channel is
-the GitHub prerelease identified above; it is not a Google Play or F-Droid
-publication. The accepted production APK is the canonical direct-install
-artifact, and its public manifest and `SHA256SUMS` remain the integrity
-references for users.
+## Product authority
 
-The Android product remains local-first and read-focused. Desktop/core remains
-authoritative for collection, parsing, pricing, accounting, canonical history,
-evidence and Workspace semantics.
+The Android application is a companion to an explicitly paired Metrora Desktop.
 
-## Direct distribution contract
+Desktop/core remains authoritative for:
 
-The public Android channel is a GitHub Release containing one canonical
-APK for ordinary direct installation:
+- collection and provider parsing;
+- canonical usage/history;
+- pricing and accounting;
+- Projects and evidence semantics;
+- provider Capacity projections;
+- Workspace authority where applicable.
+
+Android consumes bounded projections from that authority. It does not become a second collection, pricing or evidence engine merely because it is distributed through Google Play.
+
+## Package and version identity
+
+Canonical Android application ID:
+
+`eu.metrora.app`
+
+Android uses the native `versionName` and strictly increasing integer `versionCode` declared in `android/app/build.gradle.kts`.
+
+Current repository source line:
+
+- `versionName = 0.1.0-alpha.4`;
+- `versionCode = 4`;
+- application ID `eu.metrora.app`.
+
+Historical direct-channel evidence:
+
+- `0.1.0-alpha.1` / `versionCode = 1` — immutable historical public release;
+- `0.1.0-alpha.2` / `versionCode = 2` — failed candidate, never published;
+- `0.1.0-alpha.3` / `versionCode = 3` — accepted production-signed GitHub direct release.
+
+Google Play and direct APK releases share the same package identity and monotonic `versionCode` line. A later installable build must not reuse or decrease a previously public version code.
+
+The exact version currently served by Google Play is Store-channel authority. A repository source version or historical direct APK version must not be described as the current Play version without a corresponding published Play release.
+
+See [Versioning authority](VERSIONING.md).
+
+## Direct APK contract
+
+The direct channel uses predictable source-bound GitHub release identity:
 
 - repository: `maikolsiragusaa/metrora`;
-- release tag: `android-v<versionName>`;
-- release title: `Metrora Android <versionName>`;
+- tag: `android-v<versionName>`;
 - application ID: `eu.metrora.app`;
-- canonical APK asset: `Metrora-Android-<versionName>.apk`;
-- manifest asset: `Metrora-Android-<versionName>.manifest.json`;
-- integrity asset: `SHA256SUMS`.
+- APK: `Metrora-Android-<versionName>.apk`;
+- manifest: `Metrora-Android-<versionName>.manifest.json`;
+- integrity file: `SHA256SUMS`.
 
-The current public release is `0.1.0-alpha.3` with `versionCode = 3` and tag
-`android-v0.1.0-alpha.3`. The immutable `0.1.0-alpha.1` release remains
-historical evidence. The prior `0.1.0-alpha.2` / `versionCode = 2` candidate is
-retained as historical failed, unpublished evidence and must not be
-overwritten, reissued or described as a public release.
+The current historical direct-release authority documented here is `0.1.0-alpha.3` / `versionCode = 3`.
 
-The following illustrative manifest uses the current alpha.3 public identity;
-the certificate value remains a schema placeholder and is not release evidence:
+Accepted artifact:
 
-```json
-{
-  "schemaVersion": 1,
-  "product": "Metrora",
-  "versionName": "0.1.0-alpha.3",
-  "versionCode": 3,
-  "distributionChannel": "github",
-  "applicationId": "eu.metrora.app",
-  "sourceCommit": "<reviewed source commit>",
-  "artifactFilename": "Metrora-Android-0.1.0-alpha.3.apk",
-  "artifactSha256": "e9868958d26b58ffefa3aaa51a687cd64abc5e73219cd2e9cc8f8d0c8561f305",
-  "signingCertificateSha256": "<64-character certificate SHA-256>"
-}
-```
+`Metrora-Android-0.1.0-alpha.3.apk`
 
-The placeholder values above are illustrative schema values, not release
-evidence. The workflow generates the actual manifest from the verified APK and
-does not write secret or private-key material into it.
+SHA-256:
 
-`SHA256SUMS` contains exactly the APK and manifest filenames. The verifier
-rejects additional bundle files, path traversal, checksum mismatches, a wrong
-application ID, a wrong version, an unsigned APK/AAB, a certificate mismatch
-or a source-commit mismatch.
+`e9868958d26b58ffefa3aaa51a687cd64abc5e73219cd2e9cc8f8d0c8561f305`
 
-## Version policy
+The direct manifest/checksum bundle remains independently verifiable and must remain bound to the reviewed source commit, package/version identity and signing certificate used for that release.
 
-Android has a platform-native version authority separate from the frozen
-Windows Store package version:
-
-- source authority: `android/app/build.gradle.kts`;
-- current published direct APK authority: `0.1.0-alpha.3` / `versionCode = 3`;
-- current source / Google Play candidate line: `0.1.0-alpha.4` / `versionCode = 4`;
-- GitHub identity: `android-v<versionName>`;
-- Play and direct APK upgrades use the same `eu.metrora.app` package line and
-  the same strictly increasing `versionCode` sequence.
-
-The immutable alpha.1 production-signed artifact consumed `versionCode = 1`.
-The historical alpha.2 candidate advanced the same application identity to
-`versionCode = 2` but failed production release acceptance and remains
-unpublished. The accepted alpha.3 release advances the same identity to
-`versionCode = 3`. Every later publicly installable upgrade must use a
-strictly larger integer.
-`versionName` remains human-readable and may use the existing Metrora
-pre-release convention.
-
-Android version identity is not coupled to the Windows Store package version.
-
-## Production signing boundary
-
-The existing QA signing path remains separate and is not reused:
-
-- QA signing is still controlled by `METRORA_QA_SIGNING_ENABLED` and applies
-  only to `githubDebug` for physical acceptance;
-- the public path is controlled by `METRORA_PRODUCTION_RELEASE=true` and
-  configures only `githubRelease`;
-- enabling QA and production signing together fails closed;
-- debug signing never signs the public APK;
-- no keystore is committed;
-- production passwords and key material are never printed;
-- a production release fails before assembly when any required signing value is
-  absent;
-- ordinary pull-request validation builds do not require private signing
-  secrets.
-
-The trusted release workflow uses these secret names only as transport
-identifiers; their values belong in a protected GitHub environment and are not
-documented here:
-
-- `METRORA_ANDROID_PRODUCTION_KEYSTORE_B64`;
-- `METRORA_ANDROID_PRODUCTION_STORE_PASSWORD`;
-- `METRORA_ANDROID_PRODUCTION_KEY_PASSWORD`;
-- `METRORA_ANDROID_PRODUCTION_KEY_ALIAS`.
-
-The non-secret expected certificate fingerprint is supplied as the protected
-environment/repository variable
-`METRORA_ANDROID_PRODUCTION_CERTIFICATE_SHA256`. The workflow fails closed if
-it is missing and the verifier compares the APK certificate with it.
-
-The Play candidate path uses a separate upload-key namespace and never reuses
-the direct-APK production key as an upload key:
-
-- `METRORA_ANDROID_PLAY_UPLOAD_KEYSTORE_B64`;
-- `METRORA_ANDROID_PLAY_UPLOAD_STORE_PASSWORD`;
-- `METRORA_ANDROID_PLAY_UPLOAD_KEY_PASSWORD`;
-- `METRORA_ANDROID_PLAY_UPLOAD_KEY_ALIAS`.
-
-The existing production certificate remains the intended Android app-signing
-identity across the direct APK and Google Play channels through Google's
-supported Play App Signing enrollment flow. The distinct Play upload key only
-authorizes future AAB uploads. Neither key bytes nor passwords are repository,
-issue, PR, log or artifact content.
-
-The keystore is decoded only into the trusted runner's temporary directory and
-used inside one protected signing/build step. Signing credentials are scoped
-to that step, are not written to `GITHUB_ENV`, and are unset immediately after
-the signed APK is assembled. A shell trap and a following `always()` cleanup
-step remove the JKS even when signing fails. Metadata verification, artifact
-upload and optional draft-release preparation receive only the public
-certificate fingerprint and release outputs; they do not receive passwords,
-the key alias or private keystore material. The workflow has no push trigger
-and cannot publish a release from a push to `main`. Its optional draft-release
-job requires an existing tag already bound to the exact source commit and uses
-`--draft --verify-tag`; it never creates a tag and never makes a public release.
-
-## Key custody and recovery gate
-
-The production signing key is a Founder-owned gate, not a repository asset.
-Before a public release, the owner must complete these external operational
-steps:
-
-1. Generate one long-lived Android production signing identity in a JKS
-   keystore on a trusted, offline-controlled workstation. Use a stable
-   production alias; do not reuse the debug or QA identity.
-2. Keep the original keystore and passwords in long-term protected custody,
-   with at least one separately protected offline backup and a tested recovery
-   procedure. Do not place either in Git, issues, pull requests, workflow
-   output or public release metadata.
-3. Record the public certificate SHA-256 fingerprint and stable alias in the
-   private owner/release record, then configure the protected workflow secret
-   names and non-secret fingerprint variable.
-4. Preserve alias and certificate continuity for every direct APK upgrade.
-   Verify the production-signed candidate on the physical device before
-   publication.
-
-If the key is lost, existing direct APK installations cannot accept a normal
-upgrade signed by a replacement identity. Recovery requires the original key;
-otherwise the owner must make an explicit migration decision, which may require
-a new application identity and a reinstall rather than a silent replacement.
-The same application ID/versionCode line is required for a later Play path, but
-Play's app-signing/upload-key enrollment and migration rules are a separate
-Founder-gated decision. This public repository does not provision or recover
-the production key.
-
-## Source-bound release workflow
-
-`.github/workflows/android-public-release.yml` is manual-only and is allowed to
-run only when dispatched from `main`. The operator supplies a full source
-commit. The workflow:
-
-1. checks out that exact commit and verifies it is an ancestor of `origin/main`;
-2. sets up Java 17, Gradle 9.6.1 and Android API 36;
-3. runs focused Android tests and lint before production secrets are scoped;
-4. materializes and validates the production JKS only inside the protected
-   signing/build step;
-5. requires the production signing Gradle path and assembles `githubRelease`;
-6. removes the temporary JKS and unsets signing credentials immediately after
-   assembly, including failure paths;
-7. verifies package identity, version, signature and certificate;
-8. writes the canonical APK name, manifest and `SHA256SUMS`;
-9. independently re-verifies the complete release bundle;
-10. uploads a short-lived workflow candidate artifact; and
-11. keeps signing passwords, alias and private keystore material out of all
-    later verification, summary and draft-release steps.
-
-The optional draft preparation step is explicitly requested, requires an
-existing `android-v<versionName>` tag bound to the same commit, and creates a
-draft GitHub Release only. Final publication remains a separate Founder
-action after production-signed physical acceptance.
-
-`.github/workflows/android-play-candidate.yml` is a separate manual-only path.
-It also requires a full source commit dispatched from `main`, verifies that
-the commit is reachable from current `origin/main`, runs Android tests and
-lint before secrets are scoped, materializes the dedicated Play upload JKS
-only for `playRelease`, removes it on every exit path, and independently
-verifies the signed AAB, package, version, upload certificate, source SHA and
-SHA-256 evidence. It uploads only a short-lived candidate artifact and has no
-Google Play upload or production-submission step.
-
-## Verification procedure
-
-The deterministic verifier is
-`scripts/verify-android-release.mjs`. A trusted release invocation supplies
-the Android SDK `aapt2` and `apksigner` paths, the exact source commit, the
-expected source version and the recorded production certificate fingerprint.
-
-It verifies:
-
-- `aapt2` package name, `versionName` and `versionCode`;
-- `apksigner` verification and exactly one signing certificate;
-- expected production certificate SHA-256;
-- canonical filename and manifest shape;
-- artifact and manifest SHA-256 values;
-- exact `SHA256SUMS` membership;
-- exact source commit binding.
-
-The verifier has Node tests in
-`scripts/verify-android-release.node-test.mjs`. It is intentionally a small
-release-boundary tool rather than a new release framework. The direct APK path
-uses `aapt2`/`apksigner`. The separate small Play candidate verifier in
-`scripts/verify-android-play-candidate.mjs` reuses the same manifest/checksum
-primitives and uses `bundletool`, `jarsigner` and `keytool` to verify the AAB
-manifest and upload certificate.
-
-## Obtainium compatibility
-
-Obtainium should track the Metrora GitHub repository's Releases page using the
-stable `android-v<versionName>` release identity and select the single
-`Metrora-Android-<versionName>.apk` asset. The APK asset semantics do not
-change between releases, and the manifest/checksum assets remain available for
-independent inspection. No Metrora-hosted updater backend or in-app updater is
-required for this channel.
-
-Direct APK installation and update are for users who intentionally choose the
-technical/early channel. A GitHub release is not a Google Play publication and
-does not imply Play review or certification.
-
-## Brand token normalization
-
-The public brand authority is Graphite + Signal Cyan from
-`assets/brand/README.md`. Android's product-facing primary token now uses:
-
-- Signal Cyan: `#00D4FF` (was `#0BD5F4`);
-- Signal Cyan Deep: `#007A99`;
-- Signal Cyan Soft: `#E6F9FD`.
-
-The old Android `cyanSoft` value was a dark-surface muted accent and was not
-semantically the public Soft token. It is clarified as `signalCyanDeep` rather
-than being silently mapped to a pale fill. The accepted UX structure, density,
-typography, layout, official assets, provider/model logos and semantic
-success/warning colors are unchanged.
-
-## Physical visual regression plan
-
-The primary color change is small and does not require a complete UX V2
-acceptance rerun. After the production key gate is satisfied, run a minimal
-S23-class visual comparison against the final production-signed APK:
-
-| Surface | Check |
-| --- | --- |
-| Connect / pairing | Primary CTA, QR framing accent, approval and success states remain legible and structurally unchanged |
-| Home | Chart line/fill, active navigation and active controls use Signal Cyan without layout or density drift |
-| Activity | Selection, filters and active control accents remain visible against Graphite surfaces |
-| Analyze | Models/Spend selection and emphasis preserve provider/model semantics and contrast |
-| Settings | Selected/accent state, device controls and security affordances remain clear |
-
-Record only the physical acceptance result and release facts in the private
-owner/release evidence. Do not commit personal S23 screenshots as marketing
-evidence.
-
-## Production-release functional smoke
-
-Because `githubRelease` enables minification and resource shrinking, the final
-production-signed APK needs one bounded S23-class functional smoke in addition
-to the visual matrix above. Use a clean install of the exact
-production-signed `eu.metrora.app` APK and verify:
-
-1. launch completes without a startup failure;
-2. real QR pairing completes and SAS/Desktop approval succeeds;
-3. Home loads and refreshes real data;
-4. Activity opens and renders real sessions;
-5. Analyze opens and renders accepted factual data;
-6. Settings opens and device/security state remains functional;
-7. the QR scanner remains functional; and
-8. one bounded offline-to-reconnect check completes without breaking the
-   local-first state.
-
-This is a production-variant smoke, not a repeat of the complete UX V2
-acceptance matrix. Record only the result and release facts in private owner
-evidence; do not commit personal screenshots publicly.
-
-## F-Droid characterization
-
-The existing `fdroidRelease` build remains intact, but it is not declared
-F-Droid-ready by this milestone. The current Android dependency surface
-includes Compose, CameraX, DataStore, coroutines and
-ZXing Core. A separate F-Droid tranche must review:
-
-- dependency licenses and complete transitive notices;
-- scanner/ZXing availability, repository policy and offline/reproducible build
-  behavior;
-- metadata, build reproducibility and network/privacy declarations.
-
-The GitHub and Play product paths must not be weakened or made less secure to
-avoid these separate compliance questions.
+A GitHub APK release and a Google Play release are different channel events even when they share the same application identity.
 
 ## Google Play boundary
 
-The current direct-install authority remains the published alpha.3 APK and
-`versionCode = 3`. Alpha.4 (`versionCode = 4`) is the current Play candidate
-line only; it is not a published Google Play release.
+Google Play publication uses the `play` Android flavor and Play App Signing/upload-key workflow defined by the repository release process.
 
-The Play candidate uses the same `eu.metrora.app` package and monotonic
-versionCode sequence. The existing production app-signing certificate is the
-intended cross-store identity and must be supplied to Play App Signing through
-the supported enrollment path. A distinct Play upload key signs candidate
-AABs. The two identities are deliberately separate concepts, and the
-repository does not provision either private key.
+Public invariants:
 
-The candidate verifier records the exact source SHA, package, version,
-upload-certificate verification and AAB SHA-256 in a reviewable artifact. The
-Founder must complete Play App Signing enrollment, review the candidate and
-make the final Play submission decision. This tranche does not upload to Play,
-submit to production, create a tag or claim Google Play availability.
+- Play keeps application ID `eu.metrora.app`;
+- Play uses the same monotonic `versionCode` sequence as the direct package line;
+- release/upload credentials are not repository content;
+- candidate validation is separate from final Store publication;
+- a successfully built AAB is not evidence that Google Play published it;
+- current Store status must be taken from the live listing/release authority, not inferred from CI alone.
 
-The Android Settings / Privacy surface links to the canonical policy at
-`https://metrora.eu/privacy`, which must remain live before any Store listing
-or submission.
+The public repository intentionally documents these invariants without publishing private signing material or operational custody details.
 
-## Google Play Data Safety evidence map
+## Signing boundary
 
-**Evidence snapshot:** `origin/main` at
-`8db16e19a898366647aa6088a07fa32a08db73b4` (refreshed 29 August 2026).
-This is a source-backed preparation map, not a Play Console declaration. It
-describes the Android app's current behavior; the Founder must still map the
-final signed AAB to the exact Play Console questions and review any SDK or
-platform disclosures required at submission time.
+Debug, QA, direct-production and Play-upload identities are distinct responsibilities.
 
-**Permission inventory:** the source app manifest declares `INTERNET`,
-`ACCESS_NETWORK_STATE` and `CAMERA`; camera hardware is optional. There are no
-`debug` or product-flavor manifest overlays under `android/app/src`. Selected
-QR images use the system Photo Picker path and the app manifest declares no
-broad image/media/storage permission. The CI-produced release merged manifest
-inspected for this PR also contains AndroidX's app-scoped signature permission
-`eu.metrora.app.DYNAMIC_RECEIVER_NOT_EXPORTED_PERMISSION`. AndroidX
-ProfileInstaller uses `android.permission.DUMP` as a receiver permission; it is
-not a `uses-permission` requested by the app. Re-check the exact signed Play
-AAB merged manifest before entering Console declarations because dependencies
-can contribute merged-manifest entries.
+Required principles:
 
-Google Play terminology is deliberately not used as a synonym for this table's
-observed flows. Current Play guidance defines collection around user data sent
-off device and separately describes exclusions such as qualifying end-to-end
-encryption. On-device QR/image processing and data received from Desktop do
-not, by themselves, settle a Play `collected` answer. Conversely, the current
-Android flow does send bounded pairing/authentication/request data to the
-selected Desktop. The Founder must map those exact values to Play's data types,
-purposes, required/optional status, ephemeral handling and any applicable
-sharing or end-to-end-encryption exclusion on the final candidate. TLS or
-fingerprint pinning alone must not be treated as proof that a Play exclusion
-applies.
+- no private keystore is committed;
+- no signing password/private key is printed into logs, issues, PRs or artifacts;
+- QA identity is not a production release identity;
+- direct production signing does not silently substitute for Play upload signing;
+- release jobs fail closed when required protected signing material is absent;
+- ordinary pull-request validation does not require private production credentials;
+- signing material is scoped to protected release execution and removed from temporary runner state after use.
 
-In this table, an observed recipient is the endpoint or SDK visible in current
-Android source. The paired Desktop is explicitly selected and approved by the
-user and is not a Metrora cloud relay. This operational description does not
-pre-decide whether Play's separate `sharing` definition or an exclusion applies.
+Public certificate fingerprints and source/artifact hashes may be used as non-secret verification evidence. Private key custody remains outside the public repository.
 
-| Data type | Observed Android access / origin | Observed local / outbound flow | Purpose | Observed recipient / SDK | Retention | User control | Source evidence |
-| --- | --- | --- | --- | --- | --- | --- | --- |
-| Camera frames and selected QR image | Camera frames are accessed only after the user opens QR scanning and grants `CAMERA`; an imported image is selected through the system Photo Picker path. | Processed locally to extract one bounded QR value. The scanner/image-decoder paths do not persist or upload raw frames/images. | Discover the paired Desktop endpoint. | No network recipient in the decode path and no analytics/advertising SDK. | Transient for the scan/decode operation. | Deny or revoke `CAMERA`, cancel scanning, go back, or choose not to import an image. Image import does not require the camera permission. | `AndroidManifest.xml`, `QrScanner.kt`, `QrImageDecoder.kt`, `QrCodeDecoder.kt` |
-| Pairing and connection metadata | Host/port come from manual entry or QR; Desktop name and server fingerprint come from discovery; the client fingerprint comes from the local client certificate; pairing time is generated locally. The phone also derives a bounded display name from manufacturer/model. | Host/port select the direct TLS endpoint. After Desktop identity discovery, the pairing request sends the phone display name to that Desktop while the SAS is being shown; the local pairing credential is not saved until Desktop approval completes and the phone user confirms the SAS. Server/client fingerprints and pairing time are then stored in the encrypted local credential. | Bind the phone to one Desktop identity and scope authenticated requests. | The explicitly selected Desktop only; no Metrora cloud endpoint is implemented. | Stored credential metadata remains until replacement or successful local pairing cleanup. The underlying Keystore client identity is a separate lifetime described below. | The user can cancel the flow, compare the SAS before accepting local pairing, revoke Desktop access, or forget local state. Cancellation does not imply that an already-started discovery/pair request never reached the selected Desktop. | `PairingBootstrap.kt`, `MetroraApiClient.kt`, `TlsMetroraTransport.kt`, `PairingCredentials.kt`, `MetroraCoordinator.kt` |
-| Metrora account/profile data | No Android account-creation, email, phone, contacts or provider-login flow is present; the companion pairs to a Desktop instead. | No Metrora account data is transmitted or stored by this flow. Desktop name and device/pairing identity remain covered by the connection/credential rows above. | Avoid a Metrora cloud account while enabling the paired companion. | No Metrora identity service or social/advertising provider is configured. | Not applicable to a Metrora account; paired local state follows the cleanup behavior above. | There is no Metrora account in this Android flow to delete; forget/revoke the pairing or uninstall the app for app-local state. | `MetroraFirstRun.kt`, `MetroraApiClient.kt`, `AndroidManifest.xml`, `strings.xml` |
-| Pairing credential and device cryptographic material | The Desktop returns a pairing token. The phone creates an EC client identity in Android Keystore and a separate Keystore-backed AES key protects persisted app state. | The token is encrypted in local DataStore and sent as the bearer credential in authenticated TLS requests to the paired Desktop. The client public certificate is presented to the Desktop by mutual TLS. Current app code does not serialize, export or transmit the client private key or AES key; those key handles remain in Android Keystore. | Authenticate the paired phone, protect the Desktop API and encrypt local persisted state. | The paired Desktop receives the bearer token on authenticated requests and the client public certificate through TLS; no Metrora service or telemetry recipient is present. | Successful revoke/forget cleanup removes the persisted pairing credential and product-cache values from DataStore. It does **not** delete the client-identity or AES aliases from Android Keystore, so those cryptographic keys can persist across revoke/forget; their later OS/app lifecycle is an Android platform boundary. | `Revoke access on Desktop` first requests remote revocation and then performs local cleanup; `Forget on this phone` performs local cleanup only. There is no in-app private-key export or Keystore-identity deletion action. | `PairingCredentials.kt`, `SecureStore.kt`, `EncryptedStateCodec.kt`, `DeviceIdentity.kt`, `MetroraApiClient.kt`, `MetroraCoordinator.kt` |
-| Usage, cost, model, Project, Capacity and Activity projections | Received from the paired Desktop when the user refreshes or opens supported surfaces. The Android app does not independently collect provider-side source evidence. | Received and cached locally in encrypted bounded snapshots. Period, Project, provider, route, model, source, ordering and paging values needed for supported requests can be sent to the paired Desktop over TLS. Ordinary projections exclude prompts, responses, source files/code, patches/diffs, secrets, raw tool arguments and raw tool output. | Render the read-focused companion surfaces. | The paired Desktop is the intended data source/peer; no Metrora cloud relay, ad network or behavioral analytics path is implemented. | Each persisted domain is a bounded latest snapshot/cache and is replaced by newer compatible state. It remains until overwritten or successful pairing cleanup; there is no time-based Android retention promise. | Refresh, use the explicit revoke/forget controls, or uninstall. A failed local cleanup enters recovery handling rather than being described as successful deletion. | `UsageSnapshot.kt`, `MobileFoundationSnapshot.kt`, `CapacitySnapshot.kt`, `ActivitySnapshot.kt`, `ProjectCatalogSnapshot.kt`, `MetroraApiClient.kt`, `SecureStore.kt` |
-| Network and transport metadata | Accessed to connect to the endpoint supplied by the user/QR and to build bounded period, Project and Activity requests. | The app uses HTTPS/TLS and disables cleartext. Discovery checks certificate validity, captures the presented Desktop certificate fingerprint and requires the Desktop-advertised fingerprint to match it. SAS confirmation binds Desktop and client fingerprints; later requests pin the expected Desktop fingerprint and use the Keystore client identity for mutual TLS. The custom transport uses this fingerprint authority rather than conventional hostname identity as the pairing trust decision. | Secure direct Desktop pairing and data refresh. | The explicitly paired Desktop; the app has no configured Metrora relay or remote collection service. | Connection values stored in pairing state remain until successful cleanup. Response bodies are bounded and either used for the current operation or written into the bounded caches described above. | User chooses the endpoint, can cancel pairing, and can revoke or forget paired state. | `AndroidManifest.xml`, `network_security_config.xml`, `Protocol.kt`, `TlsMetroraTransport.kt`, `MetroraApiClient.kt` |
-| Demo Mode data | Built-in synthetic data is created locally; no real Desktop, account or pairing state is accessed. | Ephemeral in memory and Activity lifecycle state only; no network request and no write to the normal encrypted real-data caches. Automated Demo launch is accepted only when every real credential/cache read is missing, so paired, cached or recovery-state evidence remains authoritative. | Product exploration and reproducible screenshots/visual QA. | None. | Until the Demo session exits or its lifecycle state ends; it is not canonical product evidence. | `Exit demo` returns to the untouched unpaired real state; normal real-data stores are not cleared or overwritten by Demo Mode. | `MetroraDemoDatasetV1.kt`, `MetroraDemoLaunchSpec.kt`, `MetroraCoordinator.kt`, `MainActivity.kt`, `ANDROID_DEMO_MODE_V1.md` |
-| Advertising, behavioral analytics and crash/telemetry data | No Android source or declared dependency currently implements these flows. | No current transmission or local store is defined for them. | Not applicable to the current companion. | No advertising, behavioral-analytics or crash/telemetry SDK is declared in the Android dependency surface. | Not applicable. | No analytics opt-out is substituted for a feature that does not exist; revisit this map if dependencies or telemetry change. | `android/app/build.gradle.kts`, `android/gradle/libs.versions.toml`, source-wide dependency audit |
-| Android backup/device-transfer copy of app state | Repository configuration sets `allowBackup=false`, supplies legacy `fullBackupContent` exclusions, and supplies Android 12+ `dataExtractionRules` exclusions for cloud backup and device transfer across the app-private storage domains. | No Metrora backup service is configured. The XML rules exclude root, file, database, shared-preference and external domains, but platform/OEM backup and migration behavior remains an external boundary and must not be described as an absolute guarantee solely from `allowBackup=false`. | Keep pairing credentials and cached projections out of configured Android backup/device-transfer domains. | Android platform behavior only; no Metrora backup recipient is configured. | Local app retention only, subject to Android app-storage/Keystore lifecycle behavior. | Revoke/forget clears the app's persisted pairing/cache values on successful cleanup; uninstall/app-platform lifecycle is separate. | `AndroidManifest.xml`, `backup_rules.xml`, `data_extraction_rules.xml`, `SecureStore.kt` |
+## Source binding and verification
 
-### Play Console interpretation boundary
+Android release tooling verifies the relevant package/channel artifact against reviewed source and expected public identity.
 
-Source proves the current Android flows above; it does not prove a completed
-Console questionnaire. Under current Play guidance, camera/photo data that is
-only processed on device is not collection merely because the app accessed it,
-and projections received from Desktop are not made into Android-originated
-collection merely by being cached locally. At the same time, current source
-has real outbound traffic to the paired Desktop: the bounded phone display
-name during pairing, the client public certificate at the TLS layer, the
-pairing bearer token on authenticated requests, and bounded request/filter
-values. Those outbound values require exact Console mapping rather than a
-blanket `no data collected` conclusion.
+Direct APK verification covers, as applicable:
 
-Current source also supports these bounded directions for Founder review: no
-Metrora account-creation flow, no advertising/behavioral-analytics/crash SDK,
-no Metrora cloud relay, and encrypted transport for the paired Desktop flow.
-The Founder still owns the final Play decisions for enumerated data types,
-purposes, required versus optional handling, ephemeral processing, sharing
-exceptions, any end-to-end-encryption exclusion, SDK disclosures and the final
-signed AAB's merged manifest. Save/submit those answers in Play Console only
-after inspecting the exact candidate; this repository map is evidence, not the
-authoritative submitted form.
+- application ID;
+- `versionName` / `versionCode`;
+- APK signature and expected public certificate fingerprint;
+- canonical artifact/manifest names;
+- artifact SHA-256;
+- `SHA256SUMS` membership;
+- exact source commit binding.
 
-The map intentionally does not infer retention or collection behavior for the
-user's paired Desktop, provider accounts, operating system logs, or future Play
-services. Those are separate authorities and must not be converted into
-claims about the current Android artifact without evidence.
+Play candidate verification additionally checks AAB/package/upload-signing identity using the repository's bounded Play verification tooling.
 
-## Demo screenshot reproducibility
-
-The existing Demo Mode can launch each relevant shipped top-level surface from
-a clean unpaired install. Use a fixed date and the same dataset version for
-every capture. The debug application ID is `eu.metrora.app.debug`; a release
-or Play candidate uses `eu.metrora.app`. The exact Demo destination values are
-`home`, `activity`, `analyze`, `workspace` and `settings`; they are destination
-selectors, not screenshot filenames.
-
-For a real installed debug build, replace `PACKAGE` with
-`eu.metrora.app.debug`; for a release/Play artifact, replace it with
-`eu.metrora.app`:
+The important release invariant is simple:
 
 ```text
-adb shell am force-stop PACKAGE
-adb shell am start -n PACKAGE/eu.metrora.app.MainActivity --ez metrora.demo true --es metrora.demo.dataset v1 --es metrora.demo.now 2026-08-29 --es metrora.demo.destination home
+reviewed source
+     ↓
+validated channel artifact
+     ↓
+identity + signature + digest checks
+     ↓
+physical/product acceptance where required
+     ↓
+separate publication action
 ```
 
-Replace `home` with another exact destination above to open the corresponding
-surface. The launch hint is one-shot and is honored only when all real
-credential/cache reads are missing; paired, cached or recovery-state evidence
-remains authoritative. Capture screenshots from the actual running artifact
-only. Do not fabricate screens or commit personal-device screenshots as public
-marketing evidence.
+A build does not become an official release merely because it passed CI.
 
-## Security and privacy regression boundary
+## Obtainium and direct installation
 
-The distribution work does not change Android runtime authority or data
-boundaries. The existing implementation and tests remain responsible for:
+Obtainium users can track the repository's `android-v*` releases and select the canonical `Metrora-Android-<versionName>.apk` asset.
 
-- QR pairing, SAS/Desktop approval, mutual TLS and certificate pinning;
-- Android Keystore client identity and encrypted local caches;
-- direct local-first behavior and explicit revoke/forget/re-pair controls;
-- prompt, response, source code, patch, secret, tool-argument and unrestricted
-  path exclusion from Android projections;
-- Desktop/core authority for collection, pricing, accounting, history,
-  Workspace and evidence semantics.
+The direct channel keeps stable naming plus manifest/checksum evidence so users can inspect what they install without requiring a Metrora-hosted updater backend.
 
-This milestone adds no account, telemetry, remote service, hosted updater or
-infrastructure.
+Google Play remains the simpler ordinary install/update path for most Android users.
 
-## Founder release checklist
+## Privacy and pairing
 
-The alpha.3 release completed the following Founder-owned gates. The same
-controls remain required before any future direct release changes from
-candidate to public:
+Distribution channel does not change the local-first companion model.
 
-- production key exists in protected custody and recovery has been checked;
-- the protected workflow environment contains the required signing values;
-- the recorded certificate fingerprint matches the production key;
-- the exact source commit and version are approved;
-- the production-signed APK passes the verifier;
-- the S23-class physical regression matrix passes;
-- the GitHub Release tag is created intentionally and points to the approved
-  source commit;
-- release notes, checksum and manifest are reviewed;
-- only then is a future draft eligible for explicit public publication.
+Android pairing uses encrypted transport and explicitly approved Desktop identity. Ordinary companion flows are designed around bounded factual projections and do not intentionally export unrestricted work content such as:
 
-The accepted alpha.3 artifact is the current public Android release.
-The historical alpha.2 candidate remains failed and unpublished, and the
-immutable alpha.1 artifact remains historical public-release evidence.
+- prompt or assistant-response bodies;
+- source files, source code, patches or diffs;
+- provider credentials or API keys;
+- unrestricted local filesystem paths.
+
+The current Android companion contains no advertising SDK or behavioral-analytics SDK according to the current source/dependency authority. See the current [Metrora privacy policy](https://metrora.eu/privacy) and [Local companion API](LOCAL_COMPANION_API.md).
+
+## Brand authority
+
+Android uses the current Metrora Graphite + Signal Cyan product identity documented under `assets/brand`.
+
+Historical visual acceptance material may remain evidence for the artifact it tested, but should not be reused as current marketing if the product surface has materially changed.
+
+This is especially relevant now that Metrora is positioned as a broader control center rather than only a usage-tracking companion.
+
+## Contributor validation
+
+For ordinary Android repository work, use the project-supported Java/Gradle/Android SDK versions and run focused unit/lint/build validation appropriate to the changed surface.
+
+Typical checks include:
+
+```bash
+gradle -p android --no-daemon :app:testGithubDebugUnitTest :app:lint :app:assembleGithubDebug
+```
+
+Distribution variants can be built for validation without implying publication:
+
+```bash
+gradle -p android --no-daemon :app:assembleGithubRelease :app:assembleFdroidRelease :app:bundlePlayRelease
+```
+
+Production signing and final publication remain protected release operations.
+
+## Historical evidence rule
+
+Historical direct releases, failed candidates, manifests, checksums and physical acceptance records remain immutable evidence for the source/artifact they name.
+
+Do not rewrite an old release into a new one, do not reuse a consumed version code, and do not treat a historical GitHub release as proof of the version currently served by Google Play.
+
+## Related documents
+
+- [Getting started](GETTING_STARTED.md)
+- [Android companion foundation](ANDROID_COMPANION_FOUNDATION.md)
+- [Local companion API](LOCAL_COMPANION_API.md)
+- [Mobile Product Parity V1](MOBILE_PRODUCT_PARITY_V1.md)
+- [Versioning authority](VERSIONING.md)
+- [Releasing Metrora](../RELEASING.md)

--- a/docs/ECOSYSTEM_SURFACES.md
+++ b/docs/ECOSYSTEM_SURFACES.md
@@ -1,255 +1,257 @@
 # Metrora ecosystem surfaces
 
 **Status:** public product direction and implementation-status guide  
-**Decision revision:** 2026-09-05  
-**Authority reviewed:** `maikolsiragusaa/metrora@c960183820467c73ce92c8ccc606a6dd3552c80c`
+**Decision revision:** 2026-09-05
 
-Metrora is a local-first control and intelligence system for AI-assisted development. Product surfaces compose around shared facts/contracts instead of growing into parallel engines that each invent their own truth or execution mechanics.
+Metrora is a local-first control and intelligence system for AI-assisted development. Its surfaces compose around shared facts and explicit authority boundaries instead of becoming parallel engines that each invent their own truth or execution mechanics.
 
-This page distinguishes what exists now from what remains future work.
+This page is deliberately public-facing: it explains what exists, how the pieces fit together and which directions are being explored. It does **not** publish private implementation sequencing, commercial packaging or internal infrastructure.
 
-## How the ecosystem fits together
+## The ecosystem in one diagram
 
-```text
-Usage · Activity · Models · Capacity · Projects
-                  ↓
-             Metrora Tools
-         ┌─────────┼───────────┐
-         ↓         ↓           ↓
-        MCP   integrations   Desktop
-                                  │
-                                  └─ Code
-                                     ↓
-                                  OpenCode
-                         Sessions · Agents · Tools
-                         files · shell · Git · MCP/ACP
+```mermaid
+flowchart LR
+    F[Canonical Metrora facts] --> U[Usage / Activity / Sessions]
+    F --> M[Models / economics]
+    F --> P[Projects / context]
+    F --> C[Capacity / coverage]
+    F --> B[Bench]
 
-Bench   = methodology-bound test/evidence system
-Widgets = shareable presentation of canonical evidence
-Wrapped = recap/share experience built on canonical evidence + Widgets
+    U --> T[Metrora Tools]
+    M --> T
+    P --> T
+    C --> T
+    B --> T
+
+    F --> D[Desktop]
+    F --> CLI[CLI / local web]
+    F --> A[Android]
+    T --> MCP[Local MCP / integrations]
+
+    D --> CODE[Code]
+    CODE --> O[OpenCode upstream]
+    O --> OM[Sessions · Agents · Tools · Files · Shell · Git · MCP/ACP]
 ```
 
-Canonical rule for the Code surface:
+Canonical rule for Code:
 
 > **Metrora adds. OpenCode executes.**
 
-Metrora owns the host boundary, canonical evidence/accounting and Metrora-specific Tools/context. OpenCode owns the commodity coding surface and its Sessions, Agents/Subagents, provider/model controls, standard Tools, filesystem/shell/Git mechanics and ordinary permissions/questions.
+Metrora owns canonical evidence/accounting, Projects, Capacity, Bench, its Tool contracts, the host/security boundary and product context. OpenCode owns the commodity coding surface and its normal session/agent/tool mechanics.
 
 ## Current status
 
-| Surface | Product job | Status |
+| Surface | Product job | Current status |
 | --- | --- | --- |
-| **Usage / Activity / Models / Capacity** | Factual local evidence, history, economics and provider-reported capacity | **Available** |
+| **Usage / Activity / Sessions / Models** | Local factual evidence, history, attribution and economics | **Available**, with ongoing data-quality and product-depth work |
 | **Projects** | User-controlled Metrora context and scope across relevant evidence | **Available** |
-| **Tools** | Typed factual access to Metrora evidence | **Available** — canonical registry, contract, evidence and privacy layer |
-| **Code** | Coding/agent work through official upstream OpenCode hosted by Desktop | **Available** — accepted OpenCode `1.18.27` runtime/Web UI with Metrora host lifecycle, security, packaging and accounting integration |
-| **Bench** | Performance-first testing plus separate Compatibility / Runtime Health evidence | **Available** — native llama.cpp/`llama-bench` Performance and Core Compatibility are separate bounded paths |
-| **ACT / ActionContract** | Trusted lifecycle for the bounded Metrora-owned Core Compatibility action | **Available for that narrow operation** — not a user-facing mode and not a universal wrapper around Code |
-| **MCP** | Standard external access to canonical Metrora Tools | **Available** — local read-only MCP Server V1 |
-| **Widgets** | Shareable visual/statistical presentation of canonical evidence | **Foundation exists through Share Card; broader Widgets family planned** |
-| **Wrapped** | Periodic recap/share experience using canonical evidence and Widgets | **Planned** |
-| **Durable Jobs / remote control** | Future Metrora-owned work/status/result control above local sessions when needed | **Future / separately gated** |
+| **Capacity** | Provider-reported quota/capacity where trustworthy evidence exists | **Available** with explicit unavailable/stale semantics |
+| **Tools** | Typed factual access to canonical Metrora evidence | **Available** — shared registry, contracts, evidence and privacy layer |
+| **Code** | Coding/agent work through upstream OpenCode hosted by Desktop | **Available** — accepted OpenCode `1.18.27` runtime/Web UI with Metrora host lifecycle, prewarm, security, persistence, packaging and accounting integration |
+| **Bench** | Performance-first testing plus separate Compatibility / Runtime Health evidence | **Available foundations** — native llama.cpp/`llama-bench` Performance and Core Compatibility remain separate bounded paths |
+| **MCP** | External factual access to canonical Metrora Tools | **Available** — local read-only MCP Server V1 |
+| **Android** | Read-focused companion to an explicitly paired Desktop | **Live on Google Play**; direct APK channel also documented |
+| **ACT / ActionContract** | Trusted lifecycle for explicitly Metrora-owned bounded actions | **Available for a narrow Core Compatibility operation**; not a universal wrapper around Code |
+| **Widgets / recap surfaces** | Privacy-aware presentation/share experiences built from canonical evidence | **Foundation exists; broader direction planned** |
+| **Remote/background/external control** | Bounded supervision and delegation above local sessions | **Future / separately gated** |
 
-Status labels are intentionally conservative. A direction is not presented as shipped until working product authority exists.
+Status labels are intentionally conservative. A public direction is not described as shipped until working product authority exists.
 
-## Code
+## Code: upstream engine, Metrora control center
 
-The Desktop **Code** destination hosts the real official upstream OpenCode Web UI/runtime rather than a Metrora reconstruction of it.
+The Desktop **Code** destination hosts the real upstream [OpenCode](https://github.com/anomalyco/opencode) Web UI/runtime rather than a Metrora reconstruction.
 
-Current accepted host boundary includes:
+The accepted host boundary includes:
 
-- pinned OpenCode `1.18.27`;
-- deterministic staged binary/provenance checks;
-- loopback-only embedded server;
-- random per-launch authentication held by the Electron main process;
+- pinned OpenCode `1.18.27` provenance;
+- deterministic staged binary checks;
+- loopback-only embedded serving;
+- random per-launch authentication held by Electron main;
 - exact-origin navigation restrictions and popup denial;
-- persistent upstream browser/project UI state;
+- persistent upstream browser/project state;
+- prewarmed hidden loading for fast Code entry;
 - clean sidecar shutdown;
-- Windows packaging paths that include the pinned OpenCode runtime.
+- Windows package paths that include the pinned runtime;
+- Metrora accounting under the canonical **OpenCode** collector.
 
-OpenCode remains upstream authority for its own coding Sessions and agent mechanics. Metrora does not create a second conversation/session universe for the same work.
+OpenCode remains upstream authority for its coding Sessions, Agents/Subagents and standard coding mechanics. Metrora does not create a second conversation/session universe for the same work.
 
-Metrora accounting continues to identify this source as **OpenCode**. Being launched inside Metrora does not invent a new provider identity.
+OpenCode is third-party upstream software and remains independently maintained. The integration does not imply affiliation or endorsement.
 
 ## Metrora Tools inside Code
 
-Metrora-specific intelligence is added to the upstream Code surface through bounded Metrora Tools rather than through a parallel coding-agent engine.
+The point of Metrora Tools is to let an accepted runtime ask Metrora-specific factual questions **without moving accounting or evidence logic into the runtime adapter**.
 
-The first accepted end-to-end proof is `metrora_usage_snapshot`:
+The first physically accepted proof is the bounded `metrora_usage_snapshot` integration:
 
 ```text
-user asks a Metrora-specific question in Code
-→ OpenCode selects metrora_usage_snapshot
-→ Metrora returns bounded canonical evidence
-→ OpenCode explains the result
+question inside Code
+      ↓
+OpenCode chooses a Metrora-specific tool
+      ↓
+Metrora returns bounded factual evidence
+      ↓
+OpenCode explains the result
 ```
 
-Future factual Tool expansion should reuse the same canonical Metrora registries/contracts used elsewhere rather than implement Code-specific accounting or evidence paths.
+The broader direction is to expose high-value canonical Metrora capabilities through the shared Tool contracts — not to create dozens of duplicate Code-only mini APIs.
 
-A Tool result remains evidence. A caller or model may explain it, but cannot silently replace Metrora's canonical measurement, scope or unavailable-state semantics.
+Examples of canonical factual families already represented in the Metrora Tool layer include:
 
-## Tools
-
-Metrora already has typed read-only capabilities for questions such as:
-
-- spend/Usage snapshots;
-- model-efficiency evidence;
-- provider Capacity/quota snapshots;
-- overview evidence;
+- spend/Usage evidence;
+- model/economics evidence;
+- overview/context evidence;
 - Project drivers;
 - Session highlights;
-- coverage information;
-- Bench evidence.
+- coverage/freshness;
+- Bench evidence;
+- provider Capacity where the consuming authority can supply it truthfully.
 
-The reusable implementation lives in `src/tools`; the factual registry is not owned by one UI.
+A model may explain a Tool result. It may not silently replace Metrora's canonical measurement, scope or unavailable-state semantics.
 
-The same factual capability can therefore be consumed by Local MCP, Code integrations and other bounded surfaces without implementing parallel evidence engines.
+## MCP: interoperability without becoming the proxy
 
-## MCP
+The shipped Metrora MCP Server V1 is **local and read-only**. It exposes canonical factual Tools to compatible external clients without requiring ordinary AI requests to pass through Metrora.
 
-Metrora adopts the Model Context Protocol as an interoperability direction.
-
-The shipped first product is a **local, read-only Metrora MCP Server V1** that exposes canonical factual Tools.
-
-A compatible external AI client can use Metrora facts without requiring AI traffic to pass through a Metrora proxy.
-
-Local MCP V1 principles:
+Principles:
 
 - local-first and account-optional;
-- public Community interoperability;
-- read-only first;
-- no duplicate MCP-specific accounting/evidence engine;
+- factual/read-only first;
+- shared Tool/evidence authority rather than MCP-specific accounting;
 - no arbitrary shell, filesystem, repository or secret access;
-- no ability to bypass Metrora privacy/scope contracts;
-- failure of MCP cannot corrupt canonical Metrora history.
+- no bypass around Metrora privacy/scope contracts;
+- MCP failure cannot corrupt canonical Metrora history.
 
-A future hosted or state-changing control surface is separate work. OpenCode's ability to consume MCP servers is also distinct from exposing Metrora for inbound external control.
+OpenCode consuming MCP servers is a different direction from an external client controlling Metrora. The two should not be confused.
 
-### Future control through external clients
+## Future external control
 
-Future external control should use an explicit bounded Metrora-owned control object rather than grant a client generic execution authority.
+Metrora's public direction includes the possibility of **bounded external control and remote/background supervision**.
 
-Conceptually:
+The public concept is intentionally simple:
 
 ```text
-external AI client
-→ Metrora MCP or bounded control API
-→ Metrora facts / Project / optional durable Job
-→ authorized execution through an accepted runtime where needed
-→ status / result / evidence
+ChatGPT / Claude / compatible external client
+                    ↓
+        bounded Metrora control boundary
+                    ↓
+       Metrora context + evidence + policy
+                    ↓
+      accepted execution runtime when needed
+                    ↓
+          status / result / evidence
 ```
 
-The exact Job/control schema, authorization and remote lifecycle are future work. Local MCP V1 remains read-only until such a contract exists.
+This is future work, not a claim that today's read-only MCP server can execute arbitrary tasks.
 
-Browser/UI automation is not part of the public architecture described here.
-
-## ACT / ActionContract
-
-The current public ActionContract foundation is intentionally narrow.
-
-Today it binds `metrora.action.v1` to the bounded `run-core-compatibility` workflow and its confirmation/lifecycle/evidence semantics.
-
-It remains useful for that Metrora-owned operation, but it should not be interpreted as a requirement that every ordinary OpenCode file edit, shell command or Git action pass through a second Metrora permission engine. Those everyday coding mechanics belong to the accepted upstream Code surface.
-
-If Metrora later introduces stronger Metrora-owned effects — for example remote/background Jobs or other explicitly authorized product workflows — they require their own bounded trust/control contracts.
+The architecture should preserve explicit authorization and avoid browser/UI automation as the product control plane.
 
 ## Bench
 
-Metrora Bench remains a separate evidence system rather than becoming a generic “AI score”.
+Metrora Bench remains a methodology-bound evidence system rather than a generic “AI score”.
 
-Primary direction:
+Primary public direction:
 
-- **Performance** — how a declared model/runtime/configuration actually runs on declared hardware.
+- **Performance** — how a declared model/runtime/configuration actually behaves on declared hardware.
 
 Separate evidence families:
 
-- **Compatibility / Runtime Health** — including the current deterministic `core-v1` checks;
-- **Coding Evaluation** — future, separately versioned and methodology/licence/sandbox gated;
-- **Agent Evaluation** — future, separately versioned and methodology/isolation gated.
+- **Compatibility / Runtime Health** — including deterministic Core Compatibility;
+- **Coding Evaluation** — future, versioned and methodology/licence/sandbox gated;
+- **Agent Evaluation** — future, versioned and methodology/isolation gated.
 
-The existence of real OpenCode Agent/Subagent execution does not by itself define an Agent Evaluation methodology.
+Real OpenCode Agent/Subagent execution already exists. That does not by itself define a reproducible Agent Evaluation methodology.
 
-A supported ActionContract may invoke a specific Bench workflow, but Bench remains the canonical owner of Bench evidence/history.
+## ACT / ActionContract
 
-## Widgets and Wrapped
+ACT is intentionally narrow.
 
-Metrora already has a local **Share Card** foundation. The broader direction is to evolve this into **Widgets**: reusable, privacy-aware visual presentations of canonical Metrora evidence.
+The current public ActionContract foundation binds a documented Metrora-owned Core Compatibility workflow to explicit confirmation/lifecycle/evidence semantics.
 
-Possible future Widgets include:
+It is **not** a requirement that ordinary OpenCode edits, shell commands or Git actions pass through a second Metrora permissions engine. Those mechanics belong to the upstream Code surface.
+
+Future stronger Metrora-owned effects, if shipped, require their own explicit trust/control boundary.
+
+## Android
+
+Metrora for Android is live on [Google Play](https://play.google.com/store/apps/details?id=eu.metrora.app).
+
+The companion consumes bounded projections from an explicitly paired Desktop. It does not independently become the collector, pricing authority or canonical history engine.
+
+The direct production-signed APK channel remains useful for intentional direct installation/Obtainium and has its own source/signing/integrity contract.
+
+## Widgets, sharing and recap direction
+
+Metrora already has a local Share Card foundation. A broader direction is to build reusable, privacy-aware presentation primitives from canonical evidence, for example:
 
 - Usage/cost cards;
 - model/provider mix;
 - Project or Activity summaries;
 - Bench Performance results;
-- Compatibility results;
-- methodology-labelled comparisons.
+- methodology-labelled comparisons;
+- periodic recap experiences.
 
-Local static sharing should remain useful without requiring an account. Any future hosted/live sharing is a separate service decision.
-
-**Wrapped** is not a second analytics engine. It is a recap/share experience — for example monthly or annual — built from canonical Metrora evidence and Widget presentation primitives.
+The important boundary is that presentation does not become a second analytics engine. A share/recap surface should be derived from canonical Metrora evidence.
 
 ## Naming
 
-Ordinary pages stay concise:
+Ordinary product navigation stays concise:
 
 `Usage · Activity · Models · Capacity · Projects · Code · Bench · Settings`
 
-Systems with an independent interaction/protocol identity can carry a fuller name on first/external mention, for example:
+Systems with an independent protocol/methodology identity can use fuller names on first mention:
 
 - **Metrora Bench**;
 - **Metrora MCP Server**.
 
-Within an established Metrora context, prefer:
+`ACT` remains a bounded action authority, not a primary product mode. There is no current separate `Swarm` product surface.
 
-`Code · Tools · MCP · Bench · Projects · Widgets`
+## Public direction
 
-rather than repeating “Metrora” before every noun.
+The next public direction is deliberately expressed as capability growth rather than a private milestone schedule:
 
-`ACT` remains an internal/bounded action authority, not a primary navigation item. There is no current separate `Swarm` product surface.
+```text
+CURRENT CONTROL CENTER
+Usage · Activity · Models · Projects · Capacity · Bench · Code
+                         │
+                         ▼
+       stronger Sessions / Models / factual quality
+                         │
+                         ▼
+      richer Projects / Capacity / Bench context
+                         │
+                         ▼
+      more canonical Tools across Code + integrations
+                         │
+                         ▼
+       bounded remote/background/external control
+                         │
+                         ▼
+       evidence-aware assistance and automation
+```
 
-## Public README direction
+Parallel work can improve collectors, pricing/provenance, Bench reliability, Android supervision and distribution quality without waiting for later control capabilities.
 
-The repository README should remain easy for users and contributors to understand at a glance:
+What is intentionally **not** published here:
 
-- immediate download/install actions near the top;
-- concise `Observe · Compare · Code · Control` thesis;
-- truthful current Code/OpenCode boundary;
-- clear current/future labels;
-- local-first/privacy positioning;
-- supported-tools credibility;
-- obvious routes into documentation and contribution.
+- internal implementation sequencing;
+- private infrastructure topology;
+- credentials or operational access patterns;
+- unpublished commercial packaging/pricing;
+- private routing/decision policy details.
 
-Original Metrora visuals/copy are preferred over cloning another project's branded imagery.
+The public promise is architectural rather than tactical: Metrora should become a stronger control center by improving its own facts, context, intelligence and control — **not by rebuilding mature commodity engines merely to own more code**.
 
-## Visual-asset provenance
+## Visual direction
 
-Metrora contains historical visual material inherited from the incorporated upstream snapshot. A 2026-08-30 audit confirmed that multiple old top-level repository marketing/screenshots in `assets/` are byte-identical to material from that incorporated upstream source.
+Current Markdown diagrams are intentionally source-versionable. Product screenshots and original Metrora diagrams can be added later without changing the authority described here.
 
-Before using assets for current Metrora marketing:
-
-- remove obsolete inherited screenshots when proven unused;
-- do not present inherited marketing imagery as new Metrora brand artwork;
-- do not delete runtime/package assets without proving they are unused;
-- review provider logos/icons separately because trademark/asset rights are independent from repository code licensing;
-- replace README/marketing visuals progressively with original Metrora artwork or current truthful screenshots.
-
-Required upstream provenance/licence notices remain governed by `THIRD_PARTY_NOTICES.md` and `LICENSES/`.
-
-## Near-term progression
-
-This is dependency-oriented direction, not a rigid roadmap gate:
-
-1. **Code/OpenCode** — keep the accepted pinned upstream surface, host/security/persistence/accounting and packaging boundary healthy.
-2. **Code host UX** — reduce first-entry latency/blank loading at the host layer without reconstructing the upstream UI.
-3. **Metrora Tools in Code** — add the highest-value bounded factual capabilities through canonical Tool contracts.
-4. **Local MCP V1** — keep factual/read-only interoperability stable; stronger control remains separately gated.
-5. **README / asset truthfulness** — keep the public story aligned with the shipped product.
-6. **Widgets** — evolve Share Card into reusable static/privacy-aware presentations when useful.
-7. Maintain independent **llama.cpp / Performance Bench** reliability/provenance work.
-8. Durable Job/external-control work remains later and separately authorized.
+Historical/inherited marketing imagery should not be presented as new Metrora artwork. Third-party logos and marks remain subject to their own trademark/licence rules.
 
 See also:
 
+- [`architecture.md`](architecture.md)
+- [`OPENCODE_UPSTREAM_SURFACE_001.md`](OPENCODE_UPSTREAM_SURFACE_001.md)
 - [`BENCH_EVIDENCE_FAMILIES.md`](BENCH_EVIDENCE_FAMILIES.md)
 - [`ACT_CONTRACT_PREP_001.md`](ACT_CONTRACT_PREP_001.md)
 - [`PRODUCT_PRINCIPLES.md`](PRODUCT_PRINCIPLES.md)

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -1,23 +1,60 @@
 # Getting started
 
-Metrora for Windows is available on the **Microsoft Store**, published by Vensent. The Store package is the supported public Windows distribution. You can also build Metrora from source for development, inspection and contribution.
+Metrora is available through official Store channels and can also be built from source for development, inspection and contribution.
+
+- **Windows:** [Microsoft Store](https://apps.microsoft.com/detail/9NXSZFQSBBDX)
+- **Android:** [Google Play](https://play.google.com/store/apps/details?id=eu.metrora.app)
+- **Source:** this repository
+
+Ordinary local use does not require a Metrora account or a mandatory AI-request proxy.
+
+## Install on Windows
+
+The Microsoft Store package is the supported public Windows distribution, published by Vensent.
 
 [Get Metrora from Microsoft Store](https://apps.microsoft.com/detail/9NXSZFQSBBDX)
 
-Repository source may be newer than the currently published Store package. Source builds must therefore be identified by their exact commit/version and must not be treated as Store-signed packages.
+The current live Store line is RC11 (`1.0.0-rc.11`, Desktop `1.0.0.11`, Store package `1.0.1.0`). The package contains the Desktop application and bundled Metrora CLI runtime; ordinary users do not need a separate Node.js installation.
 
-## Requirements
+Repository source may be newer than the currently published Store package. A source checkout or locally generated package must therefore be identified by its exact commit/version and must not be presented as Store-signed authority.
+
+## Install the Android companion
+
+Metrora for Android is live on Google Play under application ID `eu.metrora.app`.
+
+[Get Metrora on Google Play](https://play.google.com/store/apps/details?id=eu.metrora.app)
+
+Android is a companion to an explicitly paired Metrora Desktop. It consumes bounded Desktop-generated projections and does not independently become the collector, pricing engine, accounting authority or canonical history source.
+
+The production-signed direct GitHub APK channel also remains available for users who intentionally choose direct installation or Obtainium. The current documented direct release is [`0.1.0-alpha.3`](https://github.com/maikolsiragusaa/metrora/releases/tag/android-v0.1.0-alpha.3); direct-channel release history and integrity details are documented separately rather than making this getting-started guide a release ledger.
+
+See [Android public distribution](ANDROID_PUBLIC_DISTRIBUTION_V1.md), [Android companion foundation](ANDROID_COMPANION_FOUNDATION.md) and [Local companion API](LOCAL_COMPANION_API.md).
+
+## First look at Metrora Desktop
+
+The product is organized around four jobs:
+
+```text
+Observe  → Usage · Activity · Sessions · Projects
+Compare  → Models · economics · Bench · coverage
+Code     → upstream OpenCode hosted inside Metrora
+Control  → Capacity · budgets · Project context · explicit local controls
+```
+
+The **Code** destination embeds the upstream OpenCode runtime/Web UI. OpenCode owns ordinary coding sessions, agents, tools, files, shell and Git mechanics; Metrora owns the surrounding host, facts, evidence and product context.
+
+See [Architecture](architecture.md), [OpenCode upstream surface](OPENCODE_UPSTREAM_SURFACE_001.md) and [Ecosystem surfaces](ECOSYSTEM_SURFACES.md).
+
+## Build from source
 
 For repository development and source evaluation use:
 
 - Git;
 - Node.js 22.15 or newer;
 - npm;
-- at least one supported AI tool with local usage records.
+- at least one supported AI tool with local usage records for meaningful collector output.
 
-The package metadata retains a lower CLI engine floor for compatibility, but repository builds and CI use the stricter development runtime. Contributors and evaluators should use Node.js 22.15 or newer.
-
-## Build the CLI
+Clone and build the CLI:
 
 ```bash
 git clone https://github.com/maikolsiragusaa/metrora.git
@@ -26,13 +63,13 @@ npm ci
 npm run build:cli
 ```
 
-Show the canonical command surface through the development runner:
+Show the canonical command surface:
 
 ```bash
 npm run dev -- --help
 ```
 
-The root npm package is intentionally private. Do not treat npm publication or an inherited package name as an official Metrora distribution channel.
+The root npm package is intentionally private. npm publication or an inherited package identity is not an official Metrora distribution channel.
 
 ## Run the first report
 
@@ -42,13 +79,13 @@ Open the interactive terminal dashboard:
 npm run dev
 ```
 
-Generate a plain-text overview for the current month:
+Generate an overview:
 
 ```bash
 npm run dev -- overview
 ```
 
-Filter to one provider:
+Filter to a provider:
 
 ```bash
 npm run dev -- overview --provider codex
@@ -66,30 +103,30 @@ Open the local browser dashboard:
 npm run dev -- web
 ```
 
-The web dashboard is served from the local machine. It is not a hosted account service.
+The browser dashboard is served from the local machine. It is not a hosted Metrora account service.
 
 ## Confirm what Metrora found
 
-Run provider diagnostics when a tool is missing or the totals appear incomplete:
+If a tool is missing or totals look incomplete, inspect discovery and evidence before assuming zero:
 
 ```bash
 npm run dev -- doctor
 npm run dev -- doctor --provider codex
 ```
 
-Use the token audit for a closer comparison between source evidence and displayed totals:
+For a closer comparison between source evidence and displayed totals:
 
 ```bash
 npm run dev -- audit --provider codex
 ```
 
-A provider may expose measured token counts, cumulative counters, derived deltas or only enough content for an estimate. Metrora keeps those evidence classes distinguishable rather than treating every source as equally precise.
+A provider may expose measured token counts, cumulative counters, derived deltas or only enough content for an estimate. Metrora keeps these evidence classes distinguishable.
 
-See [Supported tools](SUPPORTED_TOOLS.md) and the relevant file under [`docs/providers`](providers/).
+See [Supported tools](SUPPORTED_TOOLS.md) and [`docs/providers`](providers/).
 
-## Explore common workflows
+## Common CLI workflows
 
-### Review sessions
+### Sessions
 
 ```bash
 npm run dev -- sessions
@@ -97,28 +134,29 @@ npm run dev -- sessions --provider claude
 npm run dev -- sessions --format json
 ```
 
-### Compare models
+### Models and comparison
 
 ```bash
+npm run dev -- models
 npm run dev -- compare
 npm run dev -- compare --provider codex
 ```
 
-### Find optimization opportunities
+### Diagnostics and optimization
 
 ```bash
+npm run dev -- doctor
 npm run dev -- optimize
 npm run dev -- optimize --provider claude
-npm run dev -- optimize --format json
 ```
 
-Configuration-changing optimization actions are opt-in, backed up and journaled. Review a dry run before applying changes:
+Configuration-changing optimization actions are explicit. Review a dry run before applying a supported change:
 
 ```bash
 npm run dev -- optimize --apply --dry-run
 ```
 
-### Configure budgets
+### Budgets
 
 ```bash
 npm run dev -- budget --monthly 100
@@ -126,16 +164,18 @@ npm run dev -- budget --check
 npm run dev -- budget --list
 ```
 
-### Export data
+### Export
 
 ```bash
 npm run dev -- export --format json
 npm run dev -- export --format csv --from 2026-08-01 --to 2026-08-05
 ```
 
-Exports should be reviewed before sharing. Prompts, responses, source code, patches and secrets are outside the default analytical export boundary, but project and environment metadata may still be sensitive in a particular context.
+Review exports before sharing. Ordinary analytical exports exclude prompt/response bodies, source code, patches and secrets, but Project/environment metadata can still be sensitive in context.
 
-## Build the desktop application
+The complete command surface is in [CLI reference](CLI_REFERENCE.md).
+
+## Build the Desktop application
 
 ```bash
 npm --prefix app ci
@@ -144,23 +184,13 @@ npm --prefix app run typecheck
 npm --prefix app run build
 ```
 
-Development builds are not official Store-signed releases. Windows is the first supported public desktop distribution, and the Microsoft Store package is the recommended Windows install path. The current live Store line is RC11 (`1.0.0-rc.11`, Desktop `1.0.0.11`, Store package `1.0.1.0`). Repository packaging commands remain development and verification tools rather than alternate public distribution channels.
+Development builds are not official Store-signed releases. Repository packaging commands remain development/verification tools rather than alternate public Store authority.
 
-See [Windows distribution](WINDOWS_DISTRIBUTION.md), [Versioning authority](VERSIONING.md) and [`RELEASING.md`](../RELEASING.md).
+The Desktop build also stages the pinned upstream OpenCode runtime used by the Code surface. Future OpenCode updates are reviewed/pinned deliberately rather than following an unverified `latest` binary.
 
-## Android companion
+See [Windows distribution](WINDOWS_DISTRIBUTION.md), [Versioning](VERSIONING.md) and [`RELEASING.md`](../RELEASING.md).
 
-The current public GitHub pre-release is [`0.1.0-alpha.3`](https://github.com/maikolsiragusaa/metrora/releases/tag/android-v0.1.0-alpha.3), distributed as a production-signed direct APK for `eu.metrora.app` with `versionCode = 3`. `0.1.0-alpha.1` remains immutable historical release evidence; `0.1.0-alpha.2` was never published.
-
-The current RC11 Microsoft Store Desktop includes the companion runtime used by alpha.3, so ordinary Windows users can pair the Android companion with the Store installation. The Android companion remains read-focused and does not become a second collection, pricing, accounting or history authority.
-
-For direct installation:
-
-- download `Metrora-Android-0.1.0-alpha.3.apk` from the alpha.3 GitHub Release;
-- verify the attached manifest and `SHA256SUMS` if desired;
-- Obtainium users can track the repository's `android-v*` releases.
-
-Google Play publication is planned within 30 days. Until that channel is actually live, the production-signed GitHub APK remains the current public Android distribution authority. F-Droid remains separately gated.
+## Android development
 
 For repository Android development use:
 
@@ -168,38 +198,34 @@ For repository Android development use:
 - Gradle 9.6.1, or the project-supported equivalent;
 - Android SDK Platform 36.
 
-The canonical contributor checks are:
+Canonical contributor checks include:
 
 ```bash
 gradle -p android --no-daemon :app:testGithubDebugUnitTest :app:lint :app:assembleGithubDebug
 ```
 
-To validate the unsigned distribution channels used by the repository workflow:
+To validate repository distribution variants:
 
 ```bash
 gradle -p android --no-daemon :app:assembleGithubRelease :app:assembleFdroidRelease :app:bundlePlayRelease
 ```
 
-The dedicated non-production QA identity is used only for trusted same-repository physical-acceptance CI and is not required for these commands. Production, QA, F-Droid and Play signing remain separate; no private signing material belongs in Git.
-
-See [Android public distribution v1](ANDROID_PUBLIC_DISTRIBUTION_V1.md), [Android companion foundation](ANDROID_COMPANION_FOUNDATION.md) and [Local companion API v1](LOCAL_COMPANION_API.md).
+Production, QA, direct, F-Droid and Play signing boundaries remain separate. No private signing material belongs in Git, public issues, pull requests or ordinary logs.
 
 ## Local files and compatibility
 
-The current package publishes only the `metrora` command. Fresh installations
-use canonical Metrora config and cache roots and do not infer retired
-pre-release roots, aliases or pointers. Existing canonical analytics and
-history are preserved; historical Workspace and signed-evidence identifiers
-remain a separate technical boundary documented in
-[`TECHNICAL_IDENTITY_COMPATIBILITY.md`](TECHNICAL_IDENTITY_COMPATIBILITY.md).
+The current package publishes only the `metrora` command. Fresh installations use canonical Metrora config/cache roots and do not infer retired pre-release roots, aliases or pointers.
+
+Historical Workspace/signed-evidence identifiers may remain where changing them would break installed state. They are compatibility details, not current product branding. See [Technical identity compatibility](TECHNICAL_IDENTITY_COMPATIBILITY.md).
 
 ## Troubleshooting
 
-1. Confirm Node.js and npm versions.
-2. Run `npm ci` again from a clean checkout.
+1. Confirm the relevant Store/source version first.
+2. For source builds, confirm Node.js/npm versions and run `npm ci` from a clean checkout.
 3. Run `npm run dev -- doctor`.
 4. Open the provider document for the affected tool.
-5. Verify the tool has actually written local session or usage data.
-6. Use synthetic or sanitized evidence when opening a public issue.
+5. Confirm the provider/client actually wrote local evidence in the selected period.
+6. Keep missing/unavailable evidence distinct from zero.
+7. Use synthetic or sanitized evidence when opening a public issue.
 
 Security vulnerabilities must be reported privately according to [`SECURITY.md`](../SECURITY.md).

--- a/docs/OPENCODE_UPSTREAM_SURFACE_001.md
+++ b/docs/OPENCODE_UPSTREAM_SURFACE_001.md
@@ -1,26 +1,185 @@
 # OpenCode upstream surface
 
-This public engineering note records the bounded `OPENCODE_UPSTREAM_SURFACE_001`
-spike. Metrora hosts the official OpenCode `v1.18.27` release binary from
-`anomalyco/opencode`, source commit
-`b04697366f05419e9bd7a92f841813dd976161c9`, with its embedded Web UI served by
-`opencode serve` inside an Electron `WebContentsView`.
+**Status:** accepted public Code foundation.
 
-The sidecar is application-owned and listens only on `127.0.0.1` with
-per-launch Basic Auth credentials held by Electron's main process. The Code
-renderer contains only a layout host; Sessions, agents, providers, models,
-reasoning, permissions, questions, Git, MCP, and the remaining coding-agent
-mechanics stay owned by the upstream Web UI and server.
+Metrora Desktop embeds the official upstream [OpenCode](https://github.com/anomalyco/opencode) runtime and Web UI as its **Code** destination.
 
-Metrora contributes exactly one OpenCode custom tool,
-`metrora_usage_snapshot`. It reads a bounded, sanitized, read-only projection of
-today's Metrora usage. Prompt/response content, source code, credentials, and
-arbitrary CLI payload fields are not included in that projection.
+This is a deliberate product decision: Metrora does not rebuild a second generic coding-agent engine merely to own the UI or session loop.
 
-The binary is staged from the official GitHub release asset, verified against a
-pinned archive SHA-256, and packaged with a generated binary identity record.
-The upstream MIT notice is preserved in
-[`LICENSES/OPENCODE-MIT.txt`](../LICENSES/OPENCODE-MIT.txt).
+> **Metrora adds. OpenCode executes.**
 
-This note documents adoption evidence for the spike only; Founder physical
-acceptance remains pending.
+## What this means
+
+Inside Code, OpenCode remains responsible for ordinary coding mechanics such as:
+
+- coding Sessions;
+- Agents and Subagents;
+- provider/model selection and reasoning controls;
+- standard Tools;
+- files and edits;
+- shell/terminal;
+- Git;
+- ordinary permissions/questions;
+- MCP/ACP mechanics supplied by OpenCode.
+
+Metrora owns the surrounding product boundary:
+
+- local usage/accounting evidence;
+- Models, Projects, Capacity and Bench context where Metrora has canonical facts;
+- bounded Metrora-specific Tool integrations;
+- the Electron host/security lifecycle;
+- provenance/version pinning;
+- persistent project/browser state;
+- packaging and clean shutdown.
+
+The result is one coding surface, not two competing session universes.
+
+## Current upstream pin
+
+Metrora currently hosts OpenCode `1.18.27` from `anomalyco/opencode`.
+
+Pinned upstream source commit:
+
+`b04697366f05419e9bd7a92f841813dd976161c9`
+
+The Windows binary is staged from the official release asset, verified against pinned release/binary provenance and packaged with the Desktop candidate.
+
+OpenCode is MIT licensed; the required upstream notice is preserved in [`LICENSES/OPENCODE-MIT.txt`](../LICENSES/OPENCODE-MIT.txt).
+
+Metrora does not automatically follow an unreviewed `latest` OpenCode binary. Future upstream updates require a deliberate provenance/security/packaging regression pass.
+
+## Host architecture
+
+```text
+Metrora Desktop
+      │
+      ├─ Metrora product UI / facts / Tools
+      │
+      └─ Code
+          │
+          └─ Electron WebContentsView
+                 │
+                 └─ 127.0.0.1 only
+                     OpenCode serve
+                         │
+                         └─ upstream Web UI + runtime
+```
+
+The sidecar is application-owned and listens on loopback only.
+
+Accepted host properties include:
+
+- `opencode serve` rather than opening an external browser;
+- random per-launch Basic Auth credentials;
+- credentials retained in Electron main-process authority rather than exposed to the renderer;
+- exact-origin navigation restrictions;
+- popup denial;
+- persistent browser partition/project UI state;
+- stable preferred loopback origin where available;
+- prewarmed hidden loading so first Code entry does not require a cold white-page start;
+- clean process shutdown when Metrora exits;
+- deterministic Windows staging/packaging of the pinned runtime.
+
+The Code renderer remains a host/layout surface rather than a custom OpenCode client.
+
+## Project and session continuity
+
+Metrora deliberately avoids creating a second OpenCode project/session database.
+
+OpenCode's standard local session/data store remains OpenCode authority. The Metrora-hosted Web surface preserves its own browser/project UI state and can import the normal OpenCode Desktop project list through a bounded read-only path.
+
+This gives users continuity without synchronizing two independent session engines.
+
+## Metrora accounting
+
+Activity from the embedded coding surface is identified under the canonical collector/provider identity:
+
+`OpenCode`
+
+Metrora being the host does not invent an `OpenCode-Metrora` provider or rewrite the actual model/provider identity contained in the underlying evidence.
+
+Surface metadata can remain separate from provider/accounting identity when needed.
+
+## Metrora-specific factual context
+
+The accepted foundation includes a bounded Metrora custom-tool path inside OpenCode.
+
+The first physically validated proof is:
+
+`metrora_usage_snapshot`
+
+It exposes a small sanitized read-only projection of current Metrora usage so a user can ask a Metrora-specific factual question inside Code and let OpenCode answer from Metrora evidence.
+
+```text
+user question in Code
+      ↓
+OpenCode tool selection
+      ↓
+bounded Metrora Tool/projection
+      ↓
+canonical Metrora evidence
+      ↓
+OpenCode explanation
+```
+
+The direction is to expand useful Metrora-specific factual capabilities by reusing the canonical Metrora Tool/evidence registry rather than copying accounting logic into OpenCode adapters.
+
+Prompt/response bodies, source code, credentials and unrestricted local paths remain outside the default Metrora factual Tool boundary.
+
+## MCP is a separate concept
+
+OpenCode can consume MCP servers as part of its own coding environment.
+
+Separately, Metrora exposes a local read-only MCP Server V1 for external access to canonical factual Metrora Tools.
+
+These are different directions:
+
+```text
+OpenCode → external MCP tools
+```
+
+is not the same as:
+
+```text
+external client → Metrora → controlled work
+```
+
+Future inbound external control/remote supervision remains separately gated and should use an explicit Metrora-owned control boundary rather than assuming today's read-only MCP is an execution API.
+
+## Physical acceptance
+
+The foundation has been physically exercised through the embedded Code surface, including representative checks for:
+
+- shell/terminal;
+- file read/edit/write;
+- Git/diff;
+- provider/model/reasoning interaction;
+- Agent/Subagent behavior;
+- permissions/questions;
+- MCP tool use;
+- Metrora custom-tool use;
+- navigation persistence;
+- restart persistence;
+- project continuity;
+- clean OpenCode process shutdown.
+
+The host prewarm/persistent-view behavior was also physically accepted.
+
+These results establish the Code foundation. They do not imply that every future OpenCode version or every new Metrora Tool is automatically accepted without its own regression/physical check.
+
+## Non-goals
+
+This integration intentionally does not create:
+
+- a forked OpenCode frontend;
+- a Metrora clone of OpenCode sessions/agents;
+- a second filesystem/shell/Git engine;
+- a second generic permissions system around ordinary OpenCode actions;
+- a browser-automation control plane;
+- a fake provider identity for Metrora-hosted OpenCode usage.
+
+## Third-party boundary
+
+OpenCode is third-party upstream software and remains independently maintained. Metrora's use of OpenCode does not imply affiliation with, sponsorship by or endorsement from the OpenCode project.
+
+Required licence/provenance notices remain governed by [`THIRD_PARTY_NOTICES.md`](../THIRD_PARTY_NOTICES.md), [`LICENSES/`](../LICENSES/) and the repository's pinned staging/verification authority.

--- a/docs/PRODUCT_PRINCIPLES.md
+++ b/docs/PRODUCT_PRINCIPLES.md
@@ -16,7 +16,7 @@ Metrora must not trap users behind an account, hosted dashboard or undocumented 
 
 ## Content-minimal by default
 
-The default analytical layer uses structured metadata such as timestamps, model identifiers, token counts, cost, tool names, task categories, project identifiers and measurement provenance.
+The default analytical layer uses structured metadata such as timestamps, model identifiers, token counts, cost, tool names, task categories, Project identifiers and measurement provenance.
 
 Prompts, responses, source code, patches, secrets, tool arguments and unrestricted local paths are outside the default sharing boundary.
 
@@ -47,7 +47,7 @@ A new interface must not reparse the same source data, invent missing facts, rep
 
 ## Sharing is explicit and inspectable
 
-Every device or workspace connection must state what is shared, with whom, for what purpose and how access can be revoked.
+Every device or Workspace connection must state what is shared, with whom, for what purpose and how access can be revoked.
 
 Aggregate views must not silently expose prompts, code, personal file paths or unrelated activity. Shared schemas must be versioned and testable.
 
@@ -55,9 +55,23 @@ Offline or failed delivery must not corrupt the local source of truth. Repeated 
 
 ## The CLI remains first-class
 
-The desktop application, local web interface and companion clients are views over the same trustworthy core. The CLI and public contracts must remain suitable for automation, inspection, migration and independent tooling.
+The Desktop application, local web interface and companion clients are views over the same trustworthy core. The CLI and public contracts must remain suitable for automation, inspection, migration and independent tooling.
 
 A graphical feature should not require a separate measurement implementation when the public core can own the semantics once.
+
+## Adopt mature upstream instead of rebuilding commodity engines
+
+Owning more code is not automatically a product advantage.
+
+When a mature open-source project already owns a commodity subsystem well, Metrora may adopt, pin, verify and integrate that upstream rather than maintain a weaker parallel implementation.
+
+The current Code surface is the clearest example:
+
+> **Metrora adds. OpenCode executes.**
+
+OpenCode owns ordinary coding-agent mechanics; Metrora keeps the host/security boundary and adds the facts, context, evidence and control surfaces that are specific to Metrora.
+
+Upstream adoption must preserve licence/provenance, deterministic versioning and a clean responsibility boundary. A fork or reconstruction should require a proven product/security blocker, not a preference for owning every layer.
 
 ## The open-source project remains genuinely useful
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,105 +1,207 @@
 # Metrora documentation
 
-Metrora is the local-first control center for AI-assisted development. Start with the product surfaces that let you observe Usage, Cost, Models, Projects and Activity; compare evidence; use the accepted Code surface; and manage provider Capacity and explicit local controls without requiring a mandatory Metrora account or AI-traffic gateway.
+Metrora is the local-first control center for AI-assisted development: observe local evidence, compare models and providers, code through the upstream OpenCode surface, and control the Metrora-owned context around that workflow.
 
-This index separates user guidance, current product guarantees, public contracts and contributor-facing technical references.
+If you are new to the project, start with the product first. Deep contracts, migration evidence and release mechanics are intentionally kept lower on this page.
 
-## Use Metrora
+## Start here
 
-- [Getting started](GETTING_STARTED.md) — install or build Metrora, run the first reports and understand the current distribution boundary.
+| I want to… | Read |
+| --- | --- |
+| install Metrora or build it from source | [Getting started](GETTING_STARTED.md) |
+| understand what Metrora is and why it is local-first | [Product principles](PRODUCT_PRINCIPLES.md) |
+| understand the system at a glance | [Architecture](architecture.md) |
+| see what is shipped versus future direction | [Ecosystem surfaces](ECOSYSTEM_SURFACES.md) |
+| understand Code and the OpenCode boundary | [OpenCode upstream surface](OPENCODE_UPSTREAM_SURFACE_001.md) |
+| see which AI tools Metrora can inspect | [Supported tools](SUPPORTED_TOOLS.md) |
+| use the CLI | [CLI reference](CLI_REFERENCE.md) |
+| understand cost/accounting semantics | [Accounting and pricing](ACCOUNTING_AND_PRICING.md) |
+| understand Bench | [Bench evidence families](BENCH_EVIDENCE_FAMILIES.md) |
+| pair Android with Desktop | [Android companion foundation](ANDROID_COMPANION_FOUNDATION.md) |
+| integrate with the local companion API | [Local companion API](LOCAL_COMPANION_API.md) |
+
+## The product in one map
+
+```text
+Observe   → Usage · Activity · Sessions · Projects
+Compare   → Models · economics · Bench · coverage
+Code      → upstream OpenCode inside Metrora Desktop
+Control   → Capacity · budgets · Project context · explicit Metrora-owned actions
+```
+
+The core architectural split is:
+
+> **Metrora adds. OpenCode executes.**
+
+Metrora owns canonical facts, accounting, provenance, Projects, Capacity, Bench, its Tool contracts and the Desktop host boundary. OpenCode owns commodity coding mechanics inside Code: sessions, agents/subagents, standard tools, files, shell, Git and its ordinary interaction flow.
+
+Metrora does not require a second generic agent engine in order to add value around Code.
+
+## Install and use Metrora
+
+### Desktop and Android
+
+- **Windows:** [Microsoft Store](https://apps.microsoft.com/detail/9NXSZFQSBBDX)
+- **Android:** [Google Play](https://play.google.com/store/apps/details?id=eu.metrora.app)
+- **Source / development:** [Getting started](GETTING_STARTED.md)
+
+Android is a companion to an explicitly paired Desktop. Desktop/core remains authoritative for collection, normalization, pricing, accounting, history and evidence; Android consumes bounded projections rather than creating a second factual engine.
+
+### CLI and local web
+
 - [CLI reference](CLI_REFERENCE.md) — public commands grouped by task.
-- [Bench evidence families](BENCH_EVIDENCE_FAMILIES.md) — public distinction between shipped Performance, Compatibility/Runtime Health, future Coding Evaluation and future Agent Evaluation.
-- [Local runtime and Performance Wave 001](LOCAL_RUNTIME_PERFORMANCE_WAVE_001.md) — shipped existing-binary-only native `llama-bench` setup, evidence and safety bounds.
-- [BenchRunV1 local Ollama](BENCHRUN_V1_OLLAMA_LOCAL.md) — shipped bounded runtime-timing evidence from an explicitly selected local Ollama model.
-- [Bench Core Compatibility / Runtime Health v1](BENCH_TASK_PACK_V1.md) — shipped bounded local compatibility checks, model discovery, private history and factual comparison for Ollama.
-- [Supported tools](SUPPORTED_TOOLS.md) — local collector coverage and evidence boundaries.
-- [Provider discovery outcomes v1](PROVIDER_DISCOVERY_OUTCOMES_V1.md) — truthful success/empty/unavailable/failed/partial/cancelled semantics and never-lose cache publication rules.
-- [Provider documentation](providers/) — source locations, formats, limitations and parser notes for individual integrations.
+- [Provider discovery outcomes](PROVIDER_DISCOVERY_OUTCOMES_V1.md) — success, empty, unavailable, failed, partial and cancelled semantics.
+- [Provider documentation](providers/) — source locations, formats and limitations for individual integrations.
 
-## Connect devices locally
+The local browser dashboard is served from the user's machine; it is not a hosted Metrora account service.
 
-- [Android companion foundation](ANDROID_COMPANION_FOUNDATION.md) — the accepted secure pairing foundation plus the implemented Mobile Product Foundation V1 and Activity Sessions/Pull Requests surfaces, Project scope and bounded Android limits; public Android distribution remains separate.
-- [Mobile Product Parity V1 inventory](MOBILE_PRODUCT_PARITY_V1.md) — the current Desktop/core and Android inventory, parity matrix, authority gaps and sequential implementation plan audited from `main`.
-- [Local companion API v1](LOCAL_COMPANION_API.md) — stable local HTTPS endpoints, capability discovery, Project scope and the content-minimal domain contracts used by first-party companions.
+## Understand the factual layer
 
-## Understand the product
+Metrora treats evidence quality as product data rather than an implementation detail.
 
-- [Product principles](PRODUCT_PRINCIPLES.md) — stable local-first, privacy, evidence and portability commitments.
-- [Architecture](architecture.md) — current responsibility and authority map for the public codebase.
-- [Ecosystem surfaces](ECOSYSTEM_SURFACES.md) — current composition/status map for Code, Tools, MCP, Bench, ACT, Widgets and planned capabilities.
-- [ACT contract preparation 001](ACT_CONTRACT_PREP_001.md) — trusted-action design, the current-main-native Core Compatibility first action, and its bounded implementation limits.
-- [Provider quota authority](provider-quota-authority.md) — canonical provider-reported Capacity semantics, freshness and separation from measured local usage or budgets.
-- [Canonical history read projection v1](CANONICAL_HISTORY_READ_PROJECTION_V1.md) — shadow observation/activity identity and trusted daily-history boundary.
-- [Canonical history shadow store v1](CANONICAL_HISTORY_SHADOW_STORE_V1.md) — removable content-addressed persistence and cross-refresh reconciliation.
-- [Canonical history parity observer v1](CANONICAL_HISTORY_PARITY_OBSERVER_V1.md) — non-authoritative cache-to-shadow parity validation before snapshot publication.
-- [CLI status C3 dual-read v1](CANONICAL_HISTORY_CLI_DUAL_READ_V1.md) — the bounded terminal consumer, exact parity gate and legacy fallback boundary.
-- [Accounting and pricing](ACCOUNTING_AND_PRICING.md) — user-facing semantics for multidimensional pricing identity, evidence precedence, request conditions, durable totals and evidence-aware cost valuation.
-- [Cost assignment v1](COST_ASSIGNMENT_V1.md) — immutable per-call assignments, provenance, bounded charges and settled-history compatibility.
-- [Local pricing observations](LOCAL_PRICING_OBSERVATIONS.md) — private first-observed pricing evidence, deterministic/dynamic resolution and its history boundary.
-- [Pricing history](PRICING_HISTORY.md) — generated reviewed rate history and date-effective records used by the accounting path.
-- [Collector inventory v1](COLLECTOR_INVENTORY_V1.md) — generated technical inventory of registered collectors and signed-measurement eligibility.
-- [Public contracts v1](PUBLIC_CONTRACTS_V1.md) — public schemas, signed-data behavior and compatibility commitments.
-- [Technical identity compatibility](TECHNICAL_IDENTITY_COMPATIBILITY.md) — identifiers retained to protect local state and integrations.
+Useful references:
 
-## Code surface
+- [Accounting and pricing](ACCOUNTING_AND_PRICING.md) — evidence precedence, pricing identity and durable cost semantics.
+- [Cost assignment v1](COST_ASSIGNMENT_V1.md) — immutable per-call cost assignments and provenance.
+- [Pricing history](PRICING_HISTORY.md) — reviewed date-effective pricing records.
+- [Provider quota authority](provider-quota-authority.md) — provider-reported Capacity semantics and freshness.
+- [Collector inventory v1](COLLECTOR_INVENTORY_V1.md) — generated collector inventory and signed-measurement eligibility.
+- [Canonical history read projection](CANONICAL_HISTORY_READ_PROJECTION_V1.md) — canonical observation/activity read boundary.
+- [Canonical history shadow store](CANONICAL_HISTORY_SHADOW_STORE_V1.md) — removable content-addressed persistence and reconciliation.
+- [Canonical history parity observer](CANONICAL_HISTORY_PARITY_OBSERVER_V1.md) — parity validation before publication.
+- [CLI status C3 dual-read](CANONICAL_HISTORY_CLI_DUAL_READ_V1.md) — bounded dual-read consumer and fallback boundary.
 
-The Desktop Code destination hosts the accepted upstream coding surface. Metrora
-owns its host lifecycle, navigation boundary, usage/accounting projection and
-local product integrations; the upstream UI and coding workflow remain outside
-the Metrora factual/evidence authority.
+The rule across these documents is consistent: missing, stale or uninspected evidence must not silently become a confident value.
 
-## Bench status
+## Code and integrations
 
-Current public Bench evidence is intentionally separated:
+### Code / OpenCode
+
+Metrora Desktop hosts the official upstream OpenCode Web UI/runtime instead of reconstructing it.
+
+Read:
+
+- [OpenCode upstream surface](OPENCODE_UPSTREAM_SURFACE_001.md) — pinned upstream, host lifecycle, security and persistence boundaries.
+- [Ecosystem surfaces](ECOSYSTEM_SURFACES.md) — current Code/Tools/MCP/Bench composition and future direction.
+- [Architecture](architecture.md) — responsibility map for the public repository.
+
+OpenCode is third-party upstream software and remains independently maintained. Metrora's integration does not imply affiliation with or endorsement by the OpenCode project.
+
+### Metrora Tools and MCP
+
+Metrora's factual Tool contracts are designed to be reused by bounded surfaces instead of copied into each UI or integration.
+
+The shipped local MCP Server V1 is factual/read-only. Stronger future control is intentionally separate from today's MCP authority and must not be inferred from the existence of read-only tools.
+
+See [Ecosystem surfaces](ECOSYSTEM_SURFACES.md) and [CLI reference](CLI_REFERENCE.md).
+
+## Bench
+
+Metrora Bench keeps different questions as different evidence families.
 
 | Family | Current state |
 | --- | --- |
-| small runtime timing/performance evidence | **Shipped:** BenchRunV1 local Ollama |
-| Compatibility / Runtime Health | **Shipped:** Core Compatibility v1 |
-| broader hardware Performance | **Shipped in this wave:** native llama.cpp/`llama-bench` adapter with separate history and factual comparison |
+| Performance | **Available foundations:** bounded runtime timing and native llama.cpp/`llama-bench` evidence |
+| Compatibility / Runtime Health | **Available:** deterministic Core Compatibility |
 | Coding Evaluation | **Future / not shipped** |
-| Agent Evaluation | **Future / not shipped** |
+| Agent Evaluation | **Future / not shipped**; real OpenCode Agent/Subagent execution exists, but a reproducible evaluation methodology remains separate work |
 
 No current Bench result is a universal model-quality ranking.
 
-## Local Workspace and evidence
+Read:
 
-- [Workspace v1](WORKSPACE_V1.md) — canonical current description of the local personal Workspace and its user-visible lifecycle.
-- [Local endpoint identity and outbox v1](LOCAL_ENDPOINT_IDENTITY_AND_OUTBOX_V1.md) — protected identity, immutable local evidence records and signed batches.
-- [Workspace production scope v1](WORKSPACE_PRODUCTION_SCOPE_V1.md) — trusted production window and historical-scope boundary.
-- [Workspace evidence export v1](WORKSPACE_EVIDENCE_EXPORT_V1.md) — independently verifiable user-owned export.
-- [Workspace recovery v1](WORKSPACE_RECOVERY_V1.md) — read-only inspection and explicit non-destructive recovery.
-- [Reviewed event factory v1](REVIEWED_EVENT_FACTORY_V1.md) — provenance-gated projection of normalized calls into public measurement events.
+- [Bench evidence families](BENCH_EVIDENCE_FAMILIES.md)
+- [Local runtime and Performance Wave 001](LOCAL_RUNTIME_PERFORMANCE_WAVE_001.md)
+- [BenchRunV1 local Ollama](BENCHRUN_V1_OLLAMA_LOCAL.md)
+- [Bench Core Compatibility v1](BENCH_TASK_PACK_V1.md)
 
-Component references in this section explain bounded implementation responsibilities. They do not define product sequencing or a private roadmap; [Workspace v1](WORKSPACE_V1.md) is the current status authority.
+## Android and device connectivity
 
-## Distribution and releases
+Metrora for Android is live on Google Play and remains a bounded companion to Desktop.
 
-- [Windows distribution](WINDOWS_DISTRIBUTION.md) — canonical current Windows package, identity and publication boundary.
-- [Windows Store package identity v1](WINDOWS_STORE_IDENTITY_V1.md) — assigned package identity and separate AppX/MSIX build boundary.
-- [Windows Store local package test](WINDOWS_STORE_LOCAL_TEST_GUIDED.md) — bounded local installation/cleanup path, preserved RC10 → RC11 historical procedure and RC11 starting point for any separately selected future candidate.
-- [Windows release candidate v1](WINDOWS_RELEASE_CANDIDATE_V1.md) — unsigned candidate manifest and independent verification contract.
-- [Windows format derivation v1](WINDOWS_FORMAT_DERIVATION_V1.md) — one-payload portable and installer derivation.
-- [Windows clean install v1](WINDOWS_CLEAN_INSTALL_V1.md) — isolated NSIS installation and state-preservation contract.
-- [Windows interrupted upgrade recovery v1](WINDOWS_INTERRUPTED_UPGRADE_RECOVERY_V1.md) — deterministic interruption fixture and recovery contract.
-- [Windows GitHub pre-release acceptance v1](WINDOWS_GITHUB_PRE_RELEASE_ACCEPTANCE_V1.md) — current unsigned technical-preview source, candidate, physical and publication gates.
-- [Windows physical acceptance guided path](WINDOWS_PHYSICAL_ACCEPTANCE_GUIDED.md) — two-profile guided execution for the current candidate.
-- [Windows physical acceptance R1.B.D](WINDOWS_PHYSICAL_ACCEPTANCE_R1BD.md) — historical `0.9.19` acceptance contract and evidence boundary.
-- [Android public distribution v1](ANDROID_PUBLIC_DISTRIBUTION_V1.md) — source-bound direct APK contract, production-signing boundary and Founder-gated publication path.
-- [Versioning](VERSIONING.md) — release-candidate and platform build-version authority.
-- [Releasing Metrora](../RELEASING.md) — public release responsibilities and prohibitions.
-- [Changelog](../CHANGELOG.md) — Metrora-originated public changes.
+- [Android companion foundation](ANDROID_COMPANION_FOUNDATION.md) — secure pairing and the implemented mobile product foundation.
+- [Mobile Product Parity V1](MOBILE_PRODUCT_PARITY_V1.md) — Desktop/core versus Android capability inventory.
+- [Local companion API](LOCAL_COMPANION_API.md) — stable local HTTPS endpoints and content-minimal contracts.
+- [Android public distribution](ANDROID_PUBLIC_DISTRIBUTION_V1.md) — Google Play/direct-channel identity, signing and release boundaries.
 
-Historical and guided acceptance documents preserve reproducible public evidence for the source and artifact they name. They do not override the current release status in [Windows distribution](WINDOWS_DISTRIBUTION.md), [Versioning](VERSIONING.md) or the root [README](../README.md).
+## Workspace and verifiable evidence
+
+The public repository also contains the local Workspace/evidence foundation used for endpoint identity, reviewed measurements, signed batches and user-owned export.
+
+- [Workspace v1](WORKSPACE_V1.md)
+- [Local endpoint identity and outbox v1](LOCAL_ENDPOINT_IDENTITY_AND_OUTBOX_V1.md)
+- [Workspace production scope v1](WORKSPACE_PRODUCTION_SCOPE_V1.md)
+- [Workspace evidence export v1](WORKSPACE_EVIDENCE_EXPORT_V1.md)
+- [Workspace recovery v1](WORKSPACE_RECOVERY_V1.md)
+- [Reviewed event factory v1](REVIEWED_EVENT_FACTORY_V1.md)
+- [Public contracts v1](PUBLIC_CONTRACTS_V1.md)
+
+These documents describe public behavior and compatibility boundaries. They do not publish a private product or commercial execution plan.
+
+## Distribution and release engineering
+
+Ordinary users should start from the Store links above. The documents below exist for reproducible source/artifact identity, contributor validation and release engineering.
+
+### Windows
+
+- [Windows distribution](WINDOWS_DISTRIBUTION.md)
+- [Windows Store package identity v1](WINDOWS_STORE_IDENTITY_V1.md)
+- [Windows Store local package test](WINDOWS_STORE_LOCAL_TEST_GUIDED.md)
+- [Windows release candidate v1](WINDOWS_RELEASE_CANDIDATE_V1.md)
+- [Windows format derivation v1](WINDOWS_FORMAT_DERIVATION_V1.md)
+- [Windows clean install v1](WINDOWS_CLEAN_INSTALL_V1.md)
+- [Windows interrupted upgrade recovery v1](WINDOWS_INTERRUPTED_UPGRADE_RECOVERY_V1.md)
+- [Windows GitHub pre-release acceptance v1](WINDOWS_GITHUB_PRE_RELEASE_ACCEPTANCE_V1.md)
+- [Windows physical acceptance](WINDOWS_PHYSICAL_ACCEPTANCE_GUIDED.md)
+
+### Android
+
+- [Android public distribution v1](ANDROID_PUBLIC_DISTRIBUTION_V1.md)
+- [Versioning](VERSIONING.md)
+- [Releasing Metrora](../RELEASING.md)
+- [Changelog](../CHANGELOG.md)
+
+Historical acceptance documents remain useful reproducible evidence for the source/artifact they name; they do not override current Store status.
+
+## Compatibility and implementation references
+
+These are useful when changing internals, migrations or public contracts:
+
+- [Technical identity compatibility](TECHNICAL_IDENTITY_COMPATIBILITY.md)
+- [ACT contract preparation 001](ACT_CONTRACT_PREP_001.md)
+- [Public contracts v1](PUBLIC_CONTRACTS_V1.md)
+- [Product principles](PRODUCT_PRINCIPLES.md)
+
+ACT remains a narrow Metrora-owned action authority where explicitly documented; it is not a second universal permission wrapper around ordinary OpenCode operations.
+
+## Public direction
+
+The public directional map lives in [Ecosystem surfaces](ECOSYSTEM_SURFACES.md).
+
+At a high level, Metrora is moving toward:
+
+```text
+richer factual Sessions / Activity / Models
+                ↓
+deeper Projects / Capacity / Bench context
+                ↓
+more reusable Metrora Tools
+                ↓
+bounded external control + remote/background supervision
+                ↓
+smarter evidence-aware assistance and automation
+```
+
+That is a public direction, not a delivery promise or publication of private sequencing. Shipped and future capabilities remain explicitly labelled.
 
 ## Contribute safely
 
 - [Contributing](../CONTRIBUTING.md) — contribution workflow and validation requirements.
-- [Contributing pricing data](CONTRIBUTING_PRICING.md) — evidence, identity, interval, policy and fail-closed rules for reviewed pricing changes.
+- [Contributing pricing data](CONTRIBUTING_PRICING.md) — evidence and fail-closed rules for reviewed pricing changes.
 - [Security policy](../SECURITY.md) — private vulnerability reporting.
 - [Third-party notices](../THIRD_PARTY_NOTICES.md) — required licences and component notices.
 - [Brand policy](../BRAND_POLICY.md) — product identity and permitted brand use.
 
 ## Documentation rule
 
-Public documentation explains current behavior, stable guarantees, known limitations, reproducible contracts and contribution requirements. Future direction must be labelled as planned/future rather than presented as shipped runtime capability. Internal staffing, budgets, private infrastructure, unpublished commercial plans, milestone codes and private product sequencing do not belong in this repository.
+Public documentation may explain current behavior, stable guarantees, current limitations and clearly labelled future direction. It must not expose private infrastructure, credentials, internal budgets, unpublished commercial packaging, private sequencing or implementation details that are not necessary for users, contributors or interoperability.

--- a/docs/VERSIONING.md
+++ b/docs/VERSIONING.md
@@ -58,32 +58,35 @@ Store updates must pass their own acceptance and publication gates.
 ## Android version authority
 
 Android uses the native `versionName` and integer `versionCode` declared in
-`android/app/build.gradle.kts`. The immutable historical public Android release
-is:
+`android/app/build.gradle.kts` under application ID `eu.metrora.app`.
 
-- `versionName = 0.1.0-alpha.1`;
-- `versionCode = 1`;
+Historical/direct-channel authority includes:
+
+- immutable historical public release `0.1.0-alpha.1` / `versionCode = 1`;
+- failed, never-published candidate `0.1.0-alpha.2` / `versionCode = 2`;
+- production-signed direct GitHub release `0.1.0-alpha.3` / `versionCode = 3`.
+
+The current repository source line is:
+
+- `versionName = 0.1.0-alpha.4`;
+- `versionCode = 4`;
 - application ID `eu.metrora.app`.
 
-The current public direct APK advances the same package line to:
+**Google Play is now a live Android distribution channel** for the same
+`eu.metrora.app` package identity. The Play channel and direct APK channel share
+the same monotonic `versionCode` line so a later public upgrade must always use
+a strictly larger integer.
 
-- `versionName = 0.1.0-alpha.3`;
-- `versionCode = 3`;
-- application ID `eu.metrora.app`.
+The exact version currently served by Google Play is Store-channel authority;
+do not infer it merely from a historical direct GitHub release document. The
+repository source version is likewise not automatically evidence that Google
+Play has published that exact source until the corresponding Play release gate
+has completed.
 
-The alpha.2 source candidate is historical failed evidence and was never
-public. Alpha.3 is the current public GitHub prerelease under tag
-`android-v0.1.0-alpha.3`, with the canonical direct-install APK named
-`Metrora-Android-0.1.0-alpha.3.apk`. The public alpha.1 artifact consumed
-`versionCode = 1`; every later publicly installable Android upgrade must use a
-strictly larger `versionCode`.
-
-The human-readable `versionName` is used in the deterministic GitHub identity
-`android-v<versionName>` and asset name
-`Metrora-Android-<versionName>.apk`. Android's version line is independent of
-the Windows Store package version. The planned Google Play release keeps the
-same application ID and monotonic package line; Google Play publication is
-planned within 30 days but remains non-authoritative until the listing is live.
+The human-readable `versionName` continues to be used for deterministic direct
+GitHub identities such as `android-v<versionName>` and
+`Metrora-Android-<versionName>.apk`. Android versioning remains independent of
+the Windows Store package version.
 
 ## Ordering
 
@@ -111,6 +114,7 @@ The following values must agree where they represent the same authority:
 - desktop `buildVersion` — desktop numeric build mapping;
 - `release/windows-store-package-version.v1.json` — Store package transition authority for candidate derivation;
 - Store AppX manifest — candidate Store package-version mapping after the hook;
+- `android/app/build.gradle.kts` — Android source `versionName` / `versionCode` / application ID;
 - current-version declarations in `RELEASING.md`;
 - current desktop declarations in `app/DISTRIBUTION.md`;
 - current release-line declarations in this document and `docs/WINDOWS_DISTRIBUTION.md`.
@@ -123,6 +127,6 @@ CI executes the same check on pull requests and pushes to `main`.
 
 ## Historical evidence
 
-Historical version references are immutable evidence, not active version authorities. Published RC7, RC10 and earlier accepted candidate reports, manifests, migration fixtures, provenance notices and changelog history retain their original version/source binding.
+Historical version references are immutable evidence, not active version authorities. Published RC7, RC10, Android direct releases and earlier accepted candidate reports, manifests, migration fixtures, provenance notices and changelog history retain their original version/source binding.
 
 Never rename an old report or artifact to the current version, and never treat an accepted artifact as evidence for a later source commit.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,132 +1,251 @@
 # Metrora architecture
 
-A responsibility map for the public Metrora codebase. Read this before opening a non-trivial pull request.
+This document explains the responsibility map of the public Metrora codebase: where facts come from, which surface owns which behavior, and why the Code integration deliberately relies on upstream OpenCode instead of growing a second generic coding-agent engine.
+
+## Architectural thesis
+
+Metrora is a **local-first control center for AI-assisted development**.
+
+Its public architecture follows two rules:
+
+> **Facts have one canonical authority.**
+>
+> **Metrora adds. OpenCode executes.**
+
+The first rule prevents Desktop, CLI, Android, MCP and Code integrations from inventing independent versions of usage, pricing or evidence.
+
+The second rule keeps Metrora focused on differentiated product value — measurement, evidence, Projects, Capacity, Bench, context and control — while upstream OpenCode owns commodity coding-agent mechanics inside Code.
+
+## System map
+
+```mermaid
+flowchart TD
+    S[Local AI tool / CLI / editor / gateway evidence] --> C[Collectors + provider parsers]
+    C --> N[Canonical normalized records]
+    N --> P[Pricing + provenance + reconciliation]
+    P --> F[Canonical Metrora facts]
+
+    F --> U[Usage / Activity / Sessions]
+    F --> M[Models / economics]
+    F --> R[Projects / context]
+    F --> Q[Capacity / coverage]
+    F --> B[Bench evidence]
+    F --> W[Workspace / verifiable evidence]
+
+    F --> CLI[CLI]
+    F --> WEB[Local web]
+    F --> DESK[Desktop]
+    F --> AND[Android companion]
+    F --> TOOLS[Metrora Tools]
+    TOOLS --> MCP[Local MCP / bounded integrations]
+
+    DESK --> CODE[Code]
+    CODE --> OC[OpenCode upstream]
+    OC --> OCF[Sessions · Agents · Tools · Files · Shell · Git · MCP/ACP]
+```
+
+The diagram is intentionally asymmetric: Code is not another Metrora factual engine, and Android is not another collector. Both consume or complement the canonical Metrora layer according to their responsibility.
 
 ## Product authority
 
-The public repository is authoritative for local collection, parsing, normalization, pricing, analytics, evidence, Workspace contracts and user-owned export.
+The public repository is authoritative for the local Metrora factual/product layer, including:
+
+- collection and provider parsing;
+- normalization, deduplication and reconciliation;
+- historical pricing and cost assignment;
+- Usage, Activity, Sessions, Models and Project analytics where implemented;
+- provider-reported Capacity semantics;
+- Bench evidence and methodology boundaries;
+- canonical Metrora Tool contracts;
+- local Workspace/evidence contracts;
+- user-owned export and public interoperability boundaries.
 
 Metrora is local-first:
 
-- AI traffic does not pass through Metrora;
-- ordinary local use requires no account or remote service;
-- prompts, responses, source code, patches, secrets and unrestricted local paths are not exported by default;
-- settled historical cost assignments remain immutable;
-- unavailable or uninspected evidence remains explicit rather than becoming a false zero.
+- ordinary local use requires no Metrora account or hosted service;
+- supported AI traffic does not need to pass through a Metrora proxy;
+- prompts, responses, source code, patches, secrets and unrestricted local paths are outside the ordinary sharing boundary;
+- settled historical cost assignments remain stable;
+- missing, stale, partial or unavailable evidence remains explicit rather than becoming a false zero.
 
-## Data flow
+## Canonical factual path
 
 ```text
-local AI-tool session stores
-            ↓
-collectors and provider parsers
-            ↓
-canonical normalized records, cache and pricing
-            ↓
-analytics, evidence and Workspace runtime
-            ↓
-CLI / Electron desktop / local web dashboard
-            ↓
-optional native companions and explicit exports
+source evidence
+    ↓
+provider-specific collector/parser
+    ↓
+normalized call / canonical identity
+    ↓
+pricing + provenance + reconciliation
+    ↓
+shared factual projections
+    ↓
+Desktop · CLI · local web · Android · Tools · exports
 ```
 
-## Surfaces
+A presentation surface may summarize or visualize canonical facts. It must not silently reinterpret stronger evidence or create a second pricing/accounting authority.
 
-### CLI — `src/`
-
-The canonical command is `metrora`.
-
-The CLI owns command routing and invokes shared domain modules for:
-
-- provider discovery and parsing;
-- canonical aggregation and date filtering;
-- historical pricing and evidence classification;
-- reports, exports and optimization findings;
-- MCP stdio tools;
-- endpoint, Workspace, batching and verification operations where applicable.
-
-The current package publishes only the `metrora` command. Historical signed
-evidence identifiers remain internal protocol details; new documentation,
-artifacts and user-facing text use Metrora.
-
-### Electron desktop — `app/`
-
-The desktop application is the primary local graphical surface.
-
-The Electron main process owns privileged work:
-
-- execution of the bundled Metrora runtime;
-- local filesystem and OS-vault access;
-- endpoint and Workspace runtime authority;
-- bounded inspection, production, recovery, batching and export actions;
-- validation of external URLs and export destinations.
-
-The preload bridge exposes a narrow typed API. The renderer runs with context isolation and no Node integration, consumes public DTOs and must not implement its own parser, pricing engine or evidence authority.
-
-### Code — embedded upstream surface
-
-The Desktop Code destination hosts the accepted upstream coding surface. Metrora
-owns the privileged host lifecycle, navigation boundary, usage snapshot and
-accounting projection; the upstream UI, sessions and tools remain outside
-Metrora's factual/evidence authority.
-
-State orchestration, domain formatting and presentation are extracted into focused modules before a component or main-process module becomes oversized.
-
-### Local web dashboard — `dash/`
-
-The dashboard renders canonical local analytical payloads in a browser surface served from the user's machine. It does not own a separate data model.
-
-### Native companions — `mac/`, `gnome/`, `android/`
-
-- macOS and GNOME surfaces are lightweight local companions over the canonical CLI/runtime;
-- Android is an implemented and physically accepted local companion for the current LAN scope; it does not own collection, pricing or evidence authority;
-- inherited module names, UUIDs and storage paths may remain where migration would otherwise break installed state.
-
-Compatibility identifiers are governed by [`TECHNICAL_IDENTITY_COMPATIBILITY.md`](TECHNICAL_IDENTITY_COMPATIBILITY.md), not treated as product branding.
-
-## Collection and parsing
+### Collection and parsing
 
 Provider adapters discover source records and emit normalized calls through shared parser contracts.
 
 Key rules:
 
-- source-present provider and model metadata is preferred over inference;
+- source-present provider/model metadata is preferred over inference;
 - deduplication uses canonical identities shared across providers;
-- parser caches accelerate repeated reads but do not become independent truth;
-- cache reconciliation preserves provenance and fails closed on contradictory records;
-- provider-specific parsing remains isolated from product presentation.
+- parser caches accelerate reads but do not become independent truth;
+- reconciliation preserves provenance and fails closed on contradictions;
+- provider-specific parsing stays isolated from product presentation.
 
-New or changed provider adapters require fixtures, focused tests, provenance review and validation against representative records where possible.
+New or changed collectors require fixtures, focused tests, provenance review and representative-record validation where possible.
 
-## Pricing authority
+### Pricing and accounting
 
 Historical API-equivalent pricing is date-effective and evidence-aware.
 
-- provider or client metered values are authoritative when available;
-- explicit zero is distinct from unavailable pricing;
-- subscription or proxy coverage is an overlay, not a rewrite of historical API-equivalent value;
-- a later catalog update cannot silently change an already settled call;
-- fallback behavior remains explicit and conservative.
+- provider/client metered values remain authoritative when available;
+- explicit zero is different from unavailable pricing;
+- subscription or proxy coverage is an overlay rather than a rewrite of historical API-equivalent value;
+- later pricing catalog updates cannot silently rewrite settled calls;
+- fallback behavior stays explicit and conservative.
 
-Pricing logic belongs in shared domain modules, never in renderer components or packaging configuration.
+Pricing logic belongs in shared domain modules rather than Desktop components, Code adapters or packaging scripts.
 
-## Local Workspace and evidence
+## Surfaces and ownership
 
-Workspace v1 is endpoint-owned and works without a remote service.
+### Electron Desktop — `app/`
 
-The local runtime owns:
+Desktop is the primary graphical control center.
+
+The Electron main process owns privileged host work such as:
+
+- execution/resolution of the bundled Metrora runtime;
+- local filesystem and OS-vault boundaries;
+- endpoint/Workspace authority where applicable;
+- bounded recovery, export and privileged actions;
+- external URL/export-destination validation;
+- OpenCode sidecar lifecycle, authentication, origin and view hosting.
+
+The renderer consumes typed public DTOs through a narrow preload bridge. It must not become a second provider parser, pricing engine or factual authority.
+
+### Code — upstream OpenCode hosted by Metrora
+
+The Desktop **Code** destination embeds the official upstream [OpenCode](https://github.com/anomalyco/opencode) runtime and Web UI.
+
+OpenCode owns:
+
+```text
+coding Sessions
+Agents / Subagents
+provider + model interaction inside Code
+standard Tools
+files / shell / Git
+ordinary permissions / questions
+MCP / ACP mechanics supplied by OpenCode
+```
+
+Metrora owns the surrounding integration boundary:
+
+```text
+pinned runtime provenance
+loopback-only server lifecycle
+per-launch host authentication
+persistent browser/project state
+navigation + popup restrictions
+prewarmed host experience
+clean shutdown
+Windows packaging
+Metrora accounting observation
+bounded Metrora-specific factual context
+```
+
+This split avoids a second conversation/session universe for the same coding work.
+
+Metrora accounting identifies activity from this source as **OpenCode**. Launching OpenCode inside Metrora does not invent a fake provider identity.
+
+OpenCode is third-party upstream software and remains independently maintained. The integration does not imply project affiliation or endorsement.
+
+See [`OPENCODE_UPSTREAM_SURFACE_001.md`](OPENCODE_UPSTREAM_SURFACE_001.md).
+
+### CLI — `src/`
+
+The canonical command is `metrora`.
+
+The CLI routes into shared domain modules for:
+
+- discovery/parsing;
+- canonical aggregation and date filtering;
+- pricing/evidence classification;
+- reports, exports and diagnostics;
+- Bench workflows;
+- local read-only MCP;
+- Workspace/evidence operations where documented.
+
+The CLI is a transport/product surface over shared Metrora authority, not a separate factual engine.
+
+### Local web — `dash/`
+
+The local browser dashboard renders canonical Metrora payloads served from the user's machine. It does not own a second data model or hosted account authority.
+
+### Android — `android/`
+
+The Android companion is publicly distributed through Google Play and can also have a separately documented direct APK channel.
+
+Android consumes bounded data from an explicitly paired Desktop. It does not independently collect AI-provider evidence, recalculate pricing or become canonical history authority.
+
+### macOS / GNOME — `mac/`, `gnome/`
+
+These source surfaces remain lightweight companion work over Metrora's canonical runtime. Source availability is not the same as an accepted public distribution channel.
+
+## Metrora Tools
+
+Metrora Tools expose bounded factual capabilities from the shared registry/contract layer.
+
+The architectural goal is reuse:
+
+```text
+canonical Metrora facts
+        ↓
+canonical Tool registry
+   ┌────┼──────────┐
+   ↓    ↓          ↓
+  MCP  Code   other bounded integrations
+```
+
+A new consumer should adapt to this registry rather than copy accounting/evidence logic into its own transport.
+
+Tool results preserve unavailable/stale/partial semantics. A calling model may explain evidence but cannot silently replace the underlying Metrora measurement or scope.
+
+## MCP and external interoperability
+
+The current public Metrora MCP Server V1 is **local and read-only**. It exposes bounded factual Metrora capabilities without turning Metrora into a mandatory AI-request proxy.
+
+Future state-changing/external control is a separate architecture problem. Public direction may include bounded external control and remote/background supervision, but those capabilities require explicit trust/control objects rather than granting generic execution authority because MCP exists.
+
+## Bench
+
+Bench is an evidence system with explicit methodologies, not a universal AI score.
+
+Current public families include Performance and Compatibility/Runtime Health foundations. Coding Evaluation and Agent Evaluation remain separately gated future methodologies.
+
+Real Agent/Subagent execution already exists through OpenCode; reproducible Agent Evaluation still requires its own dataset, methodology, isolation and comparison contract.
+
+## Local Workspace and verifiable evidence
+
+Workspace v1 is endpoint-owned and can work without a remote service.
+
+The public local foundation includes:
 
 - protected endpoint identity and OS-vault material;
-- local personal Workspace state and membership;
+- local Workspace state/membership;
 - reviewed measurement production;
-- private receipts and append-only outbox publication;
-- active and paused production lifecycle;
-- truthful read-only evidence inspection;
-- deterministic non-destructive recovery;
+- append-only/outbox evidence where applicable;
+- truthful inspection and non-destructive recovery;
 - Workspace-authorized signed batches;
 - independently verifiable user-owned exports.
 
-Opening the application may inspect evidence automatically, but recovery remains explicit and mutation-capable only when reconciliation is needed.
+Opening the application may inspect evidence automatically, but recovery remains explicit when mutation is required.
 
 ## Public contracts
 
@@ -136,60 +255,83 @@ Contract evolution requires:
 
 - explicit versioning or compatible extension;
 - validation at trust boundaries;
-- migration and rollback analysis;
+- migration/rollback analysis;
 - privacy review;
-- fixtures and conformance tests;
+- fixtures/conformance tests;
 - no silent reinterpretation by another surface.
 
 ## Distribution integrity
 
-Official Windows distribution is live through Microsoft Store under publisher Vensent, with RC10 as the frozen published authority. Technical candidates and non-Windows source surfaces remain engineering artifacts until their own accepted public channel publishes them.
+Official Windows distribution is live through Microsoft Store under publisher Vensent. The current public Store line is RC11.
+
+Android is live on Google Play under package identity `eu.metrora.app`; the direct APK channel remains separately documented.
 
 Distribution work preserves these boundaries:
 
-- every artifact traces to reviewed public source;
-- portable and installer formats derive from one canonical product payload where applicable;
-- publisher and channel identity are exact rather than guessed;
-- checksums, manifests and provenance are independently verifiable;
-- installation, update and rollback preserve user-owned local state;
-- technical validation artifacts remain visibly distinct from official releases;
+- artifacts trace to reviewed public source;
+- package/channel identity is exact rather than guessed;
+- checksums/manifests/provenance are independently verifiable where documented;
+- installation/update/rollback preserve user-owned state;
+- technical validation artifacts stay visibly separate from official Store releases;
 - build, verification, publication and rollback remain separate responsibilities.
 
-See [`WINDOWS_DISTRIBUTION.md`](WINDOWS_DISTRIBUTION.md), [`WINDOWS_FORMAT_DERIVATION_V1.md`](WINDOWS_FORMAT_DERIVATION_V1.md) and the Windows acceptance contracts.
+See [`WINDOWS_DISTRIBUTION.md`](WINDOWS_DISTRIBUTION.md), [`ANDROID_PUBLIC_DISTRIBUTION_V1.md`](ANDROID_PUBLIC_DISTRIBUTION_V1.md) and [`VERSIONING.md`](VERSIONING.md).
 
 ## Security boundaries
 
 - no shell interpolation for untrusted command arguments;
-- no Node integration in the renderer;
-- no remote content in privileged windows;
+- no Node integration in ordinary renderer code;
 - no protected distribution credentials in untrusted pull requests;
-- no raw user content or secret material in logs or reports;
+- no raw prompt/source/secret material in factual reports or logs;
 - no destructive reset disguised as recovery;
+- no weakening of the upstream Code host boundary merely for convenience;
 - no deployment-time patching of product semantics or visual identity.
+
+## Public direction without private sequencing
+
+The public architecture is designed to support stronger capabilities over time without advertising private implementation sequencing.
+
+Directionally:
+
+```text
+better factual Sessions / Models / Activity
+                ↓
+richer Projects / Capacity / Bench context
+                ↓
+more reusable Tools across Code and integrations
+                ↓
+bounded external control / remote supervision
+                ↓
+evidence-aware assistance and automation
+```
+
+That direction does not require a private fork of OpenCode or a second generic agent/session engine.
 
 ## Repository map
 
 ```text
-src/       canonical collection, parsing, pricing, analytics, evidence and CLI
-app/       Electron desktop application
+src/       collection, parsing, pricing, analytics, evidence, Tools and CLI
+app/       Electron Desktop host and product UI, including Code host integration
 dash/      local browser dashboard
-android/   implemented local companion; public alpha.3 release, alpha.1 historical, alpha.2 failed candidate
-mac/       native macOS menubar companion
-gnome/     GNOME Shell companion
-tests/     canonical core and integration tests
-docs/      public contracts, architecture and release boundaries
-scripts/   bounded build, validation, migration and release utilities
+android/   Google Play / direct-channel Android companion source
+mac/       macOS companion source
+gnome/     GNOME Shell companion source
+tests/     core and integration tests
+docs/      user guidance, architecture, contracts and release evidence
+scripts/   bounded build, verification, migration and release utilities
 ```
+
+Compatibility identifiers retained for installed-state safety are governed by [`TECHNICAL_IDENTITY_COMPATIBILITY.md`](TECHNICAL_IDENTITY_COMPATIBILITY.md), not treated as current product branding.
 
 ## Change discipline
 
-Every substantial change identifies:
+Every substantial change should identify:
 
-- the authority it modifies;
-- the public contract or compatibility boundary involved;
+- which authority it modifies;
+- which public contract/compatibility boundary is involved;
 - focused and full validation required;
-- migration and rollback behavior;
-- privacy and provenance impact;
-- the public documentation that must remain accurate.
+- migration/rollback behavior;
+- privacy/provenance impact;
+- documentation that must remain accurate.
 
-Prefer small independently revertible modules and pull requests. Do not solve architectural growth by raising size limits or moving unrelated responsibilities into another oversized file.
+Prefer bounded, independently revertible changes. Do not solve architectural growth by duplicating an existing authority or by raising safety limits instead of fixing responsibility boundaries.


### PR DESCRIPTION
## Summary
- reshape the public README and documentation home around Metrora as a local-first AI development control center rather than a usage-tracking project
- present the accepted upstream OpenCode Code foundation clearly, including the `Metrora adds. OpenCode executes.` responsibility split
- update Android public status to the live Google Play channel while preserving the separate direct APK evidence boundary
- add source-versionable Mermaid/text diagrams for the factual layer, product surfaces and public direction
- simplify user-facing release/distribution guidance and move deep release mechanics out of the product narrative
- keep future direction intentionally high-level: stronger Sessions/Models/data quality, richer Projects/Capacity/Bench context, broader canonical Tools, bounded external/remote control and evidence-aware assistance
- incorporate the accepted #266 canonical Code-tool surface and Founder physical acceptance into the public OpenCode/Tools documentation

## Public-boundary discipline
- no private implementation sequencing
- no unpublished commercial packaging or pricing
- no private infrastructure topology
- no credentials or signing material
- no private routing/control policy details
- OpenCode is described as independent third-party upstream software; no affiliation or endorsement is implied
- repository/source capabilities are explicitly distinguished from Store rollout so `main` is not presented as identical to the currently published Windows Store binary

## Scope
Documentation only. No product/runtime code changes and no new CI gates.

Images and Store screenshot refresh are intentionally deferred to a later visual pass; this PR uses versionable Markdown/Mermaid diagrams only.

## Coordination
PR #266 is merged. This branch has been reconciled onto that accepted main line, including the seven canonical read-only Code tools and the completed spend/model-efficiency/Bench physical acceptance.