### PR TITLE
feat: import standalone OpenCode sessions

### DIFF
--- a/app/electron/bridge-handlers.ts
+++ b/app/electron/bridge-handlers.ts
@@ -10,6 +10,7 @@ import type { DesktopShareRuntime } from './share-runtime'
 import { Telemetry } from './telemetry'
 import type { UpdateStatus } from './updates'
 import { createProjectBridgeHandlers, validateProjectScope } from './project-bridge'
+import type { OpenCodeImportResult } from './opencode/session-import'
 
 export type Envelope<T = unknown> = { ok: true; value: T } | { ok: false; error: { kind: string; message: string } }
 export type TelemetryBridge = Pick<Telemetry, 'status' | 'setEnabled' | 'completeOnboarding' | 'track'>
@@ -37,6 +38,8 @@ type Deps = {
   }
   /** Clear completed CLI projections after any explicit fresh read succeeds. */
   onFreshSuccess?: (provider: string) => void
+  /** Main-process-only standalone OpenCode session import action. */
+  openCodeImport?: () => Promise<OpenCodeImportResult>
 }
 
 export const NO_UPDATE_STATUS: UpdateStatus = { currentVersion: '', latestVersion: null, updateAvailable: false, tag: null }
@@ -484,5 +487,11 @@ export function createBridgeHandlers(deps: Deps): Record<string, Handler> {
     // One-shot read of the cached update-availability status. The check itself
     // runs in the background (launch + 24h); this returns whatever is known.
     'metrora:getUpdateStatus': async () => ({ ok: true, value: deps.getUpdateStatus ? await deps.getUpdateStatus() : NO_UPDATE_STATUS }),
+    'metrora:opencodeImport': async (...args: unknown[]) => {
+      if (args.length > 0) return { ok: false, error: { kind: 'bad-args', message: 'OpenCode session import does not accept arguments.' } }
+      if (!deps.openCodeImport) return { ok: false, error: { kind: 'unavailable', message: 'OpenCode session import is unavailable.' } }
+      try { return { ok: true, value: await deps.openCodeImport() } }
+      catch (err) { return { ok: false, error: toEnvelopeError(err) } }
+    },
   }
 }

--- a/app/electron/main.test.ts
+++ b/app/electron/main.test.ts
@@ -110,6 +110,7 @@ const CHANNELS = [
   'metrora:getPerformanceBenchComparison',
   'metrora:runPerformanceBench',
   'metrora:cancelPerformanceBench',
+  'metrora:opencodeImport',
 ] as const
 
 const ARGV_CASES: Array<{ channel: string; args: unknown[]; argv: string[] }> = [
@@ -253,6 +254,32 @@ describe('createBridgeHandlers (channel → argv for all channels)', () => {
 
 describe('createBridgeHandlers (IPC wiring)', () => {
   const withQuota = <T extends object>(value: T) => ({ ...value, getQuota: vi.fn(async () => []) })
+
+  it('routes the Metrora-owned OpenCode import action without accepting renderer arguments', async () => {
+    const openCodeImport = vi.fn(async () => ({
+      discovered: 3,
+      newSessions: 1,
+      imported: 1,
+      alreadyPresent: 2,
+      skipped: 0,
+      failed: 0,
+      reason: null,
+      reasons: [],
+    }))
+    const handlers = createBridgeHandlers({
+      spawnCli: vi.fn(),
+      spawnCliAction: vi.fn(),
+      resolveMetroraPath: () => null,
+      openCodeImport,
+    })
+
+    await expect(handlers['metrora:opencodeImport']!()).resolves.toMatchObject({ ok: true, value: { imported: 1 } })
+    await expect(handlers['metrora:opencodeImport']!('C:\\outside.exe')).resolves.toEqual({
+      ok: false,
+      error: { kind: 'bad-args', message: 'OpenCode session import does not accept arguments.' },
+    })
+    expect(openCodeImport).toHaveBeenCalledOnce()
+  })
   it('returns normalized quota through its own IPC channel and sanitizes unexpected failures', async () => {
     const base = { spawnCli: vi.fn(), spawnCliAction: vi.fn(), resolveMetroraPath: () => null }
     const value = [{

--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -14,6 +14,7 @@ import { createOpenCodeAccountingEnvironment } from './opencode/config'
 import { createOpenCodeFreshnessCoordinator, createOpenCodeSourceChangeDetector } from './opencode/freshness'
 import { OpenCodeRuntime } from './opencode/runtime'
 import { readOpenCodeDesktopProjects, resolveOpenCodeDesktopGlobalStorePath } from './opencode/project-import'
+import { OpenCodeSessionImporter, type OpenCodeImportResult } from './opencode/session-import'
 import { OpenCodeViewManager, normalizeOpenCodeBounds, type OpenCodeApp, type OpenCodeView, type OpenCodeWindow } from './opencode/view'
 
 export { createApplicationMenuTemplate } from './menu'
@@ -27,6 +28,8 @@ let updateChecker: UpdateChecker | null = null
 // Application-owned OpenCode sidecar + WebContentsView host. It is initialized
 // lazily with the rest of the IPC handlers and survives Code section changes.
 let openCodeViewManager: OpenCodeViewManager | null = null
+let openCodeImportFlight: Promise<OpenCodeImportResult> | null = null
+let cancelOpenCodeImport: (() => void) | null = null
 
 // The upstream Web UI keeps its project registry in browser storage. Keep
 // that storage stable across Metrora launches without sharing it with any
@@ -193,6 +196,34 @@ function registerHandlers(): void {
     readDesktopProjects: () => readOpenCodeDesktopProjects(openCodeDesktopGlobalStorePath, process.platform),
     platform: process.platform,
   })
+  const openCodeSessionImporter = new OpenCodeSessionImporter({
+    userDataPath: app.getPath('userData'),
+    platform: process.platform,
+    environment: process.env,
+    getMetroraCommand: () => openCodeRuntime.createCommandEnvironment(),
+    runWithRuntimeStopped: operation => {
+      if (!openCodeViewManager) return Promise.reject(new Error('OpenCode runtime is unavailable.'))
+      return openCodeViewManager.runMaintenance(operation)
+    },
+  })
+  cancelOpenCodeImport = () => openCodeSessionImporter.cancel()
+  const importOpenCodeSessions = async (): Promise<OpenCodeImportResult> => {
+    if (openCodeImportFlight) return await openCodeImportFlight
+    const promise = (async () => {
+      const result = await openCodeSessionImporter.importNewSessions()
+      if (result.imported > 0) {
+        clearCliReadCache()
+        await openCodeFreshness.onExplicitFreshSuccess('opencode')
+      }
+      return result
+    })()
+    openCodeImportFlight = promise
+    try {
+      return await promise
+    } finally {
+      if (openCodeImportFlight === promise) openCodeImportFlight = null
+    }
+  }
   const handlers = createBridgeHandlers({
     spawnCli,
     spawnCliAction,
@@ -205,6 +236,7 @@ function registerHandlers(): void {
     accountingEnv: openCodeAccountingEnv,
     openCodeFreshness,
     onFreshSuccess: () => clearCliReadCache(),
+    openCodeImport: importOpenCodeSessions,
   })
   const trustedRendererIpcChannels = new Set([
     'metrora:runPerformanceBench',
@@ -213,6 +245,7 @@ function registerHandlers(): void {
     'metrora:opencodeActivate',
     'metrora:opencodeBounds',
     'metrora:opencodeDeactivate',
+    'metrora:opencodeImport',
   ])
   function isTrustedRendererSender(event: { senderFrame?: { url?: string } | null }): boolean {
     const frameUrl = event.senderFrame?.url
@@ -426,7 +459,11 @@ function bootstrap(): void {
     getTelemetry: () => telemetryInstance,
     killAll: shutdownCli,
     stopShare: stopDesktopShareRuntime,
-    stopOpenCode: () => openCodeViewManager?.shutdown() ?? Promise.resolve(),
+    stopOpenCode: async () => {
+      cancelOpenCodeImport?.()
+      await openCodeImportFlight?.catch(() => undefined)
+      await openCodeViewManager?.shutdown()
+    },
     quit: () => app.quit(),
   }))
 

--- a/app/electron/opencode/runtime.test.ts
+++ b/app/electron/opencode/runtime.test.ts
@@ -82,6 +82,51 @@ describe('OpenCode upstream sidecar runtime', () => {
     expect(OPENCODE_COMMIT).toBe('b04697366f05419e9bd7a92f841813dd976161c9')
   })
 
+  it('reuses the pinned runtime environment for maintenance commands and keeps every storage root private', async () => {
+    const root = tempDirectory()
+    const userData = join(root, 'user-data')
+    const executable = join(root, 'opencode.exe')
+    writeFileSync(executable, 'official binary placeholder')
+    const commandRuntime = new OpenCodeRuntime({
+      appPath: root,
+      resourcesPath: root,
+      userDataPath: userData,
+      isPackaged: false,
+      executableOverride: executable,
+      baseEnv: {
+        OPENCODE_DB: join(root, 'standalone', 'opencode.db'),
+        XDG_DATA_HOME: join(root, 'standalone-data'),
+        XDG_CACHE_HOME: join(root, 'standalone-cache'),
+        XDG_STATE_HOME: join(root, 'standalone-state'),
+        XDG_CONFIG_HOME: join(root, 'standalone-config'),
+        OPENCODE_CONFIG_DIR: join(root, 'standalone-config'),
+        OPENCODE_CONFIG: join(root, 'standalone-config', 'opencode.json'),
+        METRORA_USAGE_SNAPSHOT_FILE: 'must-be-replaced',
+      },
+      randomPassword: () => 'p'.repeat(64),
+    })
+
+    const command = await commandRuntime.createCommandEnvironment()
+    const paths = runtimePaths(userData)
+    expect(command.executablePath).toBe(executable)
+    expect(command.paths).toEqual(paths)
+    expect(command.environment).toEqual(expect.objectContaining({
+      OPENCODE_DB: paths.databasePath,
+      OPENCODE_CONFIG_DIR: paths.runtimeDir,
+      OPENCODE_CONFIG: paths.configPath,
+      OPENCODE_DATA_DIR: paths.dataDir,
+      XDG_DATA_HOME: paths.dataDir,
+      XDG_CACHE_HOME: paths.cacheDir,
+      XDG_STATE_HOME: paths.stateDir,
+      XDG_CONFIG_HOME: paths.runtimeDir,
+      METRORA_USAGE_SNAPSHOT_FILE: paths.snapshotPath,
+      OPENCODE_SERVER_USERNAME: 'metrora',
+      OPENCODE_SERVER_PASSWORD: 'p'.repeat(64),
+    }))
+    expect(command.environment.OPENCODE_DB).not.toBe(join(root, 'standalone', 'opencode.db'))
+    expect(command.environment.XDG_DATA_HOME).not.toBe(join(root, 'standalone-data'))
+  })
+
   it('starts serve on loopback with per-launch auth, verifies health/tool discovery, and exposes no secret in status', async () => {
     const root = tempDirectory()
     const userData = join(root, 'user-data')

--- a/app/electron/opencode/runtime.ts
+++ b/app/electron/opencode/runtime.ts
@@ -74,6 +74,13 @@ export type OpenCodeExecutableResolution = Pick<OpenCodeRuntimeOptions, 'appPath
   executableOverride?: string
 }
 
+/** Main-process-only command authority for maintenance commands. */
+export type OpenCodeCommandEnvironment = {
+  executablePath: string
+  environment: NodeJS.ProcessEnv
+  paths: OpenCodeRuntimePaths
+}
+
 /** Resolve only the deterministic staged binary; never search PATH. */
 export function resolveOpenCodeExecutable(options: OpenCodeExecutableResolution): string | null {
   if (options.executableOverride && !path.isAbsolute(options.executableOverride)) return null
@@ -231,6 +238,32 @@ export class OpenCodeRuntime {
   /** Main-process-only access to the current Basic Auth material. */
   getConnection(): OpenCodeConnection | null {
     return this.connection ? { ...this.connection } : null
+  }
+
+  /**
+   * Build the same private path/environment contract used by the server. The
+   * caller must still serialize maintenance with the running WebContentsView;
+   * this method never starts a second OpenCode authority.
+   */
+  async createCommandEnvironment(): Promise<OpenCodeCommandEnvironment> {
+    const executablePath = resolveOpenCodeExecutable(this.options)
+    if (!executablePath) throw new OpenCodeError('not-staged', `OpenCode ${OPENCODE_VERSION} is not staged for this platform.`)
+    const paths = runtimePaths(this.options.userDataPath)
+    await writeRuntimeFiles(paths)
+    const password = this.connection?.password ?? this.options.randomPassword?.() ?? randomBytes(32).toString('hex')
+    if (!password || password.length < 32) throw new OpenCodeError('auth', 'OpenCode maintenance credentials could not be generated.')
+    return {
+      executablePath,
+      environment: createLaunchEnvironment({
+        baseEnv: this.options.baseEnv,
+        paths,
+        username: SERVER_USERNAME,
+        password,
+        toolBridgeSpec: this.options.toolBridgeSpec,
+        accountingEnv: this.options.accountingEnv,
+      }),
+      paths,
+    }
   }
 
   async start(): Promise<OpenCodeRuntimeStatus> {

--- a/app/electron/opencode/session-import.test.ts
+++ b/app/electron/opencode/session-import.test.ts
@@ -1,0 +1,335 @@
+// @vitest-environment node
+import { mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs'
+import { createRequire } from 'node:module'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { runtimePaths } from './config'
+import {
+  OpenCodeSessionImporter,
+  type OpenCodeCommandRequest,
+  type OpenCodeCommandResult,
+} from './session-import'
+import { readOpenCodeSessionMetadata, type OpenCodeSessionMetadata, type OpenCodeSessionMetadataRead } from './storage'
+
+const requireForTest = createRequire(import.meta.url)
+const temporaryDirectories: string[] = []
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) rmSync(directory, { recursive: true, force: true })
+})
+
+function temporaryDirectory(): string {
+  const directory = mkdtempSync(path.join(tmpdir(), 'metrora-opencode-import-'))
+  temporaryDirectories.push(directory)
+  return directory
+}
+
+function session(id: string, directory: string | null): OpenCodeSessionMetadata {
+  return { id, title: `Session ${id}`, directory, updatedAt: 1_700_000_000_000 }
+}
+
+type HarnessOptions = {
+  sourceSessions?: OpenCodeSessionMetadata[]
+  destinationSessions?: OpenCodeSessionMetadata[]
+  unavailableDirectories?: Set<string>
+  exportFailures?: Set<string>
+  malformedExports?: Set<string>
+  importFailures?: Set<string>
+  snapshotFailure?: boolean
+  rejectMaintenance?: boolean
+}
+
+function harness(options: HarnessOptions = {}) {
+  const root = temporaryDirectory()
+  const userDataPath = path.join(root, 'metrora-user-data')
+  const sourceDatabasePath = path.join(root, 'standalone', 'opencode.db')
+  mkdirSync(path.dirname(sourceDatabasePath), { recursive: true })
+  writeFileSync(sourceDatabasePath, 'standalone database placeholder')
+  const destinationPath = runtimePaths(userDataPath).databasePath
+  const sourceSessions = options.sourceSessions ?? [session('new-a', path.join(root, 'project-a'))]
+  const destinationSessions = [...(options.destinationSessions ?? [])]
+  let destinationExists = destinationSessions.length > 0
+  let maintenanceRuns = 0
+  let maintenanceCompletions = 0
+  const calls: OpenCodeCommandRequest[] = []
+
+  const standalone = {
+    executablePath: path.join(root, 'standalone-opencode.exe'),
+    version: '1.18.29',
+    databasePath: sourceDatabasePath,
+    environment: {
+      OPENCODE_DB: sourceDatabasePath,
+      XDG_DATA_HOME: path.join(root, 'standalone-data'),
+    },
+  }
+
+  const commandRunner = vi.fn(async (request: OpenCodeCommandRequest): Promise<OpenCodeCommandResult> => {
+    calls.push(request)
+    const [command, value] = request.args
+    if (command === 'export') {
+      if (options.exportFailures?.has(value ?? '')) return { code: 1, stderr: 'redacted export failure', timedOut: false }
+      const exported = sourceSessions.find(item => item.id === value)
+      if (!exported || !request.stdoutPath) return { code: 1, stderr: '', timedOut: false }
+      const info = options.malformedExports?.has(value ?? '')
+        ? { id: 'wrong-id' }
+        : { id: exported.id, title: exported.title, directory: exported.directory }
+      writeFileSync(request.stdoutPath, JSON.stringify({ info, messages: [{ info: { id: `message-${value}` }, parts: [] }] }))
+      return { code: 0, stderr: '', timedOut: false }
+    }
+    if (command === 'import') {
+      const data = JSON.parse(readFileSync(value!, 'utf8')) as { info: { id: string } }
+      if (options.importFailures?.has(data.info.id)) return { code: 1, stderr: 'redacted import failure', timedOut: false }
+      const imported = sourceSessions.find(item => item.id === data.info.id)
+      if (imported && !destinationSessions.some(item => item.id === imported.id)) destinationSessions.push(imported)
+      destinationExists = true
+      return { code: 0, stderr: '', timedOut: false }
+    }
+    return { code: 1, stderr: '', timedOut: false }
+  })
+
+  const readSessionMetadata = vi.fn(async (databasePath: string): Promise<OpenCodeSessionMetadataRead> => {
+    if (databasePath === sourceDatabasePath) return { kind: 'ok', sessions: sourceSessions }
+    if (databasePath === destinationPath) {
+      return destinationExists ? { kind: 'ok', sessions: destinationSessions } : { kind: 'missing', sessions: [] }
+    }
+    return { kind: 'unavailable', sessions: [], detail: 'unexpected database' }
+  })
+  const importer = new OpenCodeSessionImporter({
+    userDataPath,
+    platform: process.platform,
+    standaloneResolver: async () => standalone,
+    readSessionMetadata,
+    snapshotDatabase: async (_sourcePath, destinationPath) => {
+      if (options.snapshotFailure) throw new Error('snapshot failed')
+      writeFileSync(destinationPath, 'owned snapshot placeholder')
+    },
+    directoryIsAvailable: async directory => !options.unavailableDirectories?.has(directory),
+    commandRunner,
+    getMetroraCommand: async () => ({
+      executablePath: path.join(root, 'metrora-opencode.exe'),
+      environment: { OPENCODE_DB: destinationPath, XDG_DATA_HOME: runtimePaths(userDataPath).dataDir },
+      paths: runtimePaths(userDataPath),
+    }),
+    runWithRuntimeStopped: async operation => {
+      maintenanceRuns += 1
+      if (options.rejectMaintenance) throw new Error('shutdown cancelled')
+      try { return await operation() } finally { maintenanceCompletions += 1 }
+    },
+  })
+  return { root, userDataPath, sourceDatabasePath, destinationPath, destinationSessions, calls, commandRunner, readSessionMetadata, importer, maintenanceRuns: () => maintenanceRuns, maintenanceCompletions: () => maintenanceCompletions }
+}
+
+describe('OpenCode standalone session import', () => {
+  it('reports a missing standalone export runtime without touching Metrora', async () => {
+    const root = temporaryDirectory()
+    const importer = new OpenCodeSessionImporter({
+      userDataPath: path.join(root, 'user-data'),
+      standaloneResolver: async () => null,
+      getMetroraCommand: async () => { throw new Error('must not be called') },
+      runWithRuntimeStopped: async operation => operation(),
+    })
+
+    await expect(importer.importNewSessions()).resolves.toMatchObject({
+      discovered: 0,
+      imported: 0,
+      reason: 'standalone-not-found',
+      reasons: [],
+    })
+  })
+
+  it('treats an installed runtime with no standalone database as an empty source', async () => {
+    const h = harness()
+    const empty = new OpenCodeSessionImporter({
+      userDataPath: h.userDataPath,
+      standaloneResolver: async () => ({ executablePath: 'standalone', version: '1.18.29', databasePath: null, environment: {} }),
+      getMetroraCommand: async () => { throw new Error('must not be called') },
+      runWithRuntimeStopped: async operation => operation(),
+    })
+    await expect(empty.importNewSessions()).resolves.toMatchObject({ discovered: 0, newSessions: 0, imported: 0, reason: null })
+  })
+
+  it('counts overlap as already present and leaves existing sessions untouched', async () => {
+    const h = harness({
+      sourceSessions: [session('a', path.resolve('import-a'))],
+      destinationSessions: [session('a', path.resolve('different-a'))],
+    })
+    await expect(h.importer.importNewSessions()).resolves.toMatchObject({ discovered: 1, newSessions: 0, imported: 0, alreadyPresent: 1 })
+    expect(h.commandRunner).not.toHaveBeenCalled()
+    expect(h.maintenanceRuns()).toBe(0)
+  })
+
+  it('exports to a private file and imports one new session with its original directory', async () => {
+    const h = harness({ sourceSessions: [session('new-a', path.resolve('project-a'))] })
+    await expect(h.importer.importNewSessions()).resolves.toMatchObject({ discovered: 1, newSessions: 1, imported: 1, alreadyPresent: 0 })
+    expect(h.calls.map(call => call.args)).toEqual([['export', 'new-a'], ['import', expect.stringMatching(/\.json$/u)]])
+    expect(h.calls[0]?.cwd).toBe(path.resolve('project-a'))
+    expect(h.calls[1]?.cwd).toBe(path.resolve('project-a'))
+    expect(h.calls[0]?.environment.OPENCODE_DB).not.toBe(h.sourceDatabasePath)
+    expect(h.calls[0]?.environment.OPENCODE_CONFIG_DIR).toBeUndefined()
+    expect(h.calls[0]?.environment.OPENCODE_CONFIG).toBeUndefined()
+    expect(h.calls[1]?.environment.OPENCODE_DB).toBe(h.destinationPath)
+    expect(readdirSync(path.join(h.userDataPath, 'temp', 'opencode-session-import'))).toEqual([])
+    expect(h.maintenanceRuns()).toBe(1)
+    expect(h.maintenanceCompletions()).toBe(1)
+  })
+
+  it('imports multiple sessions, skips canonical overlaps, and does not update an existing directory', async () => {
+    const h = harness({
+      sourceSessions: [session('a', path.resolve('a')), session('b', path.resolve('b')), session('c', path.resolve('c'))],
+      destinationSessions: [session('a', path.resolve('old-a'))],
+    })
+    await expect(h.importer.importNewSessions()).resolves.toMatchObject({ discovered: 3, newSessions: 2, imported: 2, alreadyPresent: 1 })
+    expect(h.calls.filter(call => call.args[0] === 'export').map(call => call.args[1])).toEqual(['b', 'c'])
+    expect(h.destinationSessions.find(item => item.id === 'a')?.directory).toBe(path.resolve('old-a'))
+  })
+
+  it('is idempotent across the second invocation', async () => {
+    const h = harness({ sourceSessions: [session('new-a', path.resolve('project-a'))] })
+    await expect(h.importer.importNewSessions()).resolves.toMatchObject({ imported: 1 })
+    await expect(h.importer.importNewSessions()).resolves.toMatchObject({ newSessions: 0, imported: 0, alreadyPresent: 1 })
+    expect(h.calls.filter(call => call.args[0] === 'import')).toHaveLength(1)
+  })
+
+  it('skips a missing or unsafe project directory without inventing a path', async () => {
+    const missing = session('missing', path.join('relative', 'project'))
+    const noDirectory = session('none', null)
+    const h = harness({ sourceSessions: [missing, noDirectory] })
+    await expect(h.importer.importNewSessions()).resolves.toMatchObject({ newSessions: 2, skipped: 2, failed: 0, reason: 'directory-unavailable' })
+    expect(h.commandRunner).not.toHaveBeenCalled()
+  })
+
+  it('continues after one standalone export fails', async () => {
+    const h = harness({
+      sourceSessions: [session('failed', path.resolve('failed')), session('ok', path.resolve('ok'))],
+      exportFailures: new Set(['failed']),
+    })
+    await expect(h.importer.importNewSessions()).resolves.toMatchObject({ newSessions: 2, imported: 1, failed: 1, skipped: 0 })
+    expect(h.calls.filter(call => call.args[0] === 'import').map(call => call.args[1])).toHaveLength(1)
+  })
+
+  it('fails all export candidates safely when the read-only source snapshot cannot be created', async () => {
+    const h = harness({ sourceSessions: [session('new-a', path.resolve('project-a'))], snapshotFailure: true })
+    await expect(h.importer.importNewSessions()).resolves.toMatchObject({ newSessions: 1, imported: 0, failed: 1, reason: 'export-unavailable' })
+    expect(h.commandRunner).not.toHaveBeenCalled()
+    expect(readdirSync(path.join(h.userDataPath, 'temp', 'opencode-session-import'))).toEqual([])
+  })
+
+  it('classifies a malformed export as incompatible and continues', async () => {
+    const h = harness({
+      sourceSessions: [session('bad', path.resolve('bad')), session('ok', path.resolve('ok'))],
+      malformedExports: new Set(['bad']),
+    })
+    await expect(h.importer.importNewSessions()).resolves.toMatchObject({ imported: 1, skipped: 1, failed: 0, reason: 'incompatible-export' })
+  })
+
+  it('continues after one pinned-runtime import fails', async () => {
+    const h = harness({
+      sourceSessions: [session('failed', path.resolve('failed')), session('ok', path.resolve('ok'))],
+      importFailures: new Set(['failed']),
+    })
+    await expect(h.importer.importNewSessions()).resolves.toMatchObject({ imported: 1, failed: 1, skipped: 0 })
+    expect(h.calls.filter(call => call.args[0] === 'import')).toHaveLength(2)
+  })
+
+  it('cleans the sensitive export file after an export or import failure', async () => {
+    const h = harness({ sourceSessions: [session('failed', path.resolve('failed'))], importFailures: new Set(['failed']) })
+    await h.importer.importNewSessions()
+    const exportPath = h.calls.find(call => call.args[0] === 'export')?.stdoutPath
+    expect(exportPath).toBeTruthy()
+    expect(() => readFileSync(exportPath!, 'utf8')).toThrow()
+  })
+
+  it('never runs two imports concurrently', async () => {
+    const h = harness({ sourceSessions: [session('new-a', path.resolve('project-a'))] })
+    h.readSessionMetadata.mockImplementation(async databasePath => databasePath === h.sourceDatabasePath
+      ? { kind: 'ok', sessions: [session('new-a', path.resolve('project-a'))] }
+      : { kind: 'ok', sessions: h.destinationSessions })
+    let release!: () => void
+    const gate = new Promise<void>(resolve => { release = resolve })
+    h.commandRunner.mockImplementation(async request => {
+      if (request.args[0] === 'export') {
+        await gate
+        const exported = { info: { id: request.args[1] }, messages: [] }
+        if (request.stdoutPath) writeFileSync(request.stdoutPath, JSON.stringify(exported))
+      } else {
+        h.destinationSessions.push(session('new-a', path.join(h.root, 'project-a')))
+      }
+      return { code: 0, stderr: '', timedOut: false }
+    })
+    const first = h.importer.importNewSessions()
+    const second = h.importer.importNewSessions()
+    expect(first).toBe(second)
+    release()
+    await expect(first).resolves.toMatchObject({ imported: 1 })
+    expect(h.maintenanceRuns()).toBe(1)
+  })
+
+  it('cancels an in-flight import and reports only the uncommitted candidate as cancelled', async () => {
+    const h = harness({ sourceSessions: [session('new-a', path.resolve('project-a'))] })
+    let started!: () => void
+    const commandStarted = new Promise<void>(resolve => { started = resolve })
+    let release!: () => void
+    const commandGate = new Promise<void>(resolve => { release = resolve })
+    h.commandRunner.mockImplementation(async request => {
+      started()
+      await commandGate
+      if (request.args[0] === 'export' && request.stdoutPath) {
+        writeFileSync(request.stdoutPath, JSON.stringify({ info: { id: 'new-a' }, messages: [] }))
+      }
+      return { code: 0, stderr: '', timedOut: false }
+    })
+
+    const pending = h.importer.importNewSessions()
+    await commandStarted
+    h.importer.cancel()
+    release()
+
+    await expect(pending).resolves.toMatchObject({ imported: 0, failed: 1, reason: 'cancelled' })
+    expect(h.maintenanceCompletions()).toBe(1)
+  })
+
+  it('reports cancellation when shutdown prevents the maintenance window', async () => {
+    const h = harness({ sourceSessions: [session('new-a', path.resolve('project-a'))], rejectMaintenance: true })
+    await expect(h.importer.importNewSessions()).resolves.toMatchObject({ newSessions: 1, imported: 0, failed: 1, reason: 'cancelled' })
+  })
+
+  it('rejects a corrupt destination before running any standalone command', async () => {
+    const h = harness({ sourceSessions: [session('new-a', path.resolve('project-a'))] })
+    h.readSessionMetadata.mockImplementation(async databasePath => databasePath === h.sourceDatabasePath
+      ? { kind: 'ok', sessions: [session('new-a', path.resolve('project-a'))] }
+      : { kind: 'unavailable', sessions: [], detail: 'corrupt destination' })
+    await expect(h.importer.importNewSessions()).resolves.toMatchObject({ reason: 'import-failed', imported: 0, failed: 0 })
+    expect(h.commandRunner).not.toHaveBeenCalled()
+  })
+
+  it('deduplicates repeated source IDs before exporting', async () => {
+    const h = harness({ sourceSessions: [session('same', path.resolve('a')), session('same', path.resolve('b'))] })
+    await expect(h.importer.importNewSessions()).resolves.toMatchObject({ discovered: 1, newSessions: 1, imported: 1 })
+    expect(h.calls.filter(call => call.args[0] === 'export')).toHaveLength(1)
+  })
+})
+
+describe('OpenCode metadata-only discovery', () => {
+  it('does not deserialize message or part payloads while reading IDs and directory metadata', async () => {
+    const root = temporaryDirectory()
+    const databasePath = path.join(root, 'opencode.db')
+    const DatabaseSync = (requireForTest('node:sqlite') as { DatabaseSync: new (filePath: string) => { exec(sql: string): void; close(): void } }).DatabaseSync
+    const database = new DatabaseSync(databasePath)
+    database.exec([
+      'CREATE TABLE session (id TEXT PRIMARY KEY, title TEXT, directory TEXT, time_updated INTEGER)',
+      'CREATE TABLE message (id TEXT PRIMARY KEY, session_id TEXT, data TEXT)',
+      'CREATE TABLE part (id TEXT PRIMARY KEY, message_id TEXT, session_id TEXT, data TEXT)',
+      "INSERT INTO session VALUES ('session-1', 'A title', '/safe/project', 1700000000000)",
+      "INSERT INTO message VALUES ('message-1', 'session-1', 'not JSON and intentionally not inspected')",
+      "INSERT INTO part VALUES ('part-1', 'message-1', 'session-1', 'also not JSON')",
+    ].join(';'))
+    database.close()
+
+    await expect(readOpenCodeSessionMetadata(databasePath)).resolves.toEqual({
+      kind: 'ok',
+      sessions: [{ id: 'session-1', title: 'A title', directory: '/safe/project', updatedAt: 1700000000000 }],
+    })
+  })
+})

--- a/app/electron/opencode/session-import.ts
+++ b/app/electron/opencode/session-import.ts
@@ -1,0 +1,453 @@
+import { randomUUID } from 'node:crypto'
+import { spawn } from 'node:child_process'
+import { createWriteStream } from 'node:fs'
+import { mkdir, readFile, rm, stat } from 'node:fs/promises'
+import path from 'node:path'
+import { Transform } from 'node:stream'
+import { pipeline } from 'node:stream/promises'
+
+import { runtimePaths } from './config'
+import { readOpenCodeSessionMetadata, snapshotOpenCodeDatabase, type OpenCodeSessionMetadata, type OpenCodeSessionMetadataRead } from './storage'
+import type { OpenCodeCommandEnvironment } from './runtime'
+import { createStandaloneOpenCodeEnvironment, resolveStandaloneOpenCodeRuntime, type StandaloneOpenCodeResolverOptions, type StandaloneOpenCodeRuntime } from './standalone'
+
+export const OPEN_CODE_IMPORT_REASONS = [
+  'standalone-not-found',
+  'export-unavailable',
+  'incompatible-export',
+  'directory-unavailable',
+  'import-failed',
+  'cancelled',
+] as const
+
+export type OpenCodeImportReason = typeof OPEN_CODE_IMPORT_REASONS[number]
+
+export type OpenCodeImportResult = {
+  discovered: number
+  newSessions: number
+  imported: number
+  alreadyPresent: number
+  skipped: number
+  failed: number
+  reason: OpenCodeImportReason | null
+  reasons: Array<{ reason: OpenCodeImportReason; count: number }>
+}
+
+export type OpenCodeCommandRequest = {
+  executablePath: string
+  args: string[]
+  cwd: string
+  environment: NodeJS.ProcessEnv
+  stdoutPath?: string
+  timeoutMs?: number
+  signal?: AbortSignal
+}
+
+export type OpenCodeCommandResult = {
+  code: number | null
+  stderr: string
+  timedOut: boolean
+  cancelled?: boolean
+}
+
+export type OpenCodeCommandRunner = (request: OpenCodeCommandRequest) => Promise<OpenCodeCommandResult>
+
+export type OpenCodeSessionImporterOptions = {
+  userDataPath: string
+  platform?: NodeJS.Platform
+  environment?: NodeJS.ProcessEnv
+  standaloneResolver?: () => Promise<StandaloneOpenCodeRuntime | null>
+  standaloneResolverOptions?: Omit<StandaloneOpenCodeResolverOptions, 'environment' | 'platform' | 'excludedRoots'>
+  readSessionMetadata?: (databasePath: string) => Promise<OpenCodeSessionMetadataRead>
+  snapshotDatabase?: (sourcePath: string, destinationPath: string) => Promise<void>
+  directoryIsAvailable?: (directory: string) => Promise<boolean>
+  commandRunner?: OpenCodeCommandRunner
+  getMetroraCommand: () => Promise<OpenCodeCommandEnvironment>
+  runWithRuntimeStopped: <T>(operation: () => Promise<T>) => Promise<T>
+}
+
+type ImportCandidate = {
+  session: OpenCodeSessionMetadata
+  directory: string
+}
+
+type ImportPlan = {
+  standalone: StandaloneOpenCodeRuntime | null
+  candidates: ImportCandidate[]
+  result: OpenCodeImportResult
+}
+
+const EXPORT_TIMEOUT_MS = 10 * 60_000
+const IMPORT_TIMEOUT_MS = 10 * 60_000
+const MAX_EXPORT_BYTES = 128 * 1024 * 1024
+const MAX_STDERR_BYTES = 8 * 1024
+const TEMP_DIRECTORY_NAME = 'opencode-session-import'
+
+function platformPath(platform: NodeJS.Platform): typeof path.posix {
+  return platform === 'win32' ? path.win32 : path.posix
+}
+
+function emptyResult(reason: OpenCodeImportReason | null = null): OpenCodeImportResult {
+  return { discovered: 0, newSessions: 0, imported: 0, alreadyPresent: 0, skipped: 0, failed: 0, reason, reasons: [] }
+}
+
+function addReason(result: OpenCodeImportResult, reason: OpenCodeImportReason, count = 1): void {
+  if (count < 1) return
+  result.reason ??= reason
+  const existing = result.reasons.find(item => item.reason === reason)
+  if (existing) existing.count += count
+  else result.reasons.push({ reason, count })
+}
+
+function uniqueSessions(sessions: readonly OpenCodeSessionMetadata[]): OpenCodeSessionMetadata[] {
+  const seen = new Set<string>()
+  const unique: OpenCodeSessionMetadata[] = []
+  for (const session of sessions) {
+    if (seen.has(session.id)) continue
+    seen.add(session.id)
+    unique.push(session)
+  }
+  return unique
+}
+
+function isSafeDirectoryValue(directory: string, platform: NodeJS.Platform): boolean {
+  return directory.length > 0
+    && directory.length <= 32_768
+    && !/[\u0000-\u001f\u007f]/u.test(directory)
+    && platformPath(platform).isAbsolute(directory)
+}
+
+async function defaultDirectoryIsAvailable(directory: string): Promise<boolean> {
+  try { return (await stat(directory)).isDirectory() } catch { return false }
+}
+
+function cancellationResult(base: OpenCodeImportResult, pending: number): OpenCodeImportResult {
+  const result = { ...base, reasons: base.reasons.map(item => ({ ...item })) }
+  result.failed += pending
+  addReason(result, 'cancelled', pending)
+  return result
+}
+
+class OpenCodeImportCancelled extends Error {
+  constructor(readonly result: OpenCodeImportResult, readonly pending: number) {
+    super('OpenCode import was cancelled.')
+    this.name = 'OpenCodeImportCancelled'
+  }
+}
+
+function validateExportShape(value: unknown, expectedId: string): boolean {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false
+  const exportData = value as { info?: unknown; messages?: unknown }
+  if (!exportData.info || typeof exportData.info !== 'object' || Array.isArray(exportData.info)) return false
+  const id = (exportData.info as { id?: unknown }).id
+  return id === expectedId && Array.isArray(exportData.messages)
+}
+
+async function validateExportFile(filePath: string, expectedId: string): Promise<boolean> {
+  try {
+    const info = await stat(filePath)
+    if (!info.isFile() || info.size < 2 || info.size > MAX_EXPORT_BYTES) return false
+    const raw = await readFile(filePath, 'utf8')
+    return validateExportShape(JSON.parse(raw) as unknown, expectedId)
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Run one official OpenCode command without a shell. Export stdout is streamed
+ * to the private temporary file and bounded; stderr is never logged or sent to
+ * the renderer because it may contain provider paths or other sensitive data.
+ */
+export const runOpenCodeCommand: OpenCodeCommandRunner = async request => {
+  const timeoutMs = request.timeoutMs ?? EXPORT_TIMEOUT_MS
+  if (request.signal?.aborted) return { code: null, stderr: '', timedOut: false, cancelled: true }
+  let child: ReturnType<typeof spawn>
+  try {
+    child = spawn(request.executablePath, request.args, {
+      cwd: request.cwd,
+      env: request.environment,
+      shell: false,
+      windowsHide: true,
+      stdio: ['ignore', request.stdoutPath ? 'pipe' : 'ignore', 'pipe'],
+    })
+  } catch {
+    return { code: null, stderr: '', timedOut: false, cancelled: request.signal?.aborted ?? false }
+  }
+
+  let stderr = ''
+  child.stderr?.setEncoding('utf8')
+  child.stderr?.on('data', chunk => {
+    if (stderr.length >= MAX_STDERR_BYTES) return
+    stderr += String(chunk).slice(0, MAX_STDERR_BYTES - stderr.length)
+  })
+
+  let timedOut = false
+  let cancelled = request.signal?.aborted ?? false
+  const onAbort = () => {
+    cancelled = true
+    try { child.kill() } catch { /* best effort */ }
+  }
+  request.signal?.addEventListener('abort', onAbort, { once: true })
+  if (request.signal?.aborted) onAbort()
+  const timer = setTimeout(() => {
+    timedOut = true
+    try { child.kill() } catch { /* best effort */ }
+  }, timeoutMs)
+  timer.unref?.()
+
+  const output = request.stdoutPath && child.stdout
+    ? (() => {
+        let bytes = 0
+        const limiter = new Transform({
+          transform(chunk: Buffer, _encoding, callback) {
+            bytes += chunk.byteLength
+            if (bytes > MAX_EXPORT_BYTES) {
+              callback(new Error('OpenCode export exceeded the bounded size.'))
+              return
+            }
+            callback(null, chunk)
+          },
+        })
+        return pipeline(child.stdout, limiter, createWriteStream(request.stdoutPath, { flags: 'wx', mode: 0o600 }))
+      })()
+    : Promise.resolve()
+
+  const exit = new Promise<number | null>(resolve => {
+    child.once('error', () => resolve(null))
+    child.once('exit', code => resolve(code))
+  })
+  let outputError = false
+  try {
+    await Promise.all([exit, output.catch(() => { outputError = true; try { child.kill() } catch { /* best effort */ } })])
+  } finally {
+    clearTimeout(timer)
+    request.signal?.removeEventListener('abort', onAbort)
+  }
+  const code = await exit
+  return { code: outputError || timedOut || cancelled ? null : code, stderr, timedOut, cancelled }
+}
+
+export class OpenCodeSessionImporter {
+  private flight: Promise<OpenCodeImportResult> | null = null
+  private activeCancellation: AbortController | null = null
+
+  constructor(private readonly options: OpenCodeSessionImporterOptions) {}
+
+  cancel(): void {
+    this.activeCancellation?.abort()
+  }
+
+  importNewSessions(): Promise<OpenCodeImportResult> {
+    if (this.flight) return this.flight
+    const cancellation = new AbortController()
+    this.activeCancellation = cancellation
+    const promise = this.importInternal(cancellation.signal)
+    this.flight = promise
+    void promise.finally(() => {
+      if (this.flight === promise) this.flight = null
+      if (this.activeCancellation === cancellation) this.activeCancellation = null
+    }).catch(() => {})
+    return promise
+  }
+
+  private async importInternal(signal: AbortSignal): Promise<OpenCodeImportResult> {
+    let plan: ImportPlan | null = null
+    try {
+      plan = await this.buildPlan()
+    } catch {
+      return emptyResult('export-unavailable')
+    }
+    if (!plan) return emptyResult('export-unavailable')
+    if (plan.candidates.length === 0) return plan.result
+    if (signal.aborted) return cancellationResult(plan.result, plan.candidates.length)
+
+    try {
+      return await this.options.runWithRuntimeStopped(() => this.importPlan(plan!, signal))
+    } catch (error) {
+      if (error instanceof OpenCodeImportCancelled) return cancellationResult(error.result, error.pending)
+      const isCancelled = signal.aborted || error instanceof Error && /cancelled|shutdown/i.test(error.message)
+      return isCancelled ? cancellationResult(plan.result, plan.candidates.length) : (() => {
+        const result = { ...plan.result, reasons: plan.result.reasons.map(item => ({ ...item })) }
+        result.failed += plan.candidates.length
+        addReason(result, 'import-failed', plan.candidates.length)
+        return result
+      })()
+    }
+  }
+
+  private async buildPlan(): Promise<ImportPlan | null> {
+    const platform = this.options.platform ?? process.platform
+    const standalone = this.options.standaloneResolver
+      ? await this.options.standaloneResolver()
+      : await resolveStandaloneOpenCodeRuntime({
+          ...this.options.standaloneResolverOptions,
+          platform,
+          environment: this.options.environment,
+          excludedRoots: [this.options.userDataPath],
+        })
+    if (!standalone) return { standalone: null, candidates: [], result: emptyResult('standalone-not-found') }
+    if (!standalone.databasePath) return { standalone, candidates: [], result: emptyResult() }
+
+    const readMetadata = this.options.readSessionMetadata ?? readOpenCodeSessionMetadata
+    const source = await readMetadata(standalone.databasePath)
+    if (source.kind === 'missing') return { standalone, candidates: [], result: emptyResult() }
+    if (source.kind === 'incompatible') return { standalone, candidates: [], result: emptyResult('incompatible-export') }
+    if (source.kind !== 'ok') return { standalone, candidates: [], result: emptyResult('export-unavailable') }
+
+    const destinationDatabasePath = runtimePaths(this.options.userDataPath).databasePath
+    const destination = await readMetadata(destinationDatabasePath)
+    if (destination.kind !== 'ok' && destination.kind !== 'missing') {
+      return { standalone, candidates: [], result: emptyResult('import-failed') }
+    }
+    const existingIds = new Set(destination.kind === 'ok' ? destination.sessions.map(session => session.id) : [])
+    const sessions = uniqueSessions(source.sessions)
+    const result = emptyResult()
+    result.discovered = sessions.length
+    const fresh = sessions.filter(session => {
+      if (existingIds.has(session.id)) {
+        result.alreadyPresent += 1
+        return false
+      }
+      result.newSessions += 1
+      return true
+    })
+
+    const directoryIsAvailable = this.options.directoryIsAvailable ?? defaultDirectoryIsAvailable
+    const candidates: ImportCandidate[] = []
+    for (const session of fresh) {
+      if (!session.directory || !isSafeDirectoryValue(session.directory, platform) || !(await directoryIsAvailable(session.directory))) {
+        result.skipped += 1
+        addReason(result, 'directory-unavailable')
+        continue
+      }
+      candidates.push({ session, directory: session.directory })
+    }
+    return { standalone, candidates, result }
+  }
+
+  private async importPlan(plan: ImportPlan, signal: AbortSignal): Promise<OpenCodeImportResult> {
+    const result = { ...plan.result, reasons: plan.result.reasons.map(item => ({ ...item })) }
+    const command = await this.options.getMetroraCommand()
+    const runCommand = this.options.commandRunner ?? runOpenCodeCommand
+    const tempRoot = path.join(this.options.userDataPath, 'temp', TEMP_DIRECTORY_NAME)
+    await mkdir(tempRoot, { recursive: true, mode: 0o700 })
+    const snapshotPath = path.join(tempRoot, `${randomUUID()}.db`)
+    const standaloneRoot = path.join(tempRoot, `${randomUUID()}-standalone`)
+    const importedIds: string[] = []
+    let pending = plan.candidates.length
+    const throwIfCancelled = () => {
+      if (signal.aborted) throw new OpenCodeImportCancelled(result, pending)
+    }
+
+    try {
+      throwIfCancelled()
+      try {
+        await (this.options.snapshotDatabase ?? snapshotOpenCodeDatabase)(plan.standalone!.databasePath!, snapshotPath)
+      } catch {
+        result.failed += plan.candidates.length
+        addReason(result, 'export-unavailable', plan.candidates.length)
+        return result
+      }
+
+      const standalone = {
+        ...plan.standalone!,
+        databasePath: snapshotPath,
+        environment: createStandaloneOpenCodeEnvironment({
+          baseEnvironment: this.options.environment ?? plan.standalone!.environment,
+          databasePath: snapshotPath,
+          excludedRoots: [this.options.userDataPath],
+          platform: this.options.platform ?? process.platform,
+          isolatedRoot: standaloneRoot,
+        }),
+      }
+
+      for (const candidate of plan.candidates) {
+        throwIfCancelled()
+        const exportPath = path.join(tempRoot, `${randomUUID()}.json`)
+        let stage: 'export' | 'validate' | 'import' = 'export'
+        try {
+          const exported = await runCommand({
+            executablePath: standalone.executablePath,
+            args: ['export', candidate.session.id],
+            cwd: candidate.directory,
+            environment: standalone.environment,
+            stdoutPath: exportPath,
+            timeoutMs: EXPORT_TIMEOUT_MS,
+            signal,
+          })
+          if (exported.cancelled || signal.aborted) throw new OpenCodeImportCancelled(result, pending)
+          if (exported.code !== 0) {
+            result.failed += 1
+            addReason(result, 'export-unavailable')
+            continue
+          }
+
+          stage = 'validate'
+          const validExport = await validateExportFile(exportPath, candidate.session.id)
+          throwIfCancelled()
+          if (!validExport) {
+            result.skipped += 1
+            addReason(result, 'incompatible-export')
+            continue
+          }
+
+          stage = 'import'
+          const imported = await runCommand({
+            executablePath: command.executablePath,
+            args: ['import', exportPath],
+            cwd: candidate.directory,
+            environment: command.environment,
+            timeoutMs: IMPORT_TIMEOUT_MS,
+            signal,
+          })
+          if (imported.cancelled || signal.aborted) throw new OpenCodeImportCancelled(result, pending)
+          if (imported.code !== 0) {
+            result.failed += 1
+            addReason(result, 'import-failed')
+            continue
+          }
+          result.imported += 1
+          importedIds.push(candidate.session.id)
+        } catch (error) {
+          if (error instanceof OpenCodeImportCancelled) throw error
+          if (stage === 'validate') {
+            result.skipped += 1
+            addReason(result, 'incompatible-export')
+          } else {
+            result.failed += 1
+            addReason(result, stage === 'export' ? 'export-unavailable' : 'import-failed')
+          }
+        } finally {
+          await rm(exportPath, { force: true }).catch(() => {})
+          pending -= 1
+        }
+      }
+
+      throwIfCancelled()
+      if (importedIds.length > 0) {
+        const after = await (this.options.readSessionMetadata ?? readOpenCodeSessionMetadata)(command.paths.databasePath)
+        throwIfCancelled()
+        if (after.kind !== 'ok') {
+          result.failed += result.imported
+          addReason(result, 'import-failed', result.imported)
+          result.imported = 0
+        } else {
+          const actualIds = new Set(after.sessions.map(session => session.id))
+          const missing = importedIds.filter(id => !actualIds.has(id)).length
+          if (missing > 0) {
+            result.imported -= missing
+            result.failed += missing
+            addReason(result, 'import-failed', missing)
+          }
+        }
+      }
+      return result
+    } finally {
+      for (const suffix of ['', '-wal', '-shm', '-journal']) {
+        await rm(`${snapshotPath}${suffix}`, { force: true }).catch(() => {})
+      }
+      await rm(standaloneRoot, { recursive: true, force: true }).catch(() => {})
+    }
+  }
+}

--- a/app/electron/opencode/standalone.test.ts
+++ b/app/electron/opencode/standalone.test.ts
@@ -1,21 +1,13 @@
 // @vitest-environment node
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
-import { tmpdir } from 'node:os'
 import path from 'node:path'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import { resolveStandaloneOpenCodeRuntime } from './standalone'
 
-const temporaryDirectories: string[] = []
+const WINDOWS_FIXTURE_ROOT = 'C:\\fixture\\metrora-opencode-standalone'
 
-afterEach(() => {
-  for (const directory of temporaryDirectories.splice(0)) rmSync(directory, { recursive: true, force: true })
-})
-
-function temporaryDirectory(): string {
-  const directory = mkdtempSync(path.join(tmpdir(), 'metrora-opencode-standalone-'))
-  temporaryDirectories.push(directory)
-  return directory
+function fixturePath(...segments: string[]): string {
+  return path.win32.join(WINDOWS_FIXTURE_ROOT, ...segments)
 }
 
 function successfulProbe() {
@@ -26,47 +18,42 @@ function successfulProbe() {
 
 describe('standalone OpenCode runtime resolution', () => {
   it('resolves an explicit installed export-capable runtime without consulting PATH', async () => {
-    const root = temporaryDirectory()
-    const executable = path.join(root, 'opencode.exe')
-    const database = path.join(root, 'data', 'opencode', 'opencode.db')
-    mkdirSync(path.dirname(database), { recursive: true })
-    writeFileSync(executable, 'standalone')
-    writeFileSync(database, 'database')
+    const executable = fixturePath('explicit', 'opencode.exe')
+    const database = fixturePath('explicit', 'data', 'opencode', 'opencode.db')
     const probe = successfulProbe()
 
     await expect(resolveStandaloneOpenCodeRuntime({
       platform: 'win32',
-      environment: { PATH: path.join(root, 'old-bin'), OPENCODE_DB: database },
+      environment: { PATH: fixturePath('explicit', 'old-bin'), OPENCODE_DB: database },
       executableCandidates: [executable],
       databaseCandidates: [database],
       probe,
+      fileExists: async filePath => filePath === executable || filePath === database,
     })).resolves.toMatchObject({ executablePath: executable, version: '1.18.29', databasePath: database })
     expect(probe).toHaveBeenNthCalledWith(1, executable, ['--version'], expect.any(Object))
     expect(probe).toHaveBeenNthCalledWith(2, executable, ['export', '--help'], expect.any(Object))
   })
 
   it('finds a Desktop-staged CLI under a portable app-data version directory', async () => {
-    const root = temporaryDirectory()
-    const appData = path.join(root, 'AppData', 'Roaming')
-    const executable = path.join(appData, 'ai.opencode.desktop', 'cli', '1.18.29', 'opencode-cli.exe')
-    mkdirSync(path.dirname(executable), { recursive: true })
-    writeFileSync(executable, 'desktop cli')
+    const appData = fixturePath('desktop', 'AppData', 'Roaming')
+    const localAppData = fixturePath('desktop', 'AppData', 'Local')
+    const cliRoot = path.win32.join(appData, 'ai.opencode.desktop', 'cli')
+    const executable = path.win32.join(cliRoot, '1.18.29', 'opencode-cli.exe')
     const probe = successfulProbe()
 
     await expect(resolveStandaloneOpenCodeRuntime({
       platform: 'win32',
-      environment: { APPDATA: appData, LOCALAPPDATA: path.join(root, 'AppData', 'Local') },
+      environment: { APPDATA: appData, LOCALAPPDATA: localAppData },
       appDataPath: appData,
-      localAppDataPath: path.join(root, 'AppData', 'Local'),
+      localAppDataPath: localAppData,
       probe,
       fileExists: async filePath => filePath === executable,
+      readDirectory: async directory => directory === cliRoot ? ['1.18.29'] : [],
     })).resolves.toMatchObject({ executablePath: executable, version: '1.18.29' })
   })
 
   it('rejects an older runtime even when an executable is present', async () => {
-    const root = temporaryDirectory()
-    const executable = path.join(root, 'old-opencode.exe')
-    writeFileSync(executable, 'old')
+    const executable = fixturePath('older', 'old-opencode.exe')
     const probe = vi.fn(async () => ({ stdout: '1.14.41\n', stderr: '' }))
 
     await expect(resolveStandaloneOpenCodeRuntime({
@@ -79,9 +66,7 @@ describe('standalone OpenCode runtime resolution', () => {
   })
 
   it('rejects a runtime that does not expose the official export command', async () => {
-    const root = temporaryDirectory()
-    const executable = path.join(root, 'no-export.exe')
-    writeFileSync(executable, 'no export')
+    const executable = fixturePath('no-export', 'opencode.exe')
     const probe = vi.fn(async (_file: string, args: string[]) => args[0] === '--version'
       ? { stdout: '1.18.29', stderr: '' }
       : { stdout: 'Usage: opencode', stderr: '' })
@@ -96,17 +81,11 @@ describe('standalone OpenCode runtime resolution', () => {
   })
 
   it('excludes Metrora-owned paths and strips Metrora environment from the standalone command', async () => {
-    const root = temporaryDirectory()
-    const userData = path.join(root, 'metrora-user-data')
-    const standaloneRoot = path.join(root, 'standalone')
-    const executable = path.join(standaloneRoot, 'opencode.exe')
-    const externalDatabase = path.join(standaloneRoot, 'opencode.db')
-    const metroraDatabase = path.join(userData, 'opencode', 'runtime', '1.18.27', 'db', 'opencode.db')
-    mkdirSync(path.dirname(externalDatabase), { recursive: true })
-    mkdirSync(path.dirname(metroraDatabase), { recursive: true })
-    writeFileSync(executable, 'standalone')
-    writeFileSync(externalDatabase, 'external')
-    writeFileSync(metroraDatabase, 'metrora')
+    const userData = fixturePath('excluded', 'metrora-user-data')
+    const standaloneRoot = fixturePath('excluded', 'standalone')
+    const executable = path.win32.join(standaloneRoot, 'opencode.exe')
+    const externalDatabase = path.win32.join(standaloneRoot, 'opencode.db')
+    const metroraDatabase = path.win32.join(userData, 'opencode', 'runtime', '1.18.27', 'db', 'opencode.db')
     let probedEnvironment: NodeJS.ProcessEnv | undefined
     const probe = vi.fn(async (_file: string, args: string[], environment: NodeJS.ProcessEnv) => {
       probedEnvironment = environment

--- a/app/electron/opencode/standalone.test.ts
+++ b/app/electron/opencode/standalone.test.ts
@@ -1,0 +1,138 @@
+// @vitest-environment node
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { resolveStandaloneOpenCodeRuntime } from './standalone'
+
+const temporaryDirectories: string[] = []
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) rmSync(directory, { recursive: true, force: true })
+})
+
+function temporaryDirectory(): string {
+  const directory = mkdtempSync(path.join(tmpdir(), 'metrora-opencode-standalone-'))
+  temporaryDirectories.push(directory)
+  return directory
+}
+
+function successfulProbe() {
+  return vi.fn(async (_executable: string, args: string[]) => args[0] === '--version'
+    ? { stdout: '1.18.29\n', stderr: '' }
+    : { stdout: 'opencode export [sessionID]\n', stderr: '' })
+}
+
+describe('standalone OpenCode runtime resolution', () => {
+  it('resolves an explicit installed export-capable runtime without consulting PATH', async () => {
+    const root = temporaryDirectory()
+    const executable = path.join(root, 'opencode.exe')
+    const database = path.join(root, 'data', 'opencode', 'opencode.db')
+    mkdirSync(path.dirname(database), { recursive: true })
+    writeFileSync(executable, 'standalone')
+    writeFileSync(database, 'database')
+    const probe = successfulProbe()
+
+    await expect(resolveStandaloneOpenCodeRuntime({
+      platform: 'win32',
+      environment: { PATH: path.join(root, 'old-bin'), OPENCODE_DB: database },
+      executableCandidates: [executable],
+      databaseCandidates: [database],
+      probe,
+    })).resolves.toMatchObject({ executablePath: executable, version: '1.18.29', databasePath: database })
+    expect(probe).toHaveBeenNthCalledWith(1, executable, ['--version'], expect.any(Object))
+    expect(probe).toHaveBeenNthCalledWith(2, executable, ['export', '--help'], expect.any(Object))
+  })
+
+  it('finds a Desktop-staged CLI under a portable app-data version directory', async () => {
+    const root = temporaryDirectory()
+    const appData = path.join(root, 'AppData', 'Roaming')
+    const executable = path.join(appData, 'ai.opencode.desktop', 'cli', '1.18.29', 'opencode-cli.exe')
+    mkdirSync(path.dirname(executable), { recursive: true })
+    writeFileSync(executable, 'desktop cli')
+    const probe = successfulProbe()
+
+    await expect(resolveStandaloneOpenCodeRuntime({
+      platform: 'win32',
+      environment: { APPDATA: appData, LOCALAPPDATA: path.join(root, 'AppData', 'Local') },
+      appDataPath: appData,
+      localAppDataPath: path.join(root, 'AppData', 'Local'),
+      probe,
+      fileExists: async filePath => filePath === executable,
+    })).resolves.toMatchObject({ executablePath: executable, version: '1.18.29' })
+  })
+
+  it('rejects an older runtime even when an executable is present', async () => {
+    const root = temporaryDirectory()
+    const executable = path.join(root, 'old-opencode.exe')
+    writeFileSync(executable, 'old')
+    const probe = vi.fn(async () => ({ stdout: '1.14.41\n', stderr: '' }))
+
+    await expect(resolveStandaloneOpenCodeRuntime({
+      platform: 'win32',
+      executableCandidates: [executable],
+      probe,
+      fileExists: async filePath => filePath === executable,
+    })).resolves.toBeNull()
+    expect(probe).toHaveBeenCalledOnce()
+  })
+
+  it('rejects a runtime that does not expose the official export command', async () => {
+    const root = temporaryDirectory()
+    const executable = path.join(root, 'no-export.exe')
+    writeFileSync(executable, 'no export')
+    const probe = vi.fn(async (_file: string, args: string[]) => args[0] === '--version'
+      ? { stdout: '1.18.29', stderr: '' }
+      : { stdout: 'Usage: opencode', stderr: '' })
+
+    await expect(resolveStandaloneOpenCodeRuntime({
+      platform: 'win32',
+      executableCandidates: [executable],
+      probe,
+      fileExists: async filePath => filePath === executable,
+    })).resolves.toBeNull()
+    expect(probe).toHaveBeenCalledTimes(2)
+  })
+
+  it('excludes Metrora-owned paths and strips Metrora environment from the standalone command', async () => {
+    const root = temporaryDirectory()
+    const userData = path.join(root, 'metrora-user-data')
+    const standaloneRoot = path.join(root, 'standalone')
+    const executable = path.join(standaloneRoot, 'opencode.exe')
+    const externalDatabase = path.join(standaloneRoot, 'opencode.db')
+    const metroraDatabase = path.join(userData, 'opencode', 'runtime', '1.18.27', 'db', 'opencode.db')
+    mkdirSync(path.dirname(externalDatabase), { recursive: true })
+    mkdirSync(path.dirname(metroraDatabase), { recursive: true })
+    writeFileSync(executable, 'standalone')
+    writeFileSync(externalDatabase, 'external')
+    writeFileSync(metroraDatabase, 'metrora')
+    let probedEnvironment: NodeJS.ProcessEnv | undefined
+    const probe = vi.fn(async (_file: string, args: string[], environment: NodeJS.ProcessEnv) => {
+      probedEnvironment = environment
+      return args[0] === '--version'
+        ? { stdout: '1.18.29', stderr: '' }
+        : { stdout: 'opencode export <sessionID>', stderr: '' }
+    })
+
+    const resolved = await resolveStandaloneOpenCodeRuntime({
+      platform: 'win32',
+      environment: {
+        OPENCODE_DB: metroraDatabase,
+        METRORA_USAGE_SNAPSHOT_FILE: 'secret-path',
+        ANTHROPIC_API_KEY: 'provider-secret',
+      },
+      excludedRoots: [userData],
+      executableCandidates: [executable],
+      databaseCandidates: [metroraDatabase, externalDatabase],
+      probe,
+      fileExists: async filePath => filePath === executable || filePath === metroraDatabase || filePath === externalDatabase,
+    })
+
+    expect(resolved?.databasePath).toBe(externalDatabase)
+    expect(resolved?.environment.OPENCODE_DB).toBe(externalDatabase)
+    expect(resolved?.environment.METRORA_USAGE_SNAPSHOT_FILE).toBeUndefined()
+    expect(resolved?.environment.ANTHROPIC_API_KEY).toBe('provider-secret')
+    expect(probedEnvironment?.OPENCODE_DB).toBeUndefined()
+  })
+})

--- a/app/electron/opencode/standalone.ts
+++ b/app/electron/opencode/standalone.ts
@@ -1,0 +1,326 @@
+import { execFile } from 'node:child_process'
+import { readdir, stat } from 'node:fs/promises'
+import { homedir } from 'node:os'
+import path from 'node:path'
+import { promisify } from 'node:util'
+
+import { OPENCODE_VERSION } from './types'
+
+const execFileAsync = promisify(execFile)
+const PROBE_TIMEOUT_MS = 5_000
+const PROBE_MAX_OUTPUT_BYTES = 64 * 1024
+const SUPPORTED_EXPORT_FAMILY = OPENCODE_VERSION.split('.').slice(0, 2).join('.')
+const WINDOWS_DESKTOP_APP_IDS = ['ai.opencode.desktop', 'ai.opencode.desktop.beta', 'ai.opencode.desktop.dev'] as const
+
+export type StandaloneOpenCodeRuntime = {
+  executablePath: string
+  version: string
+  databasePath: string | null
+  environment: NodeJS.ProcessEnv
+}
+
+export type StandaloneProbeResult = { stdout: string; stderr: string; code?: number | null }
+
+export type StandaloneOpenCodeEnvironmentOptions = {
+  baseEnvironment: NodeJS.ProcessEnv
+  databasePath: string | null
+  excludedRoots?: readonly string[]
+  platform: NodeJS.Platform
+  isolatedRoot?: string
+}
+
+export type StandaloneOpenCodeResolverOptions = {
+  platform?: NodeJS.Platform
+  environment?: NodeJS.ProcessEnv
+  homePath?: string
+  appDataPath?: string
+  localAppDataPath?: string
+  programFilesPath?: string
+  programFilesX86Path?: string
+  excludedRoots?: string[]
+  executableCandidates?: string[]
+  databaseCandidates?: string[]
+  probe?: (executablePath: string, args: string[], environment: NodeJS.ProcessEnv) => Promise<StandaloneProbeResult>
+  fileExists?: (filePath: string) => Promise<boolean>
+  readDirectory?: (directory: string) => Promise<string[]>
+}
+
+function platformPath(platform: NodeJS.Platform): typeof path.posix {
+  return platform === 'win32' ? path.win32 : path.posix
+}
+
+function isAbsolute(value: string, platform: NodeJS.Platform): boolean {
+  return platformPath(platform).isAbsolute(value)
+}
+
+function resolvePath(value: string, platform: NodeJS.Platform): string {
+  return platformPath(platform).resolve(value)
+}
+
+function normalizeKey(value: string, platform: NodeJS.Platform): string {
+  const normalized = platformPath(platform).normalize(resolvePath(value, platform))
+  return platform === 'win32' ? normalized.toLowerCase() : normalized
+}
+
+function isWithin(parent: string, candidate: string, platform: NodeJS.Platform): boolean {
+  const relative = platformPath(platform).relative(resolvePath(parent, platform), resolvePath(candidate, platform))
+  return relative === '' || (relative !== '..' && !relative.startsWith(`..${platform === 'win32' ? '\\' : '/'}`))
+}
+
+function addUnique(values: string[], seen: Set<string>, value: string | undefined, platform: NodeJS.Platform): void {
+  if (!value || !isAbsolute(value, platform)) return
+  const key = normalizeKey(value, platform)
+  if (seen.has(key)) return
+  seen.add(key)
+  values.push(resolvePath(value, platform))
+}
+
+function isExcluded(value: string, excludedRoots: readonly string[], platform: NodeJS.Platform): boolean {
+  return excludedRoots.some(root => isWithin(root, value, platform))
+}
+
+function parseVersion(value: string): string | null {
+  const match = value.match(/(?:^|\s)v?(\d+\.\d+\.\d+)(?:\s|$)/u)
+  return match?.[1] ?? null
+}
+
+export function isStandaloneExportVersionCompatible(version: string): boolean {
+  return version.split('.').slice(0, 2).join('.') === SUPPORTED_EXPORT_FAMILY
+}
+
+function standaloneEnvironment(
+  baseEnvironment: NodeJS.ProcessEnv,
+  databasePath: string | null,
+  excludedRoots: readonly string[],
+  platform: NodeJS.Platform,
+  isolatedRoot?: string,
+): NodeJS.ProcessEnv {
+  const environment: NodeJS.ProcessEnv = { ...baseEnvironment }
+  for (const key of Object.keys(environment)) {
+    if (key.startsWith('METRORA_') || key.startsWith('OPENCODE_')) delete environment[key]
+  }
+
+  // Keep the standalone process on its own database and never carry a Metrora
+  // runtime XDG root into it. Other provider credentials remain available.
+  if (databasePath) {
+    environment.OPENCODE_DB = databasePath
+    const dataRoot = platformPath(platform).dirname(databasePath)
+    if (isolatedRoot) {
+      const join = platformPath(platform).join.bind(platformPath(platform))
+      environment.XDG_DATA_HOME = join(isolatedRoot, 'data')
+      environment.XDG_CACHE_HOME = join(isolatedRoot, 'cache')
+      environment.XDG_STATE_HOME = join(isolatedRoot, 'state')
+      environment.XDG_CONFIG_HOME = join(isolatedRoot, 'config')
+    } else if (!isExcluded(dataRoot, excludedRoots, platform)) {
+      environment.XDG_DATA_HOME = platformPath(platform).dirname(dataRoot)
+    }
+  }
+  environment.OPENCODE_DISABLE_AUTOUPDATE = '1'
+  return environment
+}
+
+export function createStandaloneOpenCodeEnvironment(options: StandaloneOpenCodeEnvironmentOptions): NodeJS.ProcessEnv {
+  return standaloneEnvironment(
+    options.baseEnvironment,
+    options.databasePath,
+    options.excludedRoots ?? [],
+    options.platform,
+    options.isolatedRoot,
+  )
+}
+
+async function defaultProbe(executablePath: string, args: string[], environment: NodeJS.ProcessEnv): Promise<StandaloneProbeResult> {
+  try {
+    const result = await execFileAsync(executablePath, args, {
+      env: environment,
+      windowsHide: true,
+      timeout: PROBE_TIMEOUT_MS,
+      maxBuffer: PROBE_MAX_OUTPUT_BYTES,
+    })
+    return { stdout: String(result.stdout ?? ''), stderr: String(result.stderr ?? ''), code: 0 }
+  } catch (error) {
+    const output = error as { stdout?: unknown; stderr?: unknown }
+    const code = (error as { code?: unknown }).code
+    return { stdout: String(output.stdout ?? ''), stderr: String(output.stderr ?? ''), code: typeof code === 'number' ? code : null }
+  }
+}
+
+async function defaultFileExists(filePath: string): Promise<boolean> {
+  try {
+    return (await stat(filePath)).isFile()
+  } catch {
+    return false
+  }
+}
+
+async function defaultReadDirectory(directory: string): Promise<string[]> {
+  try {
+    return (await readdir(directory, { withFileTypes: true }))
+      .filter(entry => entry.isDirectory())
+      .map(entry => entry.name)
+  } catch {
+    return []
+  }
+}
+
+function buildExecutableCandidates(options: StandaloneOpenCodeResolverOptions, platform: NodeJS.Platform): string[] {
+  const environment = options.environment ?? process.env
+  const home = options.homePath ?? homedir()
+  const appData = options.appDataPath ?? environment.APPDATA
+  const localAppData = options.localAppDataPath ?? environment.LOCALAPPDATA
+  const programFiles = options.programFilesPath ?? environment.ProgramFiles
+  const programFilesX86 = options.programFilesX86Path ?? environment['ProgramFiles(x86)']
+  const values: string[] = []
+  const seen = new Set<string>()
+  const join = platformPath(platform).join.bind(platformPath(platform))
+
+  for (const value of [environment.METRORA_STANDALONE_OPENCODE_PATH, environment.OPENCODE_BINARY, environment.OPENCODE_EXECUTABLE]) {
+    addUnique(values, seen, value, platform)
+  }
+  if (options.executableCandidates) {
+    for (const value of options.executableCandidates) addUnique(values, seen, value, platform)
+  }
+
+  if (platform === 'win32') {
+    const installRoots = [
+      localAppData ? join(localAppData, 'Programs', '@opencode-aidesktop') : undefined,
+      localAppData ? join(localAppData, 'Programs', 'OpenCode') : undefined,
+      localAppData ? join(localAppData, 'Programs', 'opencode') : undefined,
+      programFiles ? join(programFiles, 'OpenCode') : undefined,
+      programFiles ? join(programFiles, 'opencode') : undefined,
+      programFilesX86 ? join(programFilesX86, 'OpenCode') : undefined,
+      programFilesX86 ? join(programFilesX86, 'opencode') : undefined,
+    ]
+    for (const root of installRoots) {
+      if (!root) continue
+      for (const relative of [
+        ['resources', 'opencode-cli.exe'],
+        ['resources', 'opencode.exe'],
+        ['opencode-cli.exe'],
+        ['opencode.exe'],
+      ]) addUnique(values, seen, join(root, ...relative), platform)
+    }
+    if (appData) addUnique(values, seen, join(appData, 'npm', 'opencode.exe'), platform)
+    addUnique(values, seen, join(home, '.opencode', 'bin', 'opencode.exe'), platform)
+  } else {
+    addUnique(values, seen, join(home, '.local', 'bin', 'opencode'), platform)
+    addUnique(values, seen, join(home, '.opencode', 'bin', 'opencode'), platform)
+    addUnique(values, seen, '/usr/local/bin/opencode', platform)
+    addUnique(values, seen, '/opt/homebrew/bin/opencode', platform)
+    if (platform === 'darwin') addUnique(values, seen, join(home, 'Applications', 'OpenCode.app', 'Contents', 'Resources', 'opencode-cli'), platform)
+  }
+  return values
+}
+
+async function buildDesktopCliCandidates(options: StandaloneOpenCodeResolverOptions, platform: NodeJS.Platform): Promise<string[]> {
+  if (platform !== 'win32') return []
+  const environment = options.environment ?? process.env
+  const appData = options.appDataPath ?? environment.APPDATA
+  const localAppData = options.localAppDataPath ?? environment.LOCALAPPDATA
+  const values: string[] = []
+  const seen = new Set<string>()
+  const join = platformPath(platform).join.bind(platformPath(platform))
+  const readDirectory = options.readDirectory ?? defaultReadDirectory
+
+  for (const base of [appData, localAppData]) {
+    if (!base) continue
+    for (const appId of WINDOWS_DESKTOP_APP_IDS) {
+      const cliRoot = join(base, appId, 'cli')
+      for (const version of (await readDirectory(cliRoot)).sort().reverse()) {
+        addUnique(values, seen, join(cliRoot, version, 'opencode-cli.exe'), platform)
+      }
+    }
+  }
+  return values
+}
+
+function buildDatabaseRoots(options: StandaloneOpenCodeResolverOptions, platform: NodeJS.Platform): string[] {
+  const environment = options.environment ?? process.env
+  const home = options.homePath ?? homedir()
+  const appData = options.appDataPath ?? environment.APPDATA
+  const localAppData = options.localAppDataPath ?? environment.LOCALAPPDATA
+  const join = platformPath(platform).join.bind(platformPath(platform))
+  const roots: string[] = []
+  const seen = new Set<string>()
+  const addRoot = (value: string | undefined) => {
+    if (!value || !isAbsolute(value, platform) || seen.has(normalizeKey(value, platform))) return
+    seen.add(normalizeKey(value, platform))
+    roots.push(resolvePath(value, platform))
+  }
+
+  if (environment.OPENCODE_DATA_DIR) addRoot(environment.OPENCODE_DATA_DIR)
+  if (environment.XDG_DATA_HOME) addRoot(join(environment.XDG_DATA_HOME, 'opencode'))
+  if (platform === 'win32') {
+    if (localAppData) addRoot(join(localAppData, 'opencode'))
+    if (appData) addRoot(join(appData, 'opencode'))
+    addRoot(join(home, '.local', 'share', 'opencode'))
+  } else if (platform === 'darwin') {
+    addRoot(join(home, 'Library', 'Application Support', 'opencode'))
+    addRoot(join(home, '.local', 'share', 'opencode'))
+  } else {
+    addRoot(join(home, '.local', 'share', 'opencode'))
+  }
+  return roots
+}
+
+async function buildDatabaseCandidates(options: StandaloneOpenCodeResolverOptions, platform: NodeJS.Platform): Promise<string[]> {
+  const environment = options.environment ?? process.env
+  const roots = buildDatabaseRoots(options, platform)
+  const values: string[] = []
+  const seen = new Set<string>()
+  const join = platformPath(platform).join.bind(platformPath(platform))
+  const add = (value: string | undefined) => addUnique(values, seen, value, platform)
+
+  add(environment.OPENCODE_DB)
+  for (const value of options.databaseCandidates ?? []) add(value)
+  for (const root of roots) {
+    add(join(root, 'opencode.db'))
+    // Channel-specific stores are bounded and deterministic. The stable DB
+    // remains first, so the desktop's normal authority wins when present.
+    let names: string[] = []
+    try {
+      names = (await readdir(root)).filter(name => /^opencode(?:-[A-Za-z0-9._-]+)?\.db$/u.test(name)).sort()
+    } catch { /* missing data roots are normal */ }
+    for (const name of names.slice(0, 16)) add(join(root, name))
+  }
+  return values
+}
+
+export async function resolveStandaloneOpenCodeRuntime(options: StandaloneOpenCodeResolverOptions = {}): Promise<StandaloneOpenCodeRuntime | null> {
+  const platform = options.platform ?? process.platform
+  const baseEnvironment = options.environment ?? process.env
+  const excludedRoots = (options.excludedRoots ?? []).filter(value => isAbsolute(value, platform))
+  const executableCandidates = [
+    ...buildExecutableCandidates(options, platform),
+    ...(await buildDesktopCliCandidates(options, platform)),
+  ]
+  const databaseCandidates = await buildDatabaseCandidates(options, platform)
+  const fileExists = options.fileExists ?? defaultFileExists
+  const probe = options.probe ?? defaultProbe
+
+  for (const executablePath of executableCandidates) {
+    if (isExcluded(executablePath, excludedRoots, platform) || !(await fileExists(executablePath))) continue
+
+    const probeEnvironment = standaloneEnvironment(baseEnvironment, null, excludedRoots, platform)
+    const versionResult = await probe(executablePath, ['--version'], probeEnvironment)
+    if (versionResult.code !== undefined && versionResult.code !== 0) continue
+    const version = parseVersion(`${versionResult.stdout}\n${versionResult.stderr}`)
+    if (!version || !isStandaloneExportVersionCompatible(version)) continue
+
+    const helpResult = await probe(executablePath, ['export', '--help'], probeEnvironment)
+    if (helpResult.code !== undefined && helpResult.code !== 0) continue
+    if (!/^\s*opencode\s+export(?:\s|\[)/mu.test(`${helpResult.stdout}\n${helpResult.stderr}`)) continue
+
+    const databasePath = (await Promise.all(databaseCandidates.map(async candidate => ({
+      candidate,
+      exists: !isExcluded(candidate, excludedRoots, platform) && await fileExists(candidate),
+    })))).find(item => item.exists)?.candidate ?? null
+    return {
+      executablePath,
+      version,
+      databasePath,
+      environment: standaloneEnvironment(baseEnvironment, databasePath, excludedRoots, platform),
+    }
+  }
+  return null
+}

--- a/app/electron/opencode/storage.test.ts
+++ b/app/electron/opencode/storage.test.ts
@@ -8,7 +8,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { runtimePaths } from './config'
 import { OpenCodeRuntime, type OpenCodeFetch, type SpawnedOpenCodeProcess } from './runtime'
-import { prepareOpenCodeStorage, quarantineImportedOpenCodeDatabase } from './storage'
+import { prepareOpenCodeStorage, quarantineImportedOpenCodeDatabase, snapshotOpenCodeDatabase } from './storage'
 import { OPENCODE_CUSTOM_TOOL_IDS, OPENCODE_VERSION } from './types'
 
 const storageTestControls = vi.hoisted(() => ({
@@ -223,6 +223,26 @@ describe('Metrora-owned OpenCode storage continuity', () => {
       sqlitePrototype.serialize = originalSerialize
       external.database.close()
     }
+  })
+
+  it('creates an owned export snapshot without changing the external main database or WAL', async () => {
+    const root = tempDirectory()
+    const external = createExternalDatabase(root)
+    const snapshotPath = join(root, 'export-snapshot.db')
+    const beforeMain = fingerprint(external.path)
+    const beforeWal = existsSync(`${external.path}-wal`) ? fingerprint(`${external.path}-wal`) : null
+
+    await expect(snapshotOpenCodeDatabase(external.path, snapshotPath)).resolves.toBeUndefined()
+
+    expect(fingerprint(external.path)).toEqual(beforeMain)
+    expect(beforeWal && fingerprint(`${external.path}-wal`)).toEqual(beforeWal)
+    expect(existsSync(snapshotPath)).toBe(true)
+    expect(existsSync(`${snapshotPath}-wal`)).toBe(false)
+
+    const snapshot = new DatabaseSync(snapshotPath, { readOnly: true })
+    expect(snapshot.prepare('SELECT value FROM sentinel').all()).toEqual([{ value: 'external-authority' }])
+    snapshot.close()
+    external.database.close()
   })
 
   it('reuses the Metrora-owned database across restart and never chooses it as a legacy source', async () => {

--- a/app/electron/opencode/storage.ts
+++ b/app/electron/opencode/storage.ts
@@ -1,4 +1,4 @@
-import { copyFile, mkdtemp, mkdir, rename, rm, stat, statfs } from 'node:fs/promises'
+import { chmod, copyFile, mkdtemp, mkdir, rename, rm, stat, statfs } from 'node:fs/promises'
 import { homedir } from 'node:os'
 import path from 'node:path'
 
@@ -11,6 +11,7 @@ type SqliteStatement = {
 
 type SqliteDatabase = {
   prepare: (sql: string) => SqliteStatement
+  exec?: (sql: string) => void
   close: () => void
 }
 
@@ -36,6 +37,19 @@ export type OpenCodeStoragePreparation =
   | { outcome: 'imported'; sourcePath: string }
   | { outcome: 'failed'; sourcePath?: string; detail: string }
 
+export type OpenCodeSessionMetadata = {
+  id: string
+  title: string
+  directory: string | null
+  updatedAt: number | null
+}
+
+export type OpenCodeSessionMetadataRead =
+  | { kind: 'missing'; sessions: [] }
+  | { kind: 'ok'; sessions: OpenCodeSessionMetadata[] }
+  | { kind: 'incompatible'; sessions: []; detail: string }
+  | { kind: 'unavailable'; sessions: []; detail: string }
+
 export type OpenCodeStorageOptions = {
   userDataPath: string
   platform?: NodeJS.Platform
@@ -50,6 +64,8 @@ const SNAPSHOT_PREFIX = 'opencode-storage-snapshot-'
 // not a maximum source size. The source itself is bounded by available space.
 const EXTERNAL_IMPORT_DISK_RESERVE_BYTES = 256 * 1024 * 1024
 const DATABASE_SIDECARS = ['-wal', '-shm', '-journal'] as const
+const SESSION_DISCOVERY_MAX = 100_000
+const sqliteTextDecoder = new TextDecoder('utf-8', { fatal: false })
 
 let sqliteConstructorPromise: Promise<SqliteDatabaseConstructor | null> | null = null
 
@@ -60,6 +76,130 @@ async function loadSqliteConstructor(): Promise<SqliteDatabaseConstructor | null
       .catch(() => null)
   }
   return sqliteConstructorPromise
+}
+
+function metadataText(value: unknown): string {
+  if (typeof value === 'string') return value
+  if (value instanceof Uint8Array) return sqliteTextDecoder.decode(value)
+  return value == null ? '' : String(value)
+}
+
+function metadataTimestamp(value: unknown): number | null {
+  const number = typeof value === 'number' ? value : Number(value)
+  return Number.isFinite(number) ? number : null
+}
+
+/**
+ * Read only session metadata from one OpenCode authority. This intentionally
+ * opens the producer path read-only and selects no message/part payloads:
+ * import discovery must compare canonical IDs without copying or deserializing
+ * transcripts. The official runtime owns all writes to both databases.
+ */
+export async function readOpenCodeSessionMetadata(
+  databasePath: string,
+  options: { maxSessions?: number } = {},
+): Promise<OpenCodeSessionMetadataRead> {
+  let info
+  try {
+    info = await stat(databasePath)
+    if (!info.isFile()) return { kind: 'missing', sessions: [] }
+  } catch (error) {
+    if ((error as { code?: string }).code === 'ENOENT') return { kind: 'missing', sessions: [] }
+    return { kind: 'unavailable', sessions: [], detail: 'OpenCode session metadata could not be read.' }
+  }
+
+  const DatabaseSync = await loadSqliteConstructor()
+  if (!DatabaseSync) return { kind: 'unavailable', sessions: [], detail: 'SQLite support is unavailable.' }
+
+  const maxSessions = options.maxSessions ?? SESSION_DISCOVERY_MAX
+  if (!Number.isSafeInteger(maxSessions) || maxSessions < 1 || maxSessions > SESSION_DISCOVERY_MAX) {
+    return { kind: 'unavailable', sessions: [], detail: 'OpenCode session discovery bounds are invalid.' }
+  }
+
+  let database: SqliteDatabase | undefined
+  try {
+    database = new DatabaseSync(databasePath, { readOnly: true })
+    try { database.exec?.('PRAGMA busy_timeout = 1000') } catch { /* best effort for read-only connections */ }
+
+    const tableRows = database.prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name IN ('session', 'message', 'part')").all()
+    const tables = new Set(tableRows.map(row => metadataText(row.name)))
+    const missingTables = ['session', 'message', 'part'].filter(table => !tables.has(table))
+    if (missingTables.length > 0) {
+      return { kind: 'incompatible', sessions: [], detail: 'OpenCode database schema is not export-compatible.' }
+    }
+
+    const rows = database.prepare(
+      'SELECT id, CAST(title AS BLOB) AS title, CAST(directory AS BLOB) AS directory, time_updated FROM session ORDER BY time_updated DESC, id ASC LIMIT ?',
+    ).all(maxSessions + 1)
+    if (rows.length > maxSessions) {
+      return { kind: 'unavailable', sessions: [], detail: 'OpenCode session discovery exceeded its bounded limit.' }
+    }
+
+    const sessions: OpenCodeSessionMetadata[] = []
+    for (const row of rows) {
+      const id = metadataText(row.id)
+      if (!id || /[\u0000-\u001f\u007f]/u.test(id)) {
+        return { kind: 'incompatible', sessions: [], detail: 'OpenCode session metadata is malformed.' }
+      }
+      const directory = metadataText(row.directory)
+      sessions.push({
+        id,
+        title: metadataText(row.title),
+        directory: directory || null,
+        updatedAt: metadataTimestamp(row.time_updated),
+      })
+    }
+    return { kind: 'ok', sessions }
+  } catch {
+    return { kind: 'unavailable', sessions: [], detail: 'OpenCode session metadata could not be read.' }
+  } finally {
+    try { database?.close() } catch { /* best effort for a read-only connection */ }
+  }
+}
+
+/**
+ * Create an owned SQLite snapshot without opening the standalone database with
+ * a write-capable connection. VACUUM INTO reads the source (including its WAL
+ * view when present) and writes a new main database; it never copies or
+ * publishes the source WAL. The official standalone export command can then
+ * perform its normal project bookkeeping against this disposable snapshot.
+ */
+export async function snapshotOpenCodeDatabase(sourcePath: string, destinationPath: string): Promise<void> {
+  if (!path.isAbsolute(sourcePath) || !path.isAbsolute(destinationPath) || samePath(sourcePath, destinationPath, process.platform)) {
+    throw new Error('OpenCode snapshot paths are invalid.')
+  }
+
+  const source = await stat(sourcePath)
+  if (!source.isFile()) throw new Error('OpenCode source database is unavailable.')
+  try {
+    const journal = await stat(`${sourcePath}-journal`)
+    if (journal.isFile()) throw new Error('OpenCode source database is busy.')
+  } catch (error) {
+    if ((error as { code?: string }).code !== 'ENOENT') throw error
+  }
+
+  const destinationRoot = path.dirname(destinationPath)
+  const filesystem = await statfs(destinationRoot, { bigint: true })
+  const requiredBytes = BigInt(source.size) + BigInt(EXTERNAL_IMPORT_DISK_RESERVE_BYTES)
+  if (filesystem.bavail * filesystem.bsize < requiredBytes) throw new Error('Not enough space for the OpenCode export snapshot.')
+
+  const DatabaseSync = await loadSqliteConstructor()
+  if (!DatabaseSync) throw new Error('SQLite support is unavailable.')
+
+  let database: SqliteDatabase | undefined
+  try {
+    database = new DatabaseSync(sourcePath, { readOnly: true })
+    if (!database.exec) throw new Error('SQLite snapshot support is unavailable.')
+    const quote = String.fromCharCode(39)
+    const escapedDestination = destinationPath.replaceAll(quote, `${quote}${quote}`)
+    database.exec(`VACUUM INTO ${quote}${escapedDestination}${quote}`)
+  } finally {
+    try { database?.close() } catch { /* best effort for a read-only source connection */ }
+  }
+
+  const destination = await stat(destinationPath)
+  if (!destination.isFile()) throw new Error('OpenCode export snapshot was not created.')
+  try { await chmod(destinationPath, 0o600) } catch { /* Windows ACLs are managed by the OS. */ }
 }
 
 function errorMessage(error: unknown): string {

--- a/app/electron/opencode/view.test.ts
+++ b/app/electron/opencode/view.test.ts
@@ -224,4 +224,38 @@ describe('OpenCode WebContentsView boundary', () => {
     expect(view.visible).toBe(false)
     expect(window.attached).toEqual(new Set())
   })
+
+  it('stops the isolated runtime and disposes the view around maintenance, then restarts cleanly', async () => {
+    const app: OpenCodeApp = { on: vi.fn(), removeListener: vi.fn() }
+    const connection = { origin: 'http://127.0.0.1:43127', username: 'metrora', password: 'secret-password' }
+    const runtime = {
+      start: vi.fn(async () => status),
+      stop: vi.fn(async () => undefined),
+      status: vi.fn(() => status),
+      getConnection: vi.fn(() => connection),
+    }
+    const window = fakeWindow()
+    const views = [fakeView(), fakeView()]
+    const createdViews: FakeView[] = []
+    const createView = vi.fn(() => {
+      const view = views.shift()!
+      createdViews.push(view)
+      return view
+    })
+    const manager = new OpenCodeViewManager(runtime, { app, createView })
+
+    await manager.activate(window, { x: 0, y: 0, width: 900, height: 600 })
+    const attachedBefore = [...window.attached]
+    await expect(manager.runMaintenance(async () => {
+      expect(window.attached).toEqual(new Set())
+      expect(attachedBefore[0]).toMatchObject({ webContents: { destroyed: true } })
+      return 'imported'
+    })).resolves.toBe('imported')
+
+    expect(runtime.stop).toHaveBeenCalledOnce()
+    expect(runtime.start).toHaveBeenCalledTimes(2)
+    await manager.activate(window, { x: 0, y: 0, width: 900, height: 600 })
+    expect(createView).toHaveBeenCalledTimes(2)
+    expect(window.attached).toEqual(new Set([createdViews[1]]))
+  })
 })

--- a/app/electron/opencode/view.ts
+++ b/app/electron/opencode/view.ts
@@ -4,7 +4,7 @@ import {
   type OpenCodeDesktopProjectSnapshot,
 } from './project-import'
 import type { OpenCodeRuntime } from './runtime'
-import type { OpenCodeConnection, OpenCodeRuntimeStatus } from './types'
+import { OpenCodeError, type OpenCodeConnection, type OpenCodeRuntimeStatus } from './types'
 
 export type OpenCodeBounds = { x: number; y: number; width: number; height: number }
 
@@ -125,6 +125,7 @@ export class OpenCodeViewManager {
   private readonly desiredVisibility = new WeakMap<OpenCodeWindow, boolean>()
   private readonly disposedWindows = new WeakSet<OpenCodeWindow>()
   private readonly loginListener: (event: LoginEvent, webContents: OpenCodeWebContents, details: unknown, authInfo: LoginAuthInfo, callback: LoginCallback) => void
+  private maintenancePromise: Promise<unknown> | null = null
   private shuttingDown = false
 
   constructor(private readonly runtime: Pick<OpenCodeRuntime, 'start' | 'stop' | 'status' | 'getConnection'>, private readonly options: OpenCodeViewManagerOptions) {
@@ -185,10 +186,38 @@ export class OpenCodeViewManager {
     if (record) this.disposeRecord(record)
   }
 
+  /**
+   * Stop the isolated server before a command writes its database, then bring
+   * the server back when the command finishes. The upstream WebContentsView is
+   * disposed so no UI process can race the maintenance write.
+   */
+  async runMaintenance<T>(operation: () => Promise<T>): Promise<T> {
+    if (this.maintenancePromise) await this.maintenancePromise
+    if (this.shuttingDown) throw new OpenCodeError('cancelled', 'OpenCode maintenance was cancelled during shutdown.')
+
+    const promise = (async () => {
+      for (const record of [...this.records]) this.disposeRecord(record)
+      await this.runtime.stop()
+      if (this.shuttingDown) throw new OpenCodeError('cancelled', 'OpenCode maintenance was cancelled during shutdown.')
+      try {
+        return await operation()
+      } finally {
+        if (!this.shuttingDown) await this.runtime.start()
+      }
+    })()
+    this.maintenancePromise = promise
+    try {
+      return await promise
+    } finally {
+      if (this.maintenancePromise === promise) this.maintenancePromise = null
+    }
+  }
+
   async shutdown(): Promise<void> {
     this.shuttingDown = true
     for (const record of [...this.records]) this.disposeRecord(record)
     this.options.app.removeListener?.('login', this.loginListener)
+    await this.maintenancePromise?.catch(() => undefined)
     await this.runtime.stop()
   }
 

--- a/app/electron/preload.ts
+++ b/app/electron/preload.ts
@@ -2,6 +2,7 @@ import { contextBridge, ipcRenderer } from 'electron'
 
 import type { Envelope } from './main'
 import type { OpenCodeRuntimeStatus } from './opencode/types'
+import type { OpenCodeImportResult } from './opencode/session-import'
 
 type DateRange = { from: string; to: string }
 type PriceRates = { input?: number; output?: number; cacheRead?: number; cacheCreation?: number }
@@ -87,6 +88,7 @@ const bridge = {
   opencodeActivate: (bounds: OpenCodeBounds) => invoke('metrora:opencodeActivate', bounds) as Promise<OpenCodeRuntimeStatus>,
   opencodeUpdateBounds: (bounds: OpenCodeBounds) => invoke('metrora:opencodeBounds', bounds) as Promise<boolean>,
   opencodeDeactivate: () => invoke('metrora:opencodeDeactivate') as Promise<boolean>,
+  importOpenCodeSessions: () => invoke('metrora:opencodeImport') as Promise<OpenCodeImportResult>,
   setWindowChromeTheme: (theme: 'dark' | 'light') => invoke('metrora:setWindowChromeTheme', theme) as Promise<boolean>,
   setWindowChromeMode: (mode: 'always' | 'auto') => invoke('metrora:setWindowChromeMode', mode) as Promise<boolean>,
 

--- a/app/renderer/components/OpenCodeHost.tsx
+++ b/app/renderer/components/OpenCodeHost.tsx
@@ -10,7 +10,7 @@ function readBounds(element: HTMLDivElement): OpenCodeViewBounds | null {
 }
 
 /** Empty renderer host only: the actual Code surface is a main-process View. */
-export function OpenCodeHost() {
+export function OpenCodeHost({ restartToken = 0 }: { restartToken?: number }) {
   const hostRef = useRef<HTMLDivElement>(null)
   const [state, setState] = useState<'loading' | 'ready' | 'unavailable'>('loading')
 
@@ -18,6 +18,7 @@ export function OpenCodeHost() {
     const host = hostRef.current
     if (!host) return
     let active = true
+    setState('loading')
     const bounds = () => {
       const value = readBounds(host)
       if (value) void metrora.opencodeUpdateBounds(value).catch(() => {})
@@ -44,7 +45,7 @@ export function OpenCodeHost() {
       window.removeEventListener('resize', bounds)
       void metrora.opencodeDeactivate().catch(() => {})
     }
-  }, [])
+  }, [restartToken])
 
   return (
     <div ref={hostRef} className="code-view-host" data-testid="opencode-web-contents-host" aria-label="OpenCode upstream surface">

--- a/app/renderer/lib/metrora-bridge-types.ts
+++ b/app/renderer/lib/metrora-bridge-types.ts
@@ -30,6 +30,7 @@ import type { PerformanceRunV1 } from '../../../src/bench/performance-contract-v
 import type { PerformanceComparisonV1 } from '../../../src/bench/performance-compare-v1'
 import type { CanonicalBenchEvidenceV1 } from '../../../src/bench/evidence-contract-v1'
 import type { OpenCodeRuntimeStatus } from '../../electron/opencode/types'
+import type { OpenCodeImportResult } from '../../electron/opencode/session-import'
 
 export type OpenCodeViewBounds = { x: number; y: number; width: number; height: number }
 export type BenchTaskResult = {
@@ -163,6 +164,7 @@ export interface MetroraBridge extends ProjectBridge {
   opencodeActivate(bounds: OpenCodeViewBounds): Promise<OpenCodeRuntimeStatus>
   opencodeUpdateBounds(bounds: OpenCodeViewBounds): Promise<boolean>
   opencodeDeactivate(): Promise<boolean>
+  importOpenCodeSessions(): Promise<OpenCodeImportResult>
   setWindowChromeTheme(theme: 'dark' | 'light'): Promise<boolean>
   setWindowChromeMode(mode: 'always' | 'auto'): Promise<boolean>
   telemetryStatus(): Promise<TelemetryStatus | null>

--- a/app/renderer/sections/Code.test.tsx
+++ b/app/renderer/sections/Code.test.tsx
@@ -1,11 +1,12 @@
 // @vitest-environment jsdom
-import { render, screen, waitFor } from '@testing-library/react'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const bridge = vi.hoisted(() => ({
   opencodeActivate: vi.fn(async () => ({ state: 'ready', version: '1.18.27', commit: 'b04697366f05419e9bd7a92f841813dd976161c9', customToolRegistered: true, detail: null })),
   opencodeUpdateBounds: vi.fn(async () => true),
   opencodeDeactivate: vi.fn(async () => true),
+  importOpenCodeSessions: vi.fn(async () => ({ discovered: 0, newSessions: 0, imported: 0, alreadyPresent: 0, skipped: 0, failed: 0, reason: null, reasons: [] })),
 }))
 
 vi.mock('../lib/ipc', () => ({ metrora: bridge }))
@@ -13,6 +14,7 @@ vi.mock('../lib/ipc', () => ({ metrora: bridge }))
 import { Code } from './Code'
 
 describe('Code upstream surface', () => {
+  beforeEach(() => window.localStorage.clear())
   afterEach(() => vi.restoreAllMocks())
 
   it('keeps the renderer as an empty layout host and owns activation lifecycle through the bridge', async () => {
@@ -28,5 +30,18 @@ describe('Code upstream surface', () => {
 
     rendered.unmount()
     await waitFor(() => expect(bridge.opencodeDeactivate).toHaveBeenCalledOnce())
+  })
+
+  it('requires a lightweight confirmation and reports a successful Metrora-owned import', async () => {
+    vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue({ left: 4, top: 5, width: 800, height: 600, right: 804, bottom: 605, x: 4, y: 5, toJSON: () => ({}) })
+    const confirm = vi.spyOn(window, 'confirm').mockReturnValue(true)
+    bridge.importOpenCodeSessions.mockResolvedValue({ discovered: 2, newSessions: 1, imported: 1, alreadyPresent: 1, skipped: 0, failed: 0, reason: null, reasons: [] })
+
+    render(<Code />)
+    fireEvent.click(screen.getByRole('button', { name: 'Import new OpenCode sessions' }))
+
+    await waitFor(() => expect(bridge.importOpenCodeSessions).toHaveBeenCalledOnce())
+    expect(confirm).toHaveBeenCalledOnce()
+    expect(screen.getByText('OpenCode import: 1 new session; 1 already present.')).toBeInTheDocument()
   })
 })

--- a/app/renderer/sections/Code.tsx
+++ b/app/renderer/sections/Code.tsx
@@ -1,14 +1,72 @@
+import { useState } from 'react'
+
 import { OpenCodeHost } from '../components/OpenCodeHost'
+import { metrora } from '../lib/ipc'
+
+const IMPORT_CONFIRMATION_KEY = 'metrora.opencode-session-import.confirmed.v1'
+
+function hasImportConfirmation(): boolean {
+  try { return window.localStorage.getItem(IMPORT_CONFIRMATION_KEY) === '1' } catch { return false }
+}
+
+function confirmImport(): boolean {
+  if (hasImportConfirmation()) return true
+  if (!window.confirm('Import new OpenCode sessions into Metrora’s private OpenCode store? Existing Metrora sessions will be left unchanged.')) return false
+  try { window.localStorage.setItem(IMPORT_CONFIRMATION_KEY, '1') } catch { /* confirmation can remain in-memory for this action */ }
+  return true
+}
+
+function resultMessage(result: Awaited<ReturnType<typeof metrora.importOpenCodeSessions>>): string {
+  if (result.newSessions === 0 && result.imported === 0 && result.skipped === 0 && result.failed === 0) {
+    if (result.reason === 'standalone-not-found') return 'Standalone OpenCode export runtime was not found.'
+    if (result.reason === 'export-unavailable') return 'Standalone OpenCode export is unavailable.'
+    if (result.reason === 'incompatible-export') return 'OpenCode export format was not compatible.'
+    if (result.reason === 'import-failed') return 'OpenCode sessions could not be imported.'
+    if (result.reason === 'cancelled') return 'OpenCode import was cancelled.'
+  }
+  if (result.imported === 0 && result.newSessions === 0) return 'No new OpenCode sessions found.'
+
+  const imported = `${result.imported} new session${result.imported === 1 ? '' : 's'}`
+  const present = `${result.alreadyPresent} already present`
+  const skipped = result.skipped > 0 ? `, ${result.skipped} skipped` : ''
+  const failed = result.failed > 0 ? `, ${result.failed} failed` : ''
+  return `OpenCode import: ${imported}; ${present}${skipped}${failed}.`
+}
 
 /** Code keeps the execution surface in the upstream OpenCode WebContentsView host. */
 export function Code() {
+  const [restartToken, setRestartToken] = useState(0)
+  const [importing, setImporting] = useState(false)
+  const [importMessage, setImportMessage] = useState<string | null>(null)
+
+  const importSessions = async () => {
+    if (importing || !confirmImport()) return
+    setImporting(true)
+    setImportMessage(null)
+    try {
+      const result = await metrora.importOpenCodeSessions()
+      setImportMessage(resultMessage(result))
+      if (result.newSessions > 0) setRestartToken(value => value + 1)
+    } catch {
+      setImportMessage('OpenCode session import is unavailable.')
+    } finally {
+      setImporting(false)
+    }
+  }
+
   return (
     <section className="code-section" aria-label="Code">
       <div className="code-section__header">
         <div><span className="eyebrow">Code</span><strong>OpenCode workspace</strong></div>
-        <span>Powered by upstream OpenCode</span>
+        <div className="code-section__tools">
+          {importMessage ? <span className="code-import-status" role="status" aria-live="polite">{importMessage}</span> : null}
+          <button className="code-import-button" type="button" onClick={() => { void importSessions() }} disabled={importing}>
+            {importing ? 'Importing…' : 'Import new OpenCode sessions'}
+          </button>
+          <span>Powered by upstream OpenCode</span>
+        </div>
       </div>
-      <OpenCodeHost />
+      <OpenCodeHost restartToken={restartToken} />
     </section>
   )
 }

--- a/app/renderer/styles/control-center-home.css
+++ b/app/renderer/styles/control-center-home.css
@@ -897,6 +897,29 @@
 .code-section__header strong { color: var(--cc-text); font-size: 13px; }
 .code-section__header > span { color: var(--cc-muted); font-size: 10.5px; }
 
+.code-section__tools {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 10px;
+  min-width: 0;
+}
+
+.code-import-button {
+  border: 1px solid var(--cc-border-strong, var(--cc-border));
+  border-radius: 5px;
+  padding: 6px 9px;
+  color: var(--cc-text);
+  background: var(--cc-panel-raised);
+  font: inherit;
+  font-size: 10.5px;
+  cursor: pointer;
+}
+
+.code-import-button:hover:not(:disabled) { background: var(--cc-panel); }
+.code-import-button:disabled { cursor: wait; opacity: .6; }
+.code-import-status { color: var(--cc-muted); font-size: 10.5px; }
+
 .metrora-shell .code-view-host { background: var(--cc-canvas); }
 
 @media (max-width: 1120px) {

--- a/docs/OPENCODE_SESSION_IMPORT_001.md
+++ b/docs/OPENCODE_SESSION_IMPORT_001.md
@@ -1,0 +1,91 @@
+# OPENCODE_SESSION_IMPORT_001
+
+## Closeout
+
+Base main: `0c24a8e495848bb3d5e71e4924dff56e24b185d5`
+
+Branch: `feat/opencode-session-import-001`
+
+HEAD: `0c24a8e495848bb3d5e71e4924dff56e24b185d5` before the feature commit
+
+PR: draft pending push
+
+Standalone version tested: `1.18.29`
+
+Metrora OpenCode version: `1.18.27` (`b04697366f05419e9bd7a92f841813dd976161c9`)
+
+Official export used: YES — `opencode export <sessionID>`
+
+Official import used: YES — `opencode import <file>`
+
+Cross-version export/import: PASS
+
+Standalone session discovery: PASS — bounded SQLite metadata read found the real standalone store without deserializing transcripts.
+
+New-session comparison: PASS — canonical IDs only; overlaps are `alreadyPresent` and are never sent to import.
+
+First import:
+
+- discovered: 1
+- new: 1
+- imported: 1
+- already present: 0
+- skipped: 0
+- failed: 0
+
+Second import:
+
+- imported: 0
+- already present: 1
+- duplicates created: 0
+
+Transcript preserved: PASS — the 1.18.29 export contained 37 messages, 104 parts, 24 text parts, 12 tool parts, and 12 tool states; all were present after pinned 1.18.27 import.
+
+Imported session usable: PASS — the imported session and its message/part/tool records remained readable from the pinned destination store.
+
+Restart persistence: PASS — a new process reopened the disposable pinned destination and found the imported session; a provider-backed new prompt was intentionally not sent.
+
+Standalone source mutated by Metrora: NO on the product path — the live standalone DB SHA-256 was unchanged before/after the snapshot-backed importer run. A separate diagnostic direct invocation of the upstream CLI against the live DB updated upstream project bookkeeping; that unsafe diagnostic was not accepted as product behavior and is the reason the implementation snapshots the source first.
+
+Metrora isolated DB preserved: YES
+
+Shared DB restored: NO
+
+Accounting overlap dedup: PASS — the existing OpenCode source-union regression suite still counts overlapping standalone/Metrora evidence once.
+
+New Metrora prompt counted once: NOT RUN — no provider-backed prompt was issued against the founder account.
+
+Temp artifacts cleaned: PASS — export JSON, source snapshot, and isolated command roots are removed in success and failure paths. Disposable validation directories remain outside the repository under the OS temp folder for manual cleanup.
+
+Tests:
+
+- Desktop: 96 files, 804 tests passed
+- Repository: 353 files passed, 2 skipped; 3,419 tests passed, 5 skipped
+- Importer/runtime/storage/resolver tests: 45 tests passed
+- OpenCode source-union regression: 3 tests passed
+
+Typecheck: PASS — `npm run typecheck` from `app`
+
+Build: PASS — root CLI build, Electron TypeScript build, and renderer Vite build
+
+Source-size: PASS — `SOURCE_SIZE_BASE_REF=origin/main node scripts/check-source-size-ratchet.mjs`
+
+Architecture: PASS — public identity boundary, Windows Store identity/version, and source-size boundary checks
+
+Commit: `feat: import standalone OpenCode sessions` (pending)
+
+Push: pending
+
+Merge: NOT PERFORMED
+
+STOP.
+
+## Boundary implemented
+
+The standalone authority is discovered portably and used only for metadata discovery and official export. The export command runs against a read-only SQLite `VACUUM INTO` snapshot under Metrora-owned temporary storage, because the upstream CLI bootstraps project bookkeeping even for export. The source WAL is never copied or published.
+
+The pinned Metrora runtime is the only import authority. It receives the existing Metrora runtime path and environment contract, is run only while the Metrora sidecar is cleanly stopped, and writes only the Metrora-owned isolated database. The WebContentsView is disposed and restarted around maintenance, while renderer IPC accepts no paths, executable names, or arguments.
+
+The import action is explicit, one-way, single-flight, ID-idempotent, directory-aware, bounded, and returns safe reason enums. It does not modify upstream OpenCode UI, add synchronization, merge existing sessions, or expose export JSON to telemetry/logs.
+
+The upstream command implementation audited for this work is [export.ts](https://raw.githubusercontent.com/anomalyco/opencode/v1.18.29/packages/opencode/src/cli/cmd/export.ts) and [import.ts](https://raw.githubusercontent.com/anomalyco/opencode/v1.18.29/packages/opencode/src/cli/cmd/import.ts).

--- a/docs/OPENCODE_SESSION_IMPORT_001.md
+++ b/docs/OPENCODE_SESSION_IMPORT_001.md
@@ -6,9 +6,9 @@ Base main: `0c24a8e495848bb3d5e71e4924dff56e24b185d5`
 
 Branch: `feat/opencode-session-import-001`
 
-HEAD: `0c24a8e495848bb3d5e71e4924dff56e24b185d5` before the feature commit
+HEAD: `0e786cb59f80898a8acd6c919d55611b365ac21b` feature commit (this closeout metadata is committed immediately after it)
 
-PR: draft pending push
+PR: [#272](https://github.com/maikolsiragusaa/metrora/pull/272) — DRAFT
 
 Standalone version tested: `1.18.29`
 
@@ -72,9 +72,9 @@ Source-size: PASS — `SOURCE_SIZE_BASE_REF=origin/main node scripts/check-sourc
 
 Architecture: PASS — public identity boundary, Windows Store identity/version, and source-size boundary checks
 
-Commit: `feat: import standalone OpenCode sessions` (pending)
+Commit: `0e786cb59f80898a8acd6c919d55611b365ac21b` — `feat: import standalone OpenCode sessions`
 
-Push: pending
+Push: PASS
 
 Merge: NOT PERFORMED
 


### PR DESCRIPTION
## Summary
- add the Metrora-owned `Import new OpenCode sessions` action to Code
- discover standalone OpenCode metadata read-only, export through the standalone runtime, and import through the pinned 1.18.27 runtime
- protect the one-way boundary with an owned SQLite snapshot, isolated environments, canonical-ID idempotence, directory checks, bounded result reasons, and single-flight shutdown-safe maintenance

## Validation
- Desktop: 96 files / 805 tests passed
- Repository: 353 files passed, 2 skipped; 3,419 tests passed, 5 skipped
- typecheck, CLI build, Electron build, renderer build, identity/version checks, and source-size ratchet passed
- physical 1.18.29 export -> 1.18.27 import preserved session/messages/parts/tool data; product-path source hash was unchanged; repeat import created zero duplicates

A provider-backed new prompt was intentionally not issued against the founder account, so that accounting point remains a follow-up validation item. Merge is intentionally not performed.