### PR TITLE
fix(opencode): isolate bundled runtime storage

### DIFF
--- a/app/electron/opencode/config.ts
+++ b/app/electron/opencode/config.ts
@@ -14,7 +14,13 @@ export type OpenCodeWebSurfaceState = {
 }
 
 export type OpenCodeRuntimePaths = {
+  runtimeRoot: string
   runtimeDir: string
+  dataDir: string
+  cacheDir: string
+  stateDir: string
+  dbDir: string
+  databasePath: string
   configPath: string
   toolsDir: string
   snapshotPath: string
@@ -22,12 +28,19 @@ export type OpenCodeRuntimePaths = {
 }
 
 export function runtimePaths(userDataPath: string): OpenCodeRuntimePaths {
-  const runtimeDir = path.join(userDataPath, 'opencode', OPENCODE_VERSION)
+  const runtimeRoot = path.join(userDataPath, 'opencode', 'runtime', OPENCODE_VERSION)
+  const runtimeDir = path.join(runtimeRoot, 'config')
   return {
+    runtimeRoot,
     runtimeDir,
+    dataDir: path.join(runtimeRoot, 'data'),
+    cacheDir: path.join(runtimeRoot, 'cache'),
+    stateDir: path.join(runtimeRoot, 'state'),
+    dbDir: path.join(runtimeRoot, 'db'),
+    databasePath: path.join(runtimeRoot, 'db', 'opencode.db'),
     configPath: path.join(runtimeDir, 'opencode.json'),
     toolsDir: path.join(runtimeDir, 'tools'),
-    snapshotPath: path.join(runtimeDir, 'metrora-usage-snapshot.json'),
+    snapshotPath: path.join(runtimeRoot, 'metrora-usage-snapshot.json'),
     webSurfacePath: path.join(userDataPath, 'opencode', OPENCODE_WEB_SURFACE_STATE_FILENAME),
   }
 }
@@ -75,7 +88,12 @@ async function restrictPermissions(filePath: string, mode: number): Promise<void
 
 /** Write only the private config/tool files needed by the official runtime. */
 export async function writeRuntimeFiles(paths: OpenCodeRuntimePaths): Promise<void> {
+  await mkdir(paths.runtimeRoot, { recursive: true, mode: 0o700 })
   await mkdir(paths.runtimeDir, { recursive: true, mode: 0o700 })
+  await mkdir(paths.dataDir, { recursive: true, mode: 0o700 })
+  await mkdir(paths.cacheDir, { recursive: true, mode: 0o700 })
+  await mkdir(paths.stateDir, { recursive: true, mode: 0o700 })
+  await mkdir(paths.dbDir, { recursive: true, mode: 0o700 })
   await mkdir(paths.toolsDir, { recursive: true, mode: 0o700 })
   // v1.18.27 eagerly checks for a node_modules directory before loading a
   // custom tool. Keeping this directory empty and declaring the bundled
@@ -83,7 +101,12 @@ export async function writeRuntimeFiles(paths: OpenCodeRuntimePaths): Promise<vo
   // prevents the official runtime from attempting a network install.
   const nodeModulesDir = path.join(paths.runtimeDir, 'node_modules')
   await mkdir(nodeModulesDir, { recursive: true, mode: 0o700 })
+  await restrictPermissions(paths.runtimeRoot, 0o700)
   await restrictPermissions(paths.runtimeDir, 0o700)
+  await restrictPermissions(paths.dataDir, 0o700)
+  await restrictPermissions(paths.cacheDir, 0o700)
+  await restrictPermissions(paths.stateDir, 0o700)
+  await restrictPermissions(paths.dbDir, 0o700)
   await restrictPermissions(paths.toolsDir, 0o700)
   await restrictPermissions(nodeModulesDir, 0o700)
 

--- a/app/electron/opencode/runtime.test.ts
+++ b/app/electron/opencode/runtime.test.ts
@@ -1,5 +1,7 @@
 // @vitest-environment node
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { readdir } from 'node:fs/promises'
+import { createRequire } from 'node:module'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
@@ -9,6 +11,8 @@ import { buildOpenCodeServerArgs, createLaunchEnvironment, OpenCodeRuntime, reso
 import { OPENCODE_COMMIT, OPENCODE_CUSTOM_TOOL_ID, OPENCODE_CUSTOM_TOOL_IDS, OPENCODE_METRORA_TOOL_IDS, OPENCODE_VERSION } from './types'
 
 const temporaryDirectories: string[] = []
+const requireForTest = createRequire(import.meta.url)
+const { DatabaseSync } = requireForTest('node:sqlite') as { DatabaseSync: new (filePath: string) => { exec(sql: string): void; close(): void } }
 
 afterEach(() => {
   for (const directory of temporaryDirectories.splice(0)) rmSync(directory, { recursive: true, force: true })
@@ -47,6 +51,21 @@ function fakeChild(): SpawnedOpenCodeProcess & { killed: boolean } {
 
 function jsonResponse(value: unknown, status = 200): Response {
   return new Response(JSON.stringify(value), { status, headers: { 'content-type': 'application/json' } })
+}
+
+function delayedJsonResponse(value: unknown, delayMs: number, signal?: AbortSignal): Promise<Response> {
+  return new Promise((resolve, reject) => {
+    const onAbort = () => {
+      clearTimeout(timer)
+      reject(new Error('request aborted'))
+    }
+    const timer = setTimeout(() => {
+      signal?.removeEventListener('abort', onAbort)
+      resolve(jsonResponse(value))
+    }, delayMs)
+    signal?.addEventListener('abort', onAbort, { once: true })
+    if (signal?.aborted) onAbort()
+  })
 }
 
 describe('OpenCode upstream sidecar runtime', () => {
@@ -156,6 +175,116 @@ describe('OpenCode upstream sidecar runtime', () => {
     await runtime.stop()
     expect(child.killed).toBe(true)
     expect(runtime.status()).toMatchObject({ state: 'idle', customToolRegistered: null })
+  })
+
+  it('allows cold custom-tool discovery after the health endpoint is ready', async () => {
+    const root = tempDirectory()
+    const userData = join(root, 'user-data')
+    const executable = join(root, 'opencode.exe')
+    writeFileSync(executable, 'official binary placeholder')
+    const child = fakeChild()
+    const runtime = new OpenCodeRuntime({
+      appPath: root,
+      resourcesPath: root,
+      userDataPath: userData,
+      isPackaged: false,
+      baseEnv: {},
+      executableOverride: executable,
+      acquirePort: async () => 43126,
+      spawnProcess: () => child,
+      fetchImpl: async (url, init) => url.endsWith('/global/health')
+        ? jsonResponse({ healthy: true, version: OPENCODE_VERSION })
+        : delayedJsonResponse([...OPENCODE_CUSTOM_TOOL_IDS], 1_100, init?.signal),
+      healthTimeoutMs: 2_000,
+      pollIntervalMs: 1,
+    })
+
+    await expect(runtime.start()).resolves.toMatchObject({ state: 'ready', customToolRegistered: true })
+    await runtime.stop()
+  })
+
+  it('keeps launching against a clean isolated store when history import fails', async () => {
+    const root = tempDirectory()
+    const externalData = join(root, 'external-data')
+    const externalDirectory = join(externalData, 'opencode')
+    mkdirSync(externalDirectory, { recursive: true })
+    writeFileSync(join(externalDirectory, 'opencode.db'), 'not-a-sqlite-database')
+    const userData = join(root, 'user-data')
+    const executable = join(root, 'opencode.exe')
+    writeFileSync(executable, 'official binary placeholder')
+    const child = fakeChild()
+    let launchEnvironment: NodeJS.ProcessEnv | undefined
+    const runtime = new OpenCodeRuntime({
+      appPath: root,
+      resourcesPath: root,
+      userDataPath: userData,
+      isPackaged: false,
+      baseEnv: { XDG_DATA_HOME: externalData },
+      executableOverride: executable,
+      acquirePort: async () => 43125,
+      spawnProcess: vi.fn((_file, _args, options) => {
+        launchEnvironment = options.env
+        return child
+      }),
+      fetchImpl: async url => url.endsWith('/global/health')
+        ? jsonResponse({ healthy: true, version: OPENCODE_VERSION })
+        : jsonResponse([...OPENCODE_CUSTOM_TOOL_IDS]),
+      healthTimeoutMs: 500,
+      pollIntervalMs: 1,
+    })
+
+    await expect(runtime.start()).resolves.toMatchObject({ state: 'ready', customToolRegistered: true })
+    expect(launchEnvironment?.OPENCODE_DB).toBe(runtimePaths(userData).databasePath)
+    expect(existsSync(runtimePaths(userData).databasePath)).toBe(false)
+    await runtime.stop()
+  })
+
+  it('quarantines an imported store that cannot start and retries clean', async () => {
+    const root = tempDirectory()
+    const externalData = join(root, 'external-data')
+    const externalDirectory = join(externalData, 'opencode')
+    mkdirSync(externalDirectory, { recursive: true })
+    const externalPath = join(externalDirectory, 'opencode.db')
+    const externalDatabase = new DatabaseSync(externalPath)
+    externalDatabase.exec('CREATE TABLE sentinel (value TEXT NOT NULL); INSERT INTO sentinel VALUES (\'external-authority\');')
+    externalDatabase.close()
+    const userData = join(root, 'user-data')
+    const executable = join(root, 'opencode.exe')
+    writeFileSync(executable, 'official binary placeholder')
+    const children: Array<SpawnedOpenCodeProcess & { killed: boolean }> = []
+    let healthCalls = 0
+    const runtime = new OpenCodeRuntime({
+      appPath: root,
+      resourcesPath: root,
+      userDataPath: userData,
+      isPackaged: false,
+      baseEnv: { XDG_DATA_HOME: externalData },
+      executableOverride: executable,
+      acquirePort: async () => 43124,
+      spawnProcess: () => {
+        const child = fakeChild()
+        children.push(child)
+        return child
+      },
+      fetchImpl: async url => {
+        if (url.endsWith('/global/health')) {
+          healthCalls += 1
+          return jsonResponse({ healthy: true, version: healthCalls === 1 ? '0.0.0' : OPENCODE_VERSION })
+        }
+        return jsonResponse([...OPENCODE_CUSTOM_TOOL_IDS])
+      },
+      healthTimeoutMs: 500,
+      pollIntervalMs: 1,
+    })
+
+    await expect(runtime.start()).resolves.toMatchObject({ state: 'ready', customToolRegistered: true })
+    const paths = runtimePaths(userData)
+    expect(existsSync(paths.databasePath)).toBe(false)
+    const databaseEntries = await readdir(paths.dbDir)
+    expect(databaseEntries).toEqual(expect.arrayContaining([expect.stringMatching(/^opencode-import-rejected-.*\.db$/u)]))
+    expect(children).toHaveLength(2)
+    expect(children[0]?.killed).toBe(true)
+    await runtime.stop()
   })
 
   it('fails closed when one expected custom tool is missing', async () => {

--- a/app/electron/opencode/runtime.test.ts
+++ b/app/electron/opencode/runtime.test.ts
@@ -82,6 +82,7 @@ describe('OpenCode upstream sidecar runtime', () => {
       resourcesPath: root,
       userDataPath: userData,
       isPackaged: false,
+      baseEnv: {},
       executableOverride: executable,
       acquirePort: async () => 43127,
       randomPassword: () => 'p'.repeat(64),
@@ -115,8 +116,14 @@ describe('OpenCode upstream sidecar runtime', () => {
         env: expect.objectContaining({
           OPENCODE_SERVER_USERNAME: 'metrora',
           OPENCODE_SERVER_PASSWORD: 'p'.repeat(64),
-          OPENCODE_CONFIG_DIR: join(userData, 'opencode', OPENCODE_VERSION),
-          OPENCODE_CONFIG: join(userData, 'opencode', OPENCODE_VERSION, 'opencode.json'),
+          OPENCODE_CONFIG_DIR: join(userData, 'opencode', 'runtime', OPENCODE_VERSION, 'config'),
+          OPENCODE_CONFIG: join(userData, 'opencode', 'runtime', OPENCODE_VERSION, 'config', 'opencode.json'),
+          OPENCODE_DATA_DIR: join(userData, 'opencode', 'runtime', OPENCODE_VERSION, 'data'),
+          OPENCODE_DB: join(userData, 'opencode', 'runtime', OPENCODE_VERSION, 'db', 'opencode.db'),
+          XDG_DATA_HOME: join(userData, 'opencode', 'runtime', OPENCODE_VERSION, 'data'),
+          XDG_CACHE_HOME: join(userData, 'opencode', 'runtime', OPENCODE_VERSION, 'cache'),
+          XDG_STATE_HOME: join(userData, 'opencode', 'runtime', OPENCODE_VERSION, 'state'),
+          XDG_CONFIG_HOME: join(userData, 'opencode', 'runtime', OPENCODE_VERSION, 'config'),
           OPENCODE_DISABLE_AUTOUPDATE: '1',
           METRORA_TOOL_BRIDGE_SPEC: expect.any(String),
         }),
@@ -163,6 +170,7 @@ describe('OpenCode upstream sidecar runtime', () => {
       resourcesPath: root,
       userDataPath: userData,
       isPackaged: false,
+      baseEnv: {},
       executableOverride: executable,
       acquirePort: async () => 43132,
       spawnProcess: () => child,
@@ -192,6 +200,7 @@ describe('OpenCode upstream sidecar runtime', () => {
       resourcesPath: root,
       userDataPath: userData,
       isPackaged: false,
+      baseEnv: {},
       executableOverride: executable,
       acquirePort: async () => 43130,
       randomPassword: () => 'p'.repeat(64),
@@ -237,6 +246,7 @@ describe('OpenCode upstream sidecar runtime', () => {
       resourcesPath: root,
       userDataPath: userData,
       isPackaged: false,
+      baseEnv: {},
       executableOverride: executable,
       acquirePort,
       isLoopbackPortAvailable,
@@ -288,6 +298,7 @@ describe('OpenCode upstream sidecar runtime', () => {
       resourcesPath: root,
       userDataPath: userData,
       isPackaged: false,
+      baseEnv: {},
       executableOverride: executable,
       acquirePort,
       isLoopbackPortAvailable,
@@ -326,6 +337,7 @@ describe('OpenCode upstream sidecar runtime', () => {
       resourcesPath: root,
       userDataPath: userData,
       isPackaged: false,
+      baseEnv: {},
       executableOverride: executable,
       acquirePort: async () => port++,
       spawnProcess: () => fakeChild(),
@@ -359,6 +371,7 @@ describe('OpenCode upstream sidecar runtime', () => {
       resourcesPath: root,
       userDataPath: join(root, 'user-data'),
       isPackaged: false,
+      baseEnv: {},
       executableOverride: executable,
       acquirePort: async () => 43128,
       spawnProcess: () => child,
@@ -379,6 +392,11 @@ describe('OpenCode upstream sidecar runtime', () => {
     const environment = createLaunchEnvironment({ paths, username: 'metrora', password: 'x'.repeat(64), baseEnv: {}, toolBridgeSpec: '{"command":["C:/cli.exe","tools","call"],"environment":{}}' })
     expect(environment.OPENCODE_SERVER_PASSWORD).toBe('x'.repeat(64))
     expect(environment.OPENCODE_CONFIG).toBe(paths.configPath)
+    expect(environment.OPENCODE_DB).toBe(paths.databasePath)
+    expect(environment.XDG_DATA_HOME).toBe(paths.dataDir)
+    expect(environment.XDG_CACHE_HOME).toBe(paths.cacheDir)
+    expect(environment.XDG_STATE_HOME).toBe(paths.stateDir)
+    expect(environment.XDG_CONFIG_HOME).toBe(paths.runtimeDir)
     expect(environment.METRORA_TOOL_BRIDGE_SPEC).toContain('C:/cli.exe')
     const withoutBridge = createLaunchEnvironment({ paths, username: 'metrora', password: 'x'.repeat(64), baseEnv: {} })
     expect(withoutBridge.METRORA_TOOL_BRIDGE_SPEC).toBeUndefined()

--- a/app/electron/opencode/runtime.ts
+++ b/app/electron/opencode/runtime.ts
@@ -20,6 +20,7 @@ import {
 } from './types'
 
 const DEFAULT_HEALTH_TIMEOUT_MS = 12_000
+const DEFAULT_TOOL_DISCOVERY_TIMEOUT_MS = 30_000
 const DEFAULT_POLL_INTERVAL_MS = 100
 const REQUEST_TIMEOUT_MS = 1_000
 const STOP_TIMEOUT_MS = 1_500
@@ -375,7 +376,13 @@ export class OpenCodeRuntime {
 
   private async verifyCustomTools(origin: string, authorization: string, signal: AbortSignal): Promise<boolean> {
     const fetchImpl = this.options.fetchImpl ?? ((url, init) => fetch(url, init))
-    const response = await fetchImpl(`${origin}/experimental/tool/ids`, { headers: { Authorization: authorization }, signal: abortAfter(signal, REQUEST_TIMEOUT_MS) })
+    // OpenCode reports health before its extension registry has finished the
+    // first cold discovery. Keep the short timeout for health polling, but
+    // allow the one-shot tool registry request its bounded cold-start budget.
+    const toolDiscoveryTimeoutMs = this.options.healthTimeoutMs === undefined
+      ? DEFAULT_TOOL_DISCOVERY_TIMEOUT_MS
+      : Math.max(REQUEST_TIMEOUT_MS, this.options.healthTimeoutMs)
+    const response = await fetchImpl(`${origin}/experimental/tool/ids`, { headers: { Authorization: authorization }, signal: abortAfter(signal, toolDiscoveryTimeoutMs) })
     if (!response.ok) throw new OpenCodeError('custom-tool', 'OpenCode tool discovery was unavailable.')
     const value = await responseJson(response)
     if (!Array.isArray(value)) throw new OpenCodeError('custom-tool', 'OpenCode tool discovery returned an invalid response.')

--- a/app/electron/opencode/runtime.ts
+++ b/app/electron/opencode/runtime.ts
@@ -7,6 +7,7 @@ import path from 'node:path'
 
 import { readPreferredOpenCodePort, runtimePaths, writePreferredOpenCodePort, writeRuntimeFiles, writeUsageSnapshot, type OpenCodeRuntimePaths } from './config'
 import { sanitizeUsageSnapshot } from './snapshot'
+import { prepareOpenCodeStorage, quarantineImportedOpenCodeDatabase, type OpenCodeStoragePreparation } from './storage'
 import {
   OPENCODE_COMMIT,
   OPENCODE_CUSTOM_TOOL_IDS,
@@ -50,6 +51,7 @@ export type OpenCodeRuntimeOptions = {
   arch?: string
   executableOverride?: string
   workingDirectory?: string
+  baseEnv?: NodeJS.ProcessEnv
   spawnProcess?: (file: string, args: string[], options: OpenCodeSpawnOptions) => SpawnedOpenCodeProcess
   fetchImpl?: OpenCodeFetch
   acquirePort?: () => Promise<number>
@@ -105,6 +107,12 @@ export function createLaunchEnvironment(options: {
     OPENCODE_SERVER_PASSWORD: options.password,
     OPENCODE_CONFIG_DIR: options.paths.runtimeDir,
     OPENCODE_CONFIG: options.paths.configPath,
+    OPENCODE_DATA_DIR: options.paths.dataDir,
+    OPENCODE_DB: options.paths.databasePath,
+    XDG_DATA_HOME: options.paths.dataDir,
+    XDG_CACHE_HOME: options.paths.cacheDir,
+    XDG_STATE_HOME: options.paths.stateDir,
+    XDG_CONFIG_HOME: options.paths.runtimeDir,
     OPENCODE_DISABLE_AUTOUPDATE: '1',
     METRORA_USAGE_SNAPSHOT_FILE: options.paths.snapshotPath,
   }
@@ -245,7 +253,7 @@ export class OpenCodeRuntime {
     }
   }
 
-  private async startInternal(): Promise<OpenCodeRuntimeStatus> {
+  private async startInternal(allowStorageImport = true): Promise<OpenCodeRuntimeStatus> {
     if (this.state === 'ready') return this.status()
     this.state = 'starting'
     this.detail = null
@@ -253,12 +261,21 @@ export class OpenCodeRuntime {
     const abort = new AbortController()
     this.startupAbort = abort
     const paths = runtimePaths(this.options.userDataPath)
+    let storagePreparation: OpenCodeStoragePreparation = { outcome: 'existing' }
 
     try {
       const executable = resolveOpenCodeExecutable(this.options)
       if (!executable) throw new OpenCodeError('not-staged', `OpenCode ${OPENCODE_VERSION} is not staged for this platform.`)
 
       await writeRuntimeFiles(paths)
+      if (allowStorageImport) {
+        storagePreparation = await prepareOpenCodeStorage(paths, {
+          userDataPath: this.options.userDataPath,
+          platform: this.options.platform,
+          environment: this.options.baseEnv,
+          onWarning: message => console.warn(`[Metrora] ${message}`),
+        })
+      }
       await ensureInitialSnapshot(paths)
       // Usage reconciliation can be slow and is not needed to launch the
       // bundled OpenCode UI. Keep it off the activation critical path.
@@ -274,7 +291,7 @@ export class OpenCodeRuntime {
         args,
         {
           cwd: this.options.workingDirectory ?? this.options.appPath,
-          env: createLaunchEnvironment({ paths, username: SERVER_USERNAME, password, toolBridgeSpec: this.options.toolBridgeSpec }),
+          env: createLaunchEnvironment({ baseEnv: this.options.baseEnv, paths, username: SERVER_USERNAME, password, toolBridgeSpec: this.options.toolBridgeSpec }),
           stdio: ['ignore', 'ignore', 'ignore'],
           windowsHide: true,
         },
@@ -313,6 +330,13 @@ export class OpenCodeRuntime {
       this.child = null
       try { child?.kill() } catch { /* best effort */ }
       if (child) await waitForExit(child, STOP_TIMEOUT_MS)
+      if (allowStorageImport && storagePreparation.outcome === 'imported' && child) {
+        const rejectedPath = await quarantineImportedOpenCodeDatabase(paths)
+        if (rejectedPath) {
+          console.warn(`[Metrora] Imported OpenCode history could not start in the pinned runtime; using a clean isolated store. Preserved at ${rejectedPath}`)
+          return await this.startInternal(false)
+        }
+      }
       this.state = 'unavailable'
       this.customToolRegistered = error instanceof OpenCodeError && error.kind === 'custom-tool' ? false : this.customToolRegistered
       this.detail = error instanceof OpenCodeError && error.kind !== 'protocol'

--- a/app/electron/opencode/storage.test.ts
+++ b/app/electron/opencode/storage.test.ts
@@ -11,6 +11,39 @@ import { OpenCodeRuntime, type OpenCodeFetch, type SpawnedOpenCodeProcess } from
 import { prepareOpenCodeStorage, quarantineImportedOpenCodeDatabase } from './storage'
 import { OPENCODE_CUSTOM_TOOL_IDS, OPENCODE_VERSION } from './types'
 
+const storageTestControls = vi.hoisted(() => ({
+  largePaths: new Set<string>(),
+  availableBytes: null as bigint | null,
+}))
+
+vi.mock('node:fs/promises', async importOriginal => {
+  const original = await importOriginal<typeof import('node:fs/promises')>()
+  return {
+    ...original,
+    stat: async (filePath: any, options?: any) => {
+      const value = await original.stat(filePath, options)
+      if (storageTestControls.largePaths.has(String(filePath))) {
+        Object.defineProperty(value, 'size', { configurable: true, value: (512 * 1024 * 1024) + 1 })
+      }
+      return value
+    },
+    statfs: async (filePath: any, options?: any) => {
+      if (storageTestControls.availableBytes === null) return original.statfs(filePath, options)
+      const blockSize = 4096n
+      const availableBlocks = storageTestControls.availableBytes / blockSize
+      return {
+        type: 0n,
+        bsize: blockSize,
+        blocks: availableBlocks,
+        bfree: availableBlocks,
+        bavail: availableBlocks,
+        files: 1n,
+        ffree: 1n,
+      }
+    },
+  }
+})
+
 type TestDatabase = {
   exec(sql: string): void
   prepare(sql: string): { all(...params: unknown[]): Array<Record<string, unknown>> }
@@ -22,6 +55,8 @@ const { DatabaseSync } = requireForTest('node:sqlite') as { DatabaseSync: new (f
 const temporaryDirectories: string[] = []
 
 afterEach(() => {
+  storageTestControls.largePaths.clear()
+  storageTestControls.availableBytes = null
   for (const directory of temporaryDirectories.splice(0)) rmSync(directory, { recursive: true, force: true })
 })
 
@@ -76,6 +111,73 @@ function jsonResponse(value: unknown): Response {
 }
 
 describe('Metrora-owned OpenCode storage continuity', () => {
+  it('treats an existing Metrora database above the former external import threshold as existing', async () => {
+    const root = tempDirectory()
+    const userDataPath = join(root, 'metrora-user-data')
+    const paths = runtimePaths(userDataPath)
+    mkdirSync(paths.dbDir, { recursive: true })
+    writeFileSync(paths.databasePath, 'Metrora-owned database')
+    storageTestControls.largePaths.add(paths.databasePath)
+
+    await expect(prepareOpenCodeStorage(paths, { userDataPath })).resolves.toEqual({ outcome: 'existing' })
+  })
+
+  it('starts with an existing Metrora database above the former external import threshold', async () => {
+    const root = tempDirectory()
+    const userDataPath = join(root, 'metrora-user-data')
+    const paths = runtimePaths(userDataPath)
+    mkdirSync(paths.dbDir, { recursive: true })
+    writeFileSync(paths.databasePath, 'Metrora-owned database')
+    storageTestControls.largePaths.add(paths.databasePath)
+    const executable = join(root, 'opencode.exe')
+    writeFileSync(executable, 'official binary placeholder')
+    const runtime = new OpenCodeRuntime({
+      appPath: root,
+      resourcesPath: root,
+      userDataPath,
+      isPackaged: false,
+      baseEnv: {},
+      executableOverride: executable,
+      acquirePort: async () => 43123,
+      isLoopbackPortAvailable: async () => true,
+      spawnProcess: () => fakeChild(),
+      fetchImpl: async url => url.endsWith('/global/health')
+        ? jsonResponse({ healthy: true, version: OPENCODE_VERSION })
+        : jsonResponse([...OPENCODE_CUSTOM_TOOL_IDS]),
+      healthTimeoutMs: 500,
+      pollIntervalMs: 1,
+    })
+
+    await expect(runtime.start()).resolves.toMatchObject({ state: 'ready', customToolRegistered: true })
+    await runtime.stop()
+  })
+
+  it('skips external import truthfully when the owned runtime lacks disk headroom', async () => {
+    const root = tempDirectory()
+    const external = createExternalDatabase(root)
+    const userDataPath = join(root, 'metrora-user-data')
+    const paths = runtimePaths(userDataPath)
+    const beforeMain = fingerprint(external.path)
+    const beforeWal = existsSync(`${external.path}-wal`) ? fingerprint(`${external.path}-wal`) : null
+    storageTestControls.availableBytes = 4096n
+
+    try {
+      await expect(prepareOpenCodeStorage(paths, {
+        userDataPath,
+        environment: { XDG_DATA_HOME: join(root, 'external-data') },
+      })).resolves.toMatchObject({
+        outcome: 'failed',
+        sourcePath: external.path,
+        detail: expect.stringContaining('external OpenCode import needs'),
+      })
+      expect(fingerprint(external.path)).toEqual(beforeMain)
+      expect(beforeWal && fingerprint(`${external.path}-wal`)).toEqual(beforeWal)
+      expect(existsSync(paths.databasePath)).toBe(false)
+    } finally {
+      external.database.close()
+    }
+  })
+
   it('imports a stable read-only snapshot without touching the external database', async () => {
     const root = tempDirectory()
     const external = createExternalDatabase(root)

--- a/app/electron/opencode/storage.test.ts
+++ b/app/electron/opencode/storage.test.ts
@@ -93,12 +93,34 @@ describe('Metrora-owned OpenCode storage continuity', () => {
     expect(beforeWal && fingerprint(`${external.path}-wal`)).toEqual(beforeWal)
     expect(paths.databasePath).not.toBe(external.path)
     expect(existsSync(paths.databasePath)).toBe(true)
+    expect(existsSync(`${paths.databasePath}-wal`)).toBe(Boolean(beforeWal))
+    expect(existsSync(`${paths.databasePath}-shm`)).toBe(false)
 
     const imported = new DatabaseSync(paths.databasePath, { readOnly: true })
     expect(imported.prepare('SELECT value FROM sentinel').all()).toEqual([{ value: 'external-authority' }])
     expect(imported.prepare('PRAGMA user_version').all()).toEqual([{ user_version: 1162 }])
     imported.close()
     external.database.close()
+  })
+
+  it('imports without depending on the non-portable DatabaseSync.serialize API', async () => {
+    const root = tempDirectory()
+    const external = createExternalDatabase(root)
+    const userDataPath = join(root, 'metrora-user-data')
+    const paths = runtimePaths(userDataPath)
+    const sqlitePrototype = (DatabaseSync as unknown as { prototype: TestDatabase & { serialize?: unknown } }).prototype
+    const originalSerialize = sqlitePrototype.serialize
+    try {
+      sqlitePrototype.serialize = undefined
+      await expect(prepareOpenCodeStorage(paths, {
+        userDataPath,
+        environment: { XDG_DATA_HOME: join(root, 'external-data') },
+      })).resolves.toMatchObject({ outcome: 'imported' })
+      expect(existsSync(paths.databasePath)).toBe(true)
+    } finally {
+      sqlitePrototype.serialize = originalSerialize
+      external.database.close()
+    }
   })
 
   it('reuses the Metrora-owned database across restart and never chooses it as a legacy source', async () => {

--- a/app/electron/opencode/storage.test.ts
+++ b/app/electron/opencode/storage.test.ts
@@ -1,0 +1,201 @@
+// @vitest-environment node
+import { createHash } from 'node:crypto'
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs'
+import { createRequire } from 'node:module'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { runtimePaths } from './config'
+import { OpenCodeRuntime, type OpenCodeFetch, type SpawnedOpenCodeProcess } from './runtime'
+import { prepareOpenCodeStorage, quarantineImportedOpenCodeDatabase } from './storage'
+import { OPENCODE_CUSTOM_TOOL_IDS, OPENCODE_VERSION } from './types'
+
+type TestDatabase = {
+  exec(sql: string): void
+  prepare(sql: string): { all(...params: unknown[]): Array<Record<string, unknown>> }
+  close(): void
+}
+
+const requireForTest = createRequire(import.meta.url)
+const { DatabaseSync } = requireForTest('node:sqlite') as { DatabaseSync: new (filePath: string, options?: { readOnly?: boolean }) => TestDatabase }
+const temporaryDirectories: string[] = []
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) rmSync(directory, { recursive: true, force: true })
+})
+
+function tempDirectory(): string {
+  const directory = mkdtempSync(join(tmpdir(), 'metrora-opencode-storage-'))
+  temporaryDirectories.push(directory)
+  return directory
+}
+
+function fingerprint(filePath: string): { hash: string; mtimeMs: number } {
+  return {
+    hash: createHash('sha256').update(readFileSync(filePath)).digest('hex'),
+    mtimeMs: statSync(filePath).mtimeMs,
+  }
+}
+
+function createExternalDatabase(root: string): { path: string; database: TestDatabase } {
+  const dataHome = join(root, 'external-data')
+  const directory = join(dataHome, 'opencode')
+  mkdirSync(directory, { recursive: true })
+  const filePath = join(directory, 'opencode.db')
+  const database = new DatabaseSync(filePath)
+  database.exec('PRAGMA journal_mode = WAL; CREATE TABLE sentinel (value TEXT NOT NULL); INSERT INTO sentinel VALUES (\'external-authority\'); PRAGMA user_version = 1162;')
+  return { path: filePath, database }
+}
+
+function fakeChild(): SpawnedOpenCodeProcess {
+  const listeners = new Map<string, Set<(...args: unknown[]) => void>>()
+  const child = {
+    exitCode: null as number | null,
+    once(event: 'exit' | 'error', listener: (...args: unknown[]) => void) {
+      const current = listeners.get(event) ?? new Set()
+      current.add(listener)
+      listeners.set(event, current)
+      return child
+    },
+    removeListener(event: 'exit' | 'error', listener: (...args: unknown[]) => void) {
+      listeners.get(event)?.delete(listener)
+      return child
+    },
+    kill() {
+      child.exitCode = 0
+      for (const listener of listeners.get('exit') ?? []) listener()
+      return true
+    },
+  }
+  return child
+}
+
+function jsonResponse(value: unknown): Response {
+  return new Response(JSON.stringify(value), { status: 200, headers: { 'content-type': 'application/json' } })
+}
+
+describe('Metrora-owned OpenCode storage continuity', () => {
+  it('imports a stable read-only snapshot without touching the external database', async () => {
+    const root = tempDirectory()
+    const external = createExternalDatabase(root)
+    const userDataPath = join(root, 'metrora-user-data')
+    const paths = runtimePaths(userDataPath)
+    const beforeMain = fingerprint(external.path)
+    const beforeWal = existsSync(`${external.path}-wal`) ? fingerprint(`${external.path}-wal`) : null
+
+    await expect(prepareOpenCodeStorage(paths, {
+      userDataPath,
+      environment: { XDG_DATA_HOME: join(root, 'external-data') },
+    })).resolves.toMatchObject({ outcome: 'imported', sourcePath: external.path })
+
+    expect(fingerprint(external.path)).toEqual(beforeMain)
+    expect(beforeWal && fingerprint(`${external.path}-wal`)).toEqual(beforeWal)
+    expect(paths.databasePath).not.toBe(external.path)
+    expect(existsSync(paths.databasePath)).toBe(true)
+
+    const imported = new DatabaseSync(paths.databasePath, { readOnly: true })
+    expect(imported.prepare('SELECT value FROM sentinel').all()).toEqual([{ value: 'external-authority' }])
+    expect(imported.prepare('PRAGMA user_version').all()).toEqual([{ user_version: 1162 }])
+    imported.close()
+    external.database.close()
+  })
+
+  it('reuses the Metrora-owned database across restart and never chooses it as a legacy source', async () => {
+    const root = tempDirectory()
+    const external = createExternalDatabase(root)
+    const userDataPath = join(root, 'metrora-user-data')
+    const paths = runtimePaths(userDataPath)
+    const environment = { XDG_DATA_HOME: join(root, 'external-data') }
+
+    await expect(prepareOpenCodeStorage(paths, { userDataPath, environment })).resolves.toMatchObject({ outcome: 'imported' })
+    const importedBeforeRestart = fingerprint(paths.databasePath)
+    await expect(prepareOpenCodeStorage(paths, { userDataPath, environment })).resolves.toEqual({ outcome: 'existing' })
+    expect(fingerprint(paths.databasePath)).toEqual(importedBeforeRestart)
+    expect(external.path).not.toBe(paths.databasePath)
+    external.database.close()
+  })
+
+  it('starts and stops with isolated launch paths while an external version-skewed store is live', async () => {
+    const root = tempDirectory()
+    const external = createExternalDatabase(root)
+    external.database.exec('PRAGMA user_version = 9999;')
+    const beforeMain = fingerprint(external.path)
+    const beforeWal = existsSync(`${external.path}-wal`) ? fingerprint(`${external.path}-wal`) : null
+    const userDataPath = join(root, 'metrora-user-data')
+    const executable = join(root, 'opencode.exe')
+    writeFileSync(executable, 'official binary placeholder')
+    let launchEnvironment: NodeJS.ProcessEnv | undefined
+    const spawnProcess = vi.fn((_file: string, _args: string[], options: { env: NodeJS.ProcessEnv }) => {
+      launchEnvironment = options.env
+      return fakeChild()
+    })
+    const fetchImpl: OpenCodeFetch = async url => url.endsWith('/global/health')
+      ? jsonResponse({ healthy: true, version: OPENCODE_VERSION })
+      : jsonResponse([...OPENCODE_CUSTOM_TOOL_IDS])
+    const runtime = new OpenCodeRuntime({
+      appPath: root,
+      resourcesPath: root,
+      userDataPath,
+      isPackaged: false,
+      executableOverride: executable,
+      baseEnv: {
+        OPENCODE_DB: external.path,
+        XDG_DATA_HOME: join(root, 'external-data'),
+        XDG_CACHE_HOME: join(root, 'external-cache'),
+        XDG_STATE_HOME: join(root, 'external-state'),
+        XDG_CONFIG_HOME: join(root, 'external-config'),
+      },
+      spawnProcess,
+      fetchImpl,
+      acquirePort: async () => 43144,
+      healthTimeoutMs: 500,
+      pollIntervalMs: 1,
+    })
+
+    await expect(runtime.start()).resolves.toMatchObject({ state: 'ready' })
+    const paths = runtimePaths(userDataPath)
+    expect(launchEnvironment?.OPENCODE_DB).toBe(paths.databasePath)
+    expect(launchEnvironment?.XDG_DATA_HOME).toBe(paths.dataDir)
+    expect(launchEnvironment?.XDG_CACHE_HOME).toBe(paths.cacheDir)
+    expect(launchEnvironment?.XDG_STATE_HOME).toBe(paths.stateDir)
+    expect(launchEnvironment?.XDG_CONFIG_HOME).toBe(paths.runtimeDir)
+    expect(launchEnvironment?.OPENCODE_DB).not.toBe(external.path)
+
+    await runtime.stop()
+    expect(fingerprint(external.path)).toEqual(beforeMain)
+    expect(beforeWal && fingerprint(`${external.path}-wal`)).toEqual(beforeWal)
+    external.database.close()
+  })
+
+  it('fails closed for an unreadable external store without blocking a clean isolated store', async () => {
+    const root = tempDirectory()
+    const externalDirectory = join(root, 'external-data', 'opencode')
+    mkdirSync(externalDirectory, { recursive: true })
+    const externalPath = join(externalDirectory, 'opencode.db')
+    writeFileSync(externalPath, 'not-a-sqlite-database')
+    const before = fingerprint(externalPath)
+    const userDataPath = join(root, 'metrora-user-data')
+    const paths = runtimePaths(userDataPath)
+
+    await expect(prepareOpenCodeStorage(paths, {
+      userDataPath,
+      environment: { XDG_DATA_HOME: join(root, 'external-data') },
+    })).resolves.toMatchObject({ outcome: 'failed', sourcePath: externalPath })
+    expect(fingerprint(externalPath)).toEqual(before)
+    expect(existsSync(paths.databasePath)).toBe(false)
+  })
+
+  it('quarantines only an imported Metrora-owned database before a clean retry', async () => {
+    const root = tempDirectory()
+    const paths = runtimePaths(join(root, 'metrora-user-data'))
+    mkdirSync(paths.dbDir, { recursive: true })
+    writeFileSync(paths.databasePath, 'owned-import')
+
+    const rejectedPath = await quarantineImportedOpenCodeDatabase(paths)
+
+    expect(rejectedPath).toBeTruthy()
+    expect(existsSync(paths.databasePath)).toBe(false)
+    expect(readFileSync(rejectedPath!, 'utf8')).toBe('owned-import')
+  })
+})

--- a/app/electron/opencode/storage.ts
+++ b/app/electron/opencode/storage.ts
@@ -1,5 +1,4 @@
-import { constants } from 'node:fs'
-import { copyFile, mkdtemp, mkdir, rename, rm, stat, unlink } from 'node:fs/promises'
+import { copyFile, mkdtemp, mkdir, rename, rm, stat, statfs } from 'node:fs/promises'
 import { homedir } from 'node:os'
 import path from 'node:path'
 
@@ -47,7 +46,9 @@ export type OpenCodeStorageOptions = {
 
 const SNAPSHOT_ATTEMPTS = 3
 const SNAPSHOT_PREFIX = 'opencode-storage-snapshot-'
-const MAX_SOURCE_BYTES = 512 * 1024 * 1024
+// This is a reserve for SQLite validation/temp files and filesystem overhead,
+// not a maximum source size. The source itself is bounded by available space.
+const EXTERNAL_IMPORT_DISK_RESERVE_BYTES = 256 * 1024 * 1024
 const DATABASE_SIDECARS = ['-wal', '-shm', '-journal'] as const
 
 let sqliteConstructorPromise: Promise<SqliteDatabaseConstructor | null> | null = null
@@ -138,7 +139,6 @@ async function fileFingerprint(filePath: string): Promise<FileFingerprint | null
   try {
     const value = await stat(filePath)
     if (!value.isFile()) return null
-    if (value.size > MAX_SOURCE_BYTES) throw new Error(`source file exceeds the bounded import size (${MAX_SOURCE_BYTES} bytes)`)
     return { size: value.size, mtimeMs: value.mtimeMs, ctimeMs: value.ctimeMs, ino: value.ino, dev: value.dev }
   } catch (error) {
     if ((error as { code?: string }).code === 'ENOENT') return null
@@ -169,6 +169,22 @@ function sameSourceState(a: SourceState, b: SourceState): boolean {
   return sameFingerprint(a.main, b.main) && sameFingerprint(a.wal, b.wal) && sameFingerprint(a.journal, b.journal)
 }
 
+async function ensureExternalImportResources(source: SourceState, destinationRoot: string): Promise<void> {
+  let availableBytes: bigint
+  try {
+    const filesystem = await statfs(destinationRoot, { bigint: true })
+    availableBytes = filesystem.bavail * filesystem.bsize
+  } catch (error) {
+    throw new Error(`available destination disk space could not be checked: ${errorMessage(error)}`)
+  }
+
+  const snapshotBytes = BigInt(source.main.size) + BigInt(source.wal?.size ?? 0)
+  const requiredBytes = snapshotBytes + BigInt(EXTERNAL_IMPORT_DISK_RESERVE_BYTES)
+  if (availableBytes < requiredBytes) {
+    throw new Error(`external OpenCode import needs ${requiredBytes.toString()} bytes but only ${availableBytes.toString()} bytes are available`)
+  }
+}
+
 function waitBriefly(): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, 10))
 }
@@ -181,7 +197,7 @@ async function createOwnedSnapshot(sourcePath: string, root: string): Promise<Ow
   for (let attempt = 0; attempt < SNAPSHOT_ATTEMPTS; attempt += 1) {
     const before = await sourceState(sourcePath)
     if (!before) {
-      lastFailure = 'source database disappeared or exceeded the bounded import size'
+      lastFailure = 'source database disappeared'
       break
     }
     if (before.journal) {
@@ -189,6 +205,7 @@ async function createOwnedSnapshot(sourcePath: string, root: string): Promise<Ow
       await waitBriefly()
       continue
     }
+    await ensureExternalImportResources(before, root)
 
     const directory = await mkdtemp(path.join(root, SNAPSHOT_PREFIX))
     const stagedDatabase = path.join(directory, 'source.sqlite.copying')
@@ -220,17 +237,6 @@ async function createOwnedSnapshot(sourcePath: string, root: string): Promise<Ow
   throw new Error(`safe SQLite snapshot failed: ${lastFailure}`)
 }
 
-async function copyFileIfAbsent(sourcePath: string, destinationPath: string): Promise<boolean> {
-  try {
-    await copyFile(sourcePath, destinationPath, constants.COPYFILE_EXCL)
-    return true
-  } catch (error) {
-    if ((error as { code?: string }).code === 'EEXIST') return false
-    try { await unlink(destinationPath) } catch { /* a partial owned file is best effort cleanup */ }
-    throw error
-  }
-}
-
 async function validateOwnedSnapshot(filePath: string): Promise<void> {
   const DatabaseSync = await loadSqliteConstructor()
   if (!DatabaseSync) throw new Error('the bundled Node runtime has no node:sqlite support')
@@ -251,17 +257,24 @@ async function removeOwnedDatabaseSidecars(paths: OpenCodeRuntimePaths): Promise
 }
 
 async function publishOwnedSnapshot(snapshot: OwnedSnapshot, paths: OpenCodeRuntimePaths): Promise<boolean> {
-  const published = await copyFileIfAbsent(snapshot.databasePath, paths.databasePath)
-  if (!published) return false
+  let publishedWal = false
+  let publishedDatabase = false
   try {
     if (snapshot.walPath) {
-      const walPublished = await copyFileIfAbsent(snapshot.walPath, `${paths.databasePath}-wal`)
-      if (!walPublished) throw new Error('Metrora-owned SQLite WAL destination already exists')
+      // Publish WAL first. If startup is interrupted before the main file is
+      // moved, the next prepare pass removes this orphan sidecar and retries
+      // from the unchanged external source.
+      await rename(snapshot.walPath, `${paths.databasePath}-wal`)
+      publishedWal = true
     }
+    // The snapshot and final database live below the same runtime root, so a
+    // rename avoids a second full-size copy at peak disk usage.
+    await rename(snapshot.databasePath, paths.databasePath)
+    publishedDatabase = true
     return true
   } catch (error) {
-    await rm(paths.databasePath, { force: true }).catch(() => {})
-    await removeOwnedDatabaseSidecars(paths).catch(() => {})
+    if (publishedDatabase) await rm(paths.databasePath, { force: true }).catch(() => {})
+    if (publishedWal) await rm(`${paths.databasePath}-wal`, { force: true }).catch(() => {})
     throw error
   }
 }

--- a/app/electron/opencode/storage.ts
+++ b/app/electron/opencode/storage.ts
@@ -1,12 +1,17 @@
-import { copyFile, mkdtemp, mkdir, open, rename, rm, stat, unlink } from 'node:fs/promises'
+import { constants } from 'node:fs'
+import { copyFile, mkdtemp, mkdir, rename, rm, stat, unlink } from 'node:fs/promises'
 import { homedir } from 'node:os'
 import path from 'node:path'
 
 import type { OpenCodeRuntimePaths } from './config'
 import { OPENCODE_VERSION } from './types'
 
+type SqliteStatement = {
+  all: (...parameters: unknown[]) => Array<Record<string, unknown>>
+}
+
 type SqliteDatabase = {
-  serialize: (name?: string) => Uint8Array
+  prepare: (sql: string) => SqliteStatement
   close: () => void
 }
 
@@ -43,6 +48,7 @@ export type OpenCodeStorageOptions = {
 const SNAPSHOT_ATTEMPTS = 3
 const SNAPSHOT_PREFIX = 'opencode-storage-snapshot-'
 const MAX_SOURCE_BYTES = 512 * 1024 * 1024
+const DATABASE_SIDECARS = ['-wal', '-shm', '-journal'] as const
 
 let sqliteConstructorPromise: Promise<SqliteDatabaseConstructor | null> | null = null
 
@@ -167,7 +173,7 @@ function waitBriefly(): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, 10))
 }
 
-type OwnedSnapshot = { directory: string; databasePath: string }
+type OwnedSnapshot = { directory: string; databasePath: string; walPath: string | null }
 
 async function createOwnedSnapshot(sourcePath: string, root: string): Promise<OwnedSnapshot> {
   let lastFailure = 'source state was not stable'
@@ -202,8 +208,9 @@ async function createOwnedSnapshot(sourcePath: string, root: string): Promise<Ow
         continue
       }
       await rename(stagedDatabase, databasePath)
-      if (before.wal) await rename(stagedWal, `${databasePath}-wal`)
-      return { directory, databasePath }
+      const walPath = before.wal ? `${databasePath}-wal` : null
+      if (walPath) await rename(stagedWal, walPath)
+      return { directory, databasePath, walPath }
     } catch (error) {
       lastFailure = errorMessage(error)
       await rm(directory, { recursive: true, force: true }).catch(() => {})
@@ -213,43 +220,63 @@ async function createOwnedSnapshot(sourcePath: string, root: string): Promise<Ow
   throw new Error(`safe SQLite snapshot failed: ${lastFailure}`)
 }
 
-async function writeDatabaseIfAbsent(filePath: string, content: Uint8Array): Promise<boolean> {
-  let handle: Awaited<ReturnType<typeof open>> | undefined
+async function copyFileIfAbsent(sourcePath: string, destinationPath: string): Promise<boolean> {
   try {
-    handle = await open(filePath, 'wx', 0o600)
-    await handle.writeFile(content)
-    await handle.sync()
+    await copyFile(sourcePath, destinationPath, constants.COPYFILE_EXCL)
     return true
   } catch (error) {
     if ((error as { code?: string }).code === 'EEXIST') return false
-    if (handle) {
-      await handle.close().catch(() => {})
-      handle = undefined
-      try { await unlink(filePath) } catch { /* a partial owned file is best effort cleanup */ }
-    }
+    try { await unlink(destinationPath) } catch { /* a partial owned file is best effort cleanup */ }
     throw error
+  }
+}
+
+async function validateOwnedSnapshot(filePath: string): Promise<void> {
+  const DatabaseSync = await loadSqliteConstructor()
+  if (!DatabaseSync) throw new Error('the bundled Node runtime has no node:sqlite support')
+  let database: SqliteDatabase | undefined
+  try {
+    database = new DatabaseSync(filePath, { readOnly: true })
+    const rows = database.prepare('PRAGMA integrity_check').all()
+    if (rows.length !== 1 || rows[0]?.integrity_check !== 'ok') throw new Error('SQLite snapshot failed integrity verification')
   } finally {
-    await handle?.close().catch(() => {})
+    try { database?.close() } catch { /* best effort for an owned snapshot */ }
+  }
+}
+
+async function removeOwnedDatabaseSidecars(paths: OpenCodeRuntimePaths): Promise<void> {
+  for (const suffix of DATABASE_SIDECARS) {
+    await rm(`${paths.databasePath}${suffix}`, { force: true })
+  }
+}
+
+async function publishOwnedSnapshot(snapshot: OwnedSnapshot, paths: OpenCodeRuntimePaths): Promise<boolean> {
+  const published = await copyFileIfAbsent(snapshot.databasePath, paths.databasePath)
+  if (!published) return false
+  try {
+    if (snapshot.walPath) {
+      const walPublished = await copyFileIfAbsent(snapshot.walPath, `${paths.databasePath}-wal`)
+      if (!walPublished) throw new Error('Metrora-owned SQLite WAL destination already exists')
+    }
+    return true
+  } catch (error) {
+    await rm(paths.databasePath, { force: true }).catch(() => {})
+    await removeOwnedDatabaseSidecars(paths).catch(() => {})
+    throw error
   }
 }
 
 async function importDatabaseSnapshot(sourcePath: string, paths: OpenCodeRuntimePaths): Promise<boolean> {
-  const DatabaseSync = await loadSqliteConstructor()
-  if (!DatabaseSync) throw new Error('the bundled Node runtime has no node:sqlite support')
-
   const snapshotRoot = path.join(paths.runtimeRoot, 'storage-imports')
   await mkdir(snapshotRoot, { recursive: true, mode: 0o700 })
   const snapshot = await createOwnedSnapshot(sourcePath, snapshotRoot)
-  let database: SqliteDatabase | undefined
   try {
-    // serialize() runs against the owned snapshot, never the external path.
-    // The destination is a fresh Metrora-owned database with no shared WAL.
-    database = new DatabaseSync(snapshot.databasePath)
-    const serialized = database.serialize()
-    if (!(serialized instanceof Uint8Array) || serialized.byteLength === 0) throw new Error('SQLite snapshot was empty')
-    return await writeDatabaseIfAbsent(paths.databasePath, serialized)
+    // Validate only the owned snapshot. The external database is never opened
+    // by SQLite, and the source SHM index is intentionally omitted.
+    await validateOwnedSnapshot(snapshot.databasePath)
+    // Publish only the owned main+WAL pair; no serialization API is required.
+    return await publishOwnedSnapshot(snapshot, paths)
   } finally {
-    try { database?.close() } catch { /* best effort for an owned snapshot */ }
     await rm(snapshot.directory, { recursive: true, force: true }).catch(() => {})
   }
 }
@@ -257,6 +284,10 @@ async function importDatabaseSnapshot(sourcePath: string, paths: OpenCodeRuntime
 export async function prepareOpenCodeStorage(paths: OpenCodeRuntimePaths, options: OpenCodeStorageOptions): Promise<OpenCodeStoragePreparation> {
   if (await fileFingerprint(paths.databasePath)) return { outcome: 'existing' }
   await mkdir(paths.dbDir, { recursive: true, mode: 0o700 })
+  // A missing main file can leave sidecars behind after an interrupted import.
+  // They are not a valid database on their own and must not be paired with a
+  // different source snapshot.
+  await removeOwnedDatabaseSidecars(paths)
 
   for (const sourcePath of legacyOpenCodeDatabaseCandidates(options, paths)) {
     try {

--- a/app/electron/opencode/storage.ts
+++ b/app/electron/opencode/storage.ts
@@ -1,0 +1,291 @@
+import { copyFile, mkdtemp, mkdir, open, rename, rm, stat, unlink } from 'node:fs/promises'
+import { homedir } from 'node:os'
+import path from 'node:path'
+
+import type { OpenCodeRuntimePaths } from './config'
+import { OPENCODE_VERSION } from './types'
+
+type SqliteDatabase = {
+  serialize: (name?: string) => Uint8Array
+  close: () => void
+}
+
+type SqliteDatabaseConstructor = new (filePath: string, options?: { readOnly?: boolean }) => SqliteDatabase
+
+type FileFingerprint = {
+  size: number
+  mtimeMs: number
+  ctimeMs: number
+  ino?: number
+  dev?: number
+}
+
+type SourceState = {
+  main: FileFingerprint
+  wal: FileFingerprint | null
+  journal: FileFingerprint | null
+}
+
+export type OpenCodeStoragePreparation =
+  | { outcome: 'existing' }
+  | { outcome: 'empty' }
+  | { outcome: 'imported'; sourcePath: string }
+  | { outcome: 'failed'; sourcePath?: string; detail: string }
+
+export type OpenCodeStorageOptions = {
+  userDataPath: string
+  platform?: NodeJS.Platform
+  environment?: NodeJS.ProcessEnv
+  discoverDefaultLocations?: boolean
+  onWarning?: (message: string) => void
+}
+
+const SNAPSHOT_ATTEMPTS = 3
+const SNAPSHOT_PREFIX = 'opencode-storage-snapshot-'
+const MAX_SOURCE_BYTES = 512 * 1024 * 1024
+
+let sqliteConstructorPromise: Promise<SqliteDatabaseConstructor | null> | null = null
+
+async function loadSqliteConstructor(): Promise<SqliteDatabaseConstructor | null> {
+  if (!sqliteConstructorPromise) {
+    sqliteConstructorPromise = import('node:sqlite')
+      .then(module => (module as { DatabaseSync?: SqliteDatabaseConstructor }).DatabaseSync ?? null)
+      .catch(() => null)
+  }
+  return sqliteConstructorPromise
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}
+
+function isAbsolute(value: string, platform: NodeJS.Platform): boolean {
+  return platform === 'win32' ? path.win32.isAbsolute(value) : path.isAbsolute(value)
+}
+
+function normalizedPath(value: string, platform: NodeJS.Platform): string {
+  const resolved = platform === 'win32' ? path.win32.resolve(value) : path.resolve(value)
+  return platform === 'win32' ? resolved.toLowerCase() : resolved
+}
+
+function samePath(a: string, b: string, platform: NodeJS.Platform): boolean {
+  return normalizedPath(a, platform) === normalizedPath(b, platform)
+}
+
+function isWithin(parent: string, candidate: string, platform: NodeJS.Platform): boolean {
+  const relative = platform === 'win32'
+    ? path.win32.relative(path.win32.resolve(parent), path.win32.resolve(candidate))
+    : path.relative(path.resolve(parent), path.resolve(candidate))
+  return relative === '' || (relative !== '..' && !relative.startsWith(`..${platform === 'win32' ? '\\' : path.sep}`))
+}
+
+function addCandidate(
+  candidates: string[],
+  seen: Set<string>,
+  value: string | undefined,
+  platform: NodeJS.Platform,
+  paths: OpenCodeRuntimePaths,
+): void {
+  if (!value || !isAbsolute(value, platform)) return
+  if (samePath(value, paths.databasePath, platform) || isWithin(paths.runtimeRoot, value, platform)) return
+  const key = normalizedPath(value, platform)
+  if (seen.has(key)) return
+  seen.add(key)
+  candidates.push(value)
+}
+
+/** Resolve only stores that the pre-isolation runtime could have used. */
+export function legacyOpenCodeDatabaseCandidates(options: OpenCodeStorageOptions, paths: OpenCodeRuntimePaths): string[] {
+  const platform = options.platform ?? process.platform
+  const environment = options.environment ?? process.env
+  const home = homedir()
+  const candidates: string[] = []
+  const seen = new Set<string>()
+
+  addCandidate(candidates, seen, environment.OPENCODE_DB, platform, paths)
+
+  if (environment.XDG_DATA_HOME) {
+    addCandidate(candidates, seen, path.join(environment.XDG_DATA_HOME, 'opencode', 'opencode.db'), platform, paths)
+  }
+
+  if (options.discoverDefaultLocations ?? options.environment === undefined) {
+    if (platform === 'win32') {
+      addCandidate(candidates, seen, path.join(environment.LOCALAPPDATA ?? path.join(home, 'AppData', 'Local'), 'opencode', 'opencode.db'), platform, paths)
+      addCandidate(candidates, seen, path.join(environment.APPDATA ?? path.join(home, 'AppData', 'Roaming'), 'opencode', 'opencode.db'), platform, paths)
+      addCandidate(candidates, seen, path.join(home, '.local', 'share', 'opencode', 'opencode.db'), platform, paths)
+    } else if (platform === 'darwin') {
+      addCandidate(candidates, seen, path.join(home, 'Library', 'Application Support', 'opencode', 'opencode.db'), platform, paths)
+      addCandidate(candidates, seen, path.join(home, '.local', 'share', 'opencode', 'opencode.db'), platform, paths)
+    } else {
+      addCandidate(candidates, seen, path.join(home, '.local', 'share', 'opencode', 'opencode.db'), platform, paths)
+    }
+  }
+
+  // Very early Metrora builds placed the config and any explicitly redirected
+  // database below this version directory. Keep this read-only candidate for
+  // existing users, while excluding the new runtime root above.
+  addCandidate(candidates, seen, path.join(options.userDataPath, 'opencode', OPENCODE_VERSION, 'opencode.db'), platform, paths)
+  return candidates
+}
+
+async function fileFingerprint(filePath: string): Promise<FileFingerprint | null> {
+  try {
+    const value = await stat(filePath)
+    if (!value.isFile()) return null
+    if (value.size > MAX_SOURCE_BYTES) throw new Error(`source file exceeds the bounded import size (${MAX_SOURCE_BYTES} bytes)`)
+    return { size: value.size, mtimeMs: value.mtimeMs, ctimeMs: value.ctimeMs, ino: value.ino, dev: value.dev }
+  } catch (error) {
+    if ((error as { code?: string }).code === 'ENOENT') return null
+    throw error
+  }
+}
+
+async function sourceState(filePath: string): Promise<SourceState | null> {
+  const main = await fileFingerprint(filePath)
+  if (!main) return null
+  return {
+    main,
+    wal: await fileFingerprint(`${filePath}-wal`),
+    journal: await fileFingerprint(`${filePath}-journal`),
+  }
+}
+
+function sameFingerprint(a: FileFingerprint | null, b: FileFingerprint | null): boolean {
+  if (a === null || b === null) return a === b
+  return a.size === b.size
+    && a.mtimeMs === b.mtimeMs
+    && a.ctimeMs === b.ctimeMs
+    && a.ino === b.ino
+    && a.dev === b.dev
+}
+
+function sameSourceState(a: SourceState, b: SourceState): boolean {
+  return sameFingerprint(a.main, b.main) && sameFingerprint(a.wal, b.wal) && sameFingerprint(a.journal, b.journal)
+}
+
+function waitBriefly(): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, 10))
+}
+
+type OwnedSnapshot = { directory: string; databasePath: string }
+
+async function createOwnedSnapshot(sourcePath: string, root: string): Promise<OwnedSnapshot> {
+  let lastFailure = 'source state was not stable'
+
+  for (let attempt = 0; attempt < SNAPSHOT_ATTEMPTS; attempt += 1) {
+    const before = await sourceState(sourcePath)
+    if (!before) {
+      lastFailure = 'source database disappeared or exceeded the bounded import size'
+      break
+    }
+    if (before.journal) {
+      lastFailure = 'an active rollback journal was present'
+      await waitBriefly()
+      continue
+    }
+
+    const directory = await mkdtemp(path.join(root, SNAPSHOT_PREFIX))
+    const stagedDatabase = path.join(directory, 'source.sqlite.copying')
+    const stagedWal = path.join(directory, 'source.sqlite-wal.copying')
+    const databasePath = path.join(directory, 'source.sqlite')
+    try {
+      // WAL is copied first so a stable source fence can only publish a pair
+      // that represents one read-only point in time. SHM is intentionally not
+      // copied; SQLite can rebuild that index in this Metrora-owned directory.
+      if (before.wal) await copyFile(`${sourcePath}-wal`, stagedWal)
+      await copyFile(sourcePath, stagedDatabase)
+      const after = await sourceState(sourcePath)
+      if (!after || after.journal || !sameSourceState(before, after)) {
+        lastFailure = !after ? 'source disappeared during snapshot' : after.journal ? 'a rollback journal appeared during snapshot' : 'source changed during snapshot'
+        await rm(directory, { recursive: true, force: true })
+        await waitBriefly()
+        continue
+      }
+      await rename(stagedDatabase, databasePath)
+      if (before.wal) await rename(stagedWal, `${databasePath}-wal`)
+      return { directory, databasePath }
+    } catch (error) {
+      lastFailure = errorMessage(error)
+      await rm(directory, { recursive: true, force: true }).catch(() => {})
+    }
+  }
+
+  throw new Error(`safe SQLite snapshot failed: ${lastFailure}`)
+}
+
+async function writeDatabaseIfAbsent(filePath: string, content: Uint8Array): Promise<boolean> {
+  let handle: Awaited<ReturnType<typeof open>> | undefined
+  try {
+    handle = await open(filePath, 'wx', 0o600)
+    await handle.writeFile(content)
+    await handle.sync()
+    return true
+  } catch (error) {
+    if ((error as { code?: string }).code === 'EEXIST') return false
+    if (handle) {
+      await handle.close().catch(() => {})
+      handle = undefined
+      try { await unlink(filePath) } catch { /* a partial owned file is best effort cleanup */ }
+    }
+    throw error
+  } finally {
+    await handle?.close().catch(() => {})
+  }
+}
+
+async function importDatabaseSnapshot(sourcePath: string, paths: OpenCodeRuntimePaths): Promise<boolean> {
+  const DatabaseSync = await loadSqliteConstructor()
+  if (!DatabaseSync) throw new Error('the bundled Node runtime has no node:sqlite support')
+
+  const snapshotRoot = path.join(paths.runtimeRoot, 'storage-imports')
+  await mkdir(snapshotRoot, { recursive: true, mode: 0o700 })
+  const snapshot = await createOwnedSnapshot(sourcePath, snapshotRoot)
+  let database: SqliteDatabase | undefined
+  try {
+    // serialize() runs against the owned snapshot, never the external path.
+    // The destination is a fresh Metrora-owned database with no shared WAL.
+    database = new DatabaseSync(snapshot.databasePath)
+    const serialized = database.serialize()
+    if (!(serialized instanceof Uint8Array) || serialized.byteLength === 0) throw new Error('SQLite snapshot was empty')
+    return await writeDatabaseIfAbsent(paths.databasePath, serialized)
+  } finally {
+    try { database?.close() } catch { /* best effort for an owned snapshot */ }
+    await rm(snapshot.directory, { recursive: true, force: true }).catch(() => {})
+  }
+}
+
+export async function prepareOpenCodeStorage(paths: OpenCodeRuntimePaths, options: OpenCodeStorageOptions): Promise<OpenCodeStoragePreparation> {
+  if (await fileFingerprint(paths.databasePath)) return { outcome: 'existing' }
+  await mkdir(paths.dbDir, { recursive: true, mode: 0o700 })
+
+  for (const sourcePath of legacyOpenCodeDatabaseCandidates(options, paths)) {
+    try {
+      if (!await fileFingerprint(sourcePath)) continue
+      const imported = await importDatabaseSnapshot(sourcePath, paths)
+      if (!imported) return { outcome: 'existing' }
+      return { outcome: 'imported', sourcePath }
+    } catch (error) {
+      const detail = errorMessage(error)
+      const failure: OpenCodeStoragePreparation = { outcome: 'failed', sourcePath, detail }
+      options.onWarning?.(`OpenCode history import skipped for ${sourcePath}: ${detail}`)
+      return failure
+    }
+  }
+  return { outcome: 'empty' }
+}
+
+/** Preserve an imported database for diagnosis before retrying with a clean store. */
+export async function quarantineImportedOpenCodeDatabase(paths: OpenCodeRuntimePaths): Promise<string | null> {
+  const target = path.join(paths.dbDir, `opencode-import-rejected-${Date.now()}.db`)
+  try {
+    const database = await stat(paths.databasePath)
+    if (!database.isFile()) return null
+    await rename(paths.databasePath, target)
+    for (const suffix of ['-wal', '-shm', '-journal']) {
+      try { await rename(`${paths.databasePath}${suffix}`, `${target}${suffix}`) } catch { /* sidecar may not exist */ }
+    }
+    return target
+  } catch {
+    return null
+  }
+}

--- a/docs/OPENCODE_UPSTREAM_SURFACE_001.md
+++ b/docs/OPENCODE_UPSTREAM_SURFACE_001.md
@@ -84,11 +84,18 @@ The Code renderer remains a host/layout surface rather than a custom OpenCode cl
 
 ## Project and session continuity
 
-Metrora deliberately avoids creating a second OpenCode project/session database.
+An independently installed OpenCode remains the authority for its own local
+store. The Metrora-managed bundled runtime owns a separate, version-scoped
+store and never shares a cross-version SQLite write authority with that
+application.
 
-OpenCode's standard local session/data store remains OpenCode authority. The Metrora-hosted Web surface preserves its own browser/project UI state and can import the normal OpenCode Desktop project list through a bounded read-only path.
-
-This gives users continuity without synchronizing two independent session engines.
+When prior local state is safely importable, continuity is a bounded one-way
+read-only import from the independent OpenCode store into Metrora's store. The
+source is never migrated, repaired, renamed, deleted or written back. If that
+continuity step is unavailable, Code starts with a clean Metrora-owned store
+instead of falling back to shared writes. The Metrora-hosted Web surface also
+preserves its own browser/project UI state and can import the normal OpenCode
+Desktop project list through a bounded read-only path.
 
 ## Metrora accounting
 

--- a/docs/OPENCODE_UPSTREAM_SURFACE_001.md
+++ b/docs/OPENCODE_UPSTREAM_SURFACE_001.md
@@ -91,7 +91,9 @@ application.
 
 When prior local state is safely importable, continuity is a bounded one-way
 read-only import from the independent OpenCode store into Metrora's store. The
-source is never migrated, repaired, renamed, deleted or written back. If that
+source is never migrated, repaired, renamed, deleted or written back. SQLite
+continuity uses a stable filesystem snapshot of the main database and WAL; it
+does not depend on a runtime-specific database serialization API. If that
 continuity step is unavailable, Code starts with a clean Metrora-owned store
 instead of falling back to shared writes. The Metrora-hosted Web surface also
 preserves its own browser/project UI state and can import the normal OpenCode

--- a/docs/OPENCODE_UPSTREAM_SURFACE_001.md
+++ b/docs/OPENCODE_UPSTREAM_SURFACE_001.md
@@ -89,15 +89,18 @@ store. The Metrora-managed bundled runtime owns a separate, version-scoped
 store and never shares a cross-version SQLite write authority with that
 application.
 
-When prior local state is safely importable, continuity is a bounded one-way
-read-only import from the independent OpenCode store into Metrora's store. The
-source is never migrated, repaired, renamed, deleted or written back. SQLite
-continuity uses a stable filesystem snapshot of the main database and WAL; it
-does not depend on a runtime-specific database serialization API. If that
-continuity step is unavailable, Code starts with a clean Metrora-owned store
-instead of falling back to shared writes. The Metrora-hosted Web surface also
-preserves its own browser/project UI state and can import the normal OpenCode
-Desktop project list through a bounded read-only path.
+When prior local state is safely importable, continuity is a one-way read-only
+import from the independent OpenCode store into Metrora's store. The source is
+never migrated, repaired, renamed, deleted or written back. SQLite continuity
+uses a stable filesystem snapshot of the main database and WAL; it does not
+depend on a runtime-specific database serialization API. Before copying, the
+runtime checks destination free space for the source pair plus an operational
+reserve, and moves the validated owned snapshot into place to avoid a second
+full-size copy. If that continuity step is unavailable, Code starts with a
+clean Metrora-owned store instead of falling back to shared writes. The
+Metrora-hosted Web surface also preserves its own browser/project UI state and
+can import the normal OpenCode Desktop project list through a bounded
+read-only path.
 
 ## Metrora accounting
 


### PR DESCRIPTION
## Summary

Release-blocking safety fix for the bundled OpenCode runtime.

Metrora previously isolated OpenCode configuration but allowed the pinned bundled runtime to share OpenCode's global data/SQLite store. With version skew, the bundled runtime could migrate a database also used by an independently installed OpenCode Desktop build.

This PR makes the bundled runtime own its complete storage boundary.

### Isolation
- Metrora-owned absolute `OPENCODE_DB`
- Metrora-owned XDG data/cache/state/config roots
- existing loopback, Basic Auth, staged binary, custom tools and project import preserved
- no write-back to independently installed OpenCode state

### Existing history
- bounded one-way read-only snapshot/import from legacy/external OpenCode storage when safely importable
- SQLite main/WAL source is fenced before import
- imported snapshot is migrated only inside Metrora-owned storage
- failed imported history can be quarantined and Code falls back to a clean isolated store
- external source is never mutated

### Regression coverage
- external DB mutation protection
- version-skew isolation
- Metrora-owned launch paths
- runtime persistence
- existing runtime/auth/tool behavior

### Important product invariant
A Metrora-managed bundled runtime must never mutate canonical state owned by an independently installed upstream application.

**Founder physical validation required before merge. Do not merge yet.**