### PR TITLE
fix(desktop): update Electron Windows runtime to 43.5.0

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -26,7 +26,7 @@
         "@xmldom/xmldom": "^0.8.13",
         "concurrently": "^10.0.3",
         "cross-env": "^10.1.0",
-        "electron": "^43.1.0",
+        "electron": "43.5.0",
         "electron-builder": "^26.15.3",
         "jsdom": "^29.1.1",
         "typescript": "^7.0.2",
@@ -1615,15 +1615,6 @@
         "node": ">=14.18.0"
       }
     },
-    "node_modules/@polka/url": {
-      "version": "1.0.0-next.29",
-      "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.29.tgz",
-      "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.27",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
@@ -2748,30 +2739,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/@vitest/ui": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-3.2.7.tgz",
-      "integrity": "sha512-eVtcpJXGhS0GjMuHROfbXLhlxooyUcuip8GNzzjDD5jzafZqzanJH4W3VGmUxHNx4fv6qQGUGJHRpGUdj+9D6Q==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@vitest/utils": "3.2.7",
-        "fflate": "^0.8.2",
-        "flatted": "^3.3.3",
-        "pathe": "^2.0.3",
-        "sirv": "^3.0.1",
-        "tinyglobby": "^0.2.14",
-        "tinyrainbow": "^2.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      },
-      "peerDependencies": {
-        "vitest": "3.2.7"
       }
     },
     "node_modules/@vitest/utils": {
@@ -4045,9 +4012,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "43.1.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-43.1.0.tgz",
-      "integrity": "sha512-DPfxpQLd4NL3BJ8DBxYAfmLUKKesF5Rx9dQx5FyczAP8bhOPScjHE48GArVeXu68LlAainuwkmQTQvdZwpIIAQ==",
+      "version": "43.5.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-43.5.0.tgz",
+      "integrity": "sha512-nV2aWuKatmUrxrAWP2pNIynNX7dy83TCAz+6KnsbK7hDVLE+6fa2iouOtir41AboZTa+J5w2UgicWHAqUaaUJw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4642,15 +4609,6 @@
         }
       }
     },
-    "node_modules/fflate": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
-      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/filelist": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.6.tgz",
@@ -4703,15 +4661,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/flatted": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
-      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true
     },
     "node_modules/follow-redirects": {
       "version": "1.16.0",
@@ -5705,18 +5654,6 @@
       },
       "bin": {
         "mkdirp": "bin/cmd.js"
-      }
-    },
-    "node_modules/mrmime": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
-      "integrity": "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/ms": {
@@ -6885,23 +6822,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/sirv": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/sirv/-/sirv-3.0.2.tgz",
-      "integrity": "sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@polka/url": "^1.0.0-next.24",
-        "mrmime": "^2.0.0",
-        "totalist": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -7260,18 +7180,6 @@
       "license": "MIT",
       "dependencies": {
         "tmp": "^0.2.0"
-      }
-    },
-    "node_modules/totalist": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
-      "integrity": "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/tough-cookie": {

--- a/app/package.json
+++ b/app/package.json
@@ -42,7 +42,7 @@
     "@xmldom/xmldom": "^0.8.13",
     "concurrently": "^10.0.3",
     "cross-env": "^10.1.0",
-    "electron": "^43.1.0",
+    "electron": "43.5.0",
     "electron-builder": "^26.15.3",
     "jsdom": "^29.1.1",
     "typescript": "^7.0.2",


### PR DESCRIPTION
## Summary

Converges the original Electron runtime update onto the current `main` after the approved refresh integration.

- Preserves the original commit `72173ca9d9c746763756aa016b3a3b0e25e0f3bf` in the branch history.
- Pins `app/package.json` to Electron `43.5.0`.
- Regenerates and verifies `app/package-lock.json` with Electron `43.5.0` resolved.
- Leaves the current desktop shell, WebContentsView/OpenCode runtime boundary, and branding unchanged.

## Validation

- Desktop suite: 99 files, 847 tests passed.
- Root CLI build passed.
- Desktop typecheck and production build passed.
- Bundled OpenCode `1.18.27` staged and verified for win32-x64.
- Windows unpacked packaging smoke passed and produced `app/release/win-unpacked/Metrora.exe`.
- Pricing docs, source-size ratchet against `origin/main`, public identity/Store identity, brand boundary, version consistency, and diff checks passed.
- The branch was merged with `origin/main` using a normal merge commit; no rebase or squash was used.